### PR TITLE
PERM and other arrays default colour legend type change

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
@@ -110,6 +110,7 @@ RimGridCrossPlotDataSet::RimGridCrossPlotDataSet()
 
     CAF_PDM_InitFieldNoDefault( &m_groupingProperty, "GroupingProperty", "Data Grouping Property", "", "", "" );
     m_groupingProperty = new RimEclipseCellColors;
+    m_groupingProperty->useDiscreteLogLevels( true );
     m_groupingProperty.uiCapability()->setUiHidden( true );
     CVF_ASSERT( m_groupingProperty->legendConfig() );
     m_groupingProperty->legendConfig()->setMappingMode( RimRegularLegendConfig::MappingType::CATEGORY_INTEGER );

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp
@@ -68,6 +68,8 @@ RimEclipseCellColors::RimEclipseCellColors()
 
     // Make sure we have a created legend for the default/undefined result variable
     changeLegendConfig( this->resultVariable() );
+
+    m_useDiscreteLogLevels = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -150,7 +152,9 @@ void RimEclipseCellColors::changeLegendConfig( QString resultVarNameOfNewLegend 
 
             if ( !found )
             {
-                auto newLegend = createLegendForResult( resultVarNameOfNewLegend, this->hasCategoryResult() );
+                auto newLegend = createLegendForResult( resultVarNameOfNewLegend,
+                                                        this->m_useDiscreteLogLevels,
+                                                        this->hasCategoryResult() );
 
                 m_legendConfigData.push_back( newLegend );
 
@@ -176,7 +180,9 @@ void RimEclipseCellColors::onLegendConfigChanged( const caf::SignalEmitter* emit
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimRegularLegendConfig* RimEclipseCellColors::createLegendForResult( const QString& resultName, bool isCategoryResult )
+RimRegularLegendConfig* RimEclipseCellColors::createLegendForResult( const QString& resultName,
+                                                                     bool           useDiscreteLogLevels,
+                                                                     bool           isCategoryResult )
 {
     bool useLog = false;
     {
@@ -207,7 +213,11 @@ RimRegularLegendConfig* RimEclipseCellColors::createLegendForResult( const QStri
 
     if ( useLog )
     {
-        newLegend->setMappingMode( RimRegularLegendConfig::MappingType::LOG10_DISCRETE );
+        if ( useDiscreteLogLevels )
+            newLegend->setMappingMode( RimRegularLegendConfig::MappingType::LOG10_DISCRETE );
+        else
+            newLegend->setMappingMode( RimRegularLegendConfig::MappingType::LOG10_CONTINUOUS );
+
         newLegend->setTickNumberFormat( RimRegularLegendConfig::NumberFormatType::AUTO );
         newLegend->setRangeMode( RimLegendConfig::RangeModeType::USER_DEFINED );
         newLegend->resetUserDefinedValues();
@@ -300,6 +310,14 @@ void RimEclipseCellColors::updateLegendCategorySettings()
 void RimEclipseCellColors::uiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName /*= ""*/ )
 {
     defineUiTreeOrdering( uiTreeOrdering, uiConfigName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEclipseCellColors::useDiscreteLogLevels( bool enable )
+{
+    m_useDiscreteLogLevels = true;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.h
@@ -60,6 +60,8 @@ public:
     void updateLegendCategorySettings() override;
     void uiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" );
 
+    void useDiscreteLogLevels( bool enable );
+
 protected:
     // Overridden methods
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
@@ -74,13 +76,16 @@ protected:
 private:
     void changeLegendConfig( QString resultVarNameOfNewLegend );
     void onLegendConfigChanged( const caf::SignalEmitter* emitter, RimLegendConfigChangeType changeType );
-    static RimRegularLegendConfig* createLegendForResult( const QString& resultName, bool isCategoryResult );
+    static RimRegularLegendConfig*
+        createLegendForResult( const QString& resultName, bool useDiscreteLevels, bool isCategoryResult );
 
     caf::PdmChildArrayField<RimRegularLegendConfig*> m_legendConfigData;
     caf::PdmPtrField<RimRegularLegendConfig*>        m_legendConfigPtrField;
     caf::PdmChildField<RimTernaryLegendConfig*>      m_ternaryLegendConfig;
 
     caf::PdmPointer<RimEclipseView> m_reservoirView;
+
+    bool m_useDiscreteLogLevels;
 
     // Obsolete
     caf::PdmChildField<RimRegularLegendConfig*> obsoleteField_legendConfig;


### PR DESCRIPTION
Restore default color legend to "Continuous Logarithmic" instead of "Discrete Logarithmic" 

Closes #7647