### PR TITLE
Autovcpkg repair

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ endif() # MSVC
 if(VCPKG_AUTO_INSTALL)
   vcpkg_install(boost-filesystem)
   vcpkg_install(boost-spirit)
+  include(${CMAKE_TOOLCHAIN_FILE})
 endif()
 
 add_subdirectory(ThirdParty/custom-opm-flowdiagnostics)

--- a/cmake/AutoVcpkg.cmake
+++ b/cmake/AutoVcpkg.cmake
@@ -77,7 +77,7 @@ function (vcpkg_bootstrap)
     find_program(AUTO_VCPKG_EXECUTABLE
             vcpkg PATHS ${AUTO_VCPKG_ROOT})
     if (NOT AUTO_VCPKG_EXECUTABLE)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/vcpkg-bootstrap.cmake" "${AUTO_VCPKG_ROOT}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/cmake/vcpkg-bootstrap.cmake" "${AUTO_VCPKG_ROOT}")
         execute_process(COMMAND ${CMAKE_COMMAND} -P "${AUTO_VCPKG_ROOT}/vcpkg-bootstrap.cmake"
                 WORKING_DIRECTORY ${AUTO_VCPKG_ROOT})
     endif ()


### PR DESCRIPTION
This fixes #7915.

Copy Vcpkg bootstrap file from the cmake subfolder and include the Vcpkg toolchain file at a point where it exists.