### PR TITLE
 #5905 Fix wrong percentile calculation

### DIFF
--- a/ApplicationCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
+++ b/ApplicationCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
@@ -298,9 +298,9 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
                                     std::vector<size_t>    histogram;
                                     RigHistogramCalculator histCalc( statParams[MIN], statParams[MAX], 100, &histogram );
                                     histCalc.addData( values );
-                                    statParams[PMIN] = histCalc.calculatePercentil( m_statisticsConfig.m_pMinPos );
-                                    statParams[PMID] = histCalc.calculatePercentil( m_statisticsConfig.m_pMidPos );
-                                    statParams[PMAX] = histCalc.calculatePercentil( m_statisticsConfig.m_pMaxPos );
+                                    statParams[PMIN] = histCalc.calculatePercentil( m_statisticsConfig.m_pMinPos / 100.0 );
+                                    statParams[PMID] = histCalc.calculatePercentil( m_statisticsConfig.m_pMidPos / 100.0 );
+                                    statParams[PMAX] = histCalc.calculatePercentil( m_statisticsConfig.m_pMaxPos / 100.0 );
                                 }
                                 else if ( m_statisticsConfig.m_pValMethod ==
                                           RimEclipseStatisticsCase::INTERPOLATED_OBSERVATION )

--- a/ApplicationCode/ResultStatisticsCache/RigStatisticsMath.cpp
+++ b/ApplicationCode/ResultStatisticsCache/RigStatisticsMath.cpp
@@ -317,9 +317,10 @@ double RigHistogramCalculator::calculatePercentil( double pVal )
 {
     assert( m_histogram );
     assert( m_histogram->size() );
-    assert( 0.0 <= pVal && pVal <= 1.0 );
+    auto pValClamped = cvf::Math::clamp( pVal, 0.0, 1.0 );
+    assert( 0.0 <= pValClamped && pValClamped <= 1.0 );
 
-    double pValObservationCount = pVal * m_observationCount;
+    double pValObservationCount = pValClamped * m_observationCount;
     if ( pValObservationCount == 0.0 ) return m_min;
 
     size_t accObsCount = 0;


### PR DESCRIPTION
* We sent in percent values (0-100) instead of the fractional values (0 - 1) that RigHistogramCalculator::calculatePercentile required.
* It has been like this for years AFAICT.