### PR TITLE
Print the help message if we encounter a positional command-line parameter

### DIFF
--- a/ApplicationCode/Application/RiaApplication.cpp
+++ b/ApplicationCode/Application/RiaApplication.cpp
@@ -834,7 +834,10 @@ bool RiaApplication::parseArguments()
 
     bool parseOk = progOpt.parse(cvfqt::Utils::toStringVector(arguments));
 
-    if (!parseOk || progOpt.hasOption("help") || progOpt.hasOption("?"))
+    if (!parseOk ||
+        progOpt.hasOption("help") ||
+        progOpt.hasOption("?") ||
+        progOpt.positionalParameters().size() > 0)
     {
 #if defined(_MSC_VER) && defined(_WIN32)
         showFormattedTextInMessageBox(m_helpText);


### PR DESCRIPTION
In my case, I accidentally used the old command line parameter
convention (single dash), which caused 'ResInsight -case $FOO' to do
nothing instead of bailing out.

That said, I'm not 100% sure that no positional parameters are
used. To me, he help message and the parameter parsing code looks this
way, though...
