### PR TITLE
Category Cell Results: Use color legend values

### DIFF
--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -127,9 +127,9 @@ template <>
 void AppEnum<RimRegularLegendConfig::CategoryColorModeType>::setUp()
 {
     addItem( RimRegularLegendConfig::CategoryColorModeType::INTERPOLATE, "INTERPOLATE", "Interpolate" );
-    addItem( RimRegularLegendConfig::CategoryColorModeType::COLOR_LEGEND_VALUES,
+    addItem( RimRegularLegendConfig::CategoryColorModeType::EXCLUSIVELY_COLORS,
              "COLOR_LEGEND_VALUES",
-             "Color Legend Values" );
+             "Exclusively Category Colors" );
     setDefault( RimRegularLegendConfig::CategoryColorModeType::INTERPOLATE );
 }
 
@@ -733,7 +733,7 @@ void RimRegularLegendConfig::updateCategoryItems()
 //--------------------------------------------------------------------------------------------------
 void RimRegularLegendConfig::configureCategoryMapper()
 {
-    if ( m_categoryColorMode() == CategoryColorModeType::COLOR_LEGEND_VALUES )
+    if ( m_categoryColorMode() == CategoryColorModeType::EXCLUSIVELY_COLORS )
     {
         std::vector<RimColorLegendItem*> legendItems = m_colorLegend()->colorLegendItems();
         cvf::Color3ubArray               colorArray;

--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -43,6 +43,7 @@
 #include "RimWellRftEnsembleCurveSet.h"
 #include "RimWellRftPlot.h"
 
+#include "Riu3DMainWindowTools.h"
 #include "RiuCategoryLegendFrame.h"
 #include "RiuScalarMapperLegendFrame.h"
 
@@ -56,6 +57,7 @@
 #include "cafPdmFieldCvfMat4d.h"
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiLineEditor.h"
+#include "cafPdmUiToolButtonEditor.h"
 
 #include "cvfMath.h"
 #include "cvfScalarMapperContinuousLinear.h"
@@ -179,6 +181,10 @@ RimRegularLegendConfig::RimRegularLegendConfig()
 
     CAF_PDM_InitFieldNoDefault( &m_colorLegend, "ColorLegend", "Colors", "", "", "" );
     m_colorLegend = mapToColorLegend( ColorRangeEnum( ColorRangesType::NORMAL ) );
+    CAF_PDM_InitField( &m_selectColorLegendButton, "selectColorLegendButton", false, "Edit", "", "", "" );
+    m_selectColorLegendButton.uiCapability()->setUiEditorTypeName( caf::PdmUiToolButtonEditor::uiEditorTypeName() );
+    m_selectColorLegendButton.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
+    m_selectColorLegendButton.xmlCapability()->disableIO();
 
     CAF_PDM_InitField( &m_mappingMode, "MappingMode", MappingEnum( MappingType::LINEAR_CONTINUOUS ), "Mapping", "", "", "" );
     CAF_PDM_InitField( &m_rangeMode,
@@ -255,6 +261,16 @@ void RimRegularLegendConfig::fieldChangedByUi( const caf::PdmFieldHandle* change
                                                const QVariant&            oldValue,
                                                const QVariant&            newValue )
 {
+    if ( changedField == &m_selectColorLegendButton )
+    {
+        m_selectColorLegendButton = false;
+        if ( m_colorLegend != nullptr )
+        {
+            Riu3DMainWindowTools::selectAsCurrentItem( m_colorLegend() );
+        }
+        return;
+    }
+
     if ( changedField == &m_numLevels )
     {
         int upperLimit = std::numeric_limits<int>::max();
@@ -1059,7 +1075,9 @@ void RimRegularLegendConfig::defineUiOrdering( QString uiConfigName, caf::PdmUiO
         formatGr->add( &m_numLevels );
         formatGr->add( &m_precision );
         formatGr->add( &m_tickNumberFormat );
-        formatGr->add( &m_colorLegend );
+
+        formatGr->add( &m_colorLegend, {true, 2, 1} );
+        formatGr->add( &m_selectColorLegendButton, {false, 1, 0} );
 
         caf::PdmUiOrdering* mappingGr = uiOrdering.addNewGroup( "Mapping" );
         mappingGr->add( &m_mappingMode );

--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.h
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.h
@@ -109,9 +109,16 @@ public:
         SCIENTIFIC,
         FIXED
     };
-
     typedef caf::AppEnum<MappingType> MappingEnum;
-    void                              onRecreateLegend();
+
+    enum class CategoryColorModeType
+    {
+        INTERPOLATE,
+        COLOR_LEGEND_VALUES
+    };
+    typedef caf::AppEnum<CategoryColorModeType> CategoryColorModeEnum;
+
+    void onRecreateLegend();
 
     void            setColorLegend( RimColorLegend* colorLegend );
     RimColorLegend* colorLegend() const;
@@ -166,6 +173,7 @@ private:
     double roundToNumSignificantDigits( double value, double precision );
 
     void updateCategoryItems();
+    void configureCategoryMapper();
 
     friend class RimViewLinker;
 
@@ -198,16 +206,18 @@ private:
     cvf::Color3ubArray       m_categoryColors;
 
     // Fields
-    caf::PdmField<bool>                           m_showLegend;
-    caf::PdmField<int>                            m_numLevels;
-    caf::PdmField<int>                            m_precision;
-    caf::PdmField<caf::AppEnum<NumberFormatType>> m_tickNumberFormat;
-    caf::PdmField<RangeModeEnum>                  m_rangeMode;
-    caf::PdmField<double>                         m_userDefinedMaxValue;
-    caf::PdmField<double>                         m_userDefinedMinValue;
-    caf::PdmField<caf::AppEnum<ColorRangesType>>  m_colorRangeMode_OBSOLETE;
-    caf::PdmField<caf::AppEnum<MappingType>>      m_mappingMode;
-    caf::PdmPtrField<RimColorLegend*>             m_colorLegend;
+    caf::PdmField<bool>                                m_showLegend;
+    caf::PdmField<int>                                 m_numLevels;
+    caf::PdmField<int>                                 m_precision;
+    caf::PdmField<caf::AppEnum<NumberFormatType>>      m_tickNumberFormat;
+    caf::PdmField<RangeModeEnum>                       m_rangeMode;
+    caf::PdmField<double>                              m_userDefinedMaxValue;
+    caf::PdmField<double>                              m_userDefinedMinValue;
+    caf::PdmField<caf::AppEnum<ColorRangesType>>       m_colorRangeMode_OBSOLETE;
+    caf::PdmField<caf::AppEnum<MappingType>>           m_mappingMode;
+    caf::PdmField<caf::AppEnum<CategoryColorModeType>> m_categoryColorMode;
+
+    caf::PdmPtrField<RimColorLegend*> m_colorLegend;
 
     QString m_title;
     int     m_significantDigitsInData;

--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.h
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.h
@@ -114,7 +114,7 @@ public:
     enum class CategoryColorModeType
     {
         INTERPOLATE,
-        COLOR_LEGEND_VALUES
+        EXCLUSIVELY_COLORS
     };
     typedef caf::AppEnum<CategoryColorModeType> CategoryColorModeEnum;
 

--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.h
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.h
@@ -218,6 +218,7 @@ private:
     caf::PdmField<caf::AppEnum<CategoryColorModeType>> m_categoryColorMode;
 
     caf::PdmPtrField<RimColorLegend*> m_colorLegend;
+    caf::PdmField<bool>               m_selectColorLegendButton;
 
     QString m_title;
     int     m_significantDigitsInData;

--- a/Fwk/AppFwk/cafVizExtensions/cafCategoryMapper.cpp
+++ b/Fwk/AppFwk/cafVizExtensions/cafCategoryMapper.cpp
@@ -49,6 +49,20 @@ void CategoryMapper::setCategoriesWithNames( const std::vector<int>&         cat
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void CategoryMapper::setCategoriesValueNameColor( const std::vector<int>&         categoryValues,
+                                                  const std::vector<cvf::String>& categoryNames,
+                                                  const cvf::Color3ubArray&       colorArray )
+{
+    m_categoryValues = categoryValues;
+    m_categoryNames  = categoryNames;
+    m_colors         = colorArray;
+
+    recomputeMaxTexCoord();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void CategoryMapper::setCycleColors( const Color3ubArray& colorArray )
 {
     m_colors.resize( m_categoryValues.size() );

--- a/Fwk/AppFwk/cafVizExtensions/cafCategoryMapper.h
+++ b/Fwk/AppFwk/cafVizExtensions/cafCategoryMapper.h
@@ -20,6 +20,10 @@ public:
     void setCategories( const std::vector<int>& categoryValues );
     void setCategoriesWithNames( const std::vector<int>& categoryValues, const std::vector<cvf::String>& categoryNames );
 
+    void setCategoriesValueNameColor( const std::vector<int>&         categoryValues,
+                                      const std::vector<cvf::String>& categoryNames,
+                                      const cvf::Color3ubArray&       colorArray );
+
     // Colors in color array are cycled, if category count is larger than color count, colors are reused
     void setCycleColors( const cvf::Color3ubArray& colorArray );
 


### PR DESCRIPTION
Closes #5315 

If category values are specified for a subset of category values, show only specified categories and display other values as undefined gray.

![image](https://user-images.githubusercontent.com/1793152/92405826-c7277000-f136-11ea-9e22-bc04b9cf8b31.png)
