### PR TITLE
Use hpp header files when accessing well_info from libecl

### DIFF
--- a/ApplicationCode/FileInterface/RifEclipseRestartDataAccess.h
+++ b/ApplicationCode/FileInterface/RifEclipseRestartDataAccess.h
@@ -28,7 +28,7 @@
 
 #include <vector>
 
-#include "ert/ecl_well/well_info.h"
+#include "ert/ecl_well/well_info.hpp"
 
 #include "RifReaderInterface.h"
 

--- a/ApplicationCode/FileInterface/RifEclipseUnifiedRestartFileAccess.h
+++ b/ApplicationCode/FileInterface/RifEclipseUnifiedRestartFileAccess.h
@@ -26,7 +26,7 @@ class RifEclipseOutputFileTools;
 
 //typedef struct ecl_file_struct ecl_file_type;
 
-#include "ert/ecl_well/well_info.h"
+#include "ert/ecl_well/well_info.hpp"
 
 
 


### PR DESCRIPTION
The libecl library has been converted to *compile* with a C++ compiler; the process of making it into an actual C++ library is of course a long road. The well functionality is quite limited and seems like a reasonable and simple first step. 

This PR is a very very first step to enable that conversion. The `well_info.hpp` and `well_info.h` headers have been present side-by-side for some time, and this PR should be trivial.

