### PR TITLE
GHA : Skip upload of duplicate artifacts

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
-        if: "matrix.config.name != Ubuntu Latest clang"
+        if: "matrix.config.name != 'Ubuntu Latest clang'"
         with:
           name: ResInsight-${{ matrix.config.name }}
           path: ${{ runner.workspace }}/ResInsight/cmakebuild/install

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -240,6 +240,7 @@ jobs:
         shell: bash
         run: |
           cmakebuild/ApplicationExeCode/ResInsight --unittest
+
       - name: Run pytest
         if: "matrix.config.build-python-module == true"
         env:
@@ -247,8 +248,10 @@ jobs:
         run: |
           cd GrpcInterface/Python/rips
           ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m pytest --console
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
+        if: "matrix.config.name != Ubuntu Latest clang"
         with:
           name: ResInsight-${{ matrix.config.name }}
           path: ${{ runner.workspace }}/ResInsight/cmakebuild/install


### PR DESCRIPTION
Ubuntu using clang is created to make sure the clang compiler works. The artifact name is identical and break the build if two processes upload at the same time.

This commit will disable upload of artifact for Ubuntu clang build