### PR TITLE
CMake: Add fast_float to list of submodules to init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ set(CMAKE_CXX_COMPILER_LAUNCHER ${TEMP_CMAKE_CXX_COMPILER_LAUNCHER})
 # ##############################################################################
 # Go through required git submodules #
 # ##############################################################################
-list(APPEND THIRD_PARTY_SUBMODULES qwt)
+list(APPEND THIRD_PARTY_SUBMODULES fast_float qwt)
 
 # ##############################################################################
 # Init GIT submodules if they haven't already #


### PR DESCRIPTION
CMake is set to import submodules by default but fast_float was missing
from the list.

This fixes #8525