### PR TITLE
#7863 StimPlan Model: Add TST correction for more correct zone thickness

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigStimPlanModelTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigStimPlanModelTools.cpp
@@ -88,6 +88,10 @@ cvf::Vec3d RigStimPlanModelTools::calculateTSTDirection( RigEclipseCaseData* ecl
         direction *= -1.0;
     }
 
+    // Calculate an adjusted TST direction to improve the zone thickness in the well log plot.
+    // Using average of TST and TVD (default direction) in 3D.
+    direction = ( direction + defaultDirection ) / 2.0;
+
     return direction;
 }
 


### PR DESCRIPTION
TST is now adjusted (average of TST and TVD in 3D) to improve the zone thickness
in the well log plot.

Fixes #7863.