### PR TITLE
Pdf export : Remove theme change before export to PDF

### DIFF
--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotViewToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotViewToFileFeature.cpp
@@ -29,7 +29,6 @@
 #include "RimViewWindow.h"
 
 #include "RiuFileDialogTools.h"
-#include "RiuGuiTheme.h"
 #include "RiuPlotMainWindow.h"
 
 #include "RicSnapshotFilenameGenerator.h"
@@ -87,9 +86,8 @@ void RicSnapshotViewToFileFeature::saveSnapshotAs( const QString& fileName, cons
 //--------------------------------------------------------------------------------------------------
 void RicSnapshotViewToFileFeature::savePlotPdfReportAs( const QString& fileName, RimPlotWindow* plot )
 {
-    auto currentTheme = RiuGuiTheme::currentGuiTheme();
+    if ( !plot || !plot->viewWidget() ) return;
 
-    RiuGuiTheme::updateGuiTheme( RiaDefines::ThemeEnum::LIGHT );
     RiaPlotWindowRedrawScheduler::instance()->performScheduledUpdatesAndReplots();
     QCoreApplication::processEvents();
     QFile pdfFile( fileName );
@@ -136,7 +134,6 @@ void RicSnapshotViewToFileFeature::savePlotPdfReportAs( const QString& fileName,
     {
         RiaLogging::error( QString( "Could not write PDF to %1" ).arg( fileName ) );
     }
-    RiuGuiTheme::updateGuiTheme( currentTheme );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Crash seen on Windows related to theme change as part of export to PDF. This is related to export of plots to PDF in dark mode. Investigate other solution.

Fixes #8701.