### PR TITLE
ODB 2020: Update libraries list for linking

### DIFF
--- a/ApplicationLibCode/GeoMech/OdbReader/CMakeLists.txt
+++ b/ApplicationLibCode/GeoMech/OdbReader/CMakeLists.txt
@@ -50,21 +50,19 @@ if(MSVC)
   list(
     APPEND
     RI_ODB_LIBS
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbDdbOdb.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAAbuBasicUtils.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAAbuGeom.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMABasAlloc.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMABasCoreUtils.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMABasShared.lib
     ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbApi.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbAttrEO.lib
     ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbCore.lib
     ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbCoreGeom.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbAttrEO.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAAbuBasicUtils.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMABasShared.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMABasCoreUtils.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAStiCAE_StableTime.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMABasMem.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAAbuGeom.lib
+    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAOdbDdbOdb.lib
     ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMARomDiagEx.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMASspUmaCore.lib
     ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMASimInterface.lib
-    ${RESINSIGHT_ODB_API_DIR}/lib/ABQSMAMtxCoreModule.lib)
+    )
 else()
   list(
     APPEND
@@ -77,13 +75,11 @@ else()
     ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMAAbuBasicUtils.so
     ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMABasShared.so
     ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMABasCoreUtils.so
-    ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMAStiCAE_StableTime.so
-    ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMABasMem.so
+    ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMABasAlloc.so
     ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMAAbuGeom.so
     ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMARomDiagEx.so
-    ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMASspUmaCore.so
     ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMASimInterface.so
-    ${RESINSIGHT_ODB_API_DIR}/lib/libABQSMAMtxCoreModule.so)
+    )
 endif(MSVC)
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This enables ResInsight to read abaqus 2020 odb files (and only version 2020, as there only can be one version at a time)

You need the abaqus odb 2020 libraries to build ResInsight with odb/geomech support.

Closes #7798
Closes #6886