### PR TITLE
Fixes issue #7623: ‘size_t’ does not name a type

### DIFF
--- a/Fwk/AppFwk/CommonCode/cafVecIjk.h
+++ b/Fwk/AppFwk/CommonCode/cafVecIjk.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 
 namespace caf
 {


### PR DESCRIPTION
Closes #7623