### PR TITLE
Invalid framebuffer when opening model on MacOS X

### DIFF
--- a/VisualizationModules/LibRender/cvfOpenGL.cpp
+++ b/VisualizationModules/LibRender/cvfOpenGL.cpp
@@ -182,7 +182,11 @@ void OpenGL::cvf_check_ogl(OpenGLContext* oglContext, const CodeLocation& codeLo
             CVF_ASSERT(oglContext->isCurrent());
 
             Logger* logger = oglContext->group()->logger();
+#if !defined(_DEBUG) && defined(CVF_OSX)
+            if (logger && (err != GL_INVALID_FRAMEBUFFER_OPERATION))
+#else
             if (logger)
+#endif /* defined(_DEBUG) */
             {
                 String errCodeStr = mapOpenGLErrorToString(err);
                 String msg = "OGL(" + errCodeStr + "): ";

--- a/VisualizationModules/LibRender/cvfShaderProgram.cpp
+++ b/VisualizationModules/LibRender/cvfShaderProgram.cpp
@@ -268,7 +268,9 @@ bool ShaderProgram::useProgram(OpenGLContext* oglContext) const
     }
 
     CVF_ASSERT(OglRc::safeOglId(m_oglRcProgram.p()) != 0);
+#ifndef CVF_OSX
     CVF_ASSERT(validateProgram(oglContext));
+#endif
     
     // Need this check to clear any "hanging" errors that is not produced by glUseProgram below, but still 
     // will make this method return false.


### PR DESCRIPTION
The bug is triggered by launching the program followed by selecting Debug | Mock Model from the menu:

    CVF_ASSERT(validateProgram(oglContext));

on line 271 in `VisualizationModules/LibRender/cvfShaderProgram.cpp` fails and this aborts the program. The error log says:

    Validation Failed: Current draw framebuffer is invalid

This happens regardless of whether Use Shaders are selected or not in the Preferences.

If I comment out this line, the program apparently works fine, although I haven't done any extensive testing.

Upon startup, I get a bunch of:

    OGL(GL_INVALID_FRAMEBUFFER_OPERATION)

Drawing on hidden views is apparently no longer silently ignored from MacOS X 10.8, and this *may* be the cause of these messages. That is only speculation and I don't know if it is really related to the error, though.

Note: The string above is added in commit 0c0957f in #58.

