### PR TITLE
Make ResInsight buildable on MacOS X

### DIFF
--- a/ApplicationCode/CMakeLists.txt
+++ b/ApplicationCode/CMakeLists.txt
@@ -203,6 +203,8 @@ source_group( "SocketInterface"     FILES ${SOCKET_INTERFACE_FILES} )
 
 if (MSVC)
     set( EXE_FILES WIN32)
+elseif (APPLE)
+    set( EXE_FILES MACOSX_BUNDLE)
 endif()
 set( EXE_FILES
     ${EXE_FILES}

--- a/ApplicationCode/CMakeLists.txt
+++ b/ApplicationCode/CMakeLists.txt
@@ -219,6 +219,19 @@ set( EXE_FILES
 
 add_executable( ResInsight ${EXE_FILES} )
 
+# Application icon for MacOS X bundle
+if (APPLE)
+    add_custom_command (OUTPUT Resources/ResInsight.icns
+        COMMAND sips -s format icns ${CMAKE_CURRENT_SOURCE_DIR}/Resources/AppLogo48x48.png
+            --out ${CMAKE_CURRENT_BINARY_DIR}/Resources/ResInsight.icns
+        COMMENT Converting application icon
+        )
+    add_custom_target (ResInsight-icns
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Resources/ResInsight.icns)
+    add_dependencies (ResInsight ResInsight-icns)
+    set_target_properties (ResInsight PROPERTIES
+        MACOSX_BUNDLE_ICON_FILE ${CMAKE_CURRENT_BINARY_DIR}/Resources/ResInsight.icns)
+endif ()
 
 set( LINK_LIBRARIES
     WellPathImportSsihub

--- a/ApplicationCode/ModelVisualization/RivReservoirPartMgr.h
+++ b/ApplicationCode/ModelVisualization/RivReservoirPartMgr.h
@@ -20,6 +20,7 @@
 
 #include "cvfArray.h"
 #include "cvfCollection.h"
+#include "RivGridPartMgr.h"
 
 namespace cvf
 {
@@ -29,7 +30,6 @@ namespace cvf
 
 class RimResultSlot;
 class RimCellEdgeResultSlot;
-class RivGridPartMgr;
 class RigCaseData;
 
 

--- a/OctavePlugin/CMakeLists.txt
+++ b/OctavePlugin/CMakeLists.txt
@@ -57,6 +57,36 @@ else()
     SET(OCTAVE_QT_LIBRARY_DIR            ${QT_LIBRARY_DIR})
 endif()
 
+# recreate the magic that CMake does for MacOS X frameworks in the
+# include list when we call mkoctfile as a custom command
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set (QT_INCLUDES)
+    set (QT_FRAMEWORKS)
+    # QT_INCLUDE_DIR contains two items; the first is the directory
+    # containing header files, the second is the framework. This
+    # setup is specially processed in include_directories (); CMake
+    # will add -F before the frameworks. We will have to replicate
+    # that setup here when we want to pass it directly to a command
+    # see <http://www.cmake.org/Bug/print_bug_page.php?bug_id=10632>
+    foreach (item IN ITEMS ${QT_QTNETWORK_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_INCLUDE_DIR})
+        if ("${item}" MATCHES ".framework$")
+            get_filename_component (frmwrk_path ${item} PATH)
+            get_filename_component (frmwrk_name ${item} NAME_WE)
+            # mkoctfile doesn't support arbitrary compiler command,
+            # so we must wrap in -Wl, to pass to the linker
+            list (APPEND QT_FRAMEWORKS "-Wl,-F${frmwrk_path}")
+            list (APPEND QT_FRAMEWORKS "-Wl,-framework,${frmwrk_name}")
+        else ()
+            list (APPEND QT_INCLUDES "-I${item}")
+        endif ()
+    endforeach (item)
+    if (QT_INCLUDES)
+        list (REMOVE_DUPLICATES QT_INCLUDES)
+    endif ()
+    if (QT_FRAMEWORKS)
+        list (REMOVE_DUPLICATES QT_FRAMEWORKS)
+    endif ()
+endif ()
     
 find_program(RESINSIGHT_OCTAVE_PLUGIN_MKOCTFILE_EXE mkoctfile)
 if(NOT RESINSIGHT_OCTAVE_PLUGIN_MKOCTFILE_EXE)
@@ -99,6 +129,13 @@ else()
                 COMMENT "Generating ${octFileName}"
             )
         endif()
+    elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        add_custom_command(
+            OUTPUT "${octFileName}"
+            COMMAND ${RESINSIGHT_OCTAVE_PLUGIN_MKOCTFILE_EXE} ${QT_INCLUDES} ${QT_FRAMEWORKS} ${RPATH_COMMAND} -L${QT_LIBRARY_DIR} -Wl,-framework,QtCore -Wl,-framework,QtNetwork -o "${octFileName}" "${srcFileName}"
+            DEPENDS "${srcFileName}"
+            COMMENT "Generating ${octFileName}"
+        )
     else()
         add_custom_command(
             OUTPUT "${octFileName}"

--- a/VisualizationModules/LibCore/cvfMutex.cpp
+++ b/VisualizationModules/LibCore/cvfMutex.cpp
@@ -27,7 +27,7 @@
 #pragma warning (pop)
 #endif
 
-#if defined CVF_LINUX || defined(CVF_ANDROID)
+#if defined(CVF_LINUX) || defined(CVF_ANDROID) || defined(CVF_OSX)
 #include <pthread.h>
 #endif
 

--- a/VisualizationModules/LibRender/cvfOpenGL.cpp
+++ b/VisualizationModules/LibRender/cvfOpenGL.cpp
@@ -115,6 +115,9 @@ String OpenGL::mapOpenGLErrorToString(cvfGLenum errorCode)
 		case GL_INVALID_VALUE:      errCodeStr = "GL_INVALID_VALUE";      break;
 		case GL_INVALID_OPERATION:  errCodeStr = "GL_INVALID_OPERATION";  break;
 		case GL_OUT_OF_MEMORY:      errCodeStr = "GL_OUT_OF_MEMORY";      break;
+		case GL_INVALID_FRAMEBUFFER_OPERATION:
+		                            errCodeStr = "GL_INVALID_FRAMEBUFFER_OPERATION";
+		                                                                  break;
 #ifndef CVF_OPENGL_ES
 		case GL_STACK_OVERFLOW:     errCodeStr = "GL_STACK_OVERFLOW";     break;
 		case GL_STACK_UNDERFLOW:    errCodeStr = "GL_STACK_UNDERFLOW";    break;


### PR DESCRIPTION
With these changes, ResInsight can be *built* using Apple Xcode 4.6.3 on MacOS X 10.8.4. Some of these changes may be beneficial for building with Clang on Linux as well.

Although the resulting application will launch it is not yet functional, *probably* because the use of shaders require an OpenGL 3.2 profile but this is somewhat incompatible with GLEW . I haven't looked too closely into that (yet).