### PR TITLE
Python : Do not modify result container when reading grid result data

### DIFF
--- a/GrpcInterface/Python/rips/PythonExamples/set_grid_properties.py
+++ b/GrpcInterface/Python/rips/PythonExamples/set_grid_properties.py
@@ -1,16 +1,41 @@
 ######################################################################
-# This script sets values for SOIL for all grid cells in the first case in the project
+# This script sets values for all grid cells in the first case in the project
+# The script is intended to be used for TEST10K_FLT_LGR_NNC.EGRID
+# This grid case contains one LGR
 ######################################################################
 import rips
 
 resinsight = rips.Instance.find()
 
 case = resinsight.project.case(case_id=0)
-total_cell_count = case.cell_count().reservoir_cell_count
+grid = case.grid()
+grid_cell_count = grid.cell_count()
+print("total cell count : " + str(grid_cell_count))
 
 values = []
-for i in range(0, total_cell_count):
+for i in range(0, grid_cell_count):
     values.append(i % 2 * 0.75)
 
-print("Applying values to full grid")
-case.set_grid_property(values, "DYNAMIC_NATIVE", "SOIL", 0)
+# Assign value to IJK grid cell at (31, 53, 21)
+grid = case.grid()
+property_data_index = grid.property_data_index_from_ijk(31, 53, 21)
+values[property_data_index] = 1.5
+
+print("Applying values to main grid")
+case.set_grid_property(values, "STATIC_NATIVE", "MY_DATA", 0)
+
+values_from_ri = case.grid_property("STATIC_NATIVE", "MY_DATA", 0)
+assert values[property_data_index] == values_from_ri[property_data_index]
+
+# Get LGR grid as grid index 1
+grid = case.grid(1)
+grid_cell_count = grid.cell_count()
+print("lgr cell count : " + str(grid_cell_count))
+
+values = []
+for i in range(0, grid_cell_count):
+    values.append(i % 3 * 0.75)
+
+print("Applying values to LGR grid")
+case.set_grid_property(values, "STATIC_NATIVE", "MY_DATA", 0, 1)
+values_from_ri = case.grid_property("STATIC_NATIVE", "MY_DATA", 0, 1)

--- a/GrpcInterface/Python/rips/case.py
+++ b/GrpcInterface/Python/rips/case.py
@@ -125,7 +125,7 @@ def __generate_property_input_chunks(self, array, parameters):
 
 
 @add_method(Case)
-def grid(self, index):
+def grid(self, index=0):
     """Get Grid of a given index
 
     Arguments:

--- a/GrpcInterface/Python/rips/tests/test_grids.py
+++ b/GrpcInterface/Python/rips/tests/test_grids.py
@@ -27,6 +27,9 @@ def test_10k(rips_instance, initialize_test):
     cell_centers = grid.cell_centers()
     assert len(cell_centers) == (dimensions.i * dimensions.j * dimensions.k)
 
+    property_data_index = grid.property_data_index_from_ijk(31, 53, 21)
+    assert property_data_index == 177510
+
     # Test a specific cell (results from ResInsight UI)
     cell_index = 168143
     assert math.isclose(3627.17, cell_centers[cell_index].x, abs_tol=0.1)

--- a/GrpcInterface/RiaGrpcPropertiesService.cpp
+++ b/GrpcInterface/RiaGrpcPropertiesService.cpp
@@ -351,9 +351,10 @@ protected:
     {
         m_cellCount       = caseData->grid( gridIndex )->cellCount();
         auto resultValues = caseData->results( porosityModel )->modifiableCellScalarResult( resVarAddr, timeStepIndex );
-        if ( resultValues && m_cellCount > 0 )
+        if ( resultValues && resultValues->empty() && m_cellCount > 0 )
         {
-            resultValues->resize( m_cellCount );
+            auto totalCellCount = caseData->mainGrid()->globalCellArray().size();
+            resultValues->resize( totalCellCount );
         }
 
         m_resultAccessor =


### PR DESCRIPTION
Avoid resize if data is already present
Improve functions for getting grid data and accessing single cell values
Add example for read and write of grid data

Closes #8297