### PR TITLE
#7842 Python: fix undefined variable on version mismatch.

### DIFF
--- a/GrpcInterface/Python/rips/instance.py
+++ b/GrpcInterface/Python/rips/instance.py
@@ -188,7 +188,7 @@ class Instance:
         # Main version check package
         self.app = App_pb2_grpc.AppStub(self.channel)
 
-        self._check_connection_and_version(self.channel, launched)
+        self._check_connection_and_version(self.channel, launched, location)
 
         # Intercept UNAVAILABLE errors and retry on failures
         interceptors = (
@@ -211,7 +211,7 @@ class Instance:
         path = os.getcwd()
         self.set_start_dir(path=path)
 
-    def _check_connection_and_version(self, channel, launched):
+    def _check_connection_and_version(self, channel, launched, location):
         connection_ok = False
         version_ok = False
 


### PR DESCRIPTION
The location variable was not defined when creating the error message
for version mismatch between rips and application.

Fixes #7842.