### PR TITLE
#7207 Fix flow diagnostics cell color when property filtering.

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.cpp
@@ -241,7 +241,8 @@ void RimEclipseContourMapView::updateGeometry()
 {
     caf::ProgressInfo progress( 100, "Generate Contour Map", true );
 
-    this->updateVisibleGeometriesAndCellColors();
+    updateVisibleGeometries();
+    updateVisibleCellColors();
 
     { // Step 1: generate results and some minor updates. About 30% of the time.
         if ( m_contourMapProjection->isChecked() )

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
@@ -162,7 +162,9 @@ protected:
 
     bool isShowingActiveCellsOnly() override;
     void onUpdateDisplayModelForCurrentTimeStep() override;
-    void updateVisibleGeometriesAndCellColors();
+    void updateVisibleCellColors();
+    void updateVisibleGeometries();
+
     void appendWellsAndFracturesToModel();
     void appendElementVectorResultToModel();
 


### PR DESCRIPTION
Split RimEclipseView::updateVisibleGeometriesAndCellColors() into two methods,
and make sure the visible geometries are recreated before updating the legends.

Closes #7207.