### PR TITLE
Janitor : Hide loading of date for one time step from public API

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapProjection.cpp
@@ -203,15 +203,13 @@ std::vector<double> RimEclipseContourMapProjection::generateResults( int timeSte
                     RigEclipseResultAddress( RiaDefines::ResultCatType::STATIC_NATIVE, "DZ" ) );
                 if ( m_resultAggregation == RESULTS_OIL_COLUMN || m_resultAggregation == RESULTS_HC_COLUMN )
                 {
-                    resultData->ensureKnownResultLoadedForTimeStep( RigEclipseResultAddress( RiaDefines::ResultCatType::DYNAMIC_NATIVE,
-                                                                                             "SOIL" ),
-                                                                    timeStep );
+                    resultData->ensureKnownResultLoaded(
+                        RigEclipseResultAddress( RiaDefines::ResultCatType::DYNAMIC_NATIVE, "SOIL" ) );
                 }
                 if ( m_resultAggregation == RESULTS_GAS_COLUMN || m_resultAggregation == RESULTS_HC_COLUMN )
                 {
-                    resultData->ensureKnownResultLoadedForTimeStep( RigEclipseResultAddress( RiaDefines::ResultCatType::DYNAMIC_NATIVE,
-                                                                                             "SGAS" ),
-                                                                    timeStep );
+                    resultData->ensureKnownResultLoaded(
+                        RigEclipseResultAddress( RiaDefines::ResultCatType::DYNAMIC_NATIVE, "SGAS" ) );
                 }
                 gridResultValues = calculateColumnResult( m_resultAggregation() );
             }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
@@ -190,9 +190,11 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
                     RimEclipseCase* sourceCase = m_sourceCases.at( caseIdx );
 
                     // Trigger loading of dataset
+                    // NB! Many other functions are based on loading of all time steps at the same time
+                    // Use this concept carefully
                     sourceCase->results( poroModel )
-                        ->ensureKnownResultLoadedForTimeStep( RigEclipseResultAddress( resultType, resultName ),
-                                                              dataAccessTimeStepIndex );
+                        ->findOrLoadKnownScalarResultForTimeStep( RigEclipseResultAddress( resultType, resultName ),
+                                                                  dataAccessTimeStepIndex );
 
                     cvf::ref<RigResultAccessor> resultAccessor =
                         RigResultAccessorFactory::createFromResultAddress( sourceCase->eclipseCaseData(),

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1187,17 +1187,6 @@ void RigCaseCellResultsData::createResultEntry( const RigEclipseResultAddress& r
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigCaseCellResultsData::ensureKnownResultLoadedForTimeStep( const RigEclipseResultAddress& resultAddress,
-                                                                 size_t                         timeStepIndex )
-{
-    CAF_ASSERT( resultAddress.resultCatType() != RiaDefines::ResultCatType::UNDEFINED );
-
-    findOrLoadKnownScalarResultForTimeStep( resultAddress, timeStepIndex );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 size_t RigCaseCellResultsData::findOrLoadKnownScalarResult( const RigEclipseResultAddress& resVarAddr )
 {
     if ( !resVarAddr.isValid() )

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
@@ -127,7 +127,6 @@ public:
     bool    updateResultName( RiaDefines::ResultCatType resultType, const QString& oldName, const QString& newName );
     QString makeResultNameUnique( const QString& resultNameProposal ) const;
 
-    void ensureKnownResultLoadedForTimeStep( const RigEclipseResultAddress& resultAddress, size_t timeStepIndex );
     bool ensureKnownResultLoaded( const RigEclipseResultAddress& resultAddress );
 
     bool findAndLoadResultByName( const QString&                                resultName,
@@ -150,7 +149,11 @@ private:
     size_t findOrLoadKnownScalarResultByResultTypeOrder( const RigEclipseResultAddress&                resVarAddr,
                                                          const std::vector<RiaDefines::ResultCatType>& resultCategorySearchOrder );
 
+    // Add a friend class, as this way of loading data requires careful management of state
+    // All other data access assumes all time steps are loaded at the same time
+    friend class RimEclipseStatisticsCaseEvaluator;
     size_t findOrLoadKnownScalarResultForTimeStep( const RigEclipseResultAddress& resVarAddr, size_t timeStepIndex );
+
     size_t findOrCreateScalarResultIndex( const RigEclipseResultAddress& resVarAddr, bool needsToBeStored );
 
     size_t findScalarResultIndexFromAddress( const RigEclipseResultAddress& resVarAddr ) const;


### PR DESCRIPTION
ResInsight assumes that loading of data is done for all time steps at a time. Special handling of data loading is required for statistics calculations. Make statistical class a friend to be able to do this operation.