### PR TITLE
#8143 Performance: Avoid parsing grid GRDECL file twice

### DIFF
--- a/ApplicationLibCode/FileInterface/CMakeLists_files.cmake
+++ b/ApplicationLibCode/FileInterface/CMakeLists_files.cmake
@@ -68,6 +68,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RifEclEclipseSummary.h
     ${CMAKE_CURRENT_LIST_DIR}/RifWellIAFileWriter.h
     ${CMAKE_CURRENT_LIST_DIR}/RifEclipseTextFileReader.h
+    ${CMAKE_CURRENT_LIST_DIR}/RifEclipseKeywordContent.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES

--- a/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
@@ -24,6 +24,8 @@
 #include "RiaLogging.h"
 #include "RiaStringEncodingTools.h"
 
+#include "RifEclipseInputPropertyLoader.h"
+#include "RifEclipseKeywordContent.h"
 #include "RifEclipseTextFileReader.h"
 #include "RifReaderEclipseOutput.h"
 
@@ -189,6 +191,9 @@ bool RifEclipseInputFileTools::openGridFile( const QString&      fileName,
         if ( mapAxesKw ) ecl_kw_free( mapAxesKw );
 
         ecl_grid_free( inputGrid );
+
+        // Import additional keywords as input properties
+        RifEclipseInputPropertyLoader::createInputPropertiesFromKeywords( eclipseCase, objects );
 
         return true;
     }

--- a/ApplicationLibCode/FileInterface/RifEclipseInputPropertyLoader.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseInputPropertyLoader.h
@@ -26,6 +26,8 @@
 
 class RimEclipseInputPropertyCollection;
 class RigEclipseCaseData;
+class RifEclipseKeywordContent;
+
 namespace caf
 {
 class ProgressInfo;
@@ -44,6 +46,9 @@ public:
                                                   const std::vector<QString>&        filenames,
                                                   bool                               allowImportOfFaults );
 
+    static void createInputPropertiesFromKeywords( RigEclipseCaseData*                          eclipseCase,
+                                                   const std::vector<RifEclipseKeywordContent>& keywordContent );
+
 private:
     // Hide constructor to prevent instantiation
     RifEclipseInputPropertyLoader();
@@ -54,9 +59,17 @@ private:
     static const std::vector<QString>& invalidPropertyDataKeywords();
     static bool                        isValidDataKeyword( const QString& keyword );
 
-    static bool appendInputPropertyResult( RigEclipseCaseData*       caseData,
-                                           const QString&            resultName,
-                                           const std::string&        eclipseKeyword,
-                                           const std::vector<float>& values,
-                                           QString*                  errMsg );
+    static bool isInputPropertyCandidate( const RigEclipseCaseData* caseData,
+                                          const std::string&        eclipseKeyword,
+                                          size_t                    numberOfValues );
+
+    static bool appendNewInputPropertyResult( RigEclipseCaseData*       caseData,
+                                              const QString&            resultName,
+                                              const std::string&        eclipseKeyword,
+                                              const std::vector<float>& values,
+                                              QString*                  errMsg );
+
+    static QString evaluateAndCreateInputPropertyResult( RigEclipseCaseData*             eclipseCase,
+                                                         const RifEclipseKeywordContent& keywordContent,
+                                                         QString*                        errorMessage );
 };

--- a/ApplicationLibCode/FileInterface/RifEclipseKeywordContent.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseKeywordContent.h
@@ -1,0 +1,31 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2021     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+class RifEclipseKeywordContent
+{
+public:
+    std::string        keyword;
+    std::string        content;
+    std::vector<float> values;
+    size_t             offset;
+};

--- a/ApplicationLibCode/FileInterface/RifEclipseTextFileReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseTextFileReader.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 #include "RifEclipseTextFileReader.h"
+#include "RifEclipseKeywordContent.h"
 
 // Utility class for fast conversion from string to float
 #include "fast_float/include/fast_float/fast_float.h"

--- a/ApplicationLibCode/FileInterface/RifEclipseTextFileReader.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseTextFileReader.h
@@ -20,14 +20,7 @@
 
 #include "RifReaderInterface.h"
 
-class RifEclipseKeywordContent
-{
-public:
-    std::string        keyword;
-    std::string        content;
-    std::vector<float> values;
-    size_t             offset;
-};
+class RifEclipseKeywordContent;
 
 //==================================================================================================
 //

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
@@ -678,8 +678,6 @@ void RimEclipseCase::loadAndSyncronizeInputProperties( bool importGridOrFaultDat
         filenames.push_back( fileName );
     }
 
-    if ( importGridOrFaultData ) filenames.push_back( gridFileName() );
-
     RifEclipseInputPropertyLoader::loadAndSyncronizeInputProperties( inputPropertyCollection(),
                                                                      eclipseCaseData(),
                                                                      filenames,

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
@@ -111,6 +111,8 @@ bool RimEclipseInputCase::openDataFileSet( const QStringList& fileNames )
 
     std::vector<QString> allErrorMessages;
 
+    QString gridFileName;
+
     // First find and read the grid data
     if ( this->eclipseCaseData()->mainGrid()->gridPointDimensions() == cvf::Vec3st( 0, 0, 0 ) )
     {
@@ -120,6 +122,7 @@ bool RimEclipseInputCase::openDataFileSet( const QStringList& fileNames )
             if ( RifEclipseInputFileTools::openGridFile( fileNames[i], this->eclipseCaseData(), importFaults, &errorMessages ) )
             {
                 setGridFileName( fileNames[i] );
+                gridFileName = fileNames[i];
 
                 QFileInfo gridFileName( fileNames[i] );
                 QString   caseName = gridFileName.completeBaseName();
@@ -154,6 +157,8 @@ bool RimEclipseInputCase::openDataFileSet( const QStringList& fileNames )
     std::vector<QString> filesToRead;
     for ( const QString& filename : fileNames )
     {
+        if ( filename == gridFileName ) continue;
+
         bool exists = false;
         for ( const QString& currentFileName : additionalFiles() )
         {

--- a/ApplicationLibCode/UnitTests/RifEclipseTextFileReader-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifEclipseTextFileReader-Test.cpp
@@ -19,6 +19,8 @@
 #include "gtest/gtest.h"
 
 #include "RiaTestDataDirectory.h"
+
+#include "RifEclipseKeywordContent.h"
 #include "RifEclipseTextFileReader.h"
 
 #include <QString>


### PR DESCRIPTION
Previous implementation parsed grid file twice both for geometry data and properties.