### PR TITLE
Include <cctype> for std::isdigit

### DIFF
--- a/ThirdParty/custom-opm-common/opm-common/src/opm/io/eclipse/EclUtil.cpp
+++ b/ThirdParty/custom-opm-common/opm-common/src/opm/io/eclipse/EclUtil.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <array>
 #include <stdexcept>
+#include <cctype>
 #include <cmath>
 #include <fstream>
 #include <cstring>


### PR DESCRIPTION
Fixes build on VS 2017.