### PR TITLE
Incomplete import of Restart data from 6X

### DIFF
--- a/ApplicationCode/FileInterface/RifEclipseOutputFileTools.cpp
+++ b/ApplicationCode/FileInterface/RifEclipseOutputFileTools.cpp
@@ -122,7 +122,8 @@ void getDayMonthYear( const ecl_kw_type* intehead_kw, int* day, int* month, int*
 //--------------------------------------------------------------------------------------------------
 void RifEclipseOutputFileTools::timeSteps( const ecl_file_type*    ecl_file,
                                            std::vector<QDateTime>* timeSteps,
-                                           std::vector<double>*    daysSinceSimulationStart )
+                                           std::vector<double>*    daysSinceSimulationStart,
+                                           size_t*                 perTimeStepHeaderKeywordCount )
 {
     if ( !ecl_file ) return;
 
@@ -242,6 +243,16 @@ void RifEclipseOutputFileTools::timeSteps( const ecl_file_type*    ecl_file,
             timeSteps->push_back( reportDateTime );
             daysSinceSimulationStart->push_back( dayDoubleValue );
         }
+    }
+
+    if ( perTimeStepHeaderKeywordCount )
+    {
+        // 6X simulator can report more then one keyword block per time step. Report the total number of keywords per
+        // time steps to be able to read data from correct index
+        //
+        // See https://github.com/OPM/ResInsight/issues/5763
+        //
+        *perTimeStepHeaderKeywordCount = numINTEHEAD / timeSteps->size();
     }
 }
 

--- a/ApplicationCode/FileInterface/RifEclipseOutputFileTools.h
+++ b/ApplicationCode/FileInterface/RifEclipseOutputFileTools.h
@@ -63,7 +63,8 @@ public:
 
     static void timeSteps( const ecl_file_type*    ecl_file,
                            std::vector<QDateTime>* timeSteps,
-                           std::vector<double>*    daysSinceSimulationStart );
+                           std::vector<double>*    daysSinceSimulationStart,
+                           size_t*                 perTimeStepHeaderKeywordCount );
 
     static bool       isValidEclipseFileName( const QString& fileName );
     static QByteArray md5sum( const QString& fileName );

--- a/ApplicationCode/FileInterface/RifEclipseRestartDataAccess.h
+++ b/ApplicationCode/FileInterface/RifEclipseRestartDataAccess.h
@@ -110,4 +110,6 @@ public:
     virtual int  readUnitsType()                                                       = 0;
 
     virtual std::set<RiaDefines::PhaseType> availablePhases() const = 0;
+
+    virtual void updateFromGridCount( size_t gridCount ){};
 };

--- a/ApplicationCode/FileInterface/RifEclipseRestartFilesetAccess.cpp
+++ b/ApplicationCode/FileInterface/RifEclipseRestartFilesetAccess.cpp
@@ -136,7 +136,8 @@ void RifEclipseRestartFilesetAccess::timeSteps( std::vector<QDateTime>* timeStep
 
             openTimeStep( i );
 
-            RifEclipseOutputFileTools::timeSteps( m_ecl_files[i], &stepTime, &stepDays );
+            size_t perTimeStepEmptyKeywords = 0;
+            RifEclipseOutputFileTools::timeSteps( m_ecl_files[i], &stepTime, &stepDays, &perTimeStepEmptyKeywords );
 
             if ( stepTime.size() == 1 )
             {
@@ -196,13 +197,16 @@ bool RifEclipseRestartFilesetAccess::results( const QString&       resultName,
     if ( fileGridCount == 0 ) return true;
 
     // Result handling depends on presents of result values for all grids
-    if ( gridCount != fileGridCount )
+    if ( fileGridCount < gridCount )
     {
         return false;
     }
 
-    size_t i;
-    for ( i = 0; i < fileGridCount; i++ )
+    // NB : 6X simulator can report multiple keywords for one time step. The additional keywords do not contain and
+    // data imported by ResInsight. We read all blocks of data, also empty to simplify the logic.
+    // See https://github.com/OPM/ResInsight/issues/5763
+
+    for ( size_t i = 0; i < fileGridCount; i++ )
     {
         std::vector<double> gridValues;
 

--- a/ApplicationCode/FileInterface/RifEclipseUnifiedRestartFileAccess.h
+++ b/ApplicationCode/FileInterface/RifEclipseUnifiedRestartFileAccess.h
@@ -69,6 +69,7 @@ private:
 private:
     QString        m_filename;
     ecl_file_type* m_ecl_file;
+    size_t         m_perTimeStepExtraKeywordCount;
 
     std::vector<QDateTime> m_timeSteps;
     std::vector<double>    m_daysSinceSimulationStart;

--- a/ApplicationCode/FileInterface/RifEclipseUnifiedRestartFileAccess.h
+++ b/ApplicationCode/FileInterface/RifEclipseUnifiedRestartFileAccess.h
@@ -61,6 +61,8 @@ public:
 
     std::set<RiaDefines::PhaseType> availablePhases() const override;
 
+    void updateFromGridCount( size_t gridCount ) override;
+
 private:
     bool openFile();
     bool useResultIndexFile() const;
@@ -69,7 +71,8 @@ private:
 private:
     QString        m_filename;
     ecl_file_type* m_ecl_file;
-    size_t         m_perTimeStepExtraKeywordCount;
+    size_t         m_perTimeStepHeaderCount;
+    size_t         m_noDataGridCount;
 
     std::vector<QDateTime> m_timeSteps;
     std::vector<double>    m_daysSinceSimulationStart;

--- a/ApplicationCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -2346,6 +2346,17 @@ ecl_grid_type* RifReaderEclipseOutput::loadAllGrids() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RifReaderEclipseOutput::updateFromGridCount( size_t gridCount )
+{
+    if ( m_dynamicResultsAccess.notNull() )
+    {
+        m_dynamicResultsAccess->updateFromGridCount( gridCount );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RifReaderEclipseOutput::extractResultValuesBasedOnPorosityModel( RiaDefines::PorosityModelType matrixOrFracture,
                                                                       std::vector<double>* destinationResultValues,
                                                                       const std::vector<double>& sourceResultValues )

--- a/ApplicationCode/FileInterface/RifReaderEclipseOutput.h
+++ b/ApplicationCode/FileInterface/RifReaderEclipseOutput.h
@@ -97,6 +97,8 @@ public:
     //
     ecl_grid_type* loadAllGrids() const;
 
+    void updateFromGridCount( size_t gridCount ) override;
+
 private:
     bool readActiveCellInfo();
     void buildMetaData( ecl_grid_type* grid );

--- a/ApplicationCode/FileInterface/RifReaderInterface.h
+++ b/ApplicationCode/FileInterface/RifReaderInterface.h
@@ -69,6 +69,8 @@ public:
 
     virtual std::set<RiaDefines::PhaseType> availablePhases() const;
 
+    virtual void updateFromGridCount( size_t gridCount ){};
+
 protected:
     bool   isTimeStepIncludedByFilter( size_t timeStepIndex ) const;
     size_t timeStepIndexOnFile( size_t timeStepIndex ) const;

--- a/ApplicationCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -2802,6 +2802,11 @@ void RigCaseCellResultsData::computeMobilePV()
 void RigCaseCellResultsData::setReaderInterface( RifReaderInterface* readerInterface )
 {
     m_readerInterface = readerInterface;
+
+    if ( m_ownerMainGrid )
+    {
+        m_readerInterface->updateFromGridCount( m_ownerMainGrid->gridCount() );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
6X simulator can report multiple keywords per time step. These additional keywords do not contain any data possible to import into ResInsight, but must be used when accessing the correct result keyword based on index in file.

Closes #5763 