### PR TITLE
Move RiuQssSyntaxHighlighter.h from MOC-headers to regular headers

### DIFF
--- a/ApplicationCode/UserInterface/CMakeLists_files.cmake
+++ b/ApplicationCode/UserInterface/CMakeLists_files.cmake
@@ -94,6 +94,7 @@ ${CMAKE_CURRENT_LIST_DIR}/RiuCategoryLegendFrame.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuScalarMapperLegendFrame.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuFileDialogTools.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuGuiTheme.h
+${CMAKE_CURRENT_LIST_DIR}/RiuQssSyntaxHighlighter.h
 )
 
 set (SOURCE_GROUP_SOURCE_FILES
@@ -244,7 +245,6 @@ ${CMAKE_CURRENT_LIST_DIR}/RiuAbstractOverlayContentFrame.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuAbstractLegendFrame.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuCategoryLegendFrame.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuScalarMapperLegendFrame.h
-${CMAKE_CURRENT_LIST_DIR}/RiuQssSyntaxHighlighter.h
 ${CMAKE_CURRENT_LIST_DIR}/RiuTextEditWithCompletion.h
 )
 


### PR DESCRIPTION
Currently we get a MOC-warning because there is nothing to MOC in the header. Plus it doesn't show up in Visual Studio.