### PR TITLE
fixed: compilation issues with boost < 1.57

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,11 @@ else()
 	find_package(Boost 1.44.0 COMPONENTS filesystem date_time system regex REQUIRED)
 endif()
 
+# Boost < 1.57 has c++11 name mangling issues in boost::filesystem
+if(Boost_VERSION VERSION_LESS 105700)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SCOPED_ENUMS")
+endif()
+
 ################################################################################
 # cotire 
 # Fully automated CMake module for build speedup


### PR DESCRIPTION
due to c++11 name mangling issues in boost::filesystem,
you cannot build a program with c++11 if boost was built for c++03.

workaround this by using boost's internal hack to do so,
disabling the exposure of c++11 scoped enums which is the cause
of the problems.

Motivation: Building on debian jessie.

refs: http://stackoverflow.com/questions/15634114/cant-link-program-using-boost-filesystem/17988317 and https://svn.boost.org/trac/boost/ticket/6779