### PR TITLE
Fix crash in fracture model plot.

### DIFF
--- a/ApplicationCode/ProjectDataModel/RimWellLogTrack.cpp
+++ b/ApplicationCode/ProjectDataModel/RimWellLogTrack.cpp
@@ -2352,7 +2352,7 @@ void RimWellLogTrack::updateStackedCurveData()
 {
     const double eps = 1.0e-8;
 
-    RimWellLogPlot* wellLogPlot;
+    RimDepthTrackPlot* wellLogPlot;
     firstAncestorOrThisOfTypeAsserted( wellLogPlot );
 
     RimWellLogPlot::DepthTypeEnum depthType    = wellLogPlot->depthType();


### PR DESCRIPTION
The parent of RimWellLogTrack can also be a RimDepthTrackPlot.