### PR TITLE
#8652 Import Surface: Fix ts-file import with properties on Linux

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaStdStringTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaStdStringTools.cpp
@@ -23,15 +23,32 @@
 #include <cctype>
 #include <charconv>
 
+const std::string WHITESPACE = " \n\r\t\f\v";
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::string RiaStdStringTools::leftTrimString( const std::string& s )
+{
+    size_t start = s.find_first_not_of( WHITESPACE );
+    return ( start == std::string::npos ) ? "" : s.substr( start );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::string RiaStdStringTools::rightTrimString( const std::string& s )
+{
+    size_t end = s.find_last_not_of( WHITESPACE );
+    return ( end == std::string::npos ) ? "" : s.substr( 0, end + 1 );
+}
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 std::string RiaStdStringTools::trimString( const std::string& s )
 {
-    auto sCopy = s.substr( 0, s.find_last_not_of( ' ' ) + 1 );
-    sCopy      = sCopy.substr( sCopy.find_first_not_of( ' ' ) );
-
-    return sCopy;
+    return rightTrimString( leftTrimString( s ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/Tools/RiaStdStringTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaStdStringTools.h
@@ -31,7 +31,10 @@ class RiaStdStringTools
 {
 public:
     static std::string trimString( const std::string& s );
-    static bool        isNumber( const std::string& s, char decimalPoint );
+    static std::string rightTrimString( const std::string& s );
+    static std::string leftTrimString( const std::string& s );
+
+    static bool isNumber( const std::string& s, char decimalPoint );
 
     static int16_t toInt16( const std::string& s );
     static int     toInt( const std::string& s );

--- a/ApplicationLibCode/FileInterface/RifSurfaceImporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifSurfaceImporter.cpp
@@ -89,7 +89,7 @@ void RifSurfaceImporter::readGocadFile( const QString& filename, RigGocadData* g
             auto tokens = RiaStdStringTools::splitString( line, ' ' );
 
             std::string firstToken;
-            if ( !tokens.empty() ) firstToken = tokens.front();
+            if ( !tokens.empty() ) firstToken = RiaStdStringTools::trimString( tokens.front() );
 
             if ( isInTfaceSection )
             {

--- a/ApplicationLibCode/UnitTests/RiaStdStringTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaStdStringTools-Test.cpp
@@ -62,6 +62,72 @@ TEST( RiaStdStringToolsTest, TrimStrings )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+TEST( RiaStdStringToolsTest, TrimString )
+{
+    std::vector<std::pair<std::string, std::string>> testData = {
+        std::make_pair( "   bla  ", "bla" ),
+        std::make_pair( "bla ", "bla" ),
+        std::make_pair( " bla", "bla" ),
+        std::make_pair( "\tbla", "bla" ),
+        std::make_pair( "\tbla \n\t", "bla" ),
+        std::make_pair( "\tbla\v", "bla" ),
+        std::make_pair( "bla", "bla" ),
+        std::make_pair( "", "" ),
+    };
+
+    for ( auto [input, expectedText] : testData )
+    {
+        EXPECT_EQ( RiaStdStringTools::trimString( input ), expectedText );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStdStringToolsTest, LeftTrimString )
+{
+    std::vector<std::pair<std::string, std::string>> testData = {
+        std::make_pair( "   bla  ", "bla  " ),
+        std::make_pair( "bla ", "bla " ),
+        std::make_pair( " bla", "bla" ),
+        std::make_pair( "\tbla", "bla" ),
+        std::make_pair( "\tbla \n\t", "bla \n\t" ),
+        std::make_pair( "\tbla\v", "bla\v" ),
+        std::make_pair( "bla", "bla" ),
+        std::make_pair( "", "" ),
+    };
+
+    for ( auto [input, expectedText] : testData )
+    {
+        EXPECT_EQ( RiaStdStringTools::leftTrimString( input ), expectedText );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStdStringToolsTest, RightTrimString )
+{
+    std::vector<std::pair<std::string, std::string>> testData = {
+        std::make_pair( "   bla  ", "   bla" ),
+        std::make_pair( "bla ", "bla" ),
+        std::make_pair( " bla", " bla" ),
+        std::make_pair( "\tbla", "\tbla" ),
+        std::make_pair( "\tbla \n\t", "\tbla" ),
+        std::make_pair( "\tbla\v", "\tbla" ),
+        std::make_pair( "bla", "bla" ),
+        std::make_pair( "", "" ),
+    };
+
+    for ( auto [input, expectedText] : testData )
+    {
+        EXPECT_EQ( RiaStdStringTools::rightTrimString( input ), expectedText );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 TEST( RiaStdStringToolsTest, DISABLED_PerformanceConversion )
 {
     size_t      itemCount     = 1000000;


### PR DESCRIPTION
The file had DOS line endings (\t\n) which where not properly trimmed on linux.

Fixes #8652.