### PR TITLE
#5234 Fix auto scale of cross plot x-axis

### DIFF
--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlotAxisFormatter.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlotAxisFormatter.cpp
@@ -27,6 +27,7 @@
 #include "RiuSummaryQuantityNameInfoProvider.h"
 #include "RiuSummaryQwtPlot.h"
 
+#include "qwt_date_scale_engine.h"
 #include "qwt_plot_curve.h"
 #include "qwt_scale_draw.h"
 #include "qwt_scale_engine.h"
@@ -168,7 +169,8 @@ void RimSummaryPlotAxisFormatter::applyAxisPropertiesToPlot( RiuSummaryQwtPlot* 
         {
             QwtLinearScaleEngine* currentScaleEngine = dynamic_cast<QwtLinearScaleEngine*>(
                 qwtPlot->axisScaleEngine( m_axisProperties->qwtPlotAxisType() ) );
-            if ( !currentScaleEngine )
+            QwtDateScaleEngine* dateScaleEngine = dynamic_cast<QwtDateScaleEngine*>( currentScaleEngine );
+            if ( !currentScaleEngine || dateScaleEngine )
             {
                 qwtPlot->setAxisScaleEngine( m_axisProperties->qwtPlotAxisType(), new QwtLinearScaleEngine );
                 qwtPlot->setAxisMaxMinor( m_axisProperties->qwtPlotAxisType(), 3 );


### PR DESCRIPTION
* The issue is that the bottom axis is really a QwtDateScaleEngine as opposed to a QwtLinearScaleEngine.
* This may have worked before by "accident" before the changes to the date format on the date/time axis.
* The fix is that if we want a QwtLinearScaleEngine and have a QwtDateScaleEngine we replace the scale engine.