### PR TITLE
Support Creating ECLGraph from "ecl_grid_type*"

### DIFF
--- a/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLGraph.hpp
+++ b/ThirdParty/custom-opm-flowdiag-app/opm-flowdiagnostics-applications/opm/utility/ECLGraph.hpp
@@ -38,6 +38,11 @@
 /// on-disk ECLIPSE output, featuring on-demand property loading from
 /// backing object (e.g., restart vectors at various time points).
 
+extern "C" {
+    struct ecl_grid_struct;
+    typedef ecl_grid_struct ecl_grid_type;
+} // extern "C"
+
 namespace Opm {
 
     /// Package an ECLIPSE result set (represented as GRID, INIT, and
@@ -91,6 +96,10 @@ namespace Opm {
         static ECLGraph
         load(const boost::filesystem::path& gridFile,
              const ECLInitFileData&         init);
+
+        static ECLGraph
+        load(const ecl_grid_type*   grid,
+             const ECLInitFileData& init);
 
         /// Retrieve number of grids in model.
         ///


### PR DESCRIPTION
This commit introduces a new static function
```C++
ECLGraph ECLGraph::load(const ecl_grid_type*, const ECLInitFileData&)
```
This is in order to simplify constructing the backing graph from ResInsight's .EGRID input--especially to have consistent view of a model's active cells irrespective of which simulator created the result set.