### PR TITLE
#6649 Use color legend icon in drop down list.

### DIFF
--- a/ApplicationCode/ProjectDataModel/RimFaciesProperties.cpp
+++ b/ApplicationCode/ProjectDataModel/RimFaciesProperties.cpp
@@ -19,11 +19,11 @@
 #include "RimFaciesProperties.h"
 
 #include "RimColorLegend.h"
-#include "RimColorLegendCollection.h"
 #include "RimEclipseResultDefinition.h"
 #include "RimFractureModelTemplate.h"
 #include "RimProject.h"
 #include "RimRegularLegendConfig.h"
+#include "RimTools.h"
 
 #include "RicFaciesPropertiesImportTools.h"
 
@@ -105,17 +105,7 @@ QList<caf::PdmOptionItemInfo> RimFaciesProperties::calculateValueOptions( const 
     QList<caf::PdmOptionItemInfo> options;
     if ( fieldNeedingOptions == &m_colorLegend )
     {
-        RimProject*                  project               = RimProject::current();
-        RimColorLegendCollection*    colorLegendCollection = project->colorLegendCollection();
-        std::vector<RimColorLegend*> colorLegends          = colorLegendCollection->allColorLegends();
-
-        for ( RimColorLegend* colorLegend : colorLegends )
-        {
-            options.push_back( caf::PdmOptionItemInfo( colorLegend->colorLegendName(),
-                                                       colorLegend,
-                                                       false,
-                                                       colorLegend->paletteIconProvider() ) );
-        }
+        RimTools::colorLegendOptionItems( &options );
     }
 
     return options;

--- a/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -38,6 +38,7 @@
 #include "RimIntersectionCollection.h"
 #include "RimProject.h"
 #include "RimStimPlanColors.h"
+#include "RimTools.h"
 #include "RimViewLinker.h"
 #include "RimWellMeasurementInView.h"
 #include "RimWellRftEnsembleCurveSet.h"
@@ -1153,17 +1154,7 @@ QList<caf::PdmOptionItemInfo>
     }
     else if ( fieldNeedingOptions == &m_colorLegend )
     {
-        RimProject*                  project               = RimProject::current();
-        RimColorLegendCollection*    colorLegendCollection = project->colorLegendCollection();
-        std::vector<RimColorLegend*> colorLegends          = colorLegendCollection->allColorLegends();
-
-        for ( RimColorLegend* colorLegend : colorLegends )
-        {
-            options.push_back( caf::PdmOptionItemInfo( colorLegend->colorLegendName(),
-                                                       colorLegend,
-                                                       false,
-                                                       colorLegend->paletteIconProvider() ) );
-        }
+        RimTools::colorLegendOptionItems( &options );
     }
     else if ( fieldNeedingOptions == &m_rangeMode )
     {

--- a/ApplicationCode/ProjectDataModel/RimTools.cpp
+++ b/ApplicationCode/ProjectDataModel/RimTools.cpp
@@ -21,6 +21,8 @@
 #include "RimTools.h"
 
 #include "RimCase.h"
+#include "RimColorLegend.h"
+#include "RimColorLegendCollection.h"
 #include "RimEclipseCase.h"
 #include "RimGeoMechCase.h"
 #include "RimOilField.h"
@@ -356,6 +358,25 @@ void RimTools::geoMechCaseOptionItems( QList<caf::PdmOptionItemInfo>* options )
                 options->push_back( caf::PdmOptionItemInfo( c->caseUserDescription(), c, false, c->uiIconProvider() ) );
             }
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimTools::colorLegendOptionItems( QList<caf::PdmOptionItemInfo>* options )
+{
+    CVF_ASSERT( options );
+    if ( !options ) return;
+
+    RimProject*                  project               = RimProject::current();
+    RimColorLegendCollection*    colorLegendCollection = project->colorLegendCollection();
+    std::vector<RimColorLegend*> colorLegends          = colorLegendCollection->allColorLegends();
+
+    for ( RimColorLegend* colorLegend : colorLegends )
+    {
+        options->push_back(
+            caf::PdmOptionItemInfo( colorLegend->colorLegendName(), colorLegend, false, colorLegend->paletteIconProvider() ) );
     }
 }
 

--- a/ApplicationCode/ProjectDataModel/RimTools.h
+++ b/ApplicationCode/ProjectDataModel/RimTools.h
@@ -57,6 +57,7 @@ public:
     static void                   caseOptionItems( QList<caf::PdmOptionItemInfo>* options );
     static void                   eclipseCaseOptionItems( QList<caf::PdmOptionItemInfo>* options );
     static void                   geoMechCaseOptionItems( QList<caf::PdmOptionItemInfo>* options );
+    static void                   colorLegendOptionItems( QList<caf::PdmOptionItemInfo>* options );
     static RimWellPathCollection* wellPathCollection();
 
     static void timeStepsForCase( RimCase* gridCase, QList<caf::PdmOptionItemInfo>* options );

--- a/ApplicationCode/ProjectDataModel/RimWellLogTrack.cpp
+++ b/ApplicationCode/ProjectDataModel/RimWellLogTrack.cpp
@@ -1040,14 +1040,7 @@ QList<caf::PdmOptionItemInfo> RimWellLogTrack::calculateValueOptions( const caf:
     }
     else if ( fieldNeedingOptions == &m_colorShadingLegend )
     {
-        RimProject*                  project               = RimProject::current();
-        RimColorLegendCollection*    colorLegendCollection = project->colorLegendCollection();
-        std::vector<RimColorLegend*> colorLegends          = colorLegendCollection->allColorLegends();
-
-        for ( RimColorLegend* colorLegend : colorLegends )
-        {
-            options.push_back( caf::PdmOptionItemInfo( colorLegend->colorLegendName(), colorLegend ) );
-        }
+        RimTools::colorLegendOptionItems( &options );
     }
 
     return options;


### PR DESCRIPTION
Move the generation of the options list to RimTools to avoid duplication.
This introduces color legend icons in RimWellLogTrack.

Closes #6649 