### PR TITLE
GeoMech: Allow calculating ST again without POR results

### DIFF
--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultCalculatorNormalST.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultCalculatorNormalST.cpp
@@ -86,7 +86,6 @@ RigFemScalarResultFrames* RigFemPartResultCalculatorNormalST::calculate( int    
     {
         const std::vector<float>& srcSFrameData   = srcSDataFrames->frameData( fIdx );
         const std::vector<float>& srcPORFrameData = srcPORDataFrames->frameData( fIdx );
-        if ( srcPORFrameData.empty() ) continue;
 
         int elementCount = femPart->elementCount();
 


### PR DESCRIPTION
Element types are correct now, so no need for extra check

Closes #8171 