### PR TITLE
#5979 Fix color legend crash when opening regression test project

### DIFF
--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -884,6 +884,7 @@ void RimRegularLegendConfig::setUiValuesFromLegendConfig( const RimRegularLegend
 {
     QString serializedObjectString = otherLegendConfig->writeObjectToXmlString();
     this->readObjectFromXmlString( serializedObjectString, caf::PdmDefaultObjectFactory::instance() );
+    this->resolveReferencesRecursively();
     this->updateLegend();
 }
 


### PR DESCRIPTION
Projects containing Rim2dIntersectionViews copy legend config from the view using
PdmXmlObjectHandle::writeObjectToXmlString/readObjectFromXmlString. The
resulting xml contains references to RimColorLegendCollection which are unresolved,
and this would lead to a crash (m_colorLegend == nullptr). Fixed by resolving
the references explicitly after copy the config.

Closes #5979.