### PR TITLE
dev : Update ResInsightWithCache.yml

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -100,7 +100,7 @@ jobs:
         run: New-Item ${{ env.BUILDCACHE_DIR }} -ItemType "directory" -Force 
         shell: pwsh
       - name: Add buildcache to system path
-        run: echo "::add-path::${{ github.workspace }}/bin"
+        run: echo ${{github.workspace}}/bin >> $GITHUB_PATH
 
       - name: Cache Qt        
         id: cache-qt

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -101,7 +101,8 @@ jobs:
         shell: pwsh
       - name: Add buildcache to system path
         run: echo "${{github.workspace}}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-
+        shell: pwsh
+        
       - name: Cache Qt        
         id: cache-qt
         uses: actions/cache@v2

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -100,7 +100,7 @@ jobs:
         run: New-Item ${{ env.BUILDCACHE_DIR }} -ItemType "directory" -Force 
         shell: pwsh
       - name: Add buildcache to system path
-        run: echo "${{github.workspace}}/bin" >> $GITHUB_PATH
+        run: echo "${{github.workspace}}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
 
       - name: Cache Qt        
         id: cache-qt

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -100,7 +100,7 @@ jobs:
         run: New-Item ${{ env.BUILDCACHE_DIR }} -ItemType "directory" -Force 
         shell: pwsh
       - name: Add buildcache to system path
-        run: echo ${{github.workspace}}/bin >> $GITHUB_PATH
+        run: echo "${{github.workspace}}/bin" >> $GITHUB_PATH
 
       - name: Cache Qt        
         id: cache-qt


### PR DESCRIPTION
Replace use of add-path 

Output from gha
The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/