### PR TITLE
Max 2P Sat-Sum: Don't Dereference Null Pointer

### DIFF
--- a/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLSaturationFunc.cpp
+++ b/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLSaturationFunc.cpp
@@ -2477,7 +2477,10 @@ max2PSatSum(const RawCurve&       fi,
             }
         }
         else {
-            const auto swco = this->wat_->swco();
+            const auto swco = (this->wat_ != nullptr)
+                ? this->wat_->swco()
+                : std::vector<double>(this->numTables_, 0.0);
+
             smin = swco[regID - 1];
         }
     }
@@ -2494,7 +2497,10 @@ max2PSatSum(const RawCurve&       fi,
             }
         }
         else {
-            const auto sgco = this->gas_->sgco();
+            const auto sgco = (this->gas_ != nullptr)
+                ? this->gas_->sgco()
+                : std::vector<double>(this->numTables_, 0.0);
+
             smin = sgco[regID - 1];
         }
     }


### PR DESCRIPTION
A simulation run might not activate all three phases.  We therefore must guard against querying the connate saturations of the missing phase.

This tentatively fixes #4075.

Pointy hat: Bard.Skaflestad@sintef.no
Thanks to: Magne Sjåstad