### PR TITLE
ECLFluxCalc: Remove Unused 'useEPS' Constructor Parameter

### DIFF
--- a/ApplicationCode/ReservoirDataModel/RigFlowDiagInterfaceTools.h
+++ b/ApplicationCode/ReservoirDataModel/RigFlowDiagInterfaceTools.h
@@ -110,7 +110,7 @@ namespace RigFlowDiagInterfaceTools {
     {
         auto satfunc = Opm::ECLSaturationFunc(G, init);
 
-        Opm::ECLFluxCalc calc(G, init, 9.80665, true);
+        Opm::ECLFluxCalc calc(G, init, 9.80665);
 
         auto getFlux = [&calc, &rstrt]
         (const Opm::ECLPhaseIndex p)

--- a/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLFluxCalc.cpp
+++ b/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLFluxCalc.cpp
@@ -185,8 +185,7 @@ namespace Opm
 
     ECLFluxCalc::ECLFluxCalc(const ECLGraph&        graph,
                              const ECLInitFileData& init,
-                             const double           grav,
-                             const bool             /* useEPS */)
+                             const double           grav)
         : graph_(graph)
         , satfunc_(graph, init)
         , rmap_(pvtnumVector(graph, init))

--- a/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLFluxCalc.hpp
+++ b/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLFluxCalc.hpp
@@ -56,8 +56,7 @@ namespace Opm
         ///    result set.
         ECLFluxCalc(const ECLGraph&        graph,
                     const ECLInitFileData& init,
-                    const double           grav,
-                    const bool             useEPS);
+                    const double           grav);
 
         /// Retrive phase flux on all connections defined by \code
         /// graph.neighbours() \endcode.


### PR DESCRIPTION
Recent developments have rendered this parameter unused.  Remove it to make API simpler.  The library now always loads arrays as if the caller requests end-point scaling behaviour and we defer effects of actual end-point scaling until client code queries the flux calculator at run time.