### PR TITLE
Minor improvements patch

### DIFF
--- a/ApplicationCode/GrpcInterface/Python/rips/PythonExamples/launch_load_case_snapshot_exit.py
+++ b/ApplicationCode/GrpcInterface/Python/rips/PythonExamples/launch_load_case_snapshot_exit.py
@@ -1,0 +1,38 @@
+# Access to environment variables
+import os
+# Load ResInsight Processing Server Client Library
+import rips
+# Connect to ResInsight instance
+resinsight = rips.Instance.launch()
+
+# This requires the TestModels to be installed with ResInsight (RESINSIGHT_BUNDLE_TESTMODELS):
+resinsight_exe_path = os.environ.get('RESINSIGHT_EXECUTABLE')
+
+# Get the TestModels path from the executable path
+resinsight_install_path = os.path.dirname(resinsight_exe_path)
+test_models_path = os.path.join(resinsight_install_path, 'TestModels')
+path_name = os.path.join(test_models_path, 'TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID')
+
+# Load an example case. Needs to be replaced with a valid path!
+case = resinsight.project.load_case(path_name)
+
+# Get a view
+view1 = case.views()[0]
+
+# Set the time step for view1 only
+view1.set_time_step(time_step=2)
+
+# Set cell result to SOIL
+view1.apply_cell_result(result_type='DYNAMIC_NATIVE', result_variable='SOIL')
+
+# Set export folder for snapshots and properties
+resinsight.set_export_folder(export_type='SNAPSHOTS', path="e:/temp")
+resinsight.set_export_folder(export_type='PROPERTIES', path="e:/temp")
+
+# Export all snapshots
+resinsight.project.export_snapshots()
+
+# Export properties in the view
+view1.export_property()
+
+resinsight.exit()

--- a/ApplicationCode/GrpcInterface/Python/rips/PythonExamples/load_case.py
+++ b/ApplicationCode/GrpcInterface/Python/rips/PythonExamples/load_case.py
@@ -1,11 +1,18 @@
+# Access to environment variables and path tools
+import os
 # Load ResInsight Processing Server Client Library
 import rips
 # Connect to ResInsight instance
 resinsight = rips.Instance.find()
 
-# Load an example case. Needs to be replaced with a valid path!
-case = resinsight.project.load_case(
-    "C:/Users/lindk/Projects/ResInsight/TestModels/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID")
+# This requires the TestModels to be installed with ResInsight (RESINSIGHT_BUNDLE_TESTMODELS):
+resinsight_exe_path = os.environ.get('RESINSIGHT_EXECUTABLE')
+
+# Get the TestModels path from the executable path
+resinsight_install_path = os.path.dirname(resinsight_exe_path)
+test_models_path = os.path.join(resinsight_install_path, 'TestModels')
+path_name = os.path.join(test_models_path, 'TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID')
+case = resinsight.project.load_case(path_name)
 
 # Print out lots of information from the case object
 print("Case id: " + str(case.id))

--- a/ApplicationCode/GrpcInterface/Python/rips/PythonExamples/open_project.py
+++ b/ApplicationCode/GrpcInterface/Python/rips/PythonExamples/open_project.py
@@ -1,8 +1,17 @@
+# Access to environment variables and path tools
+import os
 # Load ResInsight Processing Server Client Library
 import rips
 # Connect to ResInsight instance
 resinsight = rips.Instance.find()
 
+# This requires the TestModels to be installed with ResInsight (RESINSIGHT_BUNDLE_TESTMODELS):
+resinsight_exe_path = os.environ.get('RESINSIGHT_EXECUTABLE')
+
+# Get the TestModels path from the executable path
+resinsight_install_path = os.path.dirname(resinsight_exe_path)
+test_models_path = os.path.join(resinsight_install_path, 'TestModels')
+path_name = os.path.join(test_models_path, 'TEST10K_FLT_LGR_NNC/10KWithWellLog.rsp')
+
 # Open a project
-resinsight.project.open(
-    "C:/Users/lindk/Projects/ResInsight/TestModels/TEST10K_FLT_LGR_NNC/10KWithWellLog.rsp")
+resinsight.project.open(path_name)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ SET(BUILD_SHARED_LIBS OFF CACHE BOOL "ERT: Build shared libraries")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-option(RESINSIGHT_BUNDLE_TESTMODELS "Copy TestModels into the installation" ON)
+option(RESINSIGHT_BUNDLE_TESTMODELS "Copy TestModels into the installation" OFF)
 
 # Use CMake to enforce C++11 when using CMake 3 or newer.
 # The check can be removed when the minimum version is 3.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ SET(BUILD_SHARED_LIBS OFF CACHE BOOL "ERT: Build shared libraries")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+option(RESINSIGHT_BUNDLE_TESTMODELS "Copy TestModels into the installation" ON)
+
 # Use CMake to enforce C++11 when using CMake 3 or newer.
 # The check can be removed when the minimum version is 3.
 if( (${CMAKE_MAJOR_VERSION} GREATER 3) OR (${CMAKE_MAJOR_VERSION} EQUAL 3))
@@ -524,6 +526,9 @@ if (RESINSIGHT_HDF5_BUNDLE_LIBRARIES)
     endif()
 endif (RESINSIGHT_HDF5_BUNDLE_LIBRARIES)
 
+if (RESINSIGHT_BUNDLE_TESTMODELS)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/TestModels DESTINATION ${RESINSIGHT_INSTALL_FOLDER})
+endif()
 
 ################################################################################
 # Application 


### PR DESCRIPTION
Add another example and optionally copy test models in the install stage. This ensures that the test models are present and the example can be run without changing paths