### PR TITLE
#4703 Fix changing result position in GeoMech result definition

### DIFF
--- a/ApplicationCode/ProjectDataModel/Rim3dWellLogCurve.cpp
+++ b/ApplicationCode/ProjectDataModel/Rim3dWellLogCurve.cpp
@@ -266,15 +266,6 @@ void Rim3dWellLogCurve::initAfterRead()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void Rim3dWellLogCurve::resetMinMaxValuesAndUpdateUI()
-{
-    this->resetMinMaxValues();
-    this->updateConnectedEditors();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 bool Rim3dWellLogCurve::findClosestPointOnCurve( const cvf::Vec3d& globalIntersection,
                                                  cvf::Vec3d*       closestPoint,
                                                  double*           measuredDepthAtPoint,

--- a/ApplicationCode/ProjectDataModel/Rim3dWellLogCurve.h
+++ b/ApplicationCode/ProjectDataModel/Rim3dWellLogCurve.h
@@ -88,7 +88,7 @@ public:
 
     float minCurveUIValue() const;
     float maxCurveUIValue() const;
-    void  resetMinMaxValuesAndUpdateUI();
+    void  resetMinMaxValues();
     bool  findClosestPointOnCurve( const cvf::Vec3d& globalIntersection,
                                    cvf::Vec3d*       closestPoint,
                                    double*           measuredDepthAtPoint,
@@ -107,9 +107,6 @@ protected:
                                                 QString                    uiConfigName,
                                                 caf::PdmUiEditorAttribute* attribute ) override;
     void                 initAfterRead() override;
-
-private:
-    void resetMinMaxValues();
 
 protected:
     caf::PdmField<DrawPlaneEnum>                 m_drawPlane;

--- a/ApplicationCode/ProjectDataModel/Rim3dWellLogExtractionCurve.cpp
+++ b/ApplicationCode/ProjectDataModel/Rim3dWellLogExtractionCurve.cpp
@@ -439,11 +439,13 @@ void Rim3dWellLogExtractionCurve::fieldChangedByUi( const caf::PdmFieldHandle* c
             m_geomResultDefinition->setGeoMechCase( geoMechCase );
         }
 
-        this->resetMinMaxValuesAndUpdateUI();
+        this->resetMinMaxValues();
+        this->updateConnectedEditors();
     }
     else if ( changedField == &m_timeStep )
     {
-        this->resetMinMaxValuesAndUpdateUI();
+        this->resetMinMaxValues();
+        this->updateConnectedEditors();
     }
     Rim3dWellLogCurve::fieldChangedByUi( changedField, oldValue, newValue );
 }

--- a/ApplicationCode/ProjectDataModel/Rim3dWellLogFileCurve.cpp
+++ b/ApplicationCode/ProjectDataModel/Rim3dWellLogFileCurve.cpp
@@ -183,7 +183,8 @@ void Rim3dWellLogFileCurve::fieldChangedByUi( const caf::PdmFieldHandle* changed
 {
     if ( changedField == &m_wellLogFile || changedField == &m_wellLogChannelName )
     {
-        this->resetMinMaxValuesAndUpdateUI();
+        this->resetMinMaxValues();
+        this->updateConnectedEditors();
     }
     Rim3dWellLogCurve::fieldChangedByUi( changedField, oldValue, newValue );
 }

--- a/ApplicationCode/ProjectDataModel/Rim3dWellLogRftCurve.cpp
+++ b/ApplicationCode/ProjectDataModel/Rim3dWellLogRftCurve.cpp
@@ -148,7 +148,8 @@ void Rim3dWellLogRftCurve::fieldChangedByUi( const caf::PdmFieldHandle* changedF
 {
     if ( changedField == &m_wellLogChannelName || changedField == &m_timeStep )
     {
-        this->resetMinMaxValuesAndUpdateUI();
+        this->resetMinMaxValues();
+        this->updateConnectedEditors();
     }
     Rim3dWellLogCurve::fieldChangedByUi( changedField, oldValue, newValue );
 }

--- a/ApplicationCode/ProjectDataModel/RimEclipseResultDefinition.cpp
+++ b/ApplicationCode/ProjectDataModel/RimEclipseResultDefinition.cpp
@@ -435,7 +435,7 @@ void RimEclipseResultDefinition::updateAnyFieldHasChanged()
     this->firstAncestorOrThisOfType( rim3dWellLogCurve );
     if ( rim3dWellLogCurve )
     {
-        rim3dWellLogCurve->resetMinMaxValuesAndUpdateUI();
+        rim3dWellLogCurve->resetMinMaxValues();
     }
 
     RimEclipseContourMapProjection* contourMap = nullptr;

--- a/ApplicationCode/ProjectDataModel/RimGeoMechResultDefinition.cpp
+++ b/ApplicationCode/ProjectDataModel/RimGeoMechResultDefinition.cpp
@@ -379,19 +379,9 @@ void RimGeoMechResultDefinition::fieldChangedByUi( const caf::PdmFieldHandle* ch
         }
     }
 
-    if ( propFilter )
-    {
-        propFilter->updateConnectedEditors();
-    }
-
-    if ( curve )
-    {
-        curve->updateConnectedEditors();
-    }
-
     if ( rim3dWellLogCurve )
     {
-        rim3dWellLogCurve->resetMinMaxValuesAndUpdateUI();
+        rim3dWellLogCurve->resetMinMaxValues();
     }
 }
 


### PR DESCRIPTION
I did not have time to test this extensively before holidays, so if we need it in a patch, it needs to be tested.

The idea is that we no longer need to call updateConnectedEditors on the parent object when changing a result definition, and for GeoMech it is actually harmful, because it will cause defineUiOrdering to be called twice and the second time will mess things up.

This causes issues for plots, property filters and 3d well log plots that uses GeoMech results, but not for the regular 3d-view because we don't explicitly update the connected editors there.

The change removes all explicit updateConnectedEditors on field change in GeoMech result definition.