### PR TITLE
#7957 Move progressdialog control to General tab

### DIFF
--- a/ApplicationLibCode/Application/RiaPreferences.cpp
+++ b/ApplicationLibCode/Application/RiaPreferences.cpp
@@ -438,6 +438,7 @@ void RiaPreferences::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering&
         otherGroup->add( &showLasCurveWithoutTvdWarning );
         otherGroup->add( &holoLensDisableCertificateVerification );
         otherGroup->add( &m_useUndoRedo );
+        otherGroup->add( &m_showProgressBar );
     }
     else if ( uiConfigName == RiaPreferences::tabNameEclipseGrid() )
     {
@@ -536,7 +537,6 @@ void RiaPreferences::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering&
         }
 
         uiOrdering.add( &m_gtestFilter );
-        uiOrdering.add( &m_showProgressBar );
         uiOrdering.add( &m_showProjectChangedDialog );
         uiOrdering.add( &m_showTestToolbar );
         uiOrdering.add( &m_includeFractureDebugInfoFile );


### PR DESCRIPTION
The freeze bug in Qt is triggered when the progress bar is displayed for long-running processes. A temporary workaround for freeze issues is to disable the progress bar. Move the setting into General tab to make it easily available for all users.