### PR TITLE
Add a summary file reader able to manage multiple restart history files

### DIFF
--- a/ApplicationLibCode/Commands/CMakeLists.txt
+++ b/ApplicationLibCode/Commands/CMakeLists.txt
@@ -63,6 +63,36 @@ target_include_directories(
          ${CMAKE_SOURCE_DIR}/ThirdParty/custom-opm-common/generated-opm-common
          ${CMAKE_SOURCE_DIR}/ThirdParty/custom-opm-common/opm-common)
 
+if(MSVC)
+  # The following warnings are supposed to be used in ResInsight, but
+  # temporarily disabled to avoid too much noise warning C4245: 'return':
+  # conversion from 'int' to 'size_t', signed/unsigned mismatch warning C4005:
+  # Macro redefinition for math constants (M_PI, M_SQRT2 etc)
+
+  # If possible, the following command is supposed to be the final target
+  # set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/W3 /wd4190
+  # /wd4100 /wd4127")
+
+  set(BUILD_FLAGS_FOR_MSVC "/wd4190 /wd4100 /wd4127 /wd4245 /wd4005")
+
+  if(Qt5Core_VERSION_STRING GREATER_EQUAL 5.10)
+    # Disable warning for deprecated functions in newer versions of Qt
+    # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-160
+    set(BUILD_FLAGS_FOR_MSVC "${BUILD_FLAGS_FOR_MSVC} /wd4996")
+  endif()
+
+  if(CMAKE_CXX_COMPILER_VERSION LESS_EQUAL 19.14)
+    # The following warning is generated over 800 times from a qwt header only
+    # using VS2015 Disabling temporarily warning C4505 'function' : unreferenced
+    # local function has been removed
+    set(BUILD_FLAGS_FOR_MSVC "${BUILD_FLAGS_FOR_MSVC} /wd4505")
+  endif()
+
+  set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS
+                                                   ${BUILD_FLAGS_FOR_MSVC})
+
+endif()
+
 set(LINK_LIBRARIES
     LibCore
     cafCommand

--- a/ApplicationLibCode/Commands/FlowCommands/RicPlotProductionRateFeature.cpp
+++ b/ApplicationLibCode/Commands/FlowCommands/RicPlotProductionRateFeature.cpp
@@ -22,7 +22,7 @@
 #include "RiaPreferences.h"
 
 #include "RifEclipseSummaryAddress.h"
-#include "RifReaderEclipseSummary.h"
+#include "RifSummaryReaderInterface.h"
 
 #include "RigSimWellData.h"
 

--- a/ApplicationLibCode/Commands/RicSummaryCaseRestartDialog.cpp
+++ b/ApplicationLibCode/Commands/RicSummaryCaseRestartDialog.cpp
@@ -27,7 +27,6 @@
 #include "RiaQDateTimeTools.h"
 
 #include "RifEclipseSummaryTools.h"
-#include "RifReaderEclipseSummary.h"
 
 #include "Rim3dOverlayInfoConfig.h"
 #include "RimEclipseView.h"

--- a/ApplicationLibCode/Commands/RicSummaryCaseRestartDialog.h
+++ b/ApplicationLibCode/Commands/RicSummaryCaseRestartDialog.h
@@ -20,7 +20,7 @@
 
 #include "Rim3dOverlayInfoConfig.h"
 
-#include "RifReaderEclipseSummary.h"
+#include "RifEclipseSummaryTools.h"
 
 #include "cafPdmPointer.h"
 
@@ -81,14 +81,13 @@ public:
     bool          okToAllSelected() const;
 
 private:
-    void               updateFileListWidget( QGridLayout* gridLayout, int listIndex );
-    void               appendFileInfoToGridLayout( QGridLayout*              gridLayout,
-                                                   const RifRestartFileInfo& fileInfo,
-                                                   const QString&            fullPathFileName );
-    void               appendTextToGridLayout( QGridLayout* gridLayout, const QString& text );
-    RifRestartFileInfo getFileInfo( const QString& summaryHeaderFile );
-    void               displayWarningsIfAny( const QStringList& warnings );
-    QString            fullFileName( const QString& shortOrFullFileName );
+    void    updateFileListWidget( QGridLayout* gridLayout, int listIndex );
+    void    appendFileInfoToGridLayout( QGridLayout*              gridLayout,
+                                        const RifRestartFileInfo& fileInfo,
+                                        const QString&            fullPathFileName );
+    void    appendTextToGridLayout( QGridLayout* gridLayout, const QString& text );
+    void    displayWarningsIfAny( const std::vector<QString>& warnings );
+    QString fullFileName( const QString& shortOrFullFileName );
 
 private slots:
     void slotShowFullPathToggled( int state );

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorDialog.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorDialog.cpp
@@ -23,8 +23,6 @@
 #include "RicSummaryPlotEditorUi.h"
 #include "RicSummaryPlotEditorWidgetCreator.h"
 
-#include "RifReaderEclipseSummary.h"
-
 #include "RiuPlotMainWindow.h"
 #include "RiuTools.h"
 

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
@@ -26,8 +26,6 @@
 #include "RicSelectSummaryPlotUI.h"
 #include "RiuSummaryCurveDefinitionKeywords.h"
 
-#include "RifReaderEclipseSummary.h"
-
 #include "RimDerivedEnsembleCaseCollection.h"
 #include "RimEnsembleCurveSet.h"
 #include "RimEnsembleCurveSetCollection.h"

--- a/ApplicationLibCode/FileInterface/CMakeLists_files.cmake
+++ b/ApplicationLibCode/FileInterface/CMakeLists_files.cmake
@@ -62,6 +62,8 @@ ${CMAKE_CURRENT_LIST_DIR}/RifStimPlanModelAsymmetricFrkExporter.h
 ${CMAKE_CURRENT_LIST_DIR}/RifSurfaceExporter.h
 ${CMAKE_CURRENT_LIST_DIR}/RifOpmCommonSummary.h
 ${CMAKE_CURRENT_LIST_DIR}/RifEnsembleFractureStatisticsExporter.h
+${CMAKE_CURRENT_LIST_DIR}/RifSummaryReaderMultipleFiles.h
+${CMAKE_CURRENT_LIST_DIR}/RifEclEclipseSummary.h
 
 # HDF5 file reader is directly included in ResInsight main CmakeList.txt
 #${CMAKE_CURRENT_LIST_DIR}/RifHdf5Reader.h
@@ -128,6 +130,8 @@ ${CMAKE_CURRENT_LIST_DIR}/RifStimPlanModelAsymmetricFrkExporter.cpp
 ${CMAKE_CURRENT_LIST_DIR}/RifSurfaceExporter.cpp
 ${CMAKE_CURRENT_LIST_DIR}/RifOpmCommonSummary.cpp
 ${CMAKE_CURRENT_LIST_DIR}/RifEnsembleFractureStatisticsExporter.cpp
+${CMAKE_CURRENT_LIST_DIR}/RifSummaryReaderMultipleFiles.cpp
+${CMAKE_CURRENT_LIST_DIR}/RifEclEclipseSummary.cpp
 
 # HDF5 file reader is directly included in ResInsight main CmakeList.txt
 #${CMAKE_CURRENT_LIST_DIR}/RifHdf5Reader.cpp

--- a/ApplicationLibCode/FileInterface/RifEclEclipseSummary.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclEclipseSummary.cpp
@@ -1,0 +1,354 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) Statoil ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RifEclEclipseSummary.h"
+
+#include "RiaFilePathTools.h"
+#include "RiaLogging.h"
+#include "RiaPreferences.h"
+#include "RiaPreferencesSummary.h"
+#include "RiaStdStringTools.h"
+#include "RiaStringEncodingTools.h"
+
+#include "RifEclipseSummaryTools.h"
+#include "RifOpmCommonSummary.h"
+#include "RifReaderEclipseOutput.h"
+
+#include <cassert>
+#include <string>
+
+#include <QDateTime>
+#include <QDir>
+#include <QString>
+#include <QStringList>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RifEclEclipseSummary::RifEclEclipseSummary()
+    : m_ecl_sum( nullptr )
+    , m_ecl_SmSpec( nullptr )
+    , m_unitSystem( RiaDefines::EclipseUnitSystem::UNITS_METRIC )
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RifEclEclipseSummary::~RifEclEclipseSummary()
+{
+    if ( m_ecl_sum )
+    {
+        RifEclipseSummaryTools::closeEclSum( m_ecl_sum );
+
+        m_ecl_sum = nullptr;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifEclEclipseSummary::open( const QString& headerFileName, RiaThreadSafeLogger* threadSafeLogger )
+{
+    assert( m_ecl_sum == nullptr );
+
+    m_ecl_sum = RifEclipseSummaryTools::openEclSum( headerFileName, false );
+    if ( m_ecl_sum )
+    {
+        m_timeSteps.clear();
+        m_ecl_SmSpec = ecl_sum_get_smspec( m_ecl_sum );
+        m_timeSteps  = RifEclipseSummaryTools::getTimeSteps( m_ecl_sum );
+        m_unitSystem = RifEclipseSummaryTools::readUnitSystem( m_ecl_sum );
+    }
+
+    buildMetaData();
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::string stringFromPointer( const char* pointerToChar )
+{
+    std::string myString;
+
+    // NB! Assigning a null pointer to a std::string causes runtime crash
+    if ( pointerToChar )
+    {
+        myString = pointerToChar;
+
+        replace( myString.begin(), myString.end(), '\t', ' ' );
+    }
+
+    return myString;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RifEclipseSummaryAddress addressFromErtSmSpecNode( const ecl::smspec_node& ertSumVarNode )
+{
+    if ( ertSumVarNode.get_var_type() == ECL_SMSPEC_INVALID_VAR )
+    {
+        return RifEclipseSummaryAddress();
+    }
+
+    RifEclipseSummaryAddress::SummaryVarCategory sumCategory( RifEclipseSummaryAddress::SUMMARY_INVALID );
+    std::string                                  quantityName;
+    int                                          regionNumber( -1 );
+    int                                          regionNumber2( -1 );
+    std::string                                  wellGroupName;
+    std::string                                  wellName;
+    int                                          wellSegmentNumber( -1 );
+    std::string                                  lgrName;
+    int                                          cellI( -1 );
+    int                                          cellJ( -1 );
+    int                                          cellK( -1 );
+    int                                          aquiferNumber( -1 );
+    bool                                         isErrorResult( false );
+    int                                          id( -1 );
+
+    quantityName = stringFromPointer( ertSumVarNode.get_keyword() );
+
+    switch ( ertSumVarNode.get_var_type() )
+    {
+        case ECL_SMSPEC_AQUIFER_VAR:
+        {
+            sumCategory   = RifEclipseSummaryAddress::SUMMARY_AQUIFER;
+            aquiferNumber = ertSumVarNode.get_num();
+        }
+        break;
+        case ECL_SMSPEC_WELL_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL;
+            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
+        }
+        break;
+        case ECL_SMSPEC_REGION_VAR:
+        {
+            sumCategory  = RifEclipseSummaryAddress::SUMMARY_REGION;
+            regionNumber = ertSumVarNode.get_num();
+        }
+        break;
+        case ECL_SMSPEC_FIELD_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_FIELD;
+        }
+        break;
+        case ECL_SMSPEC_GROUP_VAR:
+        {
+            sumCategory   = RifEclipseSummaryAddress::SUMMARY_WELL_GROUP;
+            wellGroupName = stringFromPointer( ertSumVarNode.get_wgname() );
+        }
+        break;
+        case ECL_SMSPEC_BLOCK_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_BLOCK;
+
+            auto ijk = ertSumVarNode.get_ijk();
+            cellI    = ijk[0];
+            cellJ    = ijk[1];
+            cellK    = ijk[2];
+        }
+        break;
+        case ECL_SMSPEC_COMPLETION_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL_COMPLETION;
+            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
+
+            auto ijk = ertSumVarNode.get_ijk();
+            cellI    = ijk[0];
+            cellJ    = ijk[1];
+            cellK    = ijk[2];
+        }
+        break;
+        case ECL_SMSPEC_LOCAL_BLOCK_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_BLOCK_LGR;
+            lgrName     = stringFromPointer( ertSumVarNode.get_lgr_name() );
+
+            auto ijk = ertSumVarNode.get_lgr_ijk();
+            cellI    = ijk[0];
+            cellJ    = ijk[1];
+            cellK    = ijk[2];
+        }
+        break;
+        case ECL_SMSPEC_LOCAL_COMPLETION_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL_COMPLETION_LGR;
+            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
+            lgrName     = stringFromPointer( ertSumVarNode.get_lgr_name() );
+
+            auto ijk = ertSumVarNode.get_lgr_ijk();
+            cellI    = ijk[0];
+            cellJ    = ijk[1];
+            cellK    = ijk[2];
+        }
+        break;
+        case ECL_SMSPEC_LOCAL_WELL_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL_LGR;
+            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
+            lgrName     = stringFromPointer( ertSumVarNode.get_lgr_name() );
+        }
+        break;
+        case ECL_SMSPEC_NETWORK_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_NETWORK;
+        }
+        break;
+        case ECL_SMSPEC_REGION_2_REGION_VAR:
+        {
+            sumCategory   = RifEclipseSummaryAddress::SUMMARY_REGION_2_REGION;
+            regionNumber  = ertSumVarNode.get_R1();
+            regionNumber2 = ertSumVarNode.get_R2();
+        }
+        break;
+        case ECL_SMSPEC_SEGMENT_VAR:
+        {
+            sumCategory       = RifEclipseSummaryAddress::SUMMARY_WELL_SEGMENT;
+            wellName          = stringFromPointer( ertSumVarNode.get_wgname() );
+            wellSegmentNumber = ertSumVarNode.get_num();
+        }
+        break;
+        case ECL_SMSPEC_MISC_VAR:
+        {
+            sumCategory = RifEclipseSummaryAddress::SUMMARY_MISC;
+        }
+        break;
+        default:
+            CVF_ASSERT( false );
+            break;
+    }
+
+    return RifEclipseSummaryAddress( sumCategory,
+                                     quantityName,
+                                     regionNumber,
+                                     regionNumber2,
+                                     wellGroupName,
+                                     wellName,
+                                     wellSegmentNumber,
+                                     lgrName,
+                                     cellI,
+                                     cellJ,
+                                     cellK,
+                                     aquiferNumber,
+                                     isErrorResult,
+                                     id );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifEclEclipseSummary::values( const RifEclipseSummaryAddress& resultAddress, std::vector<double>* values ) const
+{
+    CVF_ASSERT( values );
+
+    if ( m_timeSteps.empty() ) return true;
+
+    values->clear();
+    values->reserve( m_timeSteps.size() );
+
+    if ( m_ecl_SmSpec )
+    {
+        int variableIndex = indexFromAddress( resultAddress );
+        if ( variableIndex < 0 ) return false;
+
+        const ecl::smspec_node& ertSumVarNode = ecl_smspec_iget_node_w_node_index( m_ecl_SmSpec, variableIndex );
+        int                     paramsIndex   = ertSumVarNode.get_params_index();
+
+        double_vector_type* dataValues = ecl_sum_alloc_data_vector( m_ecl_sum, paramsIndex, false );
+
+        if ( dataValues )
+        {
+            int           dataSize = double_vector_size( dataValues );
+            const double* dataPtr  = double_vector_get_const_ptr( dataValues );
+            values->insert( values->end(), dataPtr, dataPtr + dataSize );
+            double_vector_free( dataValues );
+        }
+    }
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+const std::vector<time_t>& RifEclEclipseSummary::timeSteps( const RifEclipseSummaryAddress& resultAddress ) const
+{
+    return m_timeSteps;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+int RifEclEclipseSummary::indexFromAddress( const RifEclipseSummaryAddress& resultAddress ) const
+{
+    auto it = m_resultAddressToErtNodeIdx.find( resultAddress );
+    if ( it != m_resultAddressToErtNodeIdx.end() )
+    {
+        return it->second;
+    }
+
+    return -1;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RifEclEclipseSummary::buildMetaData()
+{
+    m_allResultAddresses.clear();
+    m_resultAddressToErtNodeIdx.clear();
+
+    if ( m_ecl_SmSpec )
+    {
+        int varCount = ecl_smspec_num_nodes( m_ecl_SmSpec );
+        for ( int i = 0; i < varCount; i++ )
+        {
+            const ecl::smspec_node&  ertSumVarNode = ecl_smspec_iget_node_w_node_index( m_ecl_SmSpec, i );
+            RifEclipseSummaryAddress addr          = addressFromErtSmSpecNode( ertSumVarNode );
+            m_allResultAddresses.insert( addr );
+            m_resultAddressToErtNodeIdx[addr] = i;
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::string RifEclEclipseSummary::unitName( const RifEclipseSummaryAddress& resultAddress ) const
+{
+    if ( !m_ecl_SmSpec ) return "";
+
+    int variableIndex = indexFromAddress( resultAddress );
+
+    if ( variableIndex < 0 ) return "";
+
+    const ecl::smspec_node& ertSumVarNode = ecl_smspec_iget_node_w_node_index( m_ecl_SmSpec, variableIndex );
+    return ertSumVarNode.get_unit();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::EclipseUnitSystem RifEclEclipseSummary::unitSystem() const
+{
+    return m_unitSystem;
+}

--- a/ApplicationLibCode/FileInterface/RifEclEclipseSummary.h
+++ b/ApplicationLibCode/FileInterface/RifEclEclipseSummary.h
@@ -20,7 +20,10 @@
 
 #include "RiaDefines.h"
 
+#include "RifEclipseSummaryAddress.h"
 #include "RifSummaryReaderInterface.h"
+
+#include "ert/ecl/ecl_sum.hpp"
 
 #include <QString>
 #include <QStringList>
@@ -31,21 +34,17 @@
 #include <string>
 #include <vector>
 
-class RifOpmCommonEclipseSummary;
-class RifOpmHdf5Summary;
-class RifEclEclipseSummary;
 class RiaThreadSafeLogger;
-class RifEclipseSummaryAddress;
 
 //==================================================================================================
 //
 //
 //==================================================================================================
-class RifReaderEclipseSummary : public RifSummaryReaderInterface
+class RifEclEclipseSummary : public RifSummaryReaderInterface
 {
 public:
-    RifReaderEclipseSummary();
-    ~RifReaderEclipseSummary() override;
+    RifEclEclipseSummary();
+    ~RifEclEclipseSummary() override;
 
     bool open( const QString& headerFileName, RiaThreadSafeLogger* threadSafeLogger );
 
@@ -55,36 +54,16 @@ public:
     std::string unitName( const RifEclipseSummaryAddress& resultAddress ) const override;
     RiaDefines::EclipseUnitSystem unitSystem() const override;
 
-    static std::string       differenceIdentifier() { return "_DIFF"; }
-    static const std::string historyIdentifier() { return "H"; }
-
 private:
+    int  indexFromAddress( const RifEclipseSummaryAddress& resultAddress ) const;
     void buildMetaData();
 
-    RifSummaryReaderInterface* currentSummaryReader() const;
-
 private:
-    std::unique_ptr<RifSummaryReaderInterface> m_summaryReader;
-    std::set<RifEclipseSummaryAddress>         m_differenceAddresses;
+    ecl_sum_type*          m_ecl_sum;
+    const ecl_smspec_type* m_ecl_SmSpec;
+    std::vector<time_t>    m_timeSteps;
 
-private:
-    //==================================================================================================
-    //
-    //==================================================================================================
-    class ValuesCache
-    {
-        static const std::vector<double> EMPTY_VECTOR;
+    RiaDefines::EclipseUnitSystem m_unitSystem;
 
-    public:
-        ValuesCache();
-        ~ValuesCache();
-
-        void insertValues( const RifEclipseSummaryAddress& address, const std::vector<double>& values );
-        const std::vector<double>& getValues( const RifEclipseSummaryAddress& address ) const;
-
-    private:
-        std::map<const RifEclipseSummaryAddress, std::vector<double>> m_cachedValues;
-    };
-
-    std::unique_ptr<ValuesCache> m_valuesCache;
+    std::map<RifEclipseSummaryAddress, int> m_resultAddressToErtNodeIdx;
 };

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp
@@ -25,8 +25,14 @@
 
 #include "cafAppEnum.h"
 
+#include "ert/ecl/ecl_file.h"
+#include "ert/ecl/ecl_kw.h"
+#include "ert/ecl/ecl_kw_magic.h"
+#include "ert/ecl/ecl_sum.h"
 #include "ert/ecl/ecl_util.h"
+#include "ert/ecl/smspec_node.hpp"
 
+#include <QDateTime>
 #include <QDir>
 #include <QString>
 #include <QStringList>
@@ -127,7 +133,7 @@ QString RifEclipseSummaryTools::findGridCaseFileFromSummaryHeaderFile( const QSt
 //--------------------------------------------------------------------------------------------------
 void RifEclipseSummaryTools::dumpMetaData( RifSummaryReaderInterface* readerEclipseSummary )
 {
-    std::set<RifEclipseSummaryAddress> addresses = readerEclipseSummary->allResultAddresses();
+    const std::set<RifEclipseSummaryAddress>& addresses = readerEclipseSummary->allResultAddresses();
 
     for ( int category = 0; category < RifEclipseSummaryAddress::SUMMARY_BLOCK_LGR; category++ )
     {
@@ -137,23 +143,105 @@ void RifEclipseSummaryTools::dumpMetaData( RifSummaryReaderInterface* readerEcli
         std::vector<RifEclipseSummaryAddress> catAddresses =
             RiaSummaryCurveAnalyzer::addressesForCategory( addresses, categoryEnum );
 
-        if ( catAddresses.size() > 0 )
+        if ( !catAddresses.empty() )
         {
             std::cout << caf::AppEnum<RifEclipseSummaryAddress::SummaryVarCategory>::uiText( categoryEnum ).toStdString()
                       << " count : " << catAddresses.size() << std::endl;
 
-            for ( size_t i = 0; i < catAddresses.size(); i++ )
+            for ( const auto& catAddresse : catAddresses )
             {
-                std::cout << catAddresses[i].quantityName() << " " << catAddresses[i].regionNumber() << " "
-                          << catAddresses[i].regionNumber2() << " " << catAddresses[i].wellGroupName() << " "
-                          << catAddresses[i].wellName() << " " << catAddresses[i].wellSegmentNumber() << " "
-                          << catAddresses[i].lgrName() << " " << catAddresses[i].cellI() << " "
-                          << catAddresses[i].cellJ() << " " << catAddresses[i].cellK() << std::endl;
+                std::cout << catAddresse.quantityName() << " " << catAddresse.regionNumber() << " "
+                          << catAddresse.regionNumber2() << " " << catAddresse.wellGroupName() << " "
+                          << catAddresse.wellName() << " " << catAddresse.wellSegmentNumber() << " "
+                          << catAddresse.lgrName() << " " << catAddresse.cellI() << " " << catAddresse.cellJ() << " "
+                          << catAddresse.cellK() << std::endl;
             }
 
             std::cout << std::endl;
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RifRestartFileInfo> RifEclipseSummaryTools::getRestartFiles( const QString&        headerFileName,
+                                                                         std::vector<QString>& warnings )
+{
+    std::vector<RifRestartFileInfo> restartFiles;
+
+    std::set<QString> restartFilesOpened;
+
+    RifRestartFileInfo currFile;
+    currFile.fileName = headerFileName;
+    while ( !currFile.fileName.isEmpty() )
+    {
+        // Due to a weakness in libecl regarding restart summary header file selection,
+        // do some extra checking
+        {
+            QString formattedHeaderExtension    = ".FSMSPEC";
+            QString nonformattedHeaderExtension = ".SMSPEC";
+            QString formattedDataFileExtension  = ".FUNSMRY";
+
+            if ( currFile.fileName.endsWith( nonformattedHeaderExtension, Qt::CaseInsensitive ) )
+            {
+                QString formattedHeaderFile = currFile.fileName;
+                formattedHeaderFile.replace( nonformattedHeaderExtension, formattedHeaderExtension, Qt::CaseInsensitive );
+                QString formattedDateFile = currFile.fileName;
+                formattedDateFile.replace( nonformattedHeaderExtension, formattedDataFileExtension, Qt::CaseInsensitive );
+
+                QFileInfo nonformattedHeaderFileInfo = QFileInfo( currFile.fileName );
+                QFileInfo formattedHeaderFileInfo    = QFileInfo( formattedHeaderFile );
+                QFileInfo formattedDateFileInfo      = QFileInfo( formattedDateFile );
+                if ( formattedHeaderFileInfo.lastModified() < nonformattedHeaderFileInfo.lastModified() &&
+                     formattedHeaderFileInfo.exists() && !formattedDateFileInfo.exists() )
+                {
+                    warnings.push_back(
+                        QString( "RifReaderEclipseSummary: Formatted summary header file without an\n" ) +
+                        QString( "associated data file detected.\n" ) +
+                        QString( "This may cause a failure reading summary origin data.\n" ) +
+                        QString( "To avoid this problem, please delete or rename the.FSMSPEC file." ) );
+                    break;
+                }
+            }
+            QString prevFile = currFile.fileName;
+            currFile         = getRestartFile( currFile.fileName );
+
+            // Fix to stop potential infinite loop
+            if ( currFile.fileName == prevFile )
+            {
+                warnings.push_back( "RifReaderEclipseSummary: Restart file reference loop detected" );
+                break;
+            }
+            if ( restartFilesOpened.count( currFile.fileName ) != 0u )
+            {
+                warnings.push_back( "RifReaderEclipseSummary: Same restart file being opened multiple times" );
+            }
+            restartFilesOpened.insert( currFile.fileName );
+        }
+
+        if ( !currFile.fileName.isEmpty() ) restartFiles.push_back( currFile );
+    }
+    return restartFiles;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RifRestartFileInfo RifEclipseSummaryTools::getFileInfo( const QString& headerFileName )
+{
+    RifRestartFileInfo  fileInfo;
+    ecl_sum_type*       ecl_sum   = openEclSum( headerFileName, false );
+    std::vector<time_t> timeSteps = getTimeSteps( ecl_sum );
+    if ( !timeSteps.empty() )
+    {
+        fileInfo.fileName  = headerFileName;
+        fileInfo.startDate = timeSteps.front();
+        fileInfo.endDate   = timeSteps.back();
+    }
+    closeEclSum( ecl_sum );
+
+    return fileInfo;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -192,4 +280,125 @@ void RifEclipseSummaryTools::findSummaryHeaderFileInfo( const QString& inputFile
     free( myHeaderFile );
     free( myBase );
     free( myPath );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RifRestartFileInfo RifEclipseSummaryTools::getRestartFile( const QString& headerFileName )
+{
+    ecl_sum_type* ecl_sum = openEclSum( headerFileName, true );
+
+    const ecl_smspec_type* smspec  = ecl_sum ? ecl_sum_get_smspec( ecl_sum ) : nullptr;
+    const char*            rstCase = smspec ? ecl_smspec_get_restart_case( smspec ) : nullptr;
+    QString                restartCase =
+        rstCase ? RiaFilePathTools::canonicalPath( RiaStringEncodingTools::fromNativeEncoded( rstCase ) ) : "";
+    closeEclSum( ecl_sum );
+
+    if ( !restartCase.isEmpty() )
+    {
+        QString path        = QFileInfo( restartCase ).dir().path();
+        QString restartBase = QDir( restartCase ).dirName();
+
+        char*   smspec_header = ecl_util_alloc_exfilename( path.toStdString().data(),
+                                                         restartBase.toStdString().data(),
+                                                         ECL_SUMMARY_HEADER_FILE,
+                                                         false /*unformatted*/,
+                                                         0 );
+        QString restartFileName =
+            RiaFilePathTools::toInternalSeparator( RiaStringEncodingTools::fromNativeEncoded( smspec_header ) );
+        free( smspec_header );
+
+        return getFileInfo( restartFileName );
+    }
+    return RifRestartFileInfo();
+}
+
+std::vector<time_t> RifEclipseSummaryTools::getTimeSteps( ecl_sum_type* ecl_sum )
+{
+    std::vector<time_t> timeSteps;
+
+    if ( ecl_sum )
+    {
+        time_t_vector_type* steps = ecl_sum_alloc_time_vector( ecl_sum, false );
+
+        if ( steps )
+        {
+            for ( int i = 0; i < time_t_vector_size( steps ); i++ )
+            {
+                timeSteps.push_back( time_t_vector_iget( steps, i ) );
+            }
+
+            time_t_vector_free( steps );
+        }
+    }
+    return timeSteps;
+}
+
+RiaDefines::EclipseUnitSystem RifEclipseSummaryTools::readUnitSystem( ecl_sum_type* ecl_sum )
+{
+    ert_ecl_unit_enum eclUnitEnum = ecl_sum_get_unit_system( ecl_sum );
+    switch ( eclUnitEnum )
+    {
+        case ECL_METRIC_UNITS:
+            return RiaDefines::EclipseUnitSystem::UNITS_METRIC;
+        case ECL_FIELD_UNITS:
+            return RiaDefines::EclipseUnitSystem::UNITS_FIELD;
+        case ECL_LAB_UNITS:
+            return RiaDefines::EclipseUnitSystem::UNITS_LAB;
+        default:
+            return RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+ecl_sum_type* RifEclipseSummaryTools::openEclSum( const QString& inHeaderFileName, bool includeRestartFiles )
+{
+    QString     headerFileName;
+    QStringList dataFileNames;
+    QString     nativeHeaderFileName = QDir::toNativeSeparators( inHeaderFileName );
+    RifEclipseSummaryTools::findSummaryFiles( nativeHeaderFileName, &headerFileName, &dataFileNames );
+
+    if ( headerFileName.isEmpty() || dataFileNames.isEmpty() ) return nullptr;
+
+    assert( !headerFileName.isEmpty() );
+    assert( dataFileNames.size() > 0 );
+
+    stringlist_type* dataFiles = stringlist_alloc_new();
+    for ( int i = 0; i < dataFileNames.size(); i++ )
+    {
+        stringlist_append_copy( dataFiles, RiaStringEncodingTools::toNativeEncoded( dataFileNames[i] ).data() );
+    }
+
+    bool        lazyLoad                     = true;
+    std::string itemSeparatorInVariableNames = ":";
+
+    ecl_sum_type* ecl_sum = nullptr;
+    try
+    {
+        ecl_sum = ecl_sum_fread_alloc( RiaStringEncodingTools::toNativeEncoded( headerFileName ).data(),
+                                       dataFiles,
+                                       itemSeparatorInVariableNames.data(),
+                                       includeRestartFiles,
+                                       lazyLoad,
+                                       ECL_FILE_CLOSE_STREAM );
+    }
+    catch ( ... )
+    {
+        ecl_sum = nullptr;
+    }
+
+    stringlist_free( dataFiles );
+
+    return ecl_sum;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RifEclipseSummaryTools::closeEclSum( ecl_sum_type* ecl_sum )
+{
+    if ( ecl_sum ) ecl_sum_free( ecl_sum );
 }

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp
@@ -21,7 +21,7 @@
 #include "RiaFilePathTools.h"
 #include "RiaStringEncodingTools.h"
 #include "RiaSummaryCurveAnalyzer.h"
-#include "RifReaderEclipseSummary.h"
+#include "RifSummaryReaderInterface.h"
 
 #include "cafAppEnum.h"
 

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.h
@@ -18,14 +18,43 @@
 
 #pragma once
 
+#include "RiaDefines.h"
 #include "RifEclipseSummaryAddress.h"
+
+#include "ert/ecl/ecl_sum.hpp"
+
+#include <QString>
 
 #include <string>
 #include <vector>
 
 class RifSummaryReaderInterface;
 class QStringList;
-class QString;
+
+//==================================================================================================
+//
+//
+//==================================================================================================
+class RifRestartFileInfo
+{
+public:
+    RifRestartFileInfo()
+        : startDate( 0 )
+        , endDate( 0 )
+    {
+    }
+    RifRestartFileInfo( const QString& _fileName, time_t _startDate, time_t _endDate )
+        : fileName( _fileName )
+        , startDate( _startDate )
+        , endDate( _endDate )
+    {
+    }
+    bool valid() { return !fileName.isEmpty(); }
+
+    QString fileName;
+    time_t  startDate;
+    time_t  endDate;
+};
 
 //==================================================================================================
 //
@@ -38,10 +67,20 @@ public:
     static void    findSummaryHeaderFile( const QString& inputFile, QString* headerFile, bool* isFormatted );
     static QString findGridCaseFileFromSummaryHeaderFile( const QString& summaryHeaderFile );
 
-    static void findSummaryFiles( const QString& inputFile, QString* headerFile, QStringList* dataFiles );
     static void dumpMetaData( RifSummaryReaderInterface* readerEclipseSummary );
 
+    static std::vector<RifRestartFileInfo> getRestartFiles( const QString& headerFileName, std::vector<QString>& warnings );
+    static RifRestartFileInfo              getFileInfo( const QString& headerFileName );
+
+    static void                          closeEclSum( ecl_sum_type* ecl_sum );
+    static ecl_sum_type*                 openEclSum( const QString& inHeaderFileName, bool includeRestartFiles );
+    static RiaDefines::EclipseUnitSystem readUnitSystem( ecl_sum_type* ecl_sum );
+    static std::vector<time_t>           getTimeSteps( ecl_sum_type* ecl_sum );
+
 private:
+    static void               findSummaryFiles( const QString& inputFile, QString* headerFile, QStringList* dataFiles );
+    static RifRestartFileInfo getRestartFile( const QString& headerFileName );
+
     static void findSummaryHeaderFileInfo( const QString& inputFile,
                                            QString*       headerFile,
                                            QString*       path,

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp
@@ -18,16 +18,12 @@
 
 #include "RifReaderEclipseSummary.h"
 
-#include "RiaFilePathTools.h"
 #include "RiaLogging.h"
-#include "RiaPreferences.h"
 #include "RiaPreferencesSummary.h"
 #include "RiaStdStringTools.h"
-#include "RiaStringEncodingTools.h"
 
-#include "RifEclipseSummaryTools.h"
+#include "RifEclEclipseSummary.h"
 #include "RifOpmCommonSummary.h"
-#include "RifReaderEclipseOutput.h"
 
 #ifdef USE_HDF5
 #include "RifHdf5SummaryExporter.h"
@@ -42,107 +38,10 @@
 #include <QString>
 #include <QStringList>
 
-#include "ert/ecl/ecl_file.h"
-#include "ert/ecl/ecl_kw.h"
-#include "ert/ecl/ecl_kw_magic.h"
-#include "ert/ecl/ecl_sum.h"
-#include "ert/ecl/smspec_node.hpp"
-
-std::vector<time_t> getTimeSteps( ecl_sum_type* ecl_sum )
-{
-    std::vector<time_t> timeSteps;
-
-    if ( ecl_sum )
-    {
-        time_t_vector_type* steps = ecl_sum_alloc_time_vector( ecl_sum, false );
-
-        if ( steps )
-        {
-            for ( int i = 0; i < time_t_vector_size( steps ); i++ )
-            {
-                timeSteps.push_back( time_t_vector_iget( steps, i ) );
-            }
-
-            time_t_vector_free( steps );
-        }
-    }
-    return timeSteps;
-}
-
-RiaDefines::EclipseUnitSystem readUnitSystem( ecl_sum_type* ecl_sum )
-{
-    ert_ecl_unit_enum eclUnitEnum = ecl_sum_get_unit_system( ecl_sum );
-    switch ( eclUnitEnum )
-    {
-        case ECL_METRIC_UNITS:
-            return RiaDefines::EclipseUnitSystem::UNITS_METRIC;
-        case ECL_FIELD_UNITS:
-            return RiaDefines::EclipseUnitSystem::UNITS_FIELD;
-        case ECL_LAB_UNITS:
-            return RiaDefines::EclipseUnitSystem::UNITS_LAB;
-        default:
-            return RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN;
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-ecl_sum_type* openEclSum( const QString& inHeaderFileName, bool includeRestartFiles )
-{
-    QString     headerFileName;
-    QStringList dataFileNames;
-    QString     nativeHeaderFileName = QDir::toNativeSeparators( inHeaderFileName );
-    RifEclipseSummaryTools::findSummaryFiles( nativeHeaderFileName, &headerFileName, &dataFileNames );
-
-    if ( headerFileName.isEmpty() || dataFileNames.isEmpty() ) return nullptr;
-
-    assert( !headerFileName.isEmpty() );
-    assert( dataFileNames.size() > 0 );
-
-    stringlist_type* dataFiles = stringlist_alloc_new();
-    for ( int i = 0; i < dataFileNames.size(); i++ )
-    {
-        stringlist_append_copy( dataFiles, RiaStringEncodingTools::toNativeEncoded( dataFileNames[i] ).data() );
-    }
-
-    bool        lazyLoad                     = true;
-    std::string itemSeparatorInVariableNames = ":";
-
-    ecl_sum_type* ecl_sum = nullptr;
-    try
-    {
-        ecl_sum = ecl_sum_fread_alloc( RiaStringEncodingTools::toNativeEncoded( headerFileName ).data(),
-                                       dataFiles,
-                                       itemSeparatorInVariableNames.data(),
-                                       includeRestartFiles,
-                                       lazyLoad,
-                                       ECL_FILE_CLOSE_STREAM );
-    }
-    catch ( ... )
-    {
-        ecl_sum = nullptr;
-    }
-
-    stringlist_free( dataFiles );
-
-    return ecl_sum;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void closeEclSum( ecl_sum_type* ecl_sum )
-{
-    if ( ecl_sum ) ecl_sum_free( ecl_sum );
-}
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 RifReaderEclipseSummary::RifReaderEclipseSummary()
-    : m_ecl_sum( nullptr )
-    , m_ecl_SmSpec( nullptr )
-    , m_unitSystem( RiaDefines::EclipseUnitSystem::UNITS_METRIC )
 {
     m_valuesCache = std::make_unique<ValuesCache>();
 }
@@ -152,25 +51,18 @@ RifReaderEclipseSummary::RifReaderEclipseSummary()
 //--------------------------------------------------------------------------------------------------
 RifReaderEclipseSummary::~RifReaderEclipseSummary()
 {
-    if ( m_ecl_sum )
-    {
-        ecl_sum_free( m_ecl_sum );
-        m_ecl_sum = nullptr;
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RifReaderEclipseSummary::open( const QString&       headerFileName,
-                                    bool                 includeRestartFiles,
-                                    RiaThreadSafeLogger* threadSafeLogger )
+bool RifReaderEclipseSummary::open( const QString& headerFileName, RiaThreadSafeLogger* threadSafeLogger )
 {
     bool isValid = false;
 
-    // Try to create readers. If HDF5 or Opm readers fails to create, use ecllib reader
+    // Try to create readers. If HDF5 or Opm readers fails to create, use libecl reader
 
-    RiaPreferencesSummary* prefSummary = RiaPreferences::current()->summaryPreferences();
+    RiaPreferencesSummary* prefSummary = RiaPreferencesSummary::current();
 
     if ( prefSummary->summaryDataReader() == RiaPreferencesSummary::SummaryReaderMode::HDF5_OPM_COMMON )
     {
@@ -197,42 +89,32 @@ bool RifReaderEclipseSummary::open( const QString&       headerFileName,
         isValid = hdfReader->open( headerFileName, false, threadSafeLogger );
         if ( isValid )
         {
-            m_hdf5OpmReader = std::move( hdfReader );
+            m_summaryReader = std::move( hdfReader );
         }
 #endif
     }
     else if ( prefSummary->summaryDataReader() == RiaPreferencesSummary::SummaryReaderMode::OPM_COMMON )
     {
-        bool useLodsmryFiles = prefSummary->useOptimizedSummaryDataFiles();
-        if ( useLodsmryFiles && includeRestartFiles )
+        auto opmCommonReader = std::make_unique<RifOpmCommonEclipseSummary>();
+
+        opmCommonReader->useLodsmaryFiles( prefSummary->useOptimizedSummaryDataFiles() );
+        opmCommonReader->createLodsmaryFiles( prefSummary->createOptimizedSummaryDataFiles() );
+        isValid = opmCommonReader->open( headerFileName, false, threadSafeLogger );
+
+        if ( isValid )
         {
-            QString txt =
-                "LODSMRY file loading for summary restart files is not supported. Restart history might be incomplete.";
-            if ( threadSafeLogger ) threadSafeLogger->warning( txt );
+            m_summaryReader = std::move( opmCommonReader );
         }
-
-        m_opmCommonReader = std::make_unique<RifOpmCommonEclipseSummary>();
-
-        m_opmCommonReader->useLodsmaryFiles( prefSummary->useOptimizedSummaryDataFiles() );
-        m_opmCommonReader->createLodsmaryFiles( prefSummary->createOptimizedSummaryDataFiles() );
-        isValid = m_opmCommonReader->open( headerFileName, false, threadSafeLogger );
-        if ( !isValid ) m_opmCommonReader.reset();
     }
 
     if ( !isValid || prefSummary->summaryDataReader() == RiaPreferencesSummary::SummaryReaderMode::LIBECL )
     {
-        assert( m_ecl_sum == nullptr );
+        auto libeclReader = std::make_unique<RifEclEclipseSummary>();
 
-        m_ecl_sum = openEclSum( headerFileName, includeRestartFiles );
-
-        if ( m_ecl_sum )
+        isValid = libeclReader->open( headerFileName, threadSafeLogger );
+        if ( isValid )
         {
-            m_timeSteps.clear();
-            m_ecl_SmSpec = ecl_sum_get_smspec( m_ecl_sum );
-            m_timeSteps  = getTimeSteps( m_ecl_sum );
-            m_unitSystem = readUnitSystem( m_ecl_sum );
-
-            isValid = true;
+            m_summaryReader = std::move( libeclReader );
         }
     }
 
@@ -247,271 +129,14 @@ bool RifReaderEclipseSummary::open( const QString&       headerFileName,
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RifRestartFileInfo> RifReaderEclipseSummary::getRestartFiles( const QString& headerFileName, bool* hasWarnings )
-{
-    CVF_ASSERT( hasWarnings );
-
-    std::vector<RifRestartFileInfo> restartFiles;
-    m_warnings.clear();
-    *hasWarnings = false;
-
-    std::set<QString> restartFilesOpened;
-
-    RifRestartFileInfo currFile;
-    currFile.fileName = headerFileName;
-    while ( !currFile.fileName.isEmpty() )
-    {
-        // Due to a weakness in libecl regarding restart summary header file selection,
-        // do some extra checking
-        {
-            QString formattedHeaderExtension    = ".FSMSPEC";
-            QString nonformattedHeaderExtension = ".SMSPEC";
-            QString formattedDataFileExtension  = ".FUNSMRY";
-
-            if ( currFile.fileName.endsWith( nonformattedHeaderExtension, Qt::CaseInsensitive ) )
-            {
-                QString formattedHeaderFile = currFile.fileName;
-                formattedHeaderFile.replace( nonformattedHeaderExtension, formattedHeaderExtension, Qt::CaseInsensitive );
-                QString formattedDateFile = currFile.fileName;
-                formattedDateFile.replace( nonformattedHeaderExtension, formattedDataFileExtension, Qt::CaseInsensitive );
-
-                QFileInfo nonformattedHeaderFileInfo = QFileInfo( currFile.fileName );
-                QFileInfo formattedHeaderFileInfo    = QFileInfo( formattedHeaderFile );
-                QFileInfo formattedDateFileInfo      = QFileInfo( formattedDateFile );
-                if ( formattedHeaderFileInfo.lastModified() < nonformattedHeaderFileInfo.lastModified() &&
-                     formattedHeaderFileInfo.exists() && !formattedDateFileInfo.exists() )
-                {
-                    m_warnings.push_back(
-                        QString( "RifReaderEclipseSummary: Formatted summary header file without an\n" ) +
-                        QString( "associated data file detected.\n" ) +
-                        QString( "This may cause a failure reading summary origin data.\n" ) +
-                        QString( "To avoid this problem, please delete or rename the.FSMSPEC file." ) );
-                    *hasWarnings = true;
-                    break;
-                }
-            }
-            QString prevFile = currFile.fileName;
-            currFile         = getRestartFile( currFile.fileName );
-
-            // Fix to stop potential infinite loop
-            if ( currFile.fileName == prevFile )
-            {
-                m_warnings.push_back( "RifReaderEclipseSummary: Restart file reference loop detected" );
-                *hasWarnings = true;
-                break;
-            }
-            else if ( restartFilesOpened.count( currFile.fileName ) != 0u )
-            {
-                m_warnings.push_back( "RifReaderEclipseSummary: Same restart file being opened multiple times" );
-                *hasWarnings = true;
-            }
-            restartFilesOpened.insert( currFile.fileName );
-        }
-
-        if ( !currFile.fileName.isEmpty() ) restartFiles.push_back( currFile );
-    }
-    return restartFiles;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RifRestartFileInfo RifReaderEclipseSummary::getFileInfo( const QString& headerFileName )
-{
-    RifRestartFileInfo  fileInfo;
-    ecl_sum_type*       ecl_sum   = openEclSum( headerFileName, false );
-    std::vector<time_t> timeSteps = getTimeSteps( ecl_sum );
-    if ( !timeSteps.empty() )
-    {
-        fileInfo.fileName  = headerFileName;
-        fileInfo.startDate = timeSteps.front();
-        fileInfo.endDate   = timeSteps.back();
-    }
-    closeEclSum( ecl_sum );
-    return fileInfo;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-std::string stringFromPointer( const char* pointerToChar )
-{
-    std::string myString;
-
-    // NB! Assigning a null pointer to a std::string causes runtime crash
-    if ( pointerToChar )
-    {
-        myString = pointerToChar;
-
-        replace( myString.begin(), myString.end(), '\t', ' ' );
-    }
-
-    return myString;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RifEclipseSummaryAddress addressFromErtSmSpecNode( const ecl::smspec_node& ertSumVarNode )
-{
-    if ( ertSumVarNode.get_var_type() == ECL_SMSPEC_INVALID_VAR )
-    {
-        return RifEclipseSummaryAddress();
-    }
-
-    RifEclipseSummaryAddress::SummaryVarCategory sumCategory( RifEclipseSummaryAddress::SUMMARY_INVALID );
-    std::string                                  quantityName;
-    int                                          regionNumber( -1 );
-    int                                          regionNumber2( -1 );
-    std::string                                  wellGroupName;
-    std::string                                  wellName;
-    int                                          wellSegmentNumber( -1 );
-    std::string                                  lgrName;
-    int                                          cellI( -1 );
-    int                                          cellJ( -1 );
-    int                                          cellK( -1 );
-    int                                          aquiferNumber( -1 );
-    bool                                         isErrorResult( false );
-    int                                          id( -1 );
-
-    quantityName = stringFromPointer( ertSumVarNode.get_keyword() );
-
-    switch ( ertSumVarNode.get_var_type() )
-    {
-        case ECL_SMSPEC_AQUIFER_VAR:
-        {
-            sumCategory   = RifEclipseSummaryAddress::SUMMARY_AQUIFER;
-            aquiferNumber = ertSumVarNode.get_num();
-        }
-        break;
-        case ECL_SMSPEC_WELL_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL;
-            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
-        }
-        break;
-        case ECL_SMSPEC_REGION_VAR:
-        {
-            sumCategory  = RifEclipseSummaryAddress::SUMMARY_REGION;
-            regionNumber = ertSumVarNode.get_num();
-        }
-        break;
-        case ECL_SMSPEC_FIELD_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_FIELD;
-        }
-        break;
-        case ECL_SMSPEC_GROUP_VAR:
-        {
-            sumCategory   = RifEclipseSummaryAddress::SUMMARY_WELL_GROUP;
-            wellGroupName = stringFromPointer( ertSumVarNode.get_wgname() );
-        }
-        break;
-        case ECL_SMSPEC_BLOCK_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_BLOCK;
-
-            auto ijk = ertSumVarNode.get_ijk();
-            cellI    = ijk[0];
-            cellJ    = ijk[1];
-            cellK    = ijk[2];
-        }
-        break;
-        case ECL_SMSPEC_COMPLETION_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL_COMPLETION;
-            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
-
-            auto ijk = ertSumVarNode.get_ijk();
-            cellI    = ijk[0];
-            cellJ    = ijk[1];
-            cellK    = ijk[2];
-        }
-        break;
-        case ECL_SMSPEC_LOCAL_BLOCK_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_BLOCK_LGR;
-            lgrName     = stringFromPointer( ertSumVarNode.get_lgr_name() );
-
-            auto ijk = ertSumVarNode.get_lgr_ijk();
-            cellI    = ijk[0];
-            cellJ    = ijk[1];
-            cellK    = ijk[2];
-        }
-        break;
-        case ECL_SMSPEC_LOCAL_COMPLETION_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL_COMPLETION_LGR;
-            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
-            lgrName     = stringFromPointer( ertSumVarNode.get_lgr_name() );
-
-            auto ijk = ertSumVarNode.get_lgr_ijk();
-            cellI    = ijk[0];
-            cellJ    = ijk[1];
-            cellK    = ijk[2];
-        }
-        break;
-        case ECL_SMSPEC_LOCAL_WELL_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_WELL_LGR;
-            wellName    = stringFromPointer( ertSumVarNode.get_wgname() );
-            lgrName     = stringFromPointer( ertSumVarNode.get_lgr_name() );
-        }
-        break;
-        case ECL_SMSPEC_NETWORK_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_NETWORK;
-        }
-        break;
-        case ECL_SMSPEC_REGION_2_REGION_VAR:
-        {
-            sumCategory   = RifEclipseSummaryAddress::SUMMARY_REGION_2_REGION;
-            regionNumber  = ertSumVarNode.get_R1();
-            regionNumber2 = ertSumVarNode.get_R2();
-        }
-        break;
-        case ECL_SMSPEC_SEGMENT_VAR:
-        {
-            sumCategory       = RifEclipseSummaryAddress::SUMMARY_WELL_SEGMENT;
-            wellName          = stringFromPointer( ertSumVarNode.get_wgname() );
-            wellSegmentNumber = ertSumVarNode.get_num();
-        }
-        break;
-        case ECL_SMSPEC_MISC_VAR:
-        {
-            sumCategory = RifEclipseSummaryAddress::SUMMARY_MISC;
-        }
-        break;
-        default:
-            CVF_ASSERT( false );
-            break;
-    }
-
-    return RifEclipseSummaryAddress( sumCategory,
-                                     quantityName,
-                                     regionNumber,
-                                     regionNumber2,
-                                     wellGroupName,
-                                     wellName,
-                                     wellSegmentNumber,
-                                     lgrName,
-                                     cellI,
-                                     cellJ,
-                                     cellK,
-                                     aquiferNumber,
-                                     isErrorResult,
-                                     id );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 bool RifReaderEclipseSummary::values( const RifEclipseSummaryAddress& resultAddress, std::vector<double>* values ) const
 {
     CVF_ASSERT( values );
 
+    if ( timeSteps( resultAddress ).empty() ) return false;
+
     values->clear();
-    values->reserve( timeStepCount() );
+    values->reserve( timeSteps( resultAddress ).size() );
 
     const std::vector<double>& cachedValues = m_valuesCache->getValues( resultAddress );
     if ( !cachedValues.empty() )
@@ -521,73 +146,45 @@ bool RifReaderEclipseSummary::values( const RifEclipseSummaryAddress& resultAddr
         return true;
     }
 
-    if ( m_hdf5OpmReader )
+    if ( m_differenceAddresses.count( resultAddress ) )
     {
-        auto status = m_hdf5OpmReader->values( resultAddress, values );
+        const std::string& quantityName = resultAddress.quantityName();
+        auto historyQuantity = quantityName.substr( 0, quantityName.size() - differenceIdentifier().size() ) +
+                               historyIdentifier();
 
-        if ( status ) m_valuesCache->insertValues( resultAddress, *values );
+        RifEclipseSummaryAddress nativeAdrNoHistory = resultAddress;
+        nativeAdrNoHistory.setQuantityName( historyQuantity );
+        auto quantityNoHistory = quantityName.substr( 0, historyQuantity.size() - 1 );
 
-        return status;
-    }
+        RifEclipseSummaryAddress nativeAdrHistory = resultAddress;
+        nativeAdrHistory.setQuantityName( quantityNoHistory );
 
-    if ( m_opmCommonReader )
-    {
-        auto status = m_opmCommonReader->values( resultAddress, values );
-        if ( status ) m_valuesCache->insertValues( resultAddress, *values );
+        std::vector<double> nativeValues;
+        std::vector<double> historyValues;
 
-        return status;
-    }
+        if ( !this->values( nativeAdrHistory, &nativeValues ) ) return false;
+        if ( !this->values( nativeAdrNoHistory, &historyValues ) ) return false;
 
-    if ( m_ecl_SmSpec )
-    {
-        if ( m_differenceAddresses.count( resultAddress ) )
+        if ( nativeValues.size() != historyValues.size() ) return false;
+
+        for ( size_t i = 0; i < nativeValues.size(); i++ )
         {
-            const std::string& quantityName = resultAddress.quantityName();
-            auto historyQuantity = quantityName.substr( 0, quantityName.size() - differenceIdentifier().size() ) +
-                                   historyIdentifier();
-
-            RifEclipseSummaryAddress nativeAdrNoHistory = resultAddress;
-            nativeAdrNoHistory.setQuantityName( historyQuantity );
-            auto quantityNoHistory = quantityName.substr( 0, historyQuantity.size() - 1 );
-
-            RifEclipseSummaryAddress nativeAdrHistory = resultAddress;
-            nativeAdrHistory.setQuantityName( quantityNoHistory );
-
-            std::vector<double> nativeValues;
-            std::vector<double> historyValues;
-
-            if ( !this->values( nativeAdrHistory, &nativeValues ) ) return false;
-            if ( !this->values( nativeAdrNoHistory, &historyValues ) ) return false;
-
-            if ( nativeValues.size() != historyValues.size() ) return false;
-
-            for ( size_t i = 0; i < nativeValues.size(); i++ )
-            {
-                double diff = nativeValues[i] - historyValues[i];
-                values->push_back( diff );
-                m_valuesCache->insertValues( resultAddress, *values );
-            }
-
-            return true;
-        }
-
-        int variableIndex = indexFromAddress( resultAddress );
-        if ( variableIndex < 0 ) return false;
-
-        const ecl::smspec_node& ertSumVarNode = ecl_smspec_iget_node_w_node_index( m_ecl_SmSpec, variableIndex );
-        int                     paramsIndex   = ertSumVarNode.get_params_index();
-
-        double_vector_type* dataValues = ecl_sum_alloc_data_vector( m_ecl_sum, paramsIndex, false );
-
-        if ( dataValues )
-        {
-            int           dataSize = double_vector_size( dataValues );
-            const double* dataPtr  = double_vector_get_const_ptr( dataValues );
-            values->insert( values->end(), dataPtr, dataPtr + dataSize );
-            double_vector_free( dataValues );
-
+            double diff = nativeValues[i] - historyValues[i];
+            values->push_back( diff );
             m_valuesCache->insertValues( resultAddress, *values );
         }
+
+        return true;
+    }
+
+    auto reader = currentSummaryReader();
+    if ( reader )
+    {
+        auto status = reader->values( resultAddress, values );
+
+        if ( status ) m_valuesCache->insertValues( resultAddress, *values );
+
+        return status;
     }
 
     return true;
@@ -596,31 +193,13 @@ bool RifReaderEclipseSummary::values( const RifEclipseSummaryAddress& resultAddr
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-size_t RifReaderEclipseSummary::timeStepCount() const
-{
-    return m_timeSteps.size();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 const std::vector<time_t>& RifReaderEclipseSummary::timeSteps( const RifEclipseSummaryAddress& resultAddress ) const
 {
-    return m_timeSteps;
-}
+    auto reader = currentSummaryReader();
+    if ( reader ) return reader->timeSteps( resultAddress );
 
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-int RifReaderEclipseSummary::indexFromAddress( const RifEclipseSummaryAddress& resultAddress ) const
-{
-    auto it = m_resultAddressToErtNodeIdx.find( resultAddress );
-    if ( it != m_resultAddressToErtNodeIdx.end() )
-    {
-        return it->second;
-    }
-
-    return -1;
+    static std::vector<time_t> emptyVector;
+    return emptyVector;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -629,36 +208,14 @@ int RifReaderEclipseSummary::indexFromAddress( const RifEclipseSummaryAddress& r
 void RifReaderEclipseSummary::buildMetaData()
 {
     m_allResultAddresses.clear();
-    m_resultAddressToErtNodeIdx.clear();
+    m_allErrorAddresses.clear();
 
-    if ( m_hdf5OpmReader )
+    auto reader = currentSummaryReader();
+
+    if ( reader )
     {
-        m_allResultAddresses = m_hdf5OpmReader->allResultAddresses();
-        m_allErrorAddresses  = m_hdf5OpmReader->allErrorAddresses();
-
-        m_timeSteps = m_hdf5OpmReader->timeSteps( RifEclipseSummaryAddress() );
-        return;
-    }
-
-    if ( m_opmCommonReader )
-    {
-        m_allResultAddresses = m_opmCommonReader->allResultAddresses();
-        m_allErrorAddresses  = m_opmCommonReader->allErrorAddresses();
-
-        m_timeSteps = m_opmCommonReader->timeSteps( RifEclipseSummaryAddress() );
-        return;
-    }
-
-    if ( m_ecl_SmSpec )
-    {
-        int varCount = ecl_smspec_num_nodes( m_ecl_SmSpec );
-        for ( int i = 0; i < varCount; i++ )
-        {
-            const ecl::smspec_node&  ertSumVarNode = ecl_smspec_iget_node_w_node_index( m_ecl_SmSpec, i );
-            RifEclipseSummaryAddress addr          = addressFromErtSmSpecNode( ertSumVarNode );
-            m_allResultAddresses.insert( addr );
-            m_resultAddressToErtNodeIdx[addr] = i;
-        }
+        m_allResultAddresses = reader->allResultAddresses();
+        m_allErrorAddresses  = reader->allErrorAddresses();
     }
 
     bool addDifferenceVectors = true;
@@ -700,33 +257,11 @@ void RifReaderEclipseSummary::buildMetaData()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RifRestartFileInfo RifReaderEclipseSummary::getRestartFile( const QString& headerFileName )
+RifSummaryReaderInterface* RifReaderEclipseSummary::currentSummaryReader() const
 {
-    ecl_sum_type* ecl_sum = openEclSum( headerFileName, true );
+    if ( m_summaryReader ) return m_summaryReader.get();
 
-    const ecl_smspec_type* smspec  = ecl_sum ? ecl_sum_get_smspec( ecl_sum ) : nullptr;
-    const char*            rstCase = smspec ? ecl_smspec_get_restart_case( smspec ) : nullptr;
-    QString                restartCase =
-        rstCase ? RiaFilePathTools::canonicalPath( RiaStringEncodingTools::fromNativeEncoded( rstCase ) ) : "";
-    closeEclSum( ecl_sum );
-
-    if ( !restartCase.isEmpty() )
-    {
-        QString path        = QFileInfo( restartCase ).dir().path();
-        QString restartBase = QDir( restartCase ).dirName();
-
-        char*   smspec_header = ecl_util_alloc_exfilename( path.toStdString().data(),
-                                                         restartBase.toStdString().data(),
-                                                         ECL_SUMMARY_HEADER_FILE,
-                                                         false /*unformatted*/,
-                                                         0 );
-        QString restartFileName =
-            RiaFilePathTools::toInternalSeparator( RiaStringEncodingTools::fromNativeEncoded( smspec_header ) );
-        free( smspec_header );
-
-        return getFileInfo( restartFileName );
-    }
-    return RifRestartFileInfo();
+    return nullptr;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -734,14 +269,11 @@ RifRestartFileInfo RifReaderEclipseSummary::getRestartFile( const QString& heade
 //--------------------------------------------------------------------------------------------------
 std::string RifReaderEclipseSummary::unitName( const RifEclipseSummaryAddress& resultAddress ) const
 {
-    if ( !m_ecl_SmSpec ) return "";
+    auto reader = currentSummaryReader();
 
-    int variableIndex = indexFromAddress( resultAddress );
+    if ( reader ) return reader->unitName( resultAddress );
 
-    if ( variableIndex < 0 ) return "";
-
-    const ecl::smspec_node& ertSumVarNode = ecl_smspec_iget_node_w_node_index( m_ecl_SmSpec, variableIndex );
-    return ertSumVarNode.get_unit();
+    return "";
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -749,7 +281,11 @@ std::string RifReaderEclipseSummary::unitName( const RifEclipseSummaryAddress& r
 //--------------------------------------------------------------------------------------------------
 RiaDefines::EclipseUnitSystem RifReaderEclipseSummary::unitSystem() const
 {
-    return m_unitSystem;
+    auto reader = currentSummaryReader();
+
+    if ( reader ) return reader->unitSystem();
+
+    return RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp
+++ b/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp
@@ -286,10 +286,10 @@ void RifSummaryCaseRestartSelector::determineFilesToImportUsingPrefs( const std:
             else if ( defaultSummaryImportMode == RicSummaryCaseRestartDialog::ImportOptions::SEPARATE_CASES )
             {
                 m_summaryFileInfos.push_back( RifSummaryCaseFileResultInfo( initialSummaryFile, false ) );
-                bool                            hasWarnings = false;
-                RifReaderEclipseSummary         reader;
+
+                std::vector<QString>            warnings;
                 std::vector<RifRestartFileInfo> restartFileInfos =
-                    reader.getRestartFiles( initialSummaryFile, &hasWarnings );
+                    RifEclipseSummaryTools::getRestartFiles( initialSummaryFile, warnings );
                 for ( const auto& rfi : restartFileInfos )
                 {
                     RifSummaryCaseFileResultInfo resultFileInfo( RiaFilePathTools::toInternalSeparator( rfi.fileName ),
@@ -309,10 +309,10 @@ void RifSummaryCaseRestartSelector::determineFilesToImportUsingPrefs( const std:
             RicSummaryCaseRestartDialog::ImportOptions defaultGridImportMode = mapReadOption( prefs->gridImportMode() );
             if ( defaultGridImportMode == RicSummaryCaseRestartDialog::ImportOptions::SEPARATE_CASES )
             {
-                RifReaderEclipseSummary         reader;
-                bool                            hasWarnings = false;
+                std::vector<QString> warnings;
+
                 std::vector<RifRestartFileInfo> restartFileInfos =
-                    reader.getRestartFiles( initialSummaryFile, &hasWarnings );
+                    RifEclipseSummaryTools::getRestartFiles( initialSummaryFile, warnings );
                 for ( const auto& rfi : restartFileInfos )
                 {
                     QString gridFileName = RifEclipseSummaryTools::findGridCaseFileFromSummaryHeaderFile( rfi.fileName );
@@ -322,11 +322,8 @@ void RifSummaryCaseRestartSelector::determineFilesToImportUsingPrefs( const std:
                     }
                 }
 
-                if ( hasWarnings )
-                {
-                    for ( const QString& warning : reader.warnings() )
-                        RiaLogging::error( warning );
-                }
+                for ( const QString& warning : warnings )
+                    RiaLogging::error( warning );
             }
         }
 

--- a/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp
+++ b/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp
@@ -26,7 +26,6 @@
 #include "RicSummaryCaseRestartDialog.h"
 
 #include "RifEclipseSummaryTools.h"
-#include "RifReaderEclipseSummary.h"
 
 #include "cafProgressInfo.h"
 

--- a/ApplicationLibCode/FileInterface/RifSummaryReaderMultipleFiles.cpp
+++ b/ApplicationLibCode/FileInterface/RifSummaryReaderMultipleFiles.cpp
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2021-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RifSummaryReaderMultipleFiles.h"
+
+#include "RifReaderEclipseSummary.h"
+
+#include "cafAssert.h"
+
+#include <memory>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RifSummaryReaderMultipleFiles::RifSummaryReaderMultipleFiles( const std::vector<std::string>& filesOrderedByStartOfHistory )
+    : m_fileNames( filesOrderedByStartOfHistory )
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+const std::vector<time_t>& RifSummaryReaderMultipleFiles::timeSteps( const RifEclipseSummaryAddress& resultAddress ) const
+{
+    return m_aggregatedTimeSteps;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifSummaryReaderMultipleFiles::values( const RifEclipseSummaryAddress& resultAddress, std::vector<double>* values ) const
+{
+    for ( const auto& reader : m_summaryReaders )
+    {
+        std::vector<double> readerValues;
+        reader->values( resultAddress, &readerValues );
+        values->insert( values->end(), readerValues.begin(), readerValues.end() );
+    }
+
+    CAF_ASSERT( m_aggregatedTimeSteps.size() == values->size() );
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::string RifSummaryReaderMultipleFiles::unitName( const RifEclipseSummaryAddress& resultAddress ) const
+{
+    if ( !m_summaryReaders.empty() ) return m_summaryReaders.front()->unitName( resultAddress );
+
+    return "";
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::EclipseUnitSystem RifSummaryReaderMultipleFiles::unitSystem() const
+{
+    if ( !m_summaryReaders.empty() ) return m_summaryReaders.front()->unitSystem();
+
+    return RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifSummaryReaderMultipleFiles::createReadersAndImportMetaData( RiaThreadSafeLogger* threadSafeLogger )
+{
+    for ( const auto& fileName : m_fileNames )
+    {
+        auto candidate = std::make_unique<RifReaderEclipseSummary>();
+        auto result    = candidate->open( QString::fromStdString( fileName ), threadSafeLogger );
+        if ( result )
+        {
+            m_summaryReaders.push_back( std::move( candidate ) );
+        }
+    }
+
+    for ( const auto& reader : m_summaryReaders )
+    {
+        auto readerTimeSteps = reader->timeSteps( {} );
+
+        m_aggregatedTimeSteps.insert( m_aggregatedTimeSteps.end(), readerTimeSteps.begin(), readerTimeSteps.end() );
+
+        {
+            auto resultAddresses = reader->allResultAddresses();
+            m_allResultAddresses.insert( resultAddresses.begin(), resultAddresses.end() );
+        }
+
+        {
+            auto errorResultAddresses = reader->allErrorAddresses();
+            m_allErrorAddresses.insert( errorResultAddresses.begin(), errorResultAddresses.end() );
+        }
+    }
+
+    return true;
+}

--- a/ApplicationLibCode/FileInterface/RifSummaryReaderMultipleFiles.h
+++ b/ApplicationLibCode/FileInterface/RifSummaryReaderMultipleFiles.h
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2021-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RifSummaryReaderInterface.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class RiaThreadSafeLogger;
+
+//==================================================================================================
+//
+// This class is used to append time history curves from multiple summary files. The summary files are assumed to be
+// ordered, and the start of history at the front of the vector
+//
+//==================================================================================================
+class RifSummaryReaderMultipleFiles : public RifSummaryReaderInterface
+{
+public:
+    RifSummaryReaderMultipleFiles( const std::vector<std::string>& filesOrderedByStartOfHistory );
+
+    bool createReadersAndImportMetaData( RiaThreadSafeLogger* threadSafeLogger );
+
+    const std::vector<time_t>& timeSteps( const RifEclipseSummaryAddress& resultAddress ) const override;
+    bool        values( const RifEclipseSummaryAddress& resultAddress, std::vector<double>* values ) const override;
+    std::string unitName( const RifEclipseSummaryAddress& resultAddress ) const override;
+    RiaDefines::EclipseUnitSystem unitSystem() const override;
+
+private:
+    std::vector<std::string>                                m_fileNames;
+    std::vector<std::unique_ptr<RifSummaryReaderInterface>> m_summaryReaders;
+
+    std::vector<time_t> m_aggregatedTimeSteps;
+};

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimAsciiDataCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimAsciiDataCurve.cpp
@@ -18,8 +18,6 @@
 
 #include "RimAsciiDataCurve.h"
 
-#include "RifReaderEclipseSummary.h"
-
 #include "RiaDefines.h"
 #include "RimEclipseResultCase.h"
 #include "RimProject.h"

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
@@ -30,7 +30,6 @@
 #include "SummaryPlotCommands/RicSummaryPlotEditorUi.h"
 
 #include "RifEnsembleStatisticsReader.h"
-#include "RifReaderEclipseSummary.h"
 
 #include "RigStatisticsMath.h"
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp
@@ -20,8 +20,6 @@
 
 #include "RiaStdStringTools.h"
 
-#include "RifReaderEclipseSummary.h"
-
 #include "RimEnsembleCurveSet.h"
 #include "RimProject.h"
 #include "RimSummaryCase.h"

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
@@ -127,9 +127,9 @@ void RimFileSummaryCase::createRftReaderInterface()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RifReaderEclipseSummary* RimFileSummaryCase::findRelatedFilesAndCreateReader( const QString&       headerFileName,
-                                                                              bool                 includeRestartFiles,
-                                                                              RiaThreadSafeLogger* threadSafeLogger )
+RifSummaryReaderInterface* RimFileSummaryCase::findRelatedFilesAndCreateReader( const QString& headerFileName,
+                                                                                bool           includeRestartFiles,
+                                                                                RiaThreadSafeLogger* threadSafeLogger )
 {
     RifReaderEclipseSummary* summaryFileReader = new RifReaderEclipseSummary;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.h
@@ -52,14 +52,14 @@ public:
 
     void setIncludeRestartFiles( bool includeRestartFiles );
 
-    static RifReaderEclipseSummary* findRelatedFilesAndCreateReader( const QString&       headerFileName,
-                                                                     bool                 includeRestartFiles,
-                                                                     RiaThreadSafeLogger* threadSafeLogger );
+    static RifSummaryReaderInterface* findRelatedFilesAndCreateReader( const QString&       headerFileName,
+                                                                       bool                 includeRestartFiles,
+                                                                       RiaThreadSafeLogger* threadSafeLogger );
 
     static RifReaderEclipseRft* findRftDataAndCreateReader( const QString& headerFileName );
 
 private:
-    cvf::ref<RifReaderEclipseSummary> m_summaryFileReader;
-    cvf::ref<RifReaderEclipseRft>     m_summaryEclipseRftReader;
-    caf::PdmField<bool>               m_includeRestartFiles;
+    cvf::ref<RifSummaryReaderInterface> m_summaryFileReader;
+    cvf::ref<RifReaderEclipseRft>       m_summaryEclipseRftReader;
+    caf::PdmField<bool>                 m_includeRestartFiles;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimGridSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimGridSummaryCase.cpp
@@ -19,7 +19,8 @@
 #include "RimGridSummaryCase.h"
 
 #include "RicfCommandObject.h"
-#include "RifReaderEclipseSummary.h"
+
+#include "RifSummaryReaderInterface.h"
 
 #include "RimEclipseCase.h"
 #include "RimFileSummaryCase.h"

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimGridSummaryCase.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimGridSummaryCase.h
@@ -25,7 +25,7 @@
 #include "cvfObject.h"
 
 class RimEclipseCase;
-class RifReaderEclipseSummary;
+class RifSummaryReaderInterface;
 class RimFileSummaryCase;
 
 //==================================================================================================
@@ -64,6 +64,6 @@ private:
     mutable caf::PdmField<QString>    m_cachedCaseName;
     caf::PdmProxyValueField<QString>  m_eclipseGridFileName;
 
-    cvf::ref<RifReaderEclipseSummary> m_summaryFileReader;
-    caf::PdmField<bool>               m_includeRestartFiles;
+    cvf::ref<RifSummaryReaderInterface> m_summaryFileReader;
+    caf::PdmField<bool>                 m_includeRestartFiles;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
@@ -34,7 +34,6 @@
 #include "RimSummaryCase.h"
 
 #include "RifReaderEclipseRft.h"
-#include "RifReaderEclipseSummary.h"
 #include "RifReaderEnsembleStatisticsRft.h"
 #include "RifSummaryReaderInterface.h"
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -28,8 +28,6 @@
 #include "RiaSummaryCurveDefinition.h"
 #include "RiaSummaryTools.h"
 
-#include "RifReaderEclipseSummary.h"
-
 #include "RimEclipseResultCase.h"
 #include "RimEnsembleCurveSet.h"
 #include "RimEnsembleCurveSetCollection.h"

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.cpp
@@ -22,8 +22,6 @@
 
 #include "SummaryPlotCommands/RicEditSummaryPlotFeature.h"
 
-#include "RifReaderEclipseSummary.h"
-
 #include "RimProject.h"
 #include "RimSummaryCase.h"
 #include "RimSummaryCrossPlot.h"

--- a/ApplicationLibCode/UnitTests/HDF5FileWriter-Test.cpp
+++ b/ApplicationLibCode/UnitTests/HDF5FileWriter-Test.cpp
@@ -43,7 +43,7 @@ TEST( DISABLED_HDFTests, WriteDataToH5 )
     try
     {
         RifReaderEclipseSummary summaryReader;
-        summaryReader.open( file_path, true, nullptr );
+        summaryReader.open( file_path, nullptr );
 
         {
             std::string exportFileName = "e:/project/scratch_export/hdf-test.h5";

--- a/ApplicationLibCode/UnitTests/RifReaderEclipseSummary-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifReaderEclipseSummary-Test.cpp
@@ -26,21 +26,63 @@
 #include <QDateTime>
 #include <QDir>
 
+#include "RifSummaryReaderMultipleFiles.h"
 #include <memory>
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RifEclipseSummaryTest, BasicTestSetCurrentFolder )
+TEST( DISABLED_RifEclipseSummaryTest, TestRestartSummaryFileReferences_01 )
 {
-    RifReaderEclipseSummary eclSummary;
+    QString summaryFileName =
+        "d:/Dropbox/Dropbox (Ceetron Solutions)/Projects/20084 ResInsight Introduction and Advanced "
+        "courses/intro2020_data/reek_ensemble/3_r001_reek_50/realization-0/base_pred/eclipse/model/"
+        "3_R001_REEK-0.SMSPEC";
 
+    std::vector<QString>            warnings;
+    std::vector<RifRestartFileInfo> originFileInfos = RifEclipseSummaryTools::getRestartFiles( summaryFileName, warnings );
+    EXPECT_TRUE( originFileInfos.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( DISABLED_RifEclipseSummaryTest, TestRestartSummaryFileReferences_02 )
+{
+    QString summaryFileName =
+        "e:/models/reek_ensemble/3_r001_reek_50/realization-0/base_pred/eclipse/model/3_R001_REEK-0.SMSPEC";
+
+    std::vector<QString>            warnings;
+    std::vector<RifRestartFileInfo> originFileInfos = RifEclipseSummaryTools::getRestartFiles( summaryFileName, warnings );
+
+    if ( !originFileInfos.empty() )
+    {
+        std::vector<std::string> smspecFilesNewFirst;
+        smspecFilesNewFirst.push_back( summaryFileName.toStdString() );
+        for ( const auto& s : originFileInfos )
+        {
+            smspecFilesNewFirst.push_back( s.fileName.toStdString() );
+        }
+
+        RifSummaryReaderMultipleFiles multipleSummaryFiles( smspecFilesNewFirst );
+        auto                          ts = multipleSummaryFiles.timeSteps( {} );
+        std::cout << ts.size();
+    }
+
+    EXPECT_TRUE( originFileInfos.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( DISABLED_RifEclipseSummaryTest, BasicTestSetCurrentFolder )
+{
     static const QString testDataRootFolder = QString( "%1/SummaryData/Reek/" ).arg( TEST_DATA_DIR );
 
     QString summaryFileName = testDataRootFolder + "3_R001_REEK-1.SMSPEC";
 
-    bool                            hasWarning      = false;
-    std::vector<RifRestartFileInfo> originFileInfos = eclSummary.getRestartFiles( summaryFileName, &hasWarning );
+    std::vector<QString>            warnings;
+    std::vector<RifRestartFileInfo> originFileInfos = RifEclipseSummaryTools::getRestartFiles( summaryFileName, warnings );
     EXPECT_TRUE( originFileInfos.empty() );
 }
 
@@ -63,7 +105,7 @@ void printDateAndValues(const std::vector<QDateTime>& dates, const std::vector<d
 TEST(RifEclipseSummaryTest, SummaryToolsFindSummaryFiles)
 {
     {
-//        std::string filename = "g:\\Models\\Statoil\\MultipleRealisations\\Case_without_p9\\Real10\\BRUGGE_0010";
+//        std::string filename = "g:/\Models\\Statoil\\MultipleRealisations\\Case_without_p9\\Real10\\BRUGGE_0010";
         std::string filename = "g:\\Models\\Statoil\\testcase_juli_2011\\data\\TEST10K_FLT_LGR_NNC";
 
         {

--- a/ApplicationLibCode/UnitTests/RifSummaryDataReader-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifSummaryDataReader-Test.cpp
@@ -74,7 +74,7 @@ TEST( DISABLED_RifSummaryDataTest, LibEclAllData )
         {
             auto start = std::chrono::high_resolution_clock::now();
 
-            reader.open( filename, true, nullptr );
+            reader.open( filename, nullptr );
 
             auto                          end  = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> diff = end - start;


### PR DESCRIPTION
- add a summary reader able to work with multiple summary files
- remove support for reading of complete history in low level summary importers
- make sure HDF5 creation/import works as expected in this setting

Closes #7622