### PR TITLE
Fix axis property signals and memory cleanup

### DIFF
--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicNewPlotAxisPropertiesFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicNewPlotAxisPropertiesFeature.cpp
@@ -50,9 +50,8 @@ void RicNewPlotAxisPropertiesFeature::onActionTriggered( bool isChecked )
 
     RimSummaryPlot* summaryPlot = summaryPlots[0];
 
-    bool                   connectSignals = true;
     RimPlotAxisProperties* newPlotAxisProperties =
-        summaryPlot->addNewAxisProperties( RiaDefines::PlotAxis::PLOT_AXIS_LEFT, "New Axis", connectSignals );
+        summaryPlot->addNewAxisProperties( RiaDefines::PlotAxis::PLOT_AXIS_LEFT, "New Axis" );
 
     summaryPlot->updateConnectedEditors();
     RiuPlotMainWindowTools::selectAsCurrentItem( newPlotAxisProperties );

--- a/ApplicationLibCode/ProjectDataModel/RimPlotAxisProperties.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimPlotAxisProperties.cpp
@@ -54,6 +54,7 @@ RimPlotAxisProperties::RimPlotAxisProperties()
     , axisPositionChanged( this )
     , m_enableTitleTextSettings( true )
     , m_isRangeSettingsEnabled( true )
+    , m_isAlwaysRequired( false )
 {
     CAF_PDM_InitObject( "Axis Properties", ":/LeftAxis16x16.png" );
 
@@ -100,10 +101,17 @@ RimPlotAxisProperties::RimPlotAxisProperties()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimPlotAxisProperties::setAlwaysRequired( bool enable )
+{
+    m_isAlwaysRequired = enable;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RimPlotAxisProperties::isDeletable() const
 {
-    // The default axes (which have index 0) are not deletable
-    return m_plotAxisIndex != 0;
+    return !m_isAlwaysRequired;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -210,6 +218,7 @@ void RimPlotAxisProperties::defineUiOrdering( QString uiConfigName, caf::PdmUiOr
     scaleGroup.add( &m_valuesFontSize );
 
     scaleGroup.add( &m_plotAxis );
+    m_plotAxis.uiCapability()->setUiReadOnly( m_isAlwaysRequired );
 
     uiOrdering.skipRemainingFields( true );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimPlotAxisProperties.h
+++ b/ApplicationLibCode/ProjectDataModel/RimPlotAxisProperties.h
@@ -58,6 +58,8 @@ public:
 public:
     RimPlotAxisProperties();
 
+    void setAlwaysRequired( bool enable );
+
     void                  setEnableTitleTextSettings( bool enable );
     void                  enableRangeSettings( bool enable );
     void                  setNameAndAxis( const QString& name, RiaDefines::PlotAxis axis, int axisIndex = 0 );
@@ -78,7 +80,6 @@ public:
     void           setAxisInverted( bool inverted );
 
     bool isDeletable() const override;
-
 
     std::vector<RimPlotAxisAnnotation*> annotations() const override;
     void                                appendAnnotation( RimPlotAxisAnnotation* annotation ) override;
@@ -136,6 +137,7 @@ private:
 
     bool m_enableTitleTextSettings;
     bool m_isRangeSettingsEnabled;
+    bool m_isAlwaysRequired;
 
     caf::PdmField<caf::FontTools::RelativeSizeEnum>    m_titleFontSize;
     caf::PdmField<caf::AppEnum<AxisTitlePositionType>> m_titlePositionEnum;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -122,8 +122,11 @@ RimSummaryPlot::RimSummaryPlot( bool isCrossPlot )
 
     CAF_PDM_InitFieldNoDefault( &m_axisProperties, "AxisProperties", "Axes", ":/Axes16x16.png" );
 
-    addNewAxisProperties( RiuPlotAxis::defaultLeft(), "Left" );
-    addNewAxisProperties( RiuPlotAxis::defaultRight(), "Right" );
+    auto leftAxis = addNewAxisProperties( RiuPlotAxis::defaultLeft(), "Left" );
+    leftAxis->setAlwaysRequired( true );
+
+    auto rightAxis = addNewAxisProperties( RiuPlotAxis::defaultRight(), "Right" );
+    rightAxis->setAlwaysRequired( true );
 
     if ( m_isCrossPlot )
     {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -122,13 +122,12 @@ RimSummaryPlot::RimSummaryPlot( bool isCrossPlot )
 
     CAF_PDM_InitFieldNoDefault( &m_axisProperties, "AxisProperties", "Axes", ":/Axes16x16.png" );
 
-    bool connectSignals = false;
-    addNewAxisProperties( RiuPlotAxis::defaultLeft(), "Left", connectSignals );
-    addNewAxisProperties( RiuPlotAxis::defaultRight(), "Right", connectSignals );
+    addNewAxisProperties( RiuPlotAxis::defaultLeft(), "Left" );
+    addNewAxisProperties( RiuPlotAxis::defaultRight(), "Right" );
 
     if ( m_isCrossPlot )
     {
-        addNewAxisProperties( RiuPlotAxis::defaultBottom(), "Bottom", connectSignals );
+        addNewAxisProperties( RiuPlotAxis::defaultBottom(), "Bottom" );
     }
     else
     {
@@ -1727,26 +1726,21 @@ void RimSummaryPlot::axisLogarithmicChanged( const caf::SignalEmitter* emitter, 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimPlotAxisProperties*
-    RimSummaryPlot::addNewAxisProperties( RiaDefines::PlotAxis plotAxis, const QString& name, bool connectSignals )
+RimPlotAxisProperties* RimSummaryPlot::addNewAxisProperties( RiaDefines::PlotAxis plotAxis, const QString& name )
 {
     RiuPlotAxis newPlotAxis = plotWidget()->createNextPlotAxis( plotAxis );
-    return addNewAxisProperties( newPlotAxis, name, connectSignals );
+    return addNewAxisProperties( newPlotAxis, name );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimPlotAxisProperties* RimSummaryPlot::addNewAxisProperties( RiuPlotAxis plotAxis, const QString& name, bool connectSignals )
+RimPlotAxisProperties* RimSummaryPlot::addNewAxisProperties( RiuPlotAxis plotAxis, const QString& name )
 {
     RimPlotAxisProperties* axisProperties = new RimPlotAxisProperties;
     axisProperties->setNameAndAxis( name, plotAxis.axis(), plotAxis.index() );
     m_axisProperties.push_back( axisProperties );
-
-    if ( connectSignals )
-    {
-        connectAxisSignals( axisProperties );
-    }
+    connectAxisSignals( axisProperties );
 
     return axisProperties;
 }
@@ -2488,9 +2482,8 @@ void RimSummaryPlot::assignPlotAxis( RimSummaryCurve* destinationCurve )
         if ( !destinationCurve->summaryAddressY().uiText().empty() )
             axisObjectName = QString::fromStdString( destinationCurve->summaryAddressY().uiText() );
 
-        newPlotAxis         = plotWidget()->createNextPlotAxis( plotAxis );
-        bool connectSignals = true;
-        addNewAxisProperties( newPlotAxis, axisObjectName, connectSignals );
+        newPlotAxis = plotWidget()->createNextPlotAxis( plotAxis );
+        addNewAxisProperties( newPlotAxis, axisObjectName );
     }
 
     destinationCurve->setLeftOrRightAxisY( newPlotAxis );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
@@ -189,7 +189,7 @@ public:
 
     RimPlotAxisPropertiesInterface* axisPropertiesForPlotAxis( RiuPlotAxis plotAxis ) const;
 
-    RimPlotAxisProperties* addNewAxisProperties( RiaDefines::PlotAxis, const QString& name, bool connectSignals );
+    RimPlotAxisProperties* addNewAxisProperties( RiaDefines::PlotAxis, const QString& name );
 
 public:
     // RimViewWindow overrides
@@ -212,7 +212,7 @@ private:
 
     void connectCurveToPlot( RimSummaryCurve* curve, bool update, bool autoAssignPlotAxis );
 
-    RimPlotAxisProperties* addNewAxisProperties( RiuPlotAxis plotAxis, const QString& name, bool connectSignals );
+    RimPlotAxisProperties* addNewAxisProperties( RiuPlotAxis plotAxis, const QString& name );
 
 protected:
     // Overridden PDM methods

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp
@@ -215,6 +215,8 @@ int caf::PdmUiFormLayoutObjectEditor::recursivelyConfigureAndUpdateUiOrderingInG
                                 labelAndFieldVerticalLayout->addWidget( fieldLabelWidget, 0, Qt::AlignTop );
                                 labelAndFieldVerticalLayout->addWidget( fieldEditorWidget, 1, Qt::AlignTop );
 
+                                m_layouts.push_back( labelAndFieldVerticalLayout );
+
                                 // Apply margins determined by the editor type
                                 // fieldLabelWidget->setContentsMargins(fieldEditor->labelContentMargins());
                                 currentColumn += itemColumnSpan;
@@ -489,6 +491,13 @@ void caf::PdmUiFormLayoutObjectEditor::cleanupBeforeSettingPdmObject()
     }
 
     m_groupBoxes.clear();
+
+    for ( auto l : m_layouts )
+    {
+        delete l;
+        l = nullptr;
+    }
+    m_layouts.clear();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.h
@@ -47,6 +47,7 @@
 class QMinimizePanel;
 class QGridLayout;
 class QWidget;
+class QVBoxLayout;
 
 namespace caf
 {
@@ -110,6 +111,7 @@ private:
     std::map<QString, QPointer<QMinimizePanel>> m_newGroupBoxes; ///< used temporarily to store the new(complete) set of
                                                                  ///< group boxes
     std::map<QString, std::map<QString, bool>> m_objectKeywordGroupUiNameExpandedState;
+    std::vector<QPointer<QVBoxLayout>>         m_layouts;
 };
 
 } // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp
@@ -161,11 +161,23 @@ PdmUiTreeViewEditor::~PdmUiTreeViewEditor()
     m_treeView->removeEventFilter( this );
     m_treeViewModel->setPdmItemRoot( nullptr );
 
-    if ( m_mainWidget ) delete m_mainWidget;
-    if ( m_delegate ) delete m_delegate;
-    if ( m_treeViewModel ) delete m_treeViewModel;
-    if ( m_filterModel ) delete m_filterModel;
-    if ( m_treeView ) delete m_treeView;
+    delete m_mainWidget;
+    m_mainWidget = nullptr;
+
+    delete m_delegate;
+    m_delegate = nullptr;
+
+    delete m_treeViewModel;
+    m_treeViewModel = nullptr;
+
+    delete m_filterModel;
+    m_filterModel = nullptr;
+
+    delete m_treeView;
+    m_treeView = nullptr;
+
+    delete m_layout;
+    m_layout = nullptr;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.h
@@ -157,8 +157,8 @@ private:
     bool eventFilter( QObject* obj, QEvent* event ) override;
 
 private:
-    QPointer<QWidget> m_mainWidget;
-    QVBoxLayout*      m_layout;
+    QPointer<QWidget>     m_mainWidget;
+    QPointer<QVBoxLayout> m_layout;
 
     QPointer<PdmUiTreeViewWidget>       m_treeView;
     QPointer<PdmUiTreeViewQModel>       m_treeViewModel;


### PR DESCRIPTION
- Allow axis property signals to be connected multiple times, as the previous commit did not work when creating summary plot interactively
- More memory cleanup
- Make sure the two default axes are not able to delete or move to opposite side.
