### PR TITLE
#6938 Use unscaled porosity for elastic property lookup.

### DIFF
--- a/ApplicationCode/Application/RiaStimPlanModelDefines.cpp
+++ b/ApplicationCode/Application/RiaStimPlanModelDefines.cpp
@@ -52,6 +52,7 @@ void AppEnum<RiaDefines::CurveProperty>::setUp()
              "Thermal Expansion Coefficient" );
     addItem( RiaDefines::CurveProperty::IMMOBILE_FLUID_SATURATION, "IMMOBILE_FLUID_SATURATION", "Immobile Fluid Saturation" );
     addItem( RiaDefines::CurveProperty::NET_TO_GROSS, "NET_TO_GROSS", "Net-To-Gross" );
+    addItem( RiaDefines::CurveProperty::POROSITY_UNSCALED, "POROSITY_UNSCALED", "Porosity (Unscaled)" );
 
     setDefault( RiaDefines::CurveProperty::UNDEFINED );
 }

--- a/ApplicationCode/Application/RiaStimPlanModelDefines.h
+++ b/ApplicationCode/Application/RiaStimPlanModelDefines.h
@@ -51,5 +51,6 @@ enum class CurveProperty
     THERMAL_EXPANSION_COEFFICIENT,
     IMMOBILE_FLUID_SATURATION,
     NET_TO_GROSS,
+    POROSITY_UNSCALED,
 };
 }; // namespace RiaDefines

--- a/ApplicationCode/Commands/CompletionCommands/RicNewStimPlanModelPlotFeature.cpp
+++ b/ApplicationCode/Commands/CompletionCommands/RicNewStimPlanModelPlotFeature.cpp
@@ -94,7 +94,7 @@ RimStimPlanModelPlot* RicNewStimPlanModelPlotFeature::createPlot( RimStimPlanMod
         auto task = progInfo.task( "Creating parameters track", 15 );
 
         std::map<QString, std::vector<RiaDefines::CurveProperty>> plots;
-        plots["Porosity"]     = { RiaDefines::CurveProperty::POROSITY };
+        plots["Porosity"]     = { RiaDefines::CurveProperty::POROSITY, RiaDefines::CurveProperty::POROSITY_UNSCALED };
         plots["Pressure"]     = { RiaDefines::CurveProperty::INITIAL_PRESSURE, RiaDefines::CurveProperty::PRESSURE };
         plots["Permeability"] = { RiaDefines::CurveProperty::PERMEABILITY_X, RiaDefines::CurveProperty::PERMEABILITY_Z };
         plots["Net-To-Gross"] = { RiaDefines::CurveProperty::NET_TO_GROSS };

--- a/ApplicationCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
+++ b/ApplicationCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
@@ -1036,7 +1036,8 @@ double RimStimPlanModel::defaultPermeability() const
 //--------------------------------------------------------------------------------------------------
 double RimStimPlanModel::getDefaultForMissingValue( RiaDefines::CurveProperty curveProperty ) const
 {
-    if ( curveProperty == RiaDefines::CurveProperty::POROSITY )
+    if ( curveProperty == RiaDefines::CurveProperty::POROSITY ||
+         curveProperty == RiaDefines::CurveProperty::POROSITY_UNSCALED )
     {
         return defaultPorosity();
     }
@@ -1075,7 +1076,8 @@ RiaDefines::CurveProperty RimStimPlanModel::getDefaultPropertyForMissingValues( 
 //--------------------------------------------------------------------------------------------------
 double RimStimPlanModel::getDefaultForMissingOverburdenValue( RiaDefines::CurveProperty curveProperty ) const
 {
-    if ( curveProperty == RiaDefines::CurveProperty::POROSITY )
+    if ( curveProperty == RiaDefines::CurveProperty::POROSITY ||
+         curveProperty == RiaDefines::CurveProperty::POROSITY_UNSCALED )
     {
         return defaultOverburdenPorosity();
     }
@@ -1107,7 +1109,8 @@ double RimStimPlanModel::getDefaultForMissingOverburdenValue( RiaDefines::CurveP
 //--------------------------------------------------------------------------------------------------
 double RimStimPlanModel::getDefaultForMissingUnderburdenValue( RiaDefines::CurveProperty curveProperty ) const
 {
-    if ( curveProperty == RiaDefines::CurveProperty::POROSITY )
+    if ( curveProperty == RiaDefines::CurveProperty::POROSITY ||
+         curveProperty == RiaDefines::CurveProperty::POROSITY_UNSCALED )
     {
         return defaultUnderburdenPorosity();
     }
@@ -1654,7 +1657,8 @@ QString RimStimPlanModel::eclipseResultVariable( RiaDefines::CurveProperty curve
         return "PERMX";
     else if ( curveProperty == RiaDefines::CurveProperty::PERMEABILITY_Z )
         return "PERMZ";
-    else if ( curveProperty == RiaDefines::CurveProperty::POROSITY )
+    else if ( curveProperty == RiaDefines::CurveProperty::POROSITY ||
+              curveProperty == RiaDefines::CurveProperty::POROSITY_UNSCALED )
         return "PORO";
     else if ( curveProperty == RiaDefines::CurveProperty::FACIES )
     {

--- a/ApplicationCode/ProjectDataModel/StimPlanModel/RimStimPlanModelElasticPropertyCalculator.cpp
+++ b/ApplicationCode/ProjectDataModel/StimPlanModel/RimStimPlanModelElasticPropertyCalculator.cpp
@@ -177,7 +177,7 @@ bool RimStimPlanModelElasticPropertyCalculator::calculate( RiaDefines::CurveProp
     }
 
     std::vector<double> poroValues =
-        m_stimPlanModelCalculator->extractValues( RiaDefines::CurveProperty::POROSITY, timeStep );
+        m_stimPlanModelCalculator->extractValues( RiaDefines::CurveProperty::POROSITY_UNSCALED, timeStep );
 
     double overburdenHeight = stimPlanModel->overburdenHeight();
     if ( overburdenHeight > 0.0 )

--- a/ApplicationCode/ProjectDataModel/StimPlanModel/RimStimPlanModelWellLogCalculator.cpp
+++ b/ApplicationCode/ProjectDataModel/StimPlanModel/RimStimPlanModelWellLogCalculator.cpp
@@ -57,6 +57,7 @@ bool RimStimPlanModelWellLogCalculator::isMatching( RiaDefines::CurveProperty cu
     std::vector<RiaDefines::CurveProperty> matching = {
         RiaDefines::CurveProperty::FACIES,
         RiaDefines::CurveProperty::POROSITY,
+        RiaDefines::CurveProperty::POROSITY_UNSCALED,
         RiaDefines::CurveProperty::PERMEABILITY_X,
         RiaDefines::CurveProperty::PERMEABILITY_Z,
         RiaDefines::CurveProperty::INITIAL_PRESSURE,


### PR DESCRIPTION
The elastic properties are already scaled by net-to-gross. Scaling the porosity
by net-to-gross before looking up the properties was applying the scaling twice.

Closes #6938.