### PR TITLE
Make sure all NNC faces are created and assigned

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
@@ -304,8 +304,18 @@ void RigCellFaceGeometryTools::extractConnectionsForFace( const RigFault::FaultF
             }
         }
 
-        std::pair<unsigned, unsigned> candidate( static_cast<unsigned>( sourceReservoirCellIndex ),
-                                                 static_cast<unsigned>( candidateCellIndex ) );
+        // Test if this pair of cells already has a connection. Check both combinations of cell index ordering to avoid
+        // duplicate NNC geometry for the same pair of cells
+
+        auto candidate = std::make_pair( static_cast<unsigned>( sourceReservoirCellIndex ),
+                                         static_cast<unsigned>( candidateCellIndex ) );
+
+        if ( nativeCellPairs.count( candidate ) > 0 )
+        {
+            continue;
+        }
+
+        std::swap( candidate.first, candidate.second );
 
         if ( nativeCellPairs.count( candidate ) > 0 )
         {

--- a/ApplicationLibCode/ReservoirDataModel/RigFault.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigFault.cpp
@@ -203,3 +203,33 @@ void RigFault::accumulateFaultsPrCell( RigFaultsPrCellAccumulator* faultsPrCellA
                                       faultIdx );
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RigFaultsPrCellAccumulator::RigFaultsPrCellAccumulator( size_t reservoirCellCount )
+{
+    std::array<int, 6> initVals = { NO_FAULT, NO_FAULT, NO_FAULT, NO_FAULT, NO_FAULT, NO_FAULT };
+    m_faultIdxForCellFace.resize( reservoirCellCount, initVals );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+int RigFaultsPrCellAccumulator::faultIdx( size_t reservoirCellIndex, cvf::StructGridInterface::FaceType face ) const
+{
+    // Ensure no crash after creating temporary LGRs
+    if ( reservoirCellIndex < m_faultIdxForCellFace.size() )
+    {
+        return m_faultIdxForCellFace[reservoirCellIndex][face];
+    }
+    return NO_FAULT;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RigFaultsPrCellAccumulator::setFaultIdx( size_t reservoirCellIndex, cvf::StructGridInterface::FaceType face, int faultIdx )
+{
+    m_faultIdxForCellFace[reservoirCellIndex][face] = faultIdx;
+}

--- a/ApplicationLibCode/ReservoirDataModel/RigFault.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigFault.h
@@ -46,26 +46,11 @@ public:
     };
 
 public:
-    explicit RigFaultsPrCellAccumulator( size_t reservoirCellCount )
-    {
-        std::array<int, 6> initVals = {NO_FAULT, NO_FAULT, NO_FAULT, NO_FAULT, NO_FAULT, NO_FAULT};
-        m_faultIdxForCellFace.resize( reservoirCellCount, initVals );
-    }
+    explicit RigFaultsPrCellAccumulator( size_t reservoirCellCount );
 
-    inline int faultIdx( size_t reservoirCellIndex, cvf::StructGridInterface::FaceType face ) const
-    {
-        // Ensure no crash after creating temporary LGRs
-        if ( reservoirCellIndex < m_faultIdxForCellFace.size() )
-        {
-            return m_faultIdxForCellFace[reservoirCellIndex][face];
-        }
-        return NO_FAULT;
-    }
+    int faultIdx( size_t reservoirCellIndex, cvf::StructGridInterface::FaceType face ) const;
 
-    inline void setFaultIdx( size_t reservoirCellIndex, cvf::StructGridInterface::FaceType face, int faultIdx )
-    {
-        m_faultIdxForCellFace[reservoirCellIndex][face] = faultIdx;
-    }
+    void setFaultIdx( size_t reservoirCellIndex, cvf::StructGridInterface::FaceType face, int faultIdx );
 
 private:
     std::vector<std::array<int, 6>> m_faultIdxForCellFace;

--- a/ApplicationLibCode/ReservoirDataModel/RigNncConnection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigNncConnection.cpp
@@ -45,10 +45,14 @@ RigConnection::RigConnection( unsigned                           c1GlobIdx,
     if ( c1GlobIdx >= c2GlobIdx )
     {
         // Ensure the smallest cell index is the first index
-        // TODO : The face type is related to cell 1, so face should be changed to opposite face
-        // This causes visual artifacts for some models, so this change will require more investigation
         m_c1GlobIdx = c2GlobIdx;
         m_c2GlobIdx = c1GlobIdx;
+
+        if ( c1Face != cvf::StructGridInterface::FaceType::NO_FACE )
+        {
+            // The face type is related to cell 1, so use opposite face
+            m_c1Face = cvf::StructGridInterface::oppositeFace( c1Face );
+        }
     }
 }
 
@@ -69,10 +73,14 @@ RigConnection::RigConnection( size_t                             c1GlobIdx,
     if ( c1GlobIdx >= c2GlobIdx )
     {
         // Ensure the smallest cell index is the first index
-        // TODO : The face type is related to cell 1, so face should be changed to opposite face
-        // This causes visual artifacts for some models, so this change will require more investigation
         m_c1GlobIdx = static_cast<unsigned>( c2GlobIdx );
         m_c2GlobIdx = static_cast<unsigned>( c1GlobIdx );
+
+        if ( c1Face != cvf::StructGridInterface::FaceType::NO_FACE )
+        {
+            // The face type is related to cell 1, so use opposite face
+            m_c1Face = cvf::StructGridInterface::oppositeFace( c1Face );
+        }
     }
 }
 

--- a/GrpcInterface/Python/rips/tests/test_nnc_properties.py
+++ b/GrpcInterface/Python/rips/tests/test_nnc_properties.py
@@ -25,7 +25,7 @@ def test_10kSync(rips_instance, initialize_test):
     )
 
     nnc_connections = case.nnc_connections()
-    assert len(nnc_connections) == 3627
+    assert len(nnc_connections) == 3416
 
     connection = nnc_connections[0]
     assert connection.cell1.i == 33


### PR DESCRIPTION
Closes #8371

Make sure that the first cell in RigConnection is assigned the lowest cell index. Assign the opposite face if the cell indexes are swapped.
In RigCellFaceGeometryTools, test both combinations of (cellA, cellB) and (cellB, cellA)