### PR TITLE
#7283 Fix crash on exit on centos 7.

### DIFF
--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -1619,6 +1619,9 @@ void RiaGuiApplication::slotWorkerProcessFinished( int exitCode, QProcess::ExitS
 //--------------------------------------------------------------------------------------------------
 void RiaGuiApplication::onLastWindowClosed()
 {
+    // Qt can send the lastWindowClosed signal multiple times. Disconnect to avoid reentry.
+    QObject::disconnect( this, SIGNAL( lastWindowClosed() ), this, SLOT( onLastWindowClosed() ) );
+
     closeProject();
     quit();
 }


### PR DESCRIPTION
Occasionally QGuiApplication::lastWindowClosed() signal could be sent
more than once.

Closes #7283.