### PR TITLE
Ignore files generated by Qt resource compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Makefile
 CMakeFiles/
 CMakeCache.txt
 /Generated/
+*.qrc.depends
 
 # Unit testing
 *_UnitTests


### PR DESCRIPTION
It seems that Qt 4.8 which is shipped with Ubuntu Precise generates more artifacts than 4.6 on Ubuntu Lucid did, so commit 692082d did not include an ignore statement for these files.
