### PR TITLE
#3693 Intersect : Use active state of LGR to define visibility

### DIFF
--- a/ApplicationLibCode/Application/RiaDefines.cpp
+++ b/ApplicationLibCode/Application/RiaDefines.cpp
@@ -197,6 +197,52 @@ QString RiaDefines::mockModelBasicInputCase()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RiaDefines::DepthUnitType RiaDefines::fromEclipseUnit( EclipseUnitSystem eclipseUnit )
+{
+    switch ( eclipseUnit )
+    {
+        case RiaDefines::EclipseUnitSystem::UNITS_METRIC:
+            return DepthUnitType::UNIT_METER;
+            break;
+        case RiaDefines::EclipseUnitSystem::UNITS_FIELD:
+            return DepthUnitType::UNIT_FEET;
+            break;
+        case RiaDefines::EclipseUnitSystem::UNITS_LAB:
+            break;
+        case RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN:
+            break;
+        default:
+            break;
+    }
+
+    return DepthUnitType::UNIT_NONE;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::EclipseUnitSystem RiaDefines::fromDepthUnit( DepthUnitType depthUnit )
+{
+    switch ( depthUnit )
+    {
+        case RiaDefines::DepthUnitType::UNIT_METER:
+            return RiaDefines::EclipseUnitSystem::UNITS_METRIC;
+            break;
+        case RiaDefines::DepthUnitType::UNIT_FEET:
+            return RiaDefines::EclipseUnitSystem::UNITS_FIELD;
+            break;
+        case RiaDefines::DepthUnitType::UNIT_NONE:
+            break;
+        default:
+            break;
+    }
+
+    return RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 double RiaDefines::minimumDefaultValuePlot()
 {
     return -10.0;

--- a/ApplicationLibCode/Application/RiaDefines.h
+++ b/ApplicationLibCode/Application/RiaDefines.h
@@ -94,6 +94,9 @@ enum class DepthUnitType
     UNIT_NONE
 };
 
+DepthUnitType     fromEclipseUnit( EclipseUnitSystem eclipseUnit );
+EclipseUnitSystem fromDepthUnit( DepthUnitType depthUnit );
+
 // Depth types used for well log plots
 enum class DepthTypeEnum
 {

--- a/ApplicationLibCode/Application/Tools/RiaEclipseUnitTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaEclipseUnitTools.cpp
@@ -47,31 +47,6 @@ double RiaEclipseUnitTools::darcysConstant( RiaDefines::EclipseUnitSystem unitSy
 }
 
 //--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RiaDefines::DepthUnitType RiaEclipseUnitTools::depthUnit( RiaDefines::EclipseUnitSystem unit )
-{
-    switch ( unit )
-    {
-        case RiaDefines::EclipseUnitSystem::UNITS_METRIC:
-            return RiaDefines::DepthUnitType::UNIT_METER;
-            break;
-        case RiaDefines::EclipseUnitSystem::UNITS_FIELD:
-            return RiaDefines::DepthUnitType::UNIT_FEET;
-            break;
-        case RiaDefines::EclipseUnitSystem::UNITS_LAB:
-            return RiaDefines::DepthUnitType::UNIT_NONE;
-            break;
-        case RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN:
-            return RiaDefines::DepthUnitType::UNIT_NONE;
-            break;
-        default:
-            return RiaDefines::DepthUnitType::UNIT_NONE;
-            break;
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
 /// Convert Gas to oil equivalents
 /// If field unit, the Gas is in Mega ft^3 while the others are in [stb] (barrel)
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/Tools/RiaEclipseUnitTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaEclipseUnitTools.h
@@ -44,8 +44,6 @@ public:
 
     static double darcysConstant( RiaDefines::EclipseUnitSystem unitSystem );
 
-    static RiaDefines::DepthUnitType depthUnit( RiaDefines::EclipseUnitSystem unit );
-
     static double convertSurfaceGasFlowRateToOilEquivalents( RiaDefines::EclipseUnitSystem, double eclGasFlowRate );
 
     static QString unitStringPressure( RiaDefines::EclipseUnitSystem unitSystem );

--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -19,6 +19,8 @@
 #include "RicWellLogTools.h"
 
 #include "RiaGuiApplication.h"
+
+#include "RigEclipseCaseData.h"
 #include "RigWellLogCurveData.h"
 
 #include "Rim3dView.h"
@@ -181,7 +183,16 @@ ExtractionCurveType* RicWellLogTools::addExtractionCurve( RimWellLogTrack*      
                                                           bool                    showPlotWindow )
 {
     CVF_ASSERT( plotTrack );
+
+    RiaDefines::DepthUnitType defaultDepthUnit = RiaDefines::DepthUnitType::UNIT_METER;
+
+    if ( auto eclipseCase = dynamic_cast<RimEclipseCase*>( caseToApply ) )
+    {
+        defaultDepthUnit = RiaDefines::fromEclipseUnit( eclipseCase->eclipseCaseData()->unitsType() );
+    }
+
     ExtractionCurveType* curve = new ExtractionCurveType();
+    curve->setDepthUnit( defaultDepthUnit );
 
     cvf::Color3f curveColor = RicWellLogPlotCurveFeatureImpl::curveColorFromTable( plotTrack->curveCount() );
     curve->setColor( curveColor );

--- a/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp
@@ -639,12 +639,11 @@ void RivReservoirViewPartMgr::computeNativeVisibility( cvf::UByteArray*         
     for ( int cellIndex = 0; cellIndex < static_cast<int>( grid->cellCount() ); cellIndex++ )
     {
         const RigCell& cell               = grid->cell( cellIndex );
-        size_t         reservoirCellIndex = cell.mainGridCellIndex();
+        size_t         reservoirCellIndex = grid->reservoirCellIndex( cellIndex );
+        bool           isCellActive       = activeCellInfo->isActive( reservoirCellIndex );
 
-        if ( !invalidCellsIsVisible && cell.isInvalid() ||
-             !inactiveCellsIsVisible && !activeCellInfo->isActive( reservoirCellIndex ) ||
-             !activeCellsIsVisible && activeCellInfo->isActive( reservoirCellIndex ) ||
-             ( *cellIsInWellStatuses )[cellIndex] )
+        if ( !invalidCellsIsVisible && cell.isInvalid() || !inactiveCellsIsVisible && !isCellActive ||
+             !activeCellsIsVisible && isCellActive || ( *cellIsInWellStatuses )[cellIndex] )
         {
             ( *cellVisibility )[cellIndex] = false;
         }
@@ -693,8 +692,8 @@ void RivReservoirViewPartMgr::computeOverriddenCellVisibility( cvf::UByteArray* 
 
         for ( int mcIdx = 0; mcIdx < cellCount; ++mcIdx )
         {
-            ( *cellVisibility )[lcIdx] |= ( *totCellVisibility )[cellIndicesInMasterCase[mcIdx]]; // If any is visible,
-                                                                                                  // show
+            ( *cellVisibility )[lcIdx] |= ( *totCellVisibility )[cellIndicesInMasterCase[mcIdx]]; // If any is
+                                                                                                  // visible, show
         }
 
 #else
@@ -772,8 +771,8 @@ void RivReservoirViewPartMgr::computeFilterVisibility( RivCellSetEnum           
 
             if ( geometryType == RANGE_FILTERED_WELL_CELLS )
             {
-                geometryType = RANGE_FILTERED; // Use the range filtering in the parent grid, not the well cells in the
-                                               // parent grid
+                geometryType = RANGE_FILTERED; // Use the range filtering in the parent grid, not the well cells in
+                                               // the parent grid
             }
 
             RivReservoirPartMgr* reservoirGridPartMgr = &m_geometries[geometryType];

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellPltPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellPltPlot.cpp
@@ -167,19 +167,8 @@ void RimWellPltPlot::setPlotXAxisTitles( RimWellLogTrack* plotTrack )
         {
             if ( source.wellLogFile()->wellLogFileData() )
             {
-                // Todo: Handle different units in the relevant las channels
-                switch ( source.wellLogFile()->wellLogFileData()->depthUnit() )
-                {
-                    case RiaDefines::DepthUnitType::UNIT_METER:
-                        presentUnitSystems.insert( RiaDefines::EclipseUnitSystem::UNITS_METRIC );
-                        break;
-                    case RiaDefines::DepthUnitType::UNIT_FEET:
-                        presentUnitSystems.insert( RiaDefines::EclipseUnitSystem::UNITS_FIELD );
-                        break;
-                    case RiaDefines::DepthUnitType::UNIT_NONE:
-                        presentUnitSystems.insert( RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN );
-                        break;
-                }
+                auto eclipseUnit = RiaDefines::fromDepthUnit( source.wellLogFile()->wellLogFileData()->depthUnit() );
+                presentUnitSystems.insert( eclipseUnit );
             }
         }
     }
@@ -654,14 +643,7 @@ void RimWellPltPlot::syncCurvesFromUiSelection()
 
                     std::vector<double> depthValues = wellLogFileData->depthValues();
 
-                    RiaDefines::EclipseUnitSystem unitSystem = RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN;
-                    {
-                        RiaDefines::DepthUnitType depthUnit = wellLogFileData->depthUnit();
-                        if ( depthUnit == RiaDefines::DepthUnitType::UNIT_FEET )
-                            unitSystem = RiaDefines::EclipseUnitSystem::UNITS_FIELD;
-                        if ( depthUnit == RiaDefines::DepthUnitType::UNIT_METER )
-                            unitSystem = RiaDefines::EclipseUnitSystem::UNITS_METRIC;
-                    }
+                    RiaDefines::EclipseUnitSystem unitSystem = RiaDefines::fromDepthUnit( wellLogFileData->depthUnit() );
 
                     for ( const ChannelValNameIdxTuple& channelInfo : sortedChannels )
                     {

--- a/ApplicationLibCode/ProjectDataModel/RimExtrudedCurveIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimExtrudedCurveIntersection.cpp
@@ -328,8 +328,6 @@ void RimExtrudedCurveIntersection::defineUiOrdering( QString uiConfigName, caf::
 
     this->defineSeparateDataSourceUi( uiConfigName, uiOrdering );
 
-    updateWellExtentDefaultValue();
-
     uiOrdering.skipRemainingFields( true );
 }
 
@@ -623,24 +621,6 @@ void RimExtrudedCurveIntersection::addExtents( std::vector<cvf::Vec3d>& polyLine
         cvf::Vec3d newStart = polyLine.front() + startDirection * m_extentLength();
 
         polyLine.insert( polyLine.begin(), newStart );
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimExtrudedCurveIntersection::updateWellExtentDefaultValue()
-{
-    RimCase* ownerCase = nullptr;
-    firstAncestorOrThisOfType( ownerCase );
-
-    if ( ownerCase )
-    {
-        cvf::BoundingBox caseBB = ownerCase->activeCellsBoundingBox();
-        if ( m_extentLength == m_extentLength.defaultValue() && caseBB.radius() < 1000 )
-        {
-            m_extentLength = caseBB.radius() * 0.1;
-        }
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimExtrudedCurveIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimExtrudedCurveIntersection.h
@@ -139,7 +139,6 @@ private:
     RimSimWellInViewCollection* simulationWellCollection() const;
     void                        updateAzimuthLine();
     void                        updateSimulationWellCenterline() const;
-    void                        updateWellExtentDefaultValue();
     void                        addExtents( std::vector<cvf::Vec3d>& polyLine ) const;
     void                        updateName();
     static double               azimuthInRadians( cvf::Vec3d vec );

--- a/ApplicationLibCode/ProjectDataModel/RimWellLogCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimWellLogCurve.cpp
@@ -67,6 +67,14 @@ RimWellLogCurve::~RimWellLogCurve()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimWellLogCurve::setDepthUnit( RiaDefines::DepthUnitType depthUnit )
+{
+    m_curveData->setDepthUnit( depthUnit );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RimWellLogCurve::xValueRangeInData( double* minimumValue, double* maximumValue ) const
 {
     CAF_ASSERT( minimumValue && maximumValue );

--- a/ApplicationLibCode/ProjectDataModel/RimWellLogCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/RimWellLogCurve.h
@@ -40,6 +40,8 @@ public:
     RimWellLogCurve();
     ~RimWellLogCurve() override;
 
+    void setDepthUnit( RiaDefines::DepthUnitType depthUnit );
+
     bool xValueRangeInData( double* minimumValue, double* maximumValue ) const;
     bool yValueRangeInData( double* minimumValue, double* maximumValue ) const;
 

--- a/ApplicationLibCode/ProjectDataModel/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimWellLogRftCurve.cpp
@@ -456,7 +456,7 @@ void RimWellLogRftCurve::onLoadDataAndUpdate( bool updateParentPlot )
                                      measuredDepthVector,
                                      tvDepthVector,
                                      rkbDiff,
-                                     RiaEclipseUnitTools::depthUnit( unitSystem ),
+                                     RiaDefines::fromEclipseUnit( unitSystem ),
                                      false );
 
         RiaDefines::DepthUnitType displayUnit = RiaDefines::DepthUnitType::UNIT_METER;

--- a/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.cpp
@@ -48,6 +48,14 @@ RigWellLogCurveData::~RigWellLogCurveData()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RigWellLogCurveData::setDepthUnit( RiaDefines::DepthUnitType depthUnit )
+{
+    m_depthUnit = depthUnit;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>& xValues,
                                               const std::vector<double>& depths,
                                               RiaDefines::DepthTypeEnum  depthType,

--- a/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.h
@@ -41,6 +41,8 @@ public:
     RigWellLogCurveData();
     ~RigWellLogCurveData() override;
 
+    void setDepthUnit( RiaDefines::DepthUnitType depthUnit );
+
     void setValuesAndDepths( const std::vector<double>& xValues,
                              const std::vector<double>& depths,
                              RiaDefines::DepthTypeEnum  depthType,


### PR DESCRIPTION
Eclipse reports parent cell to LGR cells as active, and this property has been tested for in code.

Intersect reports inactive cell in the parent grid cell. Then we have to only check the active state of the LGR cell, not the parent cell.

Closes #3693
Closes #7765