### PR TITLE
Dock Widgets : Workaround for high CPU usage 

### DIFF
--- a/ApplicationCode/UserInterface/RiuDockWidgetTools.cpp
+++ b/ApplicationCode/UserInterface/RiuDockWidgetTools.cpp
@@ -264,6 +264,50 @@ QVariant RiuDockWidgetTools::defaultDockWidgetVisibilities()
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Qwt widgets in non-visible dock widgets (tabbed dock windows) will on some systems enter an
+/// eternal update loop. This is seen on both Windows and Linux.
+/// The workaround is to hide all dock widgets, and then set visible the docking windows seen to
+/// trigger the unwanted behavior
+///
+/// https://github.com/OPM/ResInsight/issues/6743
+/// https://github.com/OPM/ResInsight/issues/6627
+//--------------------------------------------------------------------------------------------------
+void RiuDockWidgetTools::workaroundForQwtDockWidgets()
+{
+    RiuMainWindow* mainWindow = RiuMainWindow::instance();
+
+    QList<QDockWidget*> dockWidgets = mainWindow->findChildren<QDockWidget*>();
+    dockWidgets.removeAll( nullptr );
+
+    for ( QDockWidget* dock : dockWidgets )
+    {
+        dock->setVisible( false );
+    }
+    QApplication::processEvents();
+
+    {
+        auto dock = findDockWidget( mainWindow, relPermPlotName() );
+        if ( dock )
+        {
+            dock->setVisible( true );
+        }
+    }
+
+    {
+        auto dock = findDockWidget( mainWindow, pvtPlotName() );
+        if ( dock )
+        {
+            dock->setVisible( true );
+        }
+    }
+
+    QApplication::processEvents();
+
+    mainWindow->restoreDockWidgetVisibilities();
+    mainWindow->loadWinGeoAndDockToolBarLayout();
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RiuDockWidgetTools::applyDockWidgetVisibilities( const QObject*                 parent,

--- a/ApplicationCode/UserInterface/RiuDockWidgetTools.h
+++ b/ApplicationCode/UserInterface/RiuDockWidgetTools.h
@@ -55,6 +55,8 @@ public:
     static QVariant dockWidgetsVisibility( const QObject* parent );
     static QVariant defaultDockWidgetVisibilities();
 
+    static void workaroundForQwtDockWidgets();
+
     static void setVisibleDockingWindowsForEclipse();
     static void setVisibleDockingWindowsForGeoMech();
 

--- a/ApplicationCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationCode/UserInterface/RiuMainWindow.cpp
@@ -154,6 +154,11 @@ RiuMainWindow::RiuMainWindow()
     m_memoryRefreshTimer = new QTimer( this );
     connect( m_memoryRefreshTimer, SIGNAL( timeout() ), this, SLOT( updateMemoryUsage() ) );
     m_memoryRefreshTimer->start( 1000 );
+
+    auto dockTimer = new QTimer( this );
+    dockTimer->setSingleShot( true );
+    connect( dockTimer, SIGNAL( timeout() ), this, SLOT( slotWorkaroundForQwtDockWidgets() ) );
+    dockTimer->start( 1000 );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1966,6 +1971,14 @@ void RiuMainWindow::customMenuRequested( const QPoint& pos )
         QPoint globalPos = treeView->viewport()->mapToGlobal( pos );
         menu.exec( globalPos );
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMainWindow::slotWorkaroundForQwtDockWidgets()
+{
+    RiuDockWidgetTools::workaroundForQwtDockWidgets();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationCode/UserInterface/RiuMainWindow.h
+++ b/ApplicationCode/UserInterface/RiuMainWindow.h
@@ -236,6 +236,8 @@ private slots:
     void selectedObjectsChanged();
     void customMenuRequested( const QPoint& pos );
 
+    void slotWorkaroundForQwtDockWidgets();
+
 private:
     void selectViewInProjectTreePreservingSubItemSelection( const Rim3dView* previousActiveReservoirView,
                                                             Rim3dView*       activatedView );


### PR DESCRIPTION
Closes #6743 

High CPU usage is triggered when some dock widgets containing a Qwt widget are hidden below other widgets in a tabbed state. This PR will force the rendering of relperm/pvt plots at least once, and then restore the window configuration specified by the user. The drawback is a slight flicking of windows when ResInsight starts.