### PR TITLE
Refactor signals

### DIFF
--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
@@ -202,7 +202,6 @@ RimPlotDataFilterCollection* RimAnalysisPlot::plotDataFilterCollection() const
 //--------------------------------------------------------------------------------------------------
 void RimAnalysisPlot::setCurveDefinitions( const std::vector<RiaSummaryCurveDefinition>& curveDefinitions )
 {
-    disconnectAllCaseSignals();
     m_analysisPlotDataSelection.deleteAllChildObjects();
     for ( auto curveDef : curveDefinitions )
     {
@@ -460,7 +459,6 @@ void RimAnalysisPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
         {
             std::vector<RiaSummaryCurveDefinition> summaryVectorDefinitions = dlg.curveSelection();
 
-            disconnectAllCaseSignals();
             m_analysisPlotDataSelection.deleteAllChildObjects();
             for ( const RiaSummaryCurveDefinition& vectorDef : summaryVectorDefinitions )
             {
@@ -1813,20 +1811,6 @@ void RimAnalysisPlot::connectAllCaseSignals()
         if ( dataEntry->ensemble() )
         {
             dataEntry->ensemble()->caseRemoved.connect( this, &RimAnalysisPlot::onCaseRemoved );
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimAnalysisPlot::disconnectAllCaseSignals()
-{
-    for ( auto dataEntry : m_analysisPlotDataSelection )
-    {
-        if ( dataEntry->ensemble() )
-        {
-            dataEntry->ensemble()->caseRemoved.disconnect( this );
         }
     }
 }

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.h
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.h
@@ -181,7 +181,6 @@ private:
 private:
     void onCaseRemoved( const SignalEmitter* emitter, RimSummaryCase* summaryCase );
     void connectAllCaseSignals();
-    void disconnectAllCaseSignals();
 
 private:
     std::unique_ptr<RiaSummaryCurveDefinitionAnalyser> m_analyserOfSelectedCurveDefs;

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterCollection.cpp
@@ -56,8 +56,6 @@ RimPlotDataFilterItem* RimPlotDataFilterCollection::addFilter()
 //--------------------------------------------------------------------------------------------------
 void RimPlotDataFilterCollection::removeFilter( RimPlotDataFilterItem* filter )
 {
-    filter->filterChanged.disconnect( this );
-
     m_filters.removeChildObject( filter );
     delete filter;
 

--- a/ApplicationCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
+++ b/ApplicationCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
@@ -76,7 +76,6 @@ RimAbstractCorrelationPlot::~RimAbstractCorrelationPlot()
 //--------------------------------------------------------------------------------------------------
 void RimAbstractCorrelationPlot::setCurveDefinitions( const std::vector<RiaSummaryCurveDefinition>& curveDefinitions )
 {
-    disconnectAllCaseSignals();
     m_analysisPlotDataSelection.deleteAllChildObjects();
     for ( auto curveDef : curveDefinitions )
     {
@@ -127,7 +126,6 @@ void RimAbstractCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* ch
             if ( !curveSelection.empty() )
             {
                 std::vector<RiaSummaryCurveDefinition> summaryVectorDefinitions = dlg.curveSelection();
-                disconnectAllCaseSignals();
                 m_analysisPlotDataSelection.deleteAllChildObjects();
                 for ( const RiaSummaryCurveDefinition& vectorDef : summaryVectorDefinitions )
                 {
@@ -610,20 +608,6 @@ void RimAbstractCorrelationPlot::connectAllCaseSignals()
         if ( dataEntry->ensemble() )
         {
             dataEntry->ensemble()->caseRemoved.connect( this, &RimAbstractCorrelationPlot::onCaseRemoved );
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimAbstractCorrelationPlot::disconnectAllCaseSignals()
-{
-    for ( auto dataEntry : m_analysisPlotDataSelection )
-    {
-        if ( dataEntry->ensemble() )
-        {
-            dataEntry->ensemble()->caseRemoved.disconnect( this );
         }
     }
 }

--- a/ApplicationCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
+++ b/ApplicationCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
@@ -120,7 +120,6 @@ protected:
 private:
     void onCaseRemoved( const SignalEmitter* emitter, RimSummaryCase* summaryCase );
     void connectAllCaseSignals();
-    void disconnectAllCaseSignals();
 
 protected:
     std::unique_ptr<RiaSummaryCurveDefinitionAnalyser> m_analyserOfSelectedCurveDefs;

--- a/ApplicationCode/ProjectDataModel/RimViewWindow.cpp
+++ b/ApplicationCode/ProjectDataModel/RimViewWindow.cpp
@@ -336,12 +336,12 @@ void RimViewWindow::defineObjectEditorAttribute( QString uiConfigName, caf::PdmU
     if ( treeItemAttribute && RiaApplication::instance()->preferences()->showViewIdInProjectTree() && id() >= 0 )
     {
         treeItemAttribute->tags.clear();
-        caf::PdmUiTreeViewItemAttribute::Tag tag;
-        tag.text                   = QString( "%1" ).arg( id() );
+        auto tag                   = caf::PdmUiTreeViewItemAttribute::Tag::create();
+        tag->text                  = QString( "%1" ).arg( id() );
         cvf::Color3f viewColor     = RiaColorTables::contrastCategoryPaletteColors().cycledColor3f( (size_t)id() );
         cvf::Color3f viewTextColor = RiaColorTools::contrastColor( viewColor );
-        tag.bgColor                = QColor( RiaColorTools::toQColor( viewColor ) );
-        tag.fgColor                = QColor( RiaColorTools::toQColor( viewTextColor ) );
-        treeItemAttribute->tags.push_back( tag );
+        tag->bgColor               = QColor( RiaColorTools::toQColor( viewColor ) );
+        tag->fgColor               = QColor( RiaColorTools::toQColor( viewTextColor ) );
+        treeItemAttribute->tags.push_back( std::move( tag ) );
     }
 }

--- a/ApplicationCode/ProjectDataModel/RimWellLogExtractionCurve.cpp
+++ b/ApplicationCode/ProjectDataModel/RimWellLogExtractionCurve.cpp
@@ -178,8 +178,6 @@ void RimWellLogExtractionCurve::setFromSimulationWellName( const QString& simWel
 //--------------------------------------------------------------------------------------------------
 void RimWellLogExtractionCurve::setCase( RimCase* rimCase )
 {
-    disconnectCaseSignals( m_case.value() );
-
     m_case = rimCase;
 
     connectCaseSignals( rimCase );
@@ -201,7 +199,6 @@ void RimWellLogExtractionCurve::setPropertiesFromView( Rim3dView* view )
 {
     if ( view )
     {
-        disconnectCaseSignals( m_case.value() );
         m_case = view->ownerCase();
         connectCaseSignals( m_case );
     }
@@ -1118,17 +1115,6 @@ void RimWellLogExtractionCurve::connectCaseSignals( RimCase* rimCase )
     if ( rimCase )
     {
         rimCase->settingsChanged.connect( this, &RimWellLogExtractionCurve::onCaseSettingsChanged );
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimWellLogExtractionCurve::disconnectCaseSignals( RimCase* rimCase )
-{
-    if ( rimCase != nullptr )
-    {
-        rimCase->settingsChanged.disconnect( this );
     }
 }
 

--- a/ApplicationCode/ProjectDataModel/RimWellLogExtractionCurve.h
+++ b/ApplicationCode/ProjectDataModel/RimWellLogExtractionCurve.h
@@ -98,7 +98,6 @@ protected:
     void    onLoadDataAndUpdate( bool updateParentPlot ) override;
     void    onCaseSettingsChanged( const caf::SignalEmitter* emitter );
     void    connectCaseSignals( RimCase* rimCase );
-    void    disconnectCaseSignals( RimCase* rimCase );
 
     virtual void performDataExtraction( bool* isUsingPseudoLength );
     void extractData( bool* isUsingPseudoLength, bool performDataSmoothing = false, double smoothingThreshold = -1.0 );

--- a/ApplicationCode/ProjectDataModel/RimWellLogTrack.cpp
+++ b/ApplicationCode/ProjectDataModel/RimWellLogTrack.cpp
@@ -1112,7 +1112,6 @@ void RimWellLogTrack::removeCurve( RimWellLogCurve* curve )
     {
         m_curves[index]->detachQwtCurve();
         m_curves.removeChildObject( curve );
-        disconnectCurveSignals( curve );
     }
 }
 
@@ -2043,17 +2042,6 @@ void RimWellLogTrack::connectCurveSignals( RimWellLogCurve* curve )
     curve->visibilityChanged.connect( this, &RimWellLogTrack::curveVisibilityChanged );
     curve->appearanceChanged.connect( this, &RimWellLogTrack::curveAppearanceChanged );
     curve->stackingChanged.connect( this, &RimWellLogTrack::curveStackingChanged );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimWellLogTrack::disconnectCurveSignals( RimWellLogCurve* curve )
-{
-    curve->dataChanged.disconnect( this );
-    curve->visibilityChanged.disconnect( this );
-    curve->appearanceChanged.disconnect( this );
-    curve->stackingChanged.disconnect( this );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/ProjectDataModel/RimWellLogTrack.h
+++ b/ApplicationCode/ProjectDataModel/RimWellLogTrack.h
@@ -299,7 +299,6 @@ private:
                                                                 const RigWellLogExtractor* extractor ) const;
 
     void connectCurveSignals( RimWellLogCurve* curve );
-    void disconnectCurveSignals( RimWellLogCurve* curve );
 
 private:
     QString m_xAxisTitle;

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
@@ -230,7 +230,6 @@ void RimSummaryCaseCollection::removeCase( RimSummaryCase* summaryCase )
 {
     size_t caseCountBeforeRemove = m_cases.size();
 
-    summaryCase->nameChanged.disconnect( this );
     m_cases.removeChildObject( summaryCase );
 
     m_cachedSortedEnsembleParameters.clear();

--- a/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -240,7 +240,6 @@ void RimSummaryCaseMainCollection::removeCase( RimSummaryCase* summaryCase )
         }
     }
 
-    summaryCase->nameChanged.disconnect( this );
     m_cases.removeChildObject( summaryCase );
 
     for ( RimSummaryCaseCollection* summaryCaseCollection : m_caseCollections )
@@ -307,7 +306,6 @@ RimSummaryCaseCollection*
 //--------------------------------------------------------------------------------------------------
 void RimSummaryCaseMainCollection::removeCaseCollection( RimSummaryCaseCollection* caseCollection )
 {
-    caseCollection->caseNameChanged.disconnect( this );
     m_caseCollections.removeChildObject( caseCollection );
 }
 

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp
@@ -119,8 +119,6 @@ void PdmObjectHandle::objectsWithReferringPtrFields( std::vector<PdmObjectHandle
 //--------------------------------------------------------------------------------------------------
 void PdmObjectHandle::prepareForDelete()
 {
-    this->sendDeleteSignal();
-
     m_parentField = nullptr;
 
     for ( size_t i = 0; i < m_capabilities.size(); ++i )

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp
@@ -66,7 +66,23 @@ void PdmObjectHandle::removeAsParentField( PdmFieldHandle* parentField )
 {
     CAF_ASSERT( m_parentField == parentField );
 
+    if ( parentField ) disconnectObserverFromAllSignals( parentField->ownerObject() );
+
     m_parentField = nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmObjectHandle::disconnectObserverFromAllSignals( SignalObserver* observer )
+{
+    if ( observer )
+    {
+        for ( auto emittedSignal : emittedSignals() )
+        {
+            emittedSignal->disconnect( observer );
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp
@@ -98,7 +98,11 @@ void PdmObjectHandle::addReferencingPtrField( PdmFieldHandle* fieldReferringToMe
 //--------------------------------------------------------------------------------------------------
 void PdmObjectHandle::removeReferencingPtrField( PdmFieldHandle* fieldReferringToMe )
 {
-    if ( fieldReferringToMe != nullptr ) m_referencingPtrFields.erase( fieldReferringToMe );
+    if ( fieldReferringToMe != nullptr )
+    {
+        disconnectObserverFromAllSignals( fieldReferringToMe->ownerObject() );
+        m_referencingPtrFields.erase( fieldReferringToMe );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.h
@@ -117,8 +117,10 @@ private:
     std::vector<std::pair<PdmObjectCapability*, bool>> m_capabilities;
 
     // Child/Parent Relationships
-    void            setAsParentField( PdmFieldHandle* parentField );
-    void            removeAsParentField( PdmFieldHandle* parentField );
+    void setAsParentField( PdmFieldHandle* parentField );
+    void removeAsParentField( PdmFieldHandle* parentField );
+    void disconnectObserverFromAllSignals( SignalObserver* observer );
+
     PdmFieldHandle* m_parentField;
 
     // PtrReferences

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.cpp
@@ -54,6 +54,14 @@ SignalEmitter::~SignalEmitter()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void SignalEmitter::addEmittedSignal( AbstractSignal* signalToAdd ) const
+{
+    m_signals.push_back( signalToAdd );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::list<AbstractSignal*> SignalEmitter::emittedSignals() const
 {
     return m_signals;
@@ -85,7 +93,7 @@ std::list<AbstractSignal*> SignalObserver::observedSignals() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void SignalObserver::addSignal( AbstractSignal* signalToObserve ) const
+void SignalObserver::addObservedSignal( AbstractSignal* signalToObserve ) const
 {
     m_signals.push_back( signalToObserve );
 }
@@ -93,7 +101,7 @@ void SignalObserver::addSignal( AbstractSignal* signalToObserve ) const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void SignalObserver::removeSignal( AbstractSignal* signalToRemove ) const
+void SignalObserver::removeObservedSignal( AbstractSignal* signalToRemove ) const
 {
     m_signals.remove( signalToRemove );
 }

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.cpp
@@ -40,51 +40,30 @@ using namespace caf;
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-DeleteSignal::DeleteSignal( SignalObserver* observer )
-    : m_observer( observer )
+SignalEmitter::SignalEmitter()
 {
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void DeleteSignal::disconnect( SignalObserver* observer )
+SignalEmitter::~SignalEmitter()
 {
-    // Remove the observer from the call back list
-    m_disconnectCallbacks.erase( observer );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void DeleteSignal::send()
+std::list<AbstractSignal*> SignalEmitter::emittedSignals() const
 {
-    // Make sure we swap out the disconnect signals to avoid
-    // erasing from the signal-map while looping through it.
-    std::map<SignalObserver*, DisconnectCallback> disconnectCallbacks;
-    disconnectCallbacks.swap( m_disconnectCallbacks );
-
-    for ( auto signalCallbackPair : disconnectCallbacks )
-    {
-        signalCallbackPair.second( m_observer );
-    }
+    return m_signals;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 SignalObserver::SignalObserver()
-    : beingDeleted( this )
 {
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void SignalObserver::sendDeleteSignal()
-{
-    // Make sure we
-    beingDeleted.send();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -92,5 +71,41 @@ void SignalObserver::sendDeleteSignal()
 //--------------------------------------------------------------------------------------------------
 SignalObserver::~SignalObserver()
 {
-    sendDeleteSignal();
+    disconnectAllSignals();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::list<AbstractSignal*> SignalObserver::observedSignals() const
+{
+    return m_signals;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void SignalObserver::addSignal( AbstractSignal* signalToObserve ) const
+{
+    m_signals.push_back( signalToObserve );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void SignalObserver::removeSignal( AbstractSignal* signalToRemove ) const
+{
+    m_signals.remove( signalToRemove );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void SignalObserver::disconnectAllSignals()
+{
+    auto observedSignals = m_signals;
+    for ( auto observedSignal : observedSignals )
+    {
+        observedSignal->disconnect( const_cast<SignalObserver*>( this ) );
+    }
 }

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.h
@@ -67,7 +67,7 @@ public:
     std::list<AbstractSignal*> emittedSignals() const;
 
 private:
-    std::list<AbstractSignal*> m_signals;
+    mutable std::list<AbstractSignal*> m_signals;
 };
 
 //==================================================================================================

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafSignal.h
@@ -112,30 +112,6 @@ public:
         m_emitter->addEmittedSignal( this );
     }
 
-    Signal( const Signal& rhs )
-        : m_emitter( rhs.m_emitter )
-    {
-        m_emitter->addEmittedSignal( this );
-
-        for ( auto observerCallbackPair : rhs.m_observerCallbacks )
-        {
-            connect( observerCallbackPair.first, observerCallbackPair.second.first );
-        }
-    }
-
-    Signal& operator=( const Signal& rhs )
-    {
-        m_emitter = rhs.m_emitter;
-        m_emitter->addEmittedSignal( this );
-
-        for ( auto observerCallbackPair : rhs.m_observerCallbacks )
-        {
-            connect( observerCallbackPair.first, observerCallbackPair.second.first );
-        }
-
-        return *this;
-    }
-
     virtual ~Signal()
     {
         for ( auto observerCallbackPair : m_observerCallbacks )
@@ -172,7 +148,7 @@ public:
         observer->removeObservedSignal( this );
     }
 
-    void send( Args... args )
+    void send( Args... args ) const
     {
         for ( auto observerCallbackPair : m_observerCallbacks )
         {
@@ -197,6 +173,10 @@ public:
         it->second.second = true;
     }
     size_t observerCount() const { return m_observerCallbacks.size(); }
+
+private:
+    Signal( const Signal& rhs ) = delete;
+    Signal& operator=( const Signal& rhs ) = delete;
 
 private:
     std::map<SignalObserver*, MemberCallbackAndActiveFlag> m_observerCallbacks;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.h
@@ -50,6 +50,8 @@
 #include <QTreeView>
 #include <QWidget>
 
+#include <memory>
+
 class MySortFilterProxyModel;
 
 class QGridLayout;
@@ -93,9 +95,15 @@ public:
         bool         selectedOnly;
 
         caf::Signal<size_t> clicked;
+
+        static std::unique_ptr<Tag> create() { return std::unique_ptr<Tag>( new Tag ); }
+
+    private:
+        Tag( const Tag& rhs ) = default;
+        Tag& operator         =( const Tag& rhs ) { return *this; }
     };
 
-    std::vector<Tag> tags;
+    std::vector<std::unique_ptr<Tag>> tags;
 };
 
 class PdmUiTreeViewItemDelegate : public QStyledItemDelegate
@@ -104,25 +112,25 @@ public:
     PdmUiTreeViewItemDelegate( PdmUiTreeViewEditor* parent, PdmUiTreeViewQModel* model );
     void clearTags( QModelIndex index );
     void clearAllTags();
-    void addTag( QModelIndex index, const PdmUiTreeViewItemAttribute::Tag& tag );
+    void addTag( QModelIndex index, std::unique_ptr<PdmUiTreeViewItemAttribute::Tag> tag );
     void paint( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const override;
-    std::vector<PdmUiTreeViewItemAttribute::Tag> tags( QModelIndex index ) const;
+    std::vector<const PdmUiTreeViewItemAttribute::Tag*> tags( QModelIndex index ) const;
 
 protected:
     bool  editorEvent( QEvent*                     event,
                        QAbstractItemModel*         model,
                        const QStyleOptionViewItem& option,
                        const QModelIndex&          itemIndex ) override;
-    bool  tagClicked( const QPoint&                    clickPos,
-                      const QRect&                     itemRect,
-                      const QModelIndex&               itemIndex,
-                      PdmUiTreeViewItemAttribute::Tag* tag ) const;
+    bool  tagClicked( const QPoint&                           clickPos,
+                      const QRect&                            itemRect,
+                      const QModelIndex&                      itemIndex,
+                      const PdmUiTreeViewItemAttribute::Tag** tag ) const;
     QRect tagRect( const QRect& itemRect, QModelIndex itemIndex, size_t tagIndex ) const;
 
 private:
-    PdmUiTreeViewEditor*                                                m_treeView;
-    PdmUiTreeViewQModel*                                                m_model;
-    std::map<QModelIndex, std::vector<PdmUiTreeViewItemAttribute::Tag>> m_tags;
+    PdmUiTreeViewEditor*                                                                 m_treeView;
+    PdmUiTreeViewQModel*                                                                 m_model;
+    std::map<QModelIndex, std::vector<std::unique_ptr<PdmUiTreeViewItemAttribute::Tag>>> m_tags;
 };
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Remove the DeleteSignal and instead use a list of emitted and observed signals in the Emitter and Observer respectively.
* This enables us to perform disconnections automatically when an object is removed from a field and avoid disconnections in application code.