### PR TITLE
Protect against crash in 3d view due to nullptr in linkwellpathfeature command check

### DIFF
--- a/ApplicationLibCode/Commands/WellPathCommands/RicLinkWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicLinkWellPathFeature.cpp
@@ -75,9 +75,12 @@ bool RicLinkWellPathFeature::isCommandChecked()
     if ( !wellPaths().empty() )
     {
         auto firstWell = dynamic_cast<RimModeledWellPath*>( wellPaths().front() );
-        if ( auto geoDef = firstWell->geometryDefinition() )
+        if ( firstWell )
         {
-            return geoDef->isReferencePointUpdatesLinked();
+            if ( auto geoDef = firstWell->geometryDefinition() )
+            {
+                return geoDef->isReferencePointUpdatesLinked();
+            }
         }
     }
     return false;

--- a/ApplicationLibCode/Commands/WellPathCommands/RicLinkWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicLinkWellPathFeature.cpp
@@ -74,8 +74,7 @@ bool RicLinkWellPathFeature::isCommandChecked()
 {
     if ( !wellPaths().empty() )
     {
-        auto firstWell = dynamic_cast<RimModeledWellPath*>( wellPaths().front() );
-        if ( firstWell )
+        if ( auto firstWell = dynamic_cast<RimModeledWellPath*>( wellPaths().front() ) )
         {
             if ( auto geoDef = firstWell->geometryDefinition() )
             {


### PR DESCRIPTION
Need to handle that wellpaths imported from file could exist.

If there is a mix of imported and modeled well paths, the code might have to do more than the existing fix does?