### PR TITLE
Add missing limits header in RiuGroupedBarChartBuilder.h

### DIFF
--- a/ApplicationLibCode/UserInterface/AnalysisPlots/RiuGroupedBarChartBuilder.h
+++ b/ApplicationLibCode/UserInterface/AnalysisPlots/RiuGroupedBarChartBuilder.h
@@ -24,6 +24,7 @@
 
 #include <map>
 #include <set>
+#include <limits>
 
 class QwtPlot;
 class QColor;

--- a/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/SummaryNode.hpp
+++ b/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/SummaryNode.hpp
@@ -24,6 +24,7 @@
 #include <optional>
 #include <string>
 #include <unordered_set>
+#include <limits>
 
 namespace Opm { namespace EclIO {
 


### PR DESCRIPTION
Note: this PR depends on #8329 which should be merged first.

Fixes issue #8330.