### PR TITLE
#6479 Update analysis and correlation plots are updated when closing derived cases

### DIFF
--- a/ApplicationCode/Application/RiaSummaryCurveDefinition.cpp
+++ b/ApplicationCode/Application/RiaSummaryCurveDefinition.cpp
@@ -38,11 +38,22 @@ RiaSummaryCurveDefinition::RiaSummaryCurveDefinition()
 ///
 //--------------------------------------------------------------------------------------------------
 RiaSummaryCurveDefinition::RiaSummaryCurveDefinition( RimSummaryCase*                 summaryCase,
+                                                      const RifEclipseSummaryAddress& summaryAddress )
+    : m_summaryCase( summaryCase )
+    , m_ensemble( nullptr )
+    , m_summaryAddress( summaryAddress )
+    , m_treatAsSingleSummaryCurve( true )
+{
+}
+
+RiaSummaryCurveDefinition::RiaSummaryCurveDefinition( RimSummaryCase*                 summaryCase,
                                                       const RifEclipseSummaryAddress& summaryAddress,
-                                                      RimSummaryCaseCollection*       ensemble )
+                                                      RimSummaryCaseCollection*       ensemble,
+                                                      bool                            treatAsSingleSummaryCurve )
     : m_summaryCase( summaryCase )
     , m_ensemble( ensemble )
     , m_summaryAddress( summaryAddress )
+    , m_treatAsSingleSummaryCurve( treatAsSingleSummaryCurve )
 {
 }
 
@@ -75,7 +86,7 @@ const RifEclipseSummaryAddress& RiaSummaryCurveDefinition::summaryAddress() cons
 //--------------------------------------------------------------------------------------------------
 bool RiaSummaryCurveDefinition::isEnsembleCurve() const
 {
-    return m_ensemble != nullptr;
+    return m_ensemble != nullptr && !m_treatAsSingleSummaryCurve;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -210,7 +221,12 @@ void RiaSummaryCurveDefinitionAnalyser::setCurveDefinitions( const std::vector<R
     for ( const auto& curveDef : curveDefs )
     {
         bool valid = false;
-        if ( curveDef.summaryCase() )
+        if ( curveDef.ensemble() && curveDef.isEnsembleCurve() )
+        {
+            m_ensembles.insert( curveDef.ensemble() );
+            valid = true;
+        }
+        else if ( curveDef.summaryCase() )
         {
             m_singleSummaryCases.insert( curveDef.summaryCase() );
 
@@ -219,11 +235,6 @@ void RiaSummaryCurveDefinitionAnalyser::setCurveDefinitions( const std::vector<R
                 m_ensembles.insert( curveDef.summaryCase()->ensemble() );
                 valid = true;
             }
-        }
-        else if ( curveDef.ensemble() )
-        {
-            m_ensembles.insert( curveDef.ensemble() );
-            valid = true;
         }
         if ( valid )
         {

--- a/ApplicationCode/Application/RiaSummaryCurveDefinition.cpp
+++ b/ApplicationCode/Application/RiaSummaryCurveDefinition.cpp
@@ -30,7 +30,7 @@
 RiaSummaryCurveDefinition::RiaSummaryCurveDefinition()
     : m_summaryCase( nullptr )
     , m_ensemble( nullptr )
-
+    , m_isEnsembleCurve( false )
 {
 }
 
@@ -38,22 +38,31 @@ RiaSummaryCurveDefinition::RiaSummaryCurveDefinition()
 ///
 //--------------------------------------------------------------------------------------------------
 RiaSummaryCurveDefinition::RiaSummaryCurveDefinition( RimSummaryCase*                 summaryCase,
-                                                      const RifEclipseSummaryAddress& summaryAddress )
+                                                      const RifEclipseSummaryAddress& summaryAddress,
+                                                      bool                            isEnsembleCurve )
     : m_summaryCase( summaryCase )
-    , m_ensemble( nullptr )
     , m_summaryAddress( summaryAddress )
-    , m_treatAsSingleSummaryCurve( true )
+    , m_isEnsembleCurve( isEnsembleCurve )
 {
+    CAF_ASSERT( summaryCase );
+
+    if ( summaryCase )
+    {
+        RimSummaryCaseCollection* ensemble = nullptr;
+        summaryCase->firstAncestorOfType( ensemble );
+        m_ensemble = ensemble;
+    }
 }
 
-RiaSummaryCurveDefinition::RiaSummaryCurveDefinition( RimSummaryCase*                 summaryCase,
-                                                      const RifEclipseSummaryAddress& summaryAddress,
-                                                      RimSummaryCaseCollection*       ensemble,
-                                                      bool                            treatAsSingleSummaryCurve )
-    : m_summaryCase( summaryCase )
-    , m_ensemble( ensemble )
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaSummaryCurveDefinition::RiaSummaryCurveDefinition( RimSummaryCaseCollection*       ensemble,
+                                                      const RifEclipseSummaryAddress& summaryAddress )
+    : m_summaryCase( nullptr )
     , m_summaryAddress( summaryAddress )
-    , m_treatAsSingleSummaryCurve( treatAsSingleSummaryCurve )
+    , m_ensemble( ensemble )
+    , m_isEnsembleCurve( true )
 {
 }
 
@@ -86,7 +95,7 @@ const RifEclipseSummaryAddress& RiaSummaryCurveDefinition::summaryAddress() cons
 //--------------------------------------------------------------------------------------------------
 bool RiaSummaryCurveDefinition::isEnsembleCurve() const
 {
-    return m_ensemble != nullptr && !m_treatAsSingleSummaryCurve;
+    return m_isEnsembleCurve;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -205,7 +214,12 @@ bool RiaSummaryCurveDefinition::operator<( const RiaSummaryCurveDefinition& othe
         return m_summaryCase < other.summaryCase();
     }
 
-    return ( m_summaryAddress < other.summaryAddress() );
+    if ( m_summaryAddress != other.summaryAddress() )
+    {
+        return ( m_summaryAddress < other.summaryAddress() );
+    }
+
+    return m_isEnsembleCurve < other.isEnsembleCurve();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/Application/RiaSummaryCurveDefinition.h
+++ b/ApplicationCode/Application/RiaSummaryCurveDefinition.h
@@ -35,9 +35,11 @@ class RiaSummaryCurveDefinition
 {
 public:
     RiaSummaryCurveDefinition();
+    explicit RiaSummaryCurveDefinition( RimSummaryCase* summaryCase, const RifEclipseSummaryAddress& summaryAddress );
     explicit RiaSummaryCurveDefinition( RimSummaryCase*                 summaryCase,
                                         const RifEclipseSummaryAddress& summaryAddress,
-                                        RimSummaryCaseCollection*       ensemble = nullptr );
+                                        RimSummaryCaseCollection*       ensemble,
+                                        bool                            treatAsSingleSummaryCurve );
 
     RimSummaryCase*                 summaryCase() const;
     const RifEclipseSummaryAddress& summaryAddress() const;
@@ -58,6 +60,7 @@ private:
     RimSummaryCase*           m_summaryCase;
     RifEclipseSummaryAddress  m_summaryAddress;
     RimSummaryCaseCollection* m_ensemble;
+    bool                      m_treatAsSingleSummaryCurve;
 };
 
 class RiaSummaryCurveDefinitionAnalyser

--- a/ApplicationCode/Application/RiaSummaryCurveDefinition.h
+++ b/ApplicationCode/Application/RiaSummaryCurveDefinition.h
@@ -35,11 +35,10 @@ class RiaSummaryCurveDefinition
 {
 public:
     RiaSummaryCurveDefinition();
-    explicit RiaSummaryCurveDefinition( RimSummaryCase* summaryCase, const RifEclipseSummaryAddress& summaryAddress );
     explicit RiaSummaryCurveDefinition( RimSummaryCase*                 summaryCase,
                                         const RifEclipseSummaryAddress& summaryAddress,
-                                        RimSummaryCaseCollection*       ensemble,
-                                        bool                            treatAsSingleSummaryCurve );
+                                        bool                            isEnsembleCurve );
+    explicit RiaSummaryCurveDefinition( RimSummaryCaseCollection* ensemble, const RifEclipseSummaryAddress& summaryAddress );
 
     RimSummaryCase*                 summaryCase() const;
     const RifEclipseSummaryAddress& summaryAddress() const;
@@ -60,7 +59,7 @@ private:
     RimSummaryCase*           m_summaryCase;
     RifEclipseSummaryAddress  m_summaryAddress;
     RimSummaryCaseCollection* m_ensemble;
-    bool                      m_treatAsSingleSummaryCurve;
+    bool                      m_isEnsembleCurve;
 };
 
 class RiaSummaryCurveDefinitionAnalyser

--- a/ApplicationCode/Commands/SummaryPlotCommands/RicNewDerivedEnsembleFeature.cpp
+++ b/ApplicationCode/Commands/SummaryPlotCommands/RicNewDerivedEnsembleFeature.cpp
@@ -89,7 +89,7 @@ void RicNewDerivedEnsembleFeature::onActionTriggered( bool isChecked )
             if ( ensembles.size() == 2 )
             {
                 newEnsemble->setEnsemble2( ensembles[1] );
-                newEnsemble->updateDerivedEnsembleCases();
+                newEnsemble->createDerivedEnsembleCases();
 
                 if ( newEnsemble->allSummaryCases().empty() )
                 {

--- a/ApplicationCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
+++ b/ApplicationCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
@@ -354,11 +354,7 @@ void RicSummaryPlotEditorUi::syncPreviewCurvesFromUiSelection()
 
         for ( const auto& curve : currentCurvesInPreviewPlot )
         {
-            RimSummaryCase* sumCase = curve->summaryCaseY();
-            currentCurveDefs.insert( RiaSummaryCurveDefinition( sumCase,
-                                                                curve->summaryAddressY(),
-                                                                sumCase ? sumCase->ensemble() : nullptr,
-                                                                sumCase && sumCase->ensemble() ) );
+            currentCurveDefs.insert( curve->curveDefinitionY() );
         }
 
         {
@@ -372,11 +368,7 @@ void RicSummaryPlotEditorUi::syncPreviewCurvesFromUiSelection()
 
             for ( const auto& curve : currentCurvesInPreviewPlot )
             {
-                RimSummaryCase* sumCase = curve->summaryCaseY();
-                if ( sumCase && sumCase->ensemble() ) continue;
-
-                RiaSummaryCurveDefinition curveDef =
-                    RiaSummaryCurveDefinition( sumCase, curve->summaryAddressY(), nullptr, false );
+                RiaSummaryCurveDefinition curveDef = curve->curveDefinitionY();
                 if ( deleteCurveDefs.count( curveDef ) > 0 ) curvesToDelete.insert( curve );
             }
         }
@@ -597,7 +589,7 @@ void RicSummaryPlotEditorUi::populateCurveCreator( const RimSummaryPlot& sourceS
 
     for ( const auto& curve : sourceSummaryPlot.summaryCurves() )
     {
-        curveDefs.push_back( RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY(), nullptr, false ) );
+        curveDefs.push_back( curve->curveDefinitionY() );
 
         // Copy curve object to the preview plot
         copyCurveAndAddToPlot( curve, m_previewPlot.get(), true );
@@ -613,8 +605,7 @@ void RicSummaryPlotEditorUi::populateCurveCreator( const RimSummaryPlot& sourceS
         RimSummaryCaseCollection* ensemble = curveSet->summaryCaseCollection();
         for ( const auto& curve : curveSet->curves() )
         {
-            curveDefs.push_back(
-                RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY(), ensemble, true ) );
+            curveDefs.push_back( curve->curveDefinitionY() );
         }
     }
 

--- a/ApplicationCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
+++ b/ApplicationCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
@@ -355,8 +355,10 @@ void RicSummaryPlotEditorUi::syncPreviewCurvesFromUiSelection()
         for ( const auto& curve : currentCurvesInPreviewPlot )
         {
             RimSummaryCase* sumCase = curve->summaryCaseY();
-            currentCurveDefs.insert(
-                RiaSummaryCurveDefinition( sumCase, curve->summaryAddressY(), sumCase ? sumCase->ensemble() : nullptr ) );
+            currentCurveDefs.insert( RiaSummaryCurveDefinition( sumCase,
+                                                                curve->summaryAddressY(),
+                                                                sumCase ? sumCase->ensemble() : nullptr,
+                                                                sumCase && sumCase->ensemble() ) );
         }
 
         {
@@ -373,7 +375,8 @@ void RicSummaryPlotEditorUi::syncPreviewCurvesFromUiSelection()
                 RimSummaryCase* sumCase = curve->summaryCaseY();
                 if ( sumCase && sumCase->ensemble() ) continue;
 
-                RiaSummaryCurveDefinition curveDef = RiaSummaryCurveDefinition( sumCase, curve->summaryAddressY() );
+                RiaSummaryCurveDefinition curveDef =
+                    RiaSummaryCurveDefinition( sumCase, curve->summaryAddressY(), nullptr, false );
                 if ( deleteCurveDefs.count( curveDef ) > 0 ) curvesToDelete.insert( curve );
             }
         }
@@ -594,7 +597,7 @@ void RicSummaryPlotEditorUi::populateCurveCreator( const RimSummaryPlot& sourceS
 
     for ( const auto& curve : sourceSummaryPlot.summaryCurves() )
     {
-        curveDefs.push_back( RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY() ) );
+        curveDefs.push_back( RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY(), nullptr, false ) );
 
         // Copy curve object to the preview plot
         copyCurveAndAddToPlot( curve, m_previewPlot.get(), true );
@@ -610,7 +613,8 @@ void RicSummaryPlotEditorUi::populateCurveCreator( const RimSummaryPlot& sourceS
         RimSummaryCaseCollection* ensemble = curveSet->summaryCaseCollection();
         for ( const auto& curve : curveSet->curves() )
         {
-            curveDefs.push_back( RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY(), ensemble ) );
+            curveDefs.push_back(
+                RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY(), ensemble, true ) );
         }
     }
 

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
@@ -454,7 +454,7 @@ void RimAnalysisPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
 
         dlg.enableMultiSelect( true );
         dlg.enableIndividualEnsembleCaseSelection( true );
-        dlg.setCurveSelection( this->curveDefinitionsWithoutEnsembleReference() );
+        dlg.setCurveSelection( this->curveDefinitions() );
 
         if ( dlg.exec() == QDialog::Accepted )
         {
@@ -899,7 +899,7 @@ void RimAnalysisPlot::updateAxes()
 
         std::set<QString> timeHistoryQuantities;
 
-        RimSummaryPlotAxisFormatter calc( valAxisProperties, {}, curveDefinitionsWithoutEnsembleReference(), {}, {} );
+        RimSummaryPlotAxisFormatter calc( valAxisProperties, {}, curveDefinitions(), {}, {} );
         calc.applyAxisPropertiesToPlot( m_plotWidget );
     }
     else
@@ -1047,7 +1047,7 @@ std::vector<size_t> RimAnalysisPlot::findTimestepIndices( std::vector<time_t>   
 //--------------------------------------------------------------------------------------------------
 std::vector<RiaSummaryCurveDefinition> RimAnalysisPlot::filteredCurveDefs()
 {
-    std::vector<RiaSummaryCurveDefinition> dataDefinitions = curveDefinitionsWithEmbeddedEnsembleReference();
+    std::vector<RiaSummaryCurveDefinition> dataDefinitions = curveDefinitions();
 
     // Split out the filter targets
 
@@ -1667,52 +1667,22 @@ RiaSummaryCurveDefinitionAnalyser* RimAnalysisPlot::getOrCreateSelectedCurveDefA
         m_analyserOfSelectedCurveDefs =
             std::unique_ptr<RiaSummaryCurveDefinitionAnalyser>( new RiaSummaryCurveDefinitionAnalyser );
     }
-    m_analyserOfSelectedCurveDefs->setCurveDefinitions( this->curveDefinitionsWithoutEnsembleReference() );
+    m_analyserOfSelectedCurveDefs->setCurveDefinitions( this->curveDefinitions() );
     return m_analyserOfSelectedCurveDefs.get();
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RiaSummaryCurveDefinition> RimAnalysisPlot::curveDefinitionsWithoutEnsembleReference() const
+std::vector<RiaSummaryCurveDefinition> RimAnalysisPlot::curveDefinitions() const
 {
     std::vector<RiaSummaryCurveDefinition> curveDefs;
     for ( auto dataEntry : m_analysisPlotDataSelection )
     {
-        if ( dataEntry->isEnsembleCurve() )
-        {
-            curveDefs.push_back( dataEntry->curveDefinition() );
-        }
+        curveDefs.push_back( dataEntry->curveDefinition() );
     }
 
     return curveDefs;
-}
-
-//--------------------------------------------------------------------------------------------------
-/// The curve definitions returned contain both the case AND the ensemble from which it has been spawned
-//--------------------------------------------------------------------------------------------------
-std::vector<RiaSummaryCurveDefinition> RimAnalysisPlot::curveDefinitionsWithEmbeddedEnsembleReference()
-{
-    std::vector<RiaSummaryCurveDefinition> barDataDefinitions;
-
-    for ( const RimAnalysisPlotDataEntry* dataEntry : m_analysisPlotDataSelection )
-    {
-        RiaSummaryCurveDefinition orgBarDataEntry = dataEntry->curveDefinition();
-
-        if ( orgBarDataEntry.summaryCase() && orgBarDataEntry.summaryCase()->ensemble() )
-        {
-            barDataDefinitions.push_back( RiaSummaryCurveDefinition( orgBarDataEntry.summaryCase(),
-                                                                     orgBarDataEntry.summaryAddress(),
-                                                                     orgBarDataEntry.summaryCase()->ensemble(),
-                                                                     orgBarDataEntry.isEnsembleCurve() ) );
-        }
-        else
-        {
-            barDataDefinitions.push_back( orgBarDataEntry );
-        }
-    }
-
-    return barDataDefinitions;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.h
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.h
@@ -176,7 +176,13 @@ private:
 
     void buildTestPlot( RiuGroupedBarChartBuilder& chartBuilder );
 
-    int barTextFontSize() const;
+    int  barTextFontSize() const;
+    void initAfterRead();
+
+private:
+    void onCaseRemoved( const SignalEmitter* emitter, RimSummaryCase* summaryCase );
+    void connectAllCaseSignals();
+    void disconnectAllCaseSignals();
 
 private:
     std::unique_ptr<RiaSummaryCurveDefinitionAnalyser> m_analyserOfSelectedCurveDefs;

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.h
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.h
@@ -158,8 +158,7 @@ private:
                                 const QString&                  timestepString ) const;
 
     RiaSummaryCurveDefinitionAnalyser*     getOrCreateSelectedCurveDefAnalyser();
-    std::vector<RiaSummaryCurveDefinition> curveDefinitionsWithoutEnsembleReference() const;
-    std::vector<RiaSummaryCurveDefinition> curveDefinitionsWithEmbeddedEnsembleReference();
+    std::vector<RiaSummaryCurveDefinition> curveDefinitions() const;
     std::vector<RiaSummaryCurveDefinition> filteredCurveDefs();
     void                                   applyFilter( const RimPlotDataFilterItem*        filter,
                                                         std::set<RimSummaryCase*>*          filteredSumCases,

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotCollection.cpp
@@ -147,7 +147,7 @@ void RimAnalysisPlotCollection::applyFirstEnsembleFieldAddressesToPlot( RimAnaly
                 {
                     for ( auto summaryCase : ensembles.front()->allSummaryCases() )
                     {
-                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, nullptr ) );
+                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, ensembles.front(), false ) );
                     }
                 }
             }
@@ -173,7 +173,7 @@ void RimAnalysisPlotCollection::applyEnsembleFieldAndTimeStepToPlot( RimAnalysis
                 {
                     for ( auto summaryCase : ensemble->allSummaryCases() )
                     {
-                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, nullptr ) );
+                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, ensemble, false ) );
                     }
                 }
             }

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotCollection.cpp
@@ -147,7 +147,7 @@ void RimAnalysisPlotCollection::applyFirstEnsembleFieldAddressesToPlot( RimAnaly
                 {
                     for ( auto summaryCase : ensembles.front()->allSummaryCases() )
                     {
-                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, ensembles.front(), false ) );
+                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, false ) );
                     }
                 }
             }
@@ -173,7 +173,7 @@ void RimAnalysisPlotCollection::applyEnsembleFieldAndTimeStepToPlot( RimAnalysis
                 {
                     for ( auto summaryCase : ensemble->allSummaryCases() )
                     {
-                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, ensemble, false ) );
+                        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, false ) );
                     }
                 }
             }

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.cpp
@@ -47,6 +47,8 @@ RimAnalysisPlotDataEntry::RimAnalysisPlotDataEntry()
     m_summaryAddress.uiCapability()->setUiHidden( true );
     m_summaryAddress.uiCapability()->setUiTreeChildrenHidden( true );
     m_summaryAddress = new RimSummaryAddress;
+
+    CAF_PDM_InitField( &m_isEnsembleCurve, "IsEnsembleCurve", false, "Is Ensemble Curve", "", "", "" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -66,10 +68,8 @@ void RimAnalysisPlotDataEntry::setFromCurveDefinition( const RiaSummaryCurveDefi
     {
         m_ensemble = curveDef.ensemble();
     }
-    else
-    {
-        m_summaryCase = curveDef.summaryCase();
-    }
+    m_summaryCase     = curveDef.summaryCase();
+    m_isEnsembleCurve = curveDef.isEnsembleCurve();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -79,9 +79,9 @@ RiaSummaryCurveDefinition RimAnalysisPlotDataEntry::curveDefinition() const
 {
     if ( m_ensemble )
     {
-        return RiaSummaryCurveDefinition( nullptr, m_summaryAddress->address(), m_ensemble() );
+        return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address(), m_ensemble(), m_isEnsembleCurve );
     }
-    return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address(), nullptr );
+    return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -106,4 +106,12 @@ RimSummaryCaseCollection* RimAnalysisPlotDataEntry::ensemble() const
 RifEclipseSummaryAddress RimAnalysisPlotDataEntry::summaryAddress() const
 {
     return m_summaryAddress->address();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimAnalysisPlotDataEntry::isEnsembleCurve() const
+{
+    return m_isEnsembleCurve;
 }

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.cpp
@@ -77,11 +77,15 @@ void RimAnalysisPlotDataEntry::setFromCurveDefinition( const RiaSummaryCurveDefi
 //--------------------------------------------------------------------------------------------------
 RiaSummaryCurveDefinition RimAnalysisPlotDataEntry::curveDefinition() const
 {
-    if ( m_ensemble )
+    if ( m_summaryCase() )
     {
-        return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address(), m_ensemble(), m_isEnsembleCurve );
+        return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address(), m_isEnsembleCurve );
     }
-    return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address() );
+    else
+    {
+        CAF_ASSERT( m_ensemble() );
+        return RiaSummaryCurveDefinition( m_ensemble(), m_summaryAddress->address() );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.h
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.h
@@ -21,6 +21,7 @@
 #include "RiaSummaryCurveDefinition.h"
 #include "RifEclipseSummaryAddress.h"
 #include "cafPdmChildField.h"
+#include "cafPdmField.h"
 #include "cafPdmObject.h"
 #include "cafPdmPtrField.h"
 
@@ -42,9 +43,11 @@ public:
     RimSummaryCase*           summaryCase() const;
     RimSummaryCaseCollection* ensemble() const;
     RifEclipseSummaryAddress  summaryAddress() const;
+    bool                      isEnsembleCurve() const;
 
 private:
     caf::PdmPtrField<RimSummaryCase*>           m_summaryCase;
     caf::PdmPtrField<RimSummaryCaseCollection*> m_ensemble;
     caf::PdmChildField<RimSummaryAddress*>      m_summaryAddress;
+    caf::PdmField<bool>                         m_isEnsembleCurve;
 };

--- a/ApplicationCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
+++ b/ApplicationCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
@@ -115,6 +115,13 @@ protected:
 
     QString selectedVarsText();
 
+    void initAfterRead() final;
+
+private:
+    void onCaseRemoved( const SignalEmitter* emitter, RimSummaryCase* summaryCase );
+    void connectAllCaseSignals();
+    void disconnectAllCaseSignals();
+
 protected:
     std::unique_ptr<RiaSummaryCurveDefinitionAnalyser> m_analyserOfSelectedCurveDefs;
     QPointer<RiuQwtPlotWidget>                         m_plotWidget;

--- a/ApplicationCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
@@ -228,7 +228,7 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToPlot( RimAb
             auto it = std::find( quantityNames.begin(), quantityNames.end(), QString::fromStdString( address.uiText() ) );
             if ( it != quantityNames.end() || quantityNames.empty() )
             {
-                curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front(), true ) );
+                curveDefs.push_back( RiaSummaryCurveDefinition( ensembles.front(), address ) );
             }
         }
         plot->setCurveDefinitions( curveDefs );
@@ -258,7 +258,7 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToPlot( RimAbstr
             auto it = std::find( quantityNames.begin(), quantityNames.end(), QString::fromStdString( address.uiText() ) );
             if ( it != quantityNames.end() || quantityNames.empty() )
             {
-                curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
+                curveDefs.push_back( RiaSummaryCurveDefinition( ensemble, address ) );
             }
         }
         plot->setCurveDefinitions( curveDefs );
@@ -287,14 +287,13 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToReport( Rim
                                  QString::fromStdString( address.uiText() ) );
             if ( it != matrixQuantityNames.end() || matrixQuantityNames.empty() )
             {
-                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front(), true ) );
+                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( ensembles.front(), address ) );
             }
 
             if ( tornadoAndCrossPlotQuantityName.isEmpty() ||
                  tornadoAndCrossPlotQuantityName == QString::fromStdString( address.uiText() ) )
             {
-                curveDefsTornadoAndCrossPlot.push_back(
-                    RiaSummaryCurveDefinition( nullptr, address, ensembles.front(), true ) );
+                curveDefsTornadoAndCrossPlot.push_back( RiaSummaryCurveDefinition( ensembles.front(), address ) );
             }
         }
 
@@ -326,13 +325,13 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToReport( RimCor
                                  QString::fromStdString( address.uiText() ) );
             if ( it != matrixQuantityNames.end() || matrixQuantityNames.empty() )
             {
-                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
+                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( ensemble, address ) );
             }
 
             if ( tornadoAndCrossPlotQuantityName.isEmpty() ||
                  tornadoAndCrossPlotQuantityName == QString::fromStdString( address.uiText() ) )
             {
-                curveDefsTornadoAndCrossPlot.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
+                curveDefsTornadoAndCrossPlot.push_back( RiaSummaryCurveDefinition( ensemble, address ) );
             }
         }
         plot->matrixPlot()->setCurveDefinitions( curveDefsMatrix );

--- a/ApplicationCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
@@ -228,7 +228,7 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToPlot( RimAb
             auto it = std::find( quantityNames.begin(), quantityNames.end(), QString::fromStdString( address.uiText() ) );
             if ( it != quantityNames.end() || quantityNames.empty() )
             {
-                curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front() ) );
+                curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front(), true ) );
             }
         }
         plot->setCurveDefinitions( curveDefs );
@@ -258,7 +258,7 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToPlot( RimAbstr
             auto it = std::find( quantityNames.begin(), quantityNames.end(), QString::fromStdString( address.uiText() ) );
             if ( it != quantityNames.end() || quantityNames.empty() )
             {
-                curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble ) );
+                curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
             }
         }
         plot->setCurveDefinitions( curveDefs );
@@ -287,13 +287,14 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToReport( Rim
                                  QString::fromStdString( address.uiText() ) );
             if ( it != matrixQuantityNames.end() || matrixQuantityNames.empty() )
             {
-                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front() ) );
+                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front(), true ) );
             }
 
             if ( tornadoAndCrossPlotQuantityName.isEmpty() ||
                  tornadoAndCrossPlotQuantityName == QString::fromStdString( address.uiText() ) )
             {
-                curveDefsTornadoAndCrossPlot.push_back( RiaSummaryCurveDefinition( nullptr, address, ensembles.front() ) );
+                curveDefsTornadoAndCrossPlot.push_back(
+                    RiaSummaryCurveDefinition( nullptr, address, ensembles.front(), true ) );
             }
         }
 
@@ -325,13 +326,13 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToReport( RimCor
                                  QString::fromStdString( address.uiText() ) );
             if ( it != matrixQuantityNames.end() || matrixQuantityNames.empty() )
             {
-                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble ) );
+                curveDefsMatrix.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
             }
 
             if ( tornadoAndCrossPlotQuantityName.isEmpty() ||
                  tornadoAndCrossPlotQuantityName == QString::fromStdString( address.uiText() ) )
             {
-                curveDefsTornadoAndCrossPlot.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble ) );
+                curveDefsTornadoAndCrossPlot.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
             }
         }
         plot->matrixPlot()->setCurveDefinitions( curveDefsMatrix );

--- a/ApplicationCode/ProjectDataModel/RimSummaryCalculation.cpp
+++ b/ApplicationCode/ProjectDataModel/RimSummaryCalculation.cpp
@@ -281,7 +281,7 @@ bool RimSummaryCalculation::calculate()
             return false;
         }
 
-        RiaSummaryCurveDefinition curveDef( v->summaryCase(), v->summaryAddress()->address() );
+        RiaSummaryCurveDefinition curveDef( v->summaryCase(), v->summaryAddress()->address(), false );
 
         std::vector<double> curveValues;
         RiaSummaryCurveDefinition::resultValues( curveDef, &curveValues );

--- a/ApplicationCode/ProjectDataModel/Summary/RimDerivedEnsembleCaseCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimDerivedEnsembleCaseCollection.cpp
@@ -144,7 +144,7 @@ std::set<RifEclipseSummaryAddress> RimDerivedEnsembleCaseCollection::ensembleSum
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimDerivedEnsembleCaseCollection::updateDerivedEnsembleCases()
+void RimDerivedEnsembleCaseCollection::createDerivedEnsembleCases()
 {
     if ( !m_ensemble1 || !m_ensemble2 ) return;
 
@@ -194,7 +194,7 @@ void RimDerivedEnsembleCaseCollection::updateDerivedEnsembleCases()
     // If other derived ensembles are referring to this ensemble, update their cases as well
     for ( auto referring : findReferringEnsembles() )
     {
-        referring->updateDerivedEnsembleCases();
+        referring->createDerivedEnsembleCases();
     }
 
     deleteCasesNoInUse();
@@ -343,7 +343,7 @@ void RimDerivedEnsembleCaseCollection::fieldChangedByUi( const caf::PdmFieldHand
 
         if ( doUpdateCases )
         {
-            updateDerivedEnsembleCases();
+            createDerivedEnsembleCases();
             updateConnectedEditors();
 
             if ( doShowDialog && m_ensemble1 != nullptr && m_ensemble2 != nullptr && allSummaryCases().empty() )
@@ -518,6 +518,27 @@ void RimDerivedEnsembleCaseCollection::updateAutoName()
     {
         refering->updateAutoName();
         refering->updateConnectedEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimDerivedEnsembleCaseCollection::updateDerivedEnsembleCases()
+{
+    for ( auto& derivedCase : allDerivedCases( true ) )
+    {
+        derivedCase->createSummaryReaderInterface();
+
+        auto crp = derivedCase->summaryCase1()->caseRealizationParameters();
+        if ( !crp ) continue;
+        derivedCase->setCaseRealizationParameters( crp );
+    }
+
+    // If other derived ensembles are referring to this ensemble, update their cases as well
+    for ( auto referring : findReferringEnsembles() )
+    {
+        referring->updateDerivedEnsembleCases();
     }
 }
 

--- a/ApplicationCode/ProjectDataModel/Summary/RimDerivedEnsembleCaseCollection.h
+++ b/ApplicationCode/ProjectDataModel/Summary/RimDerivedEnsembleCaseCollection.h
@@ -62,8 +62,10 @@ public:
 
     std::vector<RimSummaryCase*>       allSummaryCases() const override;
     std::set<RifEclipseSummaryAddress> ensembleSummaryAddresses() const override;
+    void                               createDerivedEnsembleCases();
     void                               updateDerivedEnsembleCases();
-    bool                               hasCaseReference( const RimSummaryCase* sumCase ) const;
+
+    bool hasCaseReference( const RimSummaryCase* sumCase ) const;
 
     void onLoadDataAndUpdate() override;
 

--- a/ApplicationCode/ProjectDataModel/Summary/RimDerivedSummaryCase.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimDerivedSummaryCase.cpp
@@ -71,10 +71,9 @@ RimDerivedSummaryCase::RimDerivedSummaryCase()
 
     CAF_PDM_InitFieldNoDefault( &m_useFixedTimeStep, "UseFixedTimeStep", "Use Fixed Time Step", "", "", "" );
     CAF_PDM_InitField( &m_fixedTimeStepIndex, "FixedTimeStepIndex", 0, "Time Step", "", "", "" );
+    CAF_PDM_InitField( &m_inUse, "InUse", false, "In Use", "", "", "" );
     m_fixedTimeStepIndex.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_fixedTimeStepIndex.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
-
-    m_inUse = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -425,6 +424,22 @@ void RimDerivedSummaryCase::updateDisplayNameFromCases()
     }
 
     m_displayName = name;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSummaryCase* RimDerivedSummaryCase::summaryCase1() const
+{
+    return m_summaryCase1;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSummaryCase* RimDerivedSummaryCase::summaryCase2() const
+{
+    return m_summaryCase2;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/Summary/RimDerivedSummaryCase.h
+++ b/ApplicationCode/ProjectDataModel/Summary/RimDerivedSummaryCase.h
@@ -83,6 +83,9 @@ public:
 
     void updateDisplayNameFromCases();
 
+    RimSummaryCase* summaryCase1() const;
+    RimSummaryCase* summaryCase2() const;
+
 protected:
     QString caseName() const override;
 
@@ -107,7 +110,7 @@ private:
     caf::PdmField<caf::AppEnum<FixedTimeStepMode>> m_useFixedTimeStep;
     caf::PdmField<int>                             m_fixedTimeStepIndex;
 
-    bool                                      m_inUse;
+    caf::PdmField<bool>                       m_inUse;
     std::unique_ptr<RifDerivedEnsembleReader> m_reader;
 
     std::map<RifEclipseSummaryAddress, std::pair<std::vector<time_t>, std::vector<double>>> m_dataCache;

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCase.h
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCase.h
@@ -63,6 +63,7 @@ public:
 
     RiaEclipseUnitTools::UnitSystemType unitsSystem();
 
+    void setDisplayNameOption( DisplayName displayNameOption );
     void updateAutoShortName();
     void updateOptionSensitivity();
 
@@ -95,7 +96,8 @@ protected:
     void initAfterRead() override;
 
 private:
-    static QString uniqueShortNameForCase( RimSummaryCase* summaryCase );
+    static QString uniqueShortNameForEnsembleCase( RimSummaryCase* summaryCase );
+    static QString uniqueShortNameForSummaryCase( RimSummaryCase* summaryCase );
 
 protected:
     caf::PdmField<QString>         m_displayName;

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
@@ -24,6 +24,7 @@
 
 #include "RicfCommandObject.h"
 
+#include "RimAnalysisPlotDataEntry.h"
 #include "RimDerivedEnsembleCaseCollection.h"
 #include "RimEnsembleCurveSet.h"
 #include "RimGridSummaryCase.h"
@@ -188,6 +189,7 @@ QString EnsembleParameter::uiName() const
 //--------------------------------------------------------------------------------------------------
 RimSummaryCaseCollection::RimSummaryCaseCollection()
     : caseNameChanged( this )
+    , caseRemoved( this )
 {
     CAF_PDM_InitScriptableObject( "Summary Case Group", ":/SummaryGroup16x16.png", "", "" );
 
@@ -234,6 +236,8 @@ void RimSummaryCaseCollection::removeCase( RimSummaryCase* summaryCase )
 
     m_cachedSortedEnsembleParameters.clear();
 
+    caseRemoved.send( summaryCase );
+
     updateReferringCurveSets();
 
     if ( m_isEnsemble && m_cases.size() != caseCountBeforeRemove )
@@ -246,7 +250,7 @@ void RimSummaryCaseCollection::removeCase( RimSummaryCase* summaryCase )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryCaseCollection::addCase( RimSummaryCase* summaryCase, bool updateCurveSets )
+void RimSummaryCaseCollection::addCase( RimSummaryCase* summaryCase )
 {
     summaryCase->nameChanged.connect( this, &RimSummaryCaseCollection::onCaseNameChanged );
 
@@ -256,12 +260,12 @@ void RimSummaryCaseCollection::addCase( RimSummaryCase* summaryCase, bool update
     // Update derived ensemble cases (if any)
     std::vector<RimDerivedEnsembleCaseCollection*> referringObjects;
     objectsWithReferringPtrFieldsOfType( referringObjects );
-    for ( auto derEnsemble : referringObjects )
+    for ( auto derivedEnsemble : referringObjects )
     {
-        if ( !derEnsemble ) continue;
+        if ( !derivedEnsemble ) continue;
 
-        derEnsemble->updateDerivedEnsembleCases();
-        if ( updateCurveSets ) derEnsemble->updateReferringCurveSets();
+        derivedEnsemble->createDerivedEnsembleCases();
+        derivedEnsemble->updateReferringCurveSets();
     }
 
     if ( m_isEnsemble )
@@ -270,7 +274,7 @@ void RimSummaryCaseCollection::addCase( RimSummaryCase* summaryCase, bool update
         calculateEnsembleParametersIntersectionHash();
     }
 
-    if ( updateCurveSets ) updateReferringCurveSets();
+    updateReferringCurveSets();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -925,13 +929,18 @@ void RimSummaryCaseCollection::onLoadDataAndUpdate()
 void RimSummaryCaseCollection::updateReferringCurveSets()
 {
     // Update curve set referring to this group
-    std::vector<RimEnsembleCurveSet*> referringObjects;
+    std::vector<caf::PdmObject*> referringObjects;
     objectsWithReferringPtrFieldsOfType( referringObjects );
 
-    for ( auto curveSet : referringObjects )
+    for ( auto object : referringObjects )
     {
+        RimEnsembleCurveSet* curveSet = dynamic_cast<RimEnsembleCurveSet*>( object );
+
         bool updateParentPlot = true;
-        if ( curveSet ) curveSet->loadDataAndUpdate( updateParentPlot );
+        if ( curveSet )
+        {
+            curveSet->loadDataAndUpdate( updateParentPlot );
+        }
     }
 }
 

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseCollection.h
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseCollection.h
@@ -92,14 +92,15 @@ class RimSummaryCaseCollection : public caf::PdmObject
     CAF_PDM_HEADER_INIT;
 
 public:
-    caf::Signal<> caseNameChanged;
+    caf::Signal<>                caseNameChanged;
+    caf::Signal<RimSummaryCase*> caseRemoved;
 
 public:
     RimSummaryCaseCollection();
     ~RimSummaryCaseCollection() override;
 
     void                                       removeCase( RimSummaryCase* summaryCase );
-    void                                       addCase( RimSummaryCase* summaryCase, bool updateCurveSets = true );
+    void                                       addCase( RimSummaryCase* summaryCase );
     virtual std::vector<RimSummaryCase*>       allSummaryCases() const;
     void                                       setName( const QString& name );
     QString                                    name() const;

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -251,7 +251,7 @@ void RimSummaryCaseMainCollection::removeCase( RimSummaryCase* summaryCase )
     // Update derived ensemble cases (if any)
     for ( auto derEnsemble : derivedEnsembles )
     {
-        derEnsemble->updateDerivedEnsembleCases();
+        derEnsemble->createDerivedEnsembleCases();
     }
 }
 

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -288,6 +288,10 @@ RimSummaryCaseCollection*
         }
 
         summaryCaseCollection->addCase( summaryCase );
+        if ( isEnsemble )
+        {
+            summaryCase->setDisplayNameOption( RimSummaryCase::DisplayName::SHORT_CASE_NAME );
+        }
     }
 
     summaryCaseCollection->setAsEnsemble( isEnsemble );

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCurve.h
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCurve.h
@@ -25,10 +25,12 @@
 #include "cafPdmPtrField.h"
 
 #include "RiaDefines.h"
+#include "RiaSummaryCurveDefinition.h"
 #include "RifEclipseSummaryAddressQMetaType.h"
 #include "RimStackablePlotCurve.h"
 
 #include "cafAppEnum.h"
+#include "cafTristate.h"
 
 class RifSummaryReaderInterface;
 class RimSummaryCase;
@@ -50,14 +52,17 @@ public:
     ~RimSummaryCurve() override;
 
     // Y Axis functions
-    void            setSummaryCaseY( RimSummaryCase* sumCase );
-    RimSummaryCase* summaryCaseY() const;
-    void            setSummaryAddressYAndApplyInterpolation( const RifEclipseSummaryAddress& address );
-    void            setSummaryAddressY( const RifEclipseSummaryAddress& address );
+    RiaSummaryCurveDefinition curveDefinitionY() const;
+    RimSummaryCase*           summaryCaseY() const;
+    RifEclipseSummaryAddress  summaryAddressY() const;
+    std::string               unitNameY() const;
+    std::vector<double>       valuesY() const;
 
-    RifEclipseSummaryAddress   summaryAddressY() const;
-    std::string                unitNameY() const;
-    std::vector<double>        valuesY() const;
+    void applyCurveDefinitionY( const RiaSummaryCurveDefinition& curveDefinition );
+    void setSummaryCaseY( RimSummaryCase* sumCase );
+    void setSummaryAddressYAndApplyInterpolation( const RifEclipseSummaryAddress& address );
+    void setSummaryAddressY( const RifEclipseSummaryAddress& address );
+
     RifEclipseSummaryAddress   errorSummaryAddressY() const;
     std::vector<double>        errorValuesY() const;
     void                       setLeftOrRightAxisY( RiaDefines::PlotAxis plotAxis );
@@ -67,14 +72,18 @@ public:
     void setOverrideCurveDataY( const std::vector<time_t>& xValues, const std::vector<double>& yValues );
 
     // X Axis functions
-    void                     setSummaryCaseX( RimSummaryCase* sumCase );
     RimSummaryCase*          summaryCaseX() const;
     RifEclipseSummaryAddress summaryAddressX() const;
-    void                     setSummaryAddressX( const RifEclipseSummaryAddress& address );
     std::string              unitNameX() const;
     std::vector<double>      valuesX() const;
 
+    void setSummaryCaseX( RimSummaryCase* sumCase );
+    void setSummaryAddressX( const RifEclipseSummaryAddress& address );
+
     // Other
+    bool isEnsembleCurve() const;
+    void setIsEnsembleCurve( bool isEnsembleCurve );
+
     void updateQwtPlotAxis();
     void applyCurveAutoNameSettings( const RimSummaryCurveAutoName& autoNameSettings );
 
@@ -97,6 +106,7 @@ protected:
     void updateLegendsInPlot() override;
 
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
+    void initAfterRead();
 
 private:
     RifSummaryReaderInterface* valuesSummaryReaderX() const;
@@ -128,6 +138,8 @@ private:
     caf::PdmChildField<RimSummaryAddress*>  m_xValuesSummaryAddress;
     caf::PdmField<RifEclipseSummaryAddress> m_xValuesSummaryAddressUiField;
     caf::PdmField<bool>                     m_xPushButtonSelectSummaryAddress;
+
+    caf::PdmField<caf::Tristate> m_isEnsembleCurve;
 
     caf::PdmChildField<RimSummaryCurveAutoName*>      m_curveNameConfig;
     caf::PdmField<caf::AppEnum<RiaDefines::PlotAxis>> m_plotAxis;

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -535,7 +535,8 @@ std::set<RiaSummaryCurveDefinition> RimSummaryPlot::summaryAndEnsembleCurveDefin
 
     for ( const auto& curve : this->summaryAndEnsembleCurves() )
     {
-        allCurveDefs.insert( RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY() ) );
+        allCurveDefs.insert(
+            RiaSummaryCurveDefinition( curve->summaryCaseY(), curve->summaryAddressY(), curve->isEnsembleCurve() ) );
     }
     return allCurveDefs;
 }

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlotFilterTextCurveSetEditor.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlotFilterTextCurveSetEditor.cpp
@@ -263,7 +263,7 @@ void RimSummaryPlotFilterTextCurveSetEditor::fieldChangedByUi( const caf::PdmFie
 
             for ( const auto& filteredAddress : filteredAddressesFromSource )
             {
-                curveDefinitions.insert( RiaSummaryCurveDefinition( sumCase, filteredAddress, ensemble, true ) );
+                curveDefinitions.insert( RiaSummaryCurveDefinition( sumCase, filteredAddress, ensemble != nullptr ) );
             }
         }
 

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlotFilterTextCurveSetEditor.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryPlotFilterTextCurveSetEditor.cpp
@@ -263,7 +263,7 @@ void RimSummaryPlotFilterTextCurveSetEditor::fieldChangedByUi( const caf::PdmFie
 
             for ( const auto& filteredAddress : filteredAddressesFromSource )
             {
-                curveDefinitions.insert( RiaSummaryCurveDefinition( sumCase, filteredAddress, ensemble ) );
+                curveDefinitions.insert( RiaSummaryCurveDefinition( sumCase, filteredAddress, ensemble, true ) );
             }
         }
 

--- a/ApplicationCode/UserInterface/RiuSummaryVectorSelectionDialog.cpp
+++ b/ApplicationCode/UserInterface/RiuSummaryVectorSelectionDialog.cpp
@@ -96,7 +96,7 @@ void RiuSummaryVectorSelectionDialog::setEnsembleAndAddress( RimSummaryCaseColle
     if ( ensemble )
     {
         std::vector<RiaSummaryCurveDefinition> curveDefs;
-        curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble ) );
+        curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
         setCurveSelection( curveDefs );
     }
 }

--- a/ApplicationCode/UserInterface/RiuSummaryVectorSelectionDialog.cpp
+++ b/ApplicationCode/UserInterface/RiuSummaryVectorSelectionDialog.cpp
@@ -82,7 +82,7 @@ void RiuSummaryVectorSelectionDialog::setCaseAndAddress( RimSummaryCase*        
     if ( summaryCase )
     {
         std::vector<RiaSummaryCurveDefinition> curveDefs;
-        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address ) );
+        curveDefs.push_back( RiaSummaryCurveDefinition( summaryCase, address, false ) );
         setCurveSelection( curveDefs );
     }
 }
@@ -96,7 +96,7 @@ void RiuSummaryVectorSelectionDialog::setEnsembleAndAddress( RimSummaryCaseColle
     if ( ensemble )
     {
         std::vector<RiaSummaryCurveDefinition> curveDefs;
-        curveDefs.push_back( RiaSummaryCurveDefinition( nullptr, address, ensemble, true ) );
+        curveDefs.push_back( RiaSummaryCurveDefinition( ensemble, address ) );
         setCurveSelection( curveDefs );
     }
 }

--- a/ApplicationCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
+++ b/ApplicationCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
@@ -445,7 +445,7 @@ std::vector<RiaSummaryCurveDefinition> RiuSummaryVectorSelectionUi::allCurveDefi
                     if ( selectedAddressesFromUi.count( addressFromSource ) > 0 )
                     {
                         curveDefinitions.insert(
-                            RiaSummaryCurveDefinition( caseFromSource, addressFromSource, ensemble, false ) );
+                            RiaSummaryCurveDefinition( caseFromSource, addressFromSource, ensemble != nullptr ) );
                     }
                 }
             }
@@ -512,7 +512,7 @@ std::vector<RiaSummaryCurveDefinition> RiuSummaryVectorSelectionUi::selection() 
             {
                 if ( addressUnion.count( addr ) )
                 {
-                    curveDefSelection.push_back( RiaSummaryCurveDefinition( nullptr, addr, ensemble, true ) );
+                    curveDefSelection.push_back( RiaSummaryCurveDefinition( ensemble, addr ) );
                 }
             }
         }
@@ -525,7 +525,7 @@ std::vector<RiaSummaryCurveDefinition> RiuSummaryVectorSelectionUi::selection() 
             {
                 if ( readerAddresses.count( addr ) )
                 {
-                    curveDefSelection.push_back( RiaSummaryCurveDefinition( sourceCase, addr ) );
+                    curveDefSelection.push_back( RiaSummaryCurveDefinition( sourceCase, addr, false ) );
                 }
             }
         }
@@ -594,9 +594,14 @@ void RiuSummaryVectorSelectionUi::setDefaultSelection( const std::vector<Summary
         {
             RimSummaryCase*           sumCase  = dynamic_cast<RimSummaryCase*>( s );
             RimSummaryCaseCollection* ensemble = dynamic_cast<RimSummaryCaseCollection*>( s );
-
-            RiaSummaryCurveDefinition curveDef( sumCase, defaultAddress, ensemble, true );
-            curveDefs.push_back( curveDef );
+            if ( ensemble )
+            {
+                curveDefs.push_back( RiaSummaryCurveDefinition( ensemble, defaultAddress ) );
+            }
+            else
+            {
+                curveDefs.push_back( RiaSummaryCurveDefinition( sumCase, defaultAddress, false ) );
+            }
         }
 
         setSelectedCurveDefinitions( curveDefs );
@@ -640,14 +645,20 @@ void RiuSummaryVectorSelectionUi::setSelectedCurveDefinitions( const std::vector
         }
 
         // Select case if not already selected
-        SummarySource* summSource = curveDef.isEnsembleCurve() ? static_cast<SummarySource*>( curveDef.ensemble() )
-                                                               : summaryCase;
-        if ( std::find( m_selectedSources.begin(), m_selectedSources.end(), summSource ) == m_selectedSources.end() )
+        if ( curveDef.isEnsembleCurve() )
         {
-            if ( summaryCase != calculatedSummaryCase() )
+            if ( curveDef.ensemble() && !m_hideEnsembles )
             {
-                m_selectedSources.push_back( summSource );
-                handleAddedSource( summSource );
+                m_selectedSources.push_back( curveDef.ensemble() );
+                handleAddedSource( curveDef.ensemble() );
+            }
+        }
+        else
+        {
+            if ( curveDef.summaryCase() && m_showIndividualEnsembleCases )
+            {
+                m_selectedSources.push_back( curveDef.summaryCase() );
+                handleAddedSource( curveDef.summaryCase() );
             }
         }
 

--- a/ApplicationCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
+++ b/ApplicationCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
@@ -444,7 +444,8 @@ std::vector<RiaSummaryCurveDefinition> RiuSummaryVectorSelectionUi::allCurveDefi
                 {
                     if ( selectedAddressesFromUi.count( addressFromSource ) > 0 )
                     {
-                        curveDefinitions.insert( RiaSummaryCurveDefinition( caseFromSource, addressFromSource, ensemble ) );
+                        curveDefinitions.insert(
+                            RiaSummaryCurveDefinition( caseFromSource, addressFromSource, ensemble, false ) );
                     }
                 }
             }
@@ -511,7 +512,7 @@ std::vector<RiaSummaryCurveDefinition> RiuSummaryVectorSelectionUi::selection() 
             {
                 if ( addressUnion.count( addr ) )
                 {
-                    curveDefSelection.push_back( RiaSummaryCurveDefinition( nullptr, addr, ensemble ) );
+                    curveDefSelection.push_back( RiaSummaryCurveDefinition( nullptr, addr, ensemble, true ) );
                 }
             }
         }
@@ -524,7 +525,7 @@ std::vector<RiaSummaryCurveDefinition> RiuSummaryVectorSelectionUi::selection() 
             {
                 if ( readerAddresses.count( addr ) )
                 {
-                    curveDefSelection.push_back( RiaSummaryCurveDefinition( sourceCase, addr, nullptr ) );
+                    curveDefSelection.push_back( RiaSummaryCurveDefinition( sourceCase, addr ) );
                 }
             }
         }
@@ -594,7 +595,7 @@ void RiuSummaryVectorSelectionUi::setDefaultSelection( const std::vector<Summary
             RimSummaryCase*           sumCase  = dynamic_cast<RimSummaryCase*>( s );
             RimSummaryCaseCollection* ensemble = dynamic_cast<RimSummaryCaseCollection*>( s );
 
-            RiaSummaryCurveDefinition curveDef( sumCase, defaultAddress, ensemble );
+            RiaSummaryCurveDefinition curveDef( sumCase, defaultAddress, ensemble, true );
             curveDefs.push_back( curveDef );
         }
 


### PR DESCRIPTION
* Split the RimSummaryCurveCollection::updateDerivedEnsembleCases into to methods, one that creates new derived ensemble cases and one that updates existing ones. The latter one is called when closing a case.
* Store the m_inUse-flag of the derived cases as an actual field so it gets stored and loaded in projects otherwise closed cases gets reset after save/load.
* Also always store the ensemble in the RiaSummaryCurveDefinition, but use a boolean to say if it should be treated as an individual case. Otherwise we lose information that requires much more connections in the code to restore.
* Add a signal when closing a case which we can monitor in Analysis and Correlation plots.
