### PR TITLE
#6877 Fix backwards compatibility for well path/fracture intersection…

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.cpp
@@ -918,3 +918,22 @@ const RigFractureGrid* RimFracture::fractureGrid() const
 {
     return m_fractureGrid.p();
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimFracture::initAfterRead()
+{
+    if ( RimProject::current()->isProjectFileVersionEqualOrOlderThan( "2020.10.2" ) )
+    {
+        if ( m_fractureTemplate() )
+        {
+            RimStimPlanFractureTemplate* stimPlanFracTemplate =
+                dynamic_cast<RimStimPlanFractureTemplate*>( m_fractureTemplate() );
+            if ( stimPlanFracTemplate )
+            {
+                m_wellPathDepthAtFracture = stimPlanFracTemplate->wellPathDepthAtFracture();
+            }
+        }
+    }
+}

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.h
@@ -143,6 +143,7 @@ protected:
     void                          defineEditorAttribute( const caf::PdmFieldHandle* field,
                                                          QString                    uiConfigName,
                                                          caf::PdmUiEditorAttribute* attribute ) override;
+    void                          initAfterRead();
 
 private:
     cvf::Vec3d fracturePositionForUi() const;


### PR DESCRIPTION
… depth.

The value needs to be copied from the template to the fracture instance for old
projects. This fixes assert seen in regression tests.