### PR TITLE
Property Editor : Check if current field is part of selection

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.h
@@ -36,6 +36,9 @@
 
 #pragma once
 
+#include <typeinfo>
+#include <vector>
+
 class QVariant;
 class QMenu;
 class QString;
@@ -58,6 +61,10 @@ public:
     void setUiValueToField( PdmUiFieldHandle* uiFieldHandle, const QVariant& newUiValue );
     void setCurrentContextMenuTargetWidget( QWidget* targetWidget );
     void populateMenuWithDefaultCommands( const QString& uiConfigName, QMenu* menu );
+
+private:
+    static std::vector<PdmFieldHandle*> fieldsFromSelection( const std::type_info& fieldOwnerTypeId,
+                                                             const QString&        fieldKeyword );
 
 private:
     PdmUiCommandSystemInterface* m_commandInterface;


### PR DESCRIPTION
Improvement of #7347 

When using toggle buttons in tree view, the current field changed might be outside of the current selection. Only apply multiple field changed if current field is part of the current selection.