### PR TITLE
Patch OPM-Common To Support VS 15 (2017)

### DIFF
--- a/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cctype>
 #include <iomanip>
 #include <iostream>
 #include <iterator>

--- a/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <cctype>
 #include <climits>
 #include <iostream>
 #include <iterator>

--- a/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <cstdlib>
 #include <stdexcept>

--- a/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
+++ b/ThirdParty/custom-opm-common/opm-common/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
@@ -15,6 +15,8 @@
   You should have received a copy of the GNU General Public License along with
   OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include <cctype>
 #include <chrono>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>


### PR DESCRIPTION
Include <cctype> to bring declarations of std::toupper() &c into
scope.  With this patch the application builds on VS 15 (2017)
using MSVC 19.16.27044 on Windows 10 1909.
