### PR TITLE
#7072 Warn when geological frk export produces NaN or inf.

### DIFF
--- a/ApplicationCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp
+++ b/ApplicationCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp
@@ -137,6 +137,7 @@ bool RifStimPlanModelGeologicalFrkExporter::writeToFile( RimStimPlanModel* stimP
 
     for ( QString label : labels )
     {
+        warnOnInvalidData( label, values[label] );
         appendToStream( stream, label, values[label] );
     }
 
@@ -209,4 +210,31 @@ void RifStimPlanModelGeologicalFrkExporter::fixupStressGradients( std::vector<do
             stressGradients[i] = defaultStressGradient;
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifStimPlanModelGeologicalFrkExporter::warnOnInvalidData( const QString& label, const std::vector<double>& values )
+{
+    bool isInvalid = hasInvalidData( values );
+    if ( isInvalid )
+    {
+        RiaLogging::warning( QString( "Found invalid data in Geological.FRK export of property '%1'." ).arg( label ) );
+    }
+
+    return isInvalid;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifStimPlanModelGeologicalFrkExporter::hasInvalidData( const std::vector<double>& values )
+{
+    for ( auto v : values )
+    {
+        if ( std::isinf( v ) || std::isnan( v ) ) return true;
+    }
+
+    return false;
 }

--- a/ApplicationCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.h
+++ b/ApplicationCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.h
@@ -46,4 +46,7 @@ private:
                                       double               minStressGradient,
                                       double               maxStressGradient,
                                       double               defaultStressGradient );
+
+    static bool warnOnInvalidData( const QString& label, const std::vector<double>& values );
+    static bool hasInvalidData( const std::vector<double>& values );
 };

--- a/ApplicationCode/ReservoirDataModel/RigElasticProperties.cpp
+++ b/ApplicationCode/ReservoirDataModel/RigElasticProperties.cpp
@@ -67,6 +67,24 @@ const std::vector<double>& RigElasticProperties::porosity() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+double RigElasticProperties::porosityMin() const
+{
+    if ( m_porosity.empty() ) return 0.0;
+    return m_porosity[0];
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RigElasticProperties::porosityMax() const
+{
+    if ( m_porosity.empty() ) return 0.0;
+    return m_porosity[m_porosity.size() - 1];
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RigElasticProperties::appendValues( double porosity,
                                          double youngsModulus,
                                          double poissonsRatio,

--- a/ApplicationCode/ReservoirDataModel/RigElasticProperties.h
+++ b/ApplicationCode/ReservoirDataModel/RigElasticProperties.h
@@ -35,22 +35,24 @@ public:
     const QString& formationName() const;
     const QString& faciesName() const;
 
-    void   appendValues( double porosity,
-                         double youngsModulus,
-                         double poissonsRatio,
-                         double m_K_Ic,
-                         double proppantEmbedment,
-                         double biotCoefficient,
-                         double k0,
-                         double fluidLossCoefficient,
-                         double spurtLoss,
-                         double immobileFluidSaturation );
+    void appendValues( double porosity,
+                       double youngsModulus,
+                       double poissonsRatio,
+                       double m_K_Ic,
+                       double proppantEmbedment,
+                       double biotCoefficient,
+                       double k0,
+                       double fluidLossCoefficient,
+                       double spurtLoss,
+                       double immobileFluidSaturation );
 
     size_t numValues() const;
     double getValue( RiaDefines::CurveProperty property, size_t index, double scale = 1.0 ) const;
     double getValueForPorosity( RiaDefines::CurveProperty property, double porosity, double scale = 1.0 ) const;
 
     const std::vector<double>& porosity() const;
+    double                     porosityMin() const;
+    double                     porosityMax() const;
 
 private:
     const std::vector<double>& getVector( RiaDefines::CurveProperty property ) const;


### PR DESCRIPTION
This can happen when the elastic properties are not defined for the
entire range of porosity in the grid.

Closes #7072.