### PR TITLE
gha : Enable RESINSIGHT_ENABLE_UNITY_BUILD

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -153,6 +153,7 @@ jobs:
               -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
               -D CMAKE_INSTALL_PREFIX=cmakebuild/install
               -D GSL_ENABLE=true
+              -D RESINSIGHT_ENABLE_UNITY_BUILD=true
               -D RESINSIGHT_INCLUDE_APPLICATION_UNIT_TESTS=true
               -D RESINSIGHT_TREAT_WARNINGS_AS_ERRORS=true
               -D RESINSIGHT_ENABLE_GRPC=true


### PR DESCRIPTION
The text arguments to the linker are now too largre causing MSVC to fail and exit. Use  Unity build to reduce the number of files.