### PR TITLE
#6526 Fracture Model: Make TVD/MD values consistent in Deviation.FRK

### DIFF
--- a/ApplicationCode/FileInterface/RifFractureModelDeviationFrkExporter.h
+++ b/ApplicationCode/FileInterface/RifFractureModelDeviationFrkExporter.h
@@ -32,6 +32,11 @@ class RifFractureModelDeviationFrkExporter
 public:
     static bool writeToFile( RimFractureModelPlot* plot, const QString& filepath );
 
+    static void fixupDepthValuesForExport( const std::vector<double>& tvdValues,
+                                           const std::vector<double>& mdValues,
+                                           std::vector<double>&       exportTvdValues,
+                                           std::vector<double>&       exportMdValues );
+
 private:
     static void appendHeaderToStream( QTextStream& stream );
     static void appendToStream( QTextStream& stream, const QString& label, const std::vector<double>& values );

--- a/ApplicationCode/UnitTests/CMakeLists_files.cmake
+++ b/ApplicationCode/UnitTests/CMakeLists_files.cmake
@@ -72,6 +72,7 @@ ${CMAKE_CURRENT_LIST_DIR}/RifRoffReader-Test.cpp
 ${CMAKE_CURRENT_LIST_DIR}/RifElasticPropertiesReader-Test.cpp
 ${CMAKE_CURRENT_LIST_DIR}/RiaStatisticsTools-Test.cpp
 ${CMAKE_CURRENT_LIST_DIR}/RifStimPlanXmlReader-Test.cpp
+${CMAKE_CURRENT_LIST_DIR}/RifFractureModelDeviationFrkExporter-Test.cpp
 )
 
 if (RESINSIGHT_ENABLE_GRPC)

--- a/ApplicationCode/UnitTests/RifFractureModelDeviationFrkExporter-Test.cpp
+++ b/ApplicationCode/UnitTests/RifFractureModelDeviationFrkExporter-Test.cpp
@@ -1,0 +1,52 @@
+#include "gtest/gtest.h"
+
+#include "RifFractureModelDeviationFrkExporter.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RifFractureModelDeviationFrkExporterTest, TvdFixup )
+{
+    std::vector<double> tvd = {
+        475.722,
+        492.126,
+        508.53,
+        524.934,
+        541.338,
+        557.743,
+        574.147,
+        590.551,
+        606.955,
+        623.359,
+        639.764,
+        656.168,
+        672.572};
+    std::vector<double> md = {
+        475.722,
+        492.126,
+        508.53,
+        524.934,
+        541.339,
+        557.743,
+        574.147,
+        590.551,
+        606.955,
+        623.36,
+        639.764,
+        656.168,
+        672.572};
+
+    std::vector<double> exportTvd;
+    std::vector<double> exportMd;
+
+    RifFractureModelDeviationFrkExporter::fixupDepthValuesForExport( tvd, md, exportTvd, exportMd );
+
+    EXPECT_EQ( tvd.size(), exportTvd.size() );
+    EXPECT_EQ( md.size(), exportMd.size() );
+
+    for ( size_t i = 1; i < exportMd.size(); i++) {
+        double changeMd = exportMd[i] - exportMd[i-1];
+        double changeTvd = exportTvd[i] - exportTvd[i-1];
+        ASSERT_GE( changeMd, changeTvd );
+    }
+}


### PR DESCRIPTION
The change in measured depth (MD) must be greater or equal to change in
true vertical depth (TVD), and this was not always the case due to
interpolation imprecision.

Closes #6526.