### PR TITLE
Revert "Use devtoolset-9 on CentOS 7"

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -30,12 +30,12 @@ jobs:
         yum install -y mesa-libGL-devel
         yum install -y freeglut-devel
 
-        yum install -y devtoolset-9
+        yum install -y devtoolset-7
         
         yum install -y rh-python36
     - name: Build QtCharts
       run: |
-        source /opt/rh/devtoolset-9/enable
+        source /opt/rh/devtoolset-7/enable
         git clone git://code.qt.io/qt/qtcharts.git
         cd qtcharts/
         git checkout v5.9.7
@@ -55,7 +55,7 @@ jobs:
         echo "::set-output name=PYTHON_EXECUTABLE::$(python -c 'import sys; import pathlib; print (pathlib.PurePath(sys.executable).as_posix())')"
     - name: Build ResInsight
       run: |
-        source /opt/rh/devtoolset-9/enable
+        source /opt/rh/devtoolset-7/enable
         source /opt/rh/rh-python36/enable
 
         cmake3 --version


### PR DESCRIPTION
For some unknown reason, gcc9 does not work on this configuration. Reverting back to gcc7

This reverts commit 72dcc46e2795cf0e172e1954f178e40464e1e8ae.
