### PR TITLE
fixed: add missing cmath include statements

### DIFF
--- a/ApplicationCode/Commands/CompletionCommands/RicNewFishbonesSubsFeature.cpp
+++ b/ApplicationCode/Commands/CompletionCommands/RicNewFishbonesSubsFeature.cpp
@@ -36,6 +36,8 @@
 #include <QAction>
 #include <QMessageBox>
 
+#include <cmath>
+
 
 CAF_CMD_SOURCE_INIT(RicNewFishbonesSubsFeature, "RicNewFishbonesSubsFeature");
 

--- a/ApplicationCode/Commands/RicFlyToObjectFeature.cpp
+++ b/ApplicationCode/Commands/RicFlyToObjectFeature.cpp
@@ -34,6 +34,7 @@
 #include <QAction>
 
 #include <algorithm>
+#include <cmath>
 
 CAF_CMD_SOURCE_INIT(RicFlyToObjectFeature, "RicFlyToObjectFeature");
 

--- a/ApplicationCode/ProjectDataModel/Completions/RimFishbonesCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Completions/RimFishbonesCollection.cpp
@@ -30,6 +30,7 @@
 #include <QColor>
 
 #include <algorithm>
+#include <cmath>
 
 namespace caf {
     template<>

--- a/ApplicationCode/ProjectDataModel/Completions/RimFishbonesMultipleSubs.cpp
+++ b/ApplicationCode/ProjectDataModel/Completions/RimFishbonesMultipleSubs.cpp
@@ -30,6 +30,7 @@
 #include "cvfBoundingBox.h"
 
 #include <cstdlib>
+#include <cmath>
 
 
 CAF_PDM_SOURCE_INIT(RimFishbonesMultipleSubs, "FishbonesMultipleSubs");

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -72,6 +72,7 @@
 #include "cvfqtPerformanceInfoHud.h"
 #include "cvfqtUtils.h"
 
+#include <cmath>
 #include <QDebug>
 #include <QHBoxLayout>
 #include <QInputEvent>


### PR DESCRIPTION
highlighted by building with gcc6.

opm ci-systems were recently bumped to debian 9.1, which included an update to gcc6. these trivial fixes are necessary to build.