### PR TITLE
#6543 Remove option for absolute value filters.

### DIFF
--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
@@ -1132,8 +1132,6 @@ void RimAnalysisPlot::applyFilter( const RimPlotDataFilterItem*        filter,
                     {
                         std::pair<double, double> minMax = filter->filterRangeMinMax();
 
-                        if ( filter->useAbsoluteValues() ) value = fabs( value );
-
                         if ( minMax.first <= value && value <= minMax.second )
                         {
                             casesToKeep.insert( sumCase );
@@ -1142,7 +1140,6 @@ void RimAnalysisPlot::applyFilter( const RimPlotDataFilterItem*        filter,
                     else if ( filter->filterOperation() == RimPlotDataFilterItem::TOP_N ||
                               filter->filterOperation() == RimPlotDataFilterItem::BOTTOM_N )
                     {
-                        if ( filter->useAbsoluteValues() ) value = fabs( value );
                         bool useLargest = filter->filterOperation() == RimPlotDataFilterItem::TOP_N;
 
                         auto itIsInsertedPair = casesToKeepWithValue.insert( {sumCase, value} );
@@ -1282,8 +1279,6 @@ void RimAnalysisPlot::applyFilter( const RimPlotDataFilterItem*        filter,
                 // clang-format off
                 storeResultCoreLambda = [&]( double value ) // clang-format on
                 {
-                    if ( filter->useAbsoluteValues() ) value = fabs( value );
-
                     if ( minMax.first <= value && value <= minMax.second )
                     {
                         casesToKeep.insert( sumCaseInEvaluation );
@@ -1296,7 +1291,6 @@ void RimAnalysisPlot::applyFilter( const RimPlotDataFilterItem*        filter,
                 // clang-format off
                 storeResultCoreLambda = [&]( double value ) // clang-format on
                 {
-                    if ( filter->useAbsoluteValues() ) value = fabs( value );
                     bool useLargest = filter->filterOperation() == RimPlotDataFilterItem::TOP_N;
 
                     auto itIsInsertedPair = casesToKeepWithValue.insert( {sumCaseInEvaluation, value} );
@@ -1336,8 +1330,6 @@ void RimAnalysisPlot::applyFilter( const RimPlotDataFilterItem*        filter,
                     // clang-format off
                     storeResultCoreLambda = [&]( double value ) // clang-format on
                     {
-                        if ( filter->useAbsoluteValues() ) value = fabs( value );
-
                         if ( minMax.first <= value && value <= minMax.second )
                         {
                             sumItemsToKeep.insert( sumItem );
@@ -1350,7 +1342,6 @@ void RimAnalysisPlot::applyFilter( const RimPlotDataFilterItem*        filter,
                     // clang-format off
                     storeResultCoreLambda = [&]( double value ) // clang-format on
                     {
-                        if ( filter->useAbsoluteValues() ) value = fabs( value );
                         bool useLargest = filter->filterOperation() == RimPlotDataFilterItem::TOP_N;
 
                         auto itIsInsertedPair = sumItemsToKeepWithValue.insert( {sumItem, value} );

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterItem.cpp
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterItem.cpp
@@ -103,7 +103,6 @@ RimPlotDataFilterItem::RimPlotDataFilterItem()
     caf::PdmUiActionPushButtonEditor::configureEditorForField( &m_filterQuantitySelectButton );
 
     CAF_PDM_InitFieldNoDefault( &m_filterOperation, "FilterOperation", "is", "", "", "" );
-    CAF_PDM_InitField( &m_useAbsoluteValue, "UseAbsoluteValue", true, "using absolute values", "", "", "" );
     CAF_PDM_InitField( &m_topBottomN, "MinTopN", 20, "N", "", "", "" );
     m_topBottomN.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
 
@@ -237,10 +236,6 @@ void RimPlotDataFilterItem::fieldChangedByUi( const caf::PdmFieldHandle* changed
     {
         this->updateMaxMinAndDefaultValues( true );
     }
-    else if ( changedField == &m_useAbsoluteValue )
-    {
-        this->updateMaxMinAndDefaultValues( false );
-    }
     else if ( changedField == &m_filterOperation )
     {
         this->updateMaxMinAndDefaultValues( false );
@@ -361,15 +356,12 @@ void RimPlotDataFilterItem::defineUiOrdering( QString uiConfigName, caf::PdmUiOr
 
         if ( m_filterOperation() == RANGE )
         {
-            uiOrdering.add( &m_useAbsoluteValue, {false} );
-
             uiOrdering.add( &m_max, {true, -1, 1} );
             uiOrdering.add( &m_min, {true, -1, 1} );
         }
         else if ( m_filterOperation == TOP_N || m_filterOperation == BOTTOM_N )
         {
             uiOrdering.add( &m_topBottomN, {false} );
-            uiOrdering.add( &m_useAbsoluteValue, {true} );
         }
     }
 
@@ -432,16 +424,16 @@ void RimPlotDataFilterItem::updateMaxMinAndDefaultValues( bool forceDefault )
             if ( RiaCurveDataTools::isValidValue( eParam.minValue, false ) )
             {
                 m_lowerLimit = eParam.minValue;
-                if ( m_useAbsoluteValue ) m_lowerLimit = fabs( eParam.minValue );
             }
             if ( RiaCurveDataTools::isValidValue( eParam.maxValue, false ) )
             {
                 m_upperLimit = eParam.maxValue;
-                if ( m_useAbsoluteValue ) m_upperLimit = fabs( eParam.maxValue );
             }
 
-            // Make sure max is > min after doing abs
-            if ( m_upperLimit < m_lowerLimit ) std::swap( m_upperLimit, m_lowerLimit );
+            if ( m_upperLimit < m_lowerLimit )
+            {
+                std::swap( m_upperLimit, m_lowerLimit );
+            }
         }
     }
     else
@@ -449,7 +441,7 @@ void RimPlotDataFilterItem::updateMaxMinAndDefaultValues( bool forceDefault )
         parentPlot->maxMinValueFromAddress( m_filterQuantityUiField,
                                             m_consideredTimestepsType(),
                                             m_explicitlySelectedTimeSteps(),
-                                            m_useAbsoluteValue(),
+                                            false,
                                             &m_lowerLimit,
                                             &m_upperLimit );
     }

--- a/ApplicationCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterItem.h
+++ b/ApplicationCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterItem.h
@@ -96,7 +96,6 @@ public:
     QString ensembleParameterName() const;
 
     FilterOperation           filterOperation() const { return m_filterOperation(); }
-    bool                      useAbsoluteValues() const { return m_useAbsoluteValue(); }
     std::pair<double, double> filterRangeMinMax() const;
     int                       topBottomN() const;
 
@@ -135,7 +134,6 @@ private:
     // Operation and parameters
 
     caf::PdmField<caf::AppEnum<FilterOperation>> m_filterOperation;
-    caf::PdmField<bool>                          m_useAbsoluteValue;
     caf::PdmField<int>                           m_topBottomN;
     caf::PdmField<double>                        m_max;
     caf::PdmField<double>                        m_min;


### PR DESCRIPTION
* The concept doesn't make sense.
* A range of -1 to +1 becomes +1 to +1 (empty range)
* A range of -0.5 to +1.0 becomes +0.5 to +1.0 excluding all values from +0.0 to +0.5.