### PR TITLE
Support for external ert source

### DIFF
--- a/ApplicationCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -1132,19 +1132,19 @@ void RifReaderEclipseOutput::readWellCells(const ecl_grid_type* mainEclGrid, boo
 
             // Production type
             well_type_enum ert_well_type = well_state_get_type(ert_well_state);
-            if (ert_well_type == PRODUCER)
+            if (ert_well_type == ERT_PRODUCER)
             {
                 wellResFrame.m_productionType = RigWellResultFrame::PRODUCER;
             }
-            else if (ert_well_type == WATER_INJECTOR)
+            else if (ert_well_type == ERT_WATER_INJECTOR)
             {
                 wellResFrame.m_productionType = RigWellResultFrame::WATER_INJECTOR;
             }
-            else if (ert_well_type == GAS_INJECTOR)
+            else if (ert_well_type == ERT_GAS_INJECTOR)
             {
                 wellResFrame.m_productionType = RigWellResultFrame::GAS_INJECTOR;
             }
-            else if (ert_well_type == OIL_INJECTOR)
+            else if (ert_well_type == ERT_OIL_INJECTOR)
             {
                 wellResFrame.m_productionType = RigWellResultFrame::OIL_INJECTOR;
             }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,22 +57,46 @@ SET(INSTALL_ERT OFF CACHE BOOL "ERT: Install library")
 SET(BUILD_SHARED_LIBS OFF CACHE BOOL "ERT: Build shared libraries")
 SET(ERT_USE_OPENMP ${OPENMP_FOUND} CACHE BOOL "ERT: Compile using OpenMP")
 
+option( ERT_EXTERNAL             "Build ERT from external source" OFF)
+SET(EXT_ERT_ROOT "" CACHE STRING "Path to ERT CMakeList.txt (source path)")
 
-add_subdirectory(ThirdParty/Ert/devel)
+if (ERT_EXTERNAL)
+    if (EXT_ERT_ROOT)
+        set(ERT_SOURCE_PATH "${EXT_ERT_ROOT}")
 
-include_directories(
+        add_subdirectory(${ERT_SOURCE_PATH} ${CMAKE_BINARY_DIR}/ThirdParty/Ert)
+        include_directories(
+        ${ERT_SOURCE_PATH}/libecl/include/ert/ecl
+        ${ERT_SOURCE_PATH}/libert_util/include/ert/util
+        ${ERT_SOURCE_PATH}/libgeometry/include/ert/geometry
+        ${ERT_SOURCE_PATH}/libecl_well/include/ert/ecl_well
+        ${ERT_SOURCE_PATH}/libecl/include
+        ${ERT_SOURCE_PATH}/libert_util/include
+        ${ERT_SOURCE_PATH}/libgeometry/include
+        ${ERT_SOURCE_PATH}/libecl_well/include
+        ${CMAKE_BINARY_DIR}/ThirdParty/Ert/libert_util/include/ert/util
+        ${CMAKE_BINARY_DIR}/ThirdParty/Ert/libert_util/include
+        )
+    endif(EXT_ERT_ROOT)
+
+else (ERT_EXTERNAL)
+    add_subdirectory(ThirdParty/Ert/devel)
+    include_directories(
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libecl/include/ert/ecl
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libert_util/include/ert/util
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libgeometry/include/ert/geometry
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libecl_well/include/ert/ecl_well
 	${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libecl/include
+    ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libecl/include
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libert_util/include
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libgeometry/include
     ${CMAKE_SOURCE_DIR}/ThirdParty/Ert/devel/libecl_well/include
 
 	${CMAKE_BINARY_DIR}/ThirdParty/Ert/devel/libert_util/include/ert/util
+    ${CMAKE_BINARY_DIR}/ThirdParty/Ert/devel/libert_util/include/ert/util
     ${CMAKE_BINARY_DIR}/ThirdParty/Ert/devel/libert_util/include
-)
+    )
+endif (ERT_EXTERNAL)
 
 
 ################################################################################


### PR DESCRIPTION
In my effort to fix issue #258 i found the need for using a external ERT source, ERT is updated with a fix for this issue so now there is a need to select either to backport this to ResInsight or to enable the use of external ERT source in ResInsight.