### PR TITLE
Legend Background: Make ternary legend follow preferences.

### DIFF
--- a/ApplicationCode/ProjectDataModel/RimEclipseCellColors.cpp
+++ b/ApplicationCode/ProjectDataModel/RimEclipseCellColors.cpp
@@ -280,6 +280,9 @@ void RimEclipseCellColors::updateLegendData(size_t currentTimeStep,
     if (!legendConfig) legendConfig = this->legendConfig();
     if (!ternaryLegendConfig) ternaryLegendConfig = this->ternaryLegendConfig();
 
+    if (legendConfig) legendConfig->applyPreferences();
+    if (ternaryLegendConfig) ternaryLegendConfig->applyPreferences();
+
     if ( this->hasResult() )
     {
         if ( this->isFlowDiagOrInjectionFlooding() )

--- a/ApplicationCode/ProjectDataModel/RimLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimLegendConfig.cpp
@@ -525,10 +525,15 @@ void RimLegendConfig::applyPreferences()
 {
     RiaApplication* app = RiaApplication::instance();
     RiaPreferences* preferences = app->preferences();
-    if (!m_scalarMapperLegend.isNull())
-      m_scalarMapperLegend->enableBackground(preferences->showLegendBackground());
-    if (!m_categoryLegend.isNull())
-      m_categoryLegend->enableBackground(preferences->showLegendBackground());
+    
+    if (m_scalarMapperLegend.notNull())
+    {
+        m_scalarMapperLegend->enableBackground(preferences->showLegendBackground());
+    }
+    if (m_categoryLegend.notNull())
+    {
+        m_categoryLegend->enableBackground(preferences->showLegendBackground());
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/RimLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimLegendConfig.cpp
@@ -370,11 +370,6 @@ void RimLegendConfig::updateLegend()
    }
    m_scalarMapperLegend->setTickPrecision(cvf::Math::clamp(numDecimalDigits, 0, 20));
 
-   RiaApplication* app = RiaApplication::instance();
-   RiaPreferences* preferences = app->preferences();
-   m_scalarMapperLegend->enableBackground(preferences->showLegendBackground());
-   m_categoryLegend->enableBackground(preferences->showLegendBackground());
-
    if (m_globalAutoMax != cvf::UNDEFINED_DOUBLE )
    {
        m_userDefinedMaxValue.uiCapability()->setUiName(QString("Max ") + "(" + QString::number(m_globalAutoMax, 'g', m_precision) + ")");
@@ -392,6 +387,8 @@ void RimLegendConfig::updateLegend()
    {
         m_userDefinedMinValue.uiCapability()->setUiName(QString());
    }
+
+   applyPreferences();
 }
 
 
@@ -519,6 +516,19 @@ void RimLegendConfig::recreateLegend()
     m_categoryLegend = new caf::CategoryLegend(standardFont, m_categoryMapper.p());
 
     updateLegend();
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Retrieve preferences and apply to the current legend(s)
+//--------------------------------------------------------------------------------------------------
+void RimLegendConfig::applyPreferences()
+{
+    RiaApplication* app = RiaApplication::instance();
+    RiaPreferences* preferences = app->preferences();
+    if (!m_scalarMapperLegend.isNull())
+      m_scalarMapperLegend->enableBackground(preferences->showLegendBackground());
+    if (!m_categoryLegend.isNull())
+      m_categoryLegend->enableBackground(preferences->showLegendBackground());
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/RimLegendConfig.h
+++ b/ApplicationCode/ProjectDataModel/RimLegendConfig.h
@@ -99,6 +99,7 @@ public:
 
     typedef caf::AppEnum<MappingType> MappingEnum;
     void                                        recreateLegend();
+    void                                        applyPreferences();
 
     void                                        setColorRangeMode(ColorRangesType colorMode);
     ColorRangesType                             colorRangeMode()    { return m_colorRangeMode();}

--- a/ApplicationCode/ProjectDataModel/RimTernaryLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimTernaryLegendConfig.cpp
@@ -247,7 +247,7 @@ void RimTernaryLegendConfig::recreateLegend()
 //--------------------------------------------------------------------------------------------------
 void RimTernaryLegendConfig::applyPreferences()
 {
-    if (!m_legend.isNull())
+    if (m_legend.notNull())
     {
         RiaApplication* app = RiaApplication::instance();
         RiaPreferences* preferences = app->preferences();

--- a/ApplicationCode/ProjectDataModel/RimTernaryLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimTernaryLegendConfig.cpp
@@ -202,11 +202,9 @@ void RimTernaryLegendConfig::updateLegend()
     if (!m_legend.isNull())
     {
         m_legend->setRangeText(soilRange, sgasRange, swatRange);
-
-        RiaApplication* app = RiaApplication::instance();
-        RiaPreferences* preferences = app->preferences();
-        m_legend->enableBackground(preferences->showLegendBackground());
     }
+
+    applyPreferences();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -242,6 +240,19 @@ void RimTernaryLegendConfig::recreateLegend()
     m_legend->setLayout(cvf::OverlayItem::VERTICAL, cvf::OverlayItem::BOTTOM_LEFT);
 
     updateLegend();
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Retrieve preferences and apply to the current legend
+//--------------------------------------------------------------------------------------------------
+void RimTernaryLegendConfig::applyPreferences()
+{
+    if (!m_legend.isNull())
+    {
+        RiaApplication* app = RiaApplication::instance();
+        RiaPreferences* preferences = app->preferences();
+        m_legend->enableBackground(preferences->showLegendBackground());
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/RimTernaryLegendConfig.h
+++ b/ApplicationCode/ProjectDataModel/RimTernaryLegendConfig.h
@@ -70,7 +70,8 @@ public:
     void                ternaryRanges(double& soilLower, double& soilUpper, double& sgasLower, double& sgasUpper, double& swatLower, double& swatUpper) const;
 
     void                recreateLegend();
-    
+    void                applyPreferences();
+
     const RivTernarySaturationOverlayItem*    legend() const;
     RivTernarySaturationOverlayItem*          legend();
     void                                      setTitle(const QString& title);


### PR DESCRIPTION
  * Move background settings into an applyPreferences() method
     for both RimTernaryLegendConfig and RimLegendConfig.
  * Always call applyPrefences in RimEclipseCellColors::updateLegendData()