### PR TITLE
#7953 StimPlan Model: always recompute anchor position and thickness …

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -665,6 +665,12 @@ bool RiaApplication::loadProject( const QString&      projectFileName,
         }
 
         oilField->annotationCollection()->loadDataAndUpdate();
+
+        for ( auto well : oilField->wellPathCollection()->allWellPaths() )
+        {
+            for ( auto stimPlan : well->stimPlanModelCollection()->allStimPlanModels() )
+                stimPlan->resetAnchorPositionAndThicknessDirection();
+        }
     }
 
     // Some procedures in onProjectOpened() may rely on the display model having been created

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
@@ -173,9 +173,11 @@ RimStimPlanModel::RimStimPlanModel()
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_anchorPosition, "AnchorPosition", "Anchor Position", "", "", "" );
     m_anchorPosition.uiCapability()->setUiReadOnly( true );
+    m_anchorPosition.xmlCapability()->disableIO();
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_thicknessDirection, "ThicknessDirection", "Thickness Direction", "", "", "" );
     m_thicknessDirection.uiCapability()->setUiReadOnly( true );
+    m_thicknessDirection.xmlCapability()->disableIO();
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_thicknessDirectionWellPath,
                                           "ThicknessDirectionWellPath",
@@ -920,6 +922,17 @@ void RimStimPlanModel::updateThicknessDirectionWellPathName()
 //--------------------------------------------------------------------------------------------------
 void RimStimPlanModel::loadDataAndUpdate()
 {
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimStimPlanModel::resetAnchorPositionAndThicknessDirection()
+{
+    // Always recompute thickness direction as MD in project file might have been changed
+    updatePositionFromMeasuredDepth();
+    updateThicknessDirection();
+    updateBarrierProperties();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.h
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.h
@@ -153,6 +153,7 @@ public:
     RimWellPath* wellPath() const;
 
     void loadDataAndUpdate();
+    void resetAnchorPositionAndThicknessDirection();
 
     RimModeledWellPath* thicknessDirectionWellPath() const;
     void                setThicknessDirectionWellPath( RimModeledWellPath* thicknessDirectionWellPath );


### PR DESCRIPTION
…direction.

This is to support manually changing the MD directly in the project file.

Fixes #7953.