### PR TITLE
#8103 Ensemble Well Logs: Index_K not available as property for geogrid

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp
@@ -23,6 +23,7 @@
 #include "RiaOptionItemFactory.h"
 #include "RiaPreferences.h"
 
+#include "RiaResultNames.h"
 #include "RigWellLogCurveData.h"
 #include "RigWellPath.h"
 
@@ -890,6 +891,13 @@ void RimDepthTrackPlot::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderi
         caf::PdmUiGroup* ensembleWellLogGroup = uiOrdering.addNewGroup( "Ensemble Well Log" );
         ensembleWellLogGroup->add( &m_depthEqualization );
         ensembleWellLogGroup->add( &m_ensembleCurveSet );
+
+        // Disable depth equalization if any of the ensmble is missing k-layer info
+        bool hasKLayerIndex = true;
+        for ( auto wellLogCurveSet : ensembleWellLogCurveSets )
+            if ( !wellLogCurveSet->hasPropertyInFile( RiaResultNames::indexKResultName() ) ) hasKLayerIndex = false;
+
+        m_depthEqualization.uiCapability()->setUiReadOnly( !hasKLayerIndex );
     }
 
     uiOrdering.skipRemainingFields( true );

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
@@ -179,6 +179,8 @@ bool RimEclipseInputCase::openDataFileSet( const QStringList& fileNames )
         this->ensureFaultDataIsComputed();
     }
 
+    results( RiaDefines::PorosityModelType::MATRIX_MODEL )->createPlaceholderResultEntries();
+
     return true;
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.cpp
@@ -472,6 +472,9 @@ void RimEnsembleWellLogCurveSet::defineUiOrdering( QString uiConfigName, caf::Pd
     uiOrdering.add( &m_ensembleCurveSet );
     uiOrdering.add( &m_depthEqualization );
 
+    bool hasKLayerIndex = hasPropertyInFile( RiaResultNames::indexKResultName() );
+    m_depthEqualization.uiCapability()->setUiReadOnly( !hasKLayerIndex );
+
     appendColorGroup( uiOrdering );
 
     {
@@ -1264,4 +1267,28 @@ cvf::ref<RigWellPathFormations>
     cvf::ref<RigWellPathFormations> wellPathFormations =
         new RigWellPathFormations( wellPathFormationItems, unusedFilePath, "Ensemble formation" );
     return wellPathFormations;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimEnsembleWellLogCurveSet::hasPropertyInFile( const QString& property ) const
+{
+    RimEnsembleWellLogs* group = m_ensembleWellLogs;
+    if ( !group ) return false;
+
+    std::vector<RimWellLogFile*> allWellLogFiles = group->wellLogFiles();
+    for ( auto& wellLogFile : allWellLogFiles )
+    {
+        QString errorMessage;
+        if ( !wellLogFile->readFile( &errorMessage ) ) return false;
+
+        RigWellLogFile* wellLogDataFile = wellLogFile->wellLogFileData();
+        CVF_ASSERT( wellLogDataFile );
+
+        std::vector<double> values = wellLogDataFile->values( RiaResultNames::indexKResultName() );
+        if ( values.empty() ) return false;
+    }
+
+    return true;
 }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.h
@@ -126,6 +126,8 @@ public:
 
     void setFilterByEnsembleCurveSet( RimEnsembleCurveSet* ensembleCurveSet );
 
+    bool hasPropertyInFile( const QString& property ) const;
+
 private:
     void updateEnsembleCurves( const std::vector<RimWellLogFile*>& curves );
     void updateStatisticsCurves( const std::vector<RimWellLogFile*>& curves );

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogStatistics.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogStatistics.cpp
@@ -169,6 +169,7 @@ void RimEnsembleWellLogStatistics::calculateByKLayer( const std::vector<RimWellL
 {
     std::shared_ptr<RigWellLogIndexDepthOffset> offsets =
         RimEnsembleWellLogStatistics::calculateIndexDepthOffset( wellLogFiles );
+    if ( !offsets ) return;
 
     std::map<int, std::vector<double>> topValues;
     std::map<int, std::vector<double>> bottomValues;


### PR DESCRIPTION
Made "Index K" available for grdecl, fixed crash, and disabled the depth
equalization when "Index K" is missing in the las files.

Fixes #8103.