### PR TITLE
#8232 Ensemble Fracture Statistics: Swap min/max and P90/P10 for Beta

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimEnsembleFractureStatistics.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimEnsembleFractureStatistics.h
@@ -197,7 +197,8 @@ protected:
         const std::vector<caf::AppEnum<RimEnsembleFractureStatistics::StatisticsType>>&       statisticsTypes,
         const RigHistogramData&                                                               areaHistogram,
         std::shared_ptr<RigSlice2D>                                                           areaGrid,
-        std::shared_ptr<RigSlice2D>                                                           distanceGrid );
+        std::shared_ptr<RigSlice2D>                                                           distanceGrid,
+        bool                                                                                  highIsLow );
 
     static bool writeStatisticsToCsv( const QString& filePath, const RigSlice2D& samples );
 


### PR DESCRIPTION
For property Beta, low values are high (max, P10) case and high values are
low (min, P90) case. Calculation of statistical Beta values now uses
inverted logic.

Fixes #8232.