### PR TITLE
#8899 Summary data: Import network vectors from Intersect files.

### DIFF
--- a/ApplicationLibCode/FileInterface/RifEclEclipseSummary.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclEclipseSummary.cpp
@@ -65,7 +65,7 @@ bool RifEclEclipseSummary::open( const QString& headerFileName, RiaThreadSafeLog
 {
     assert( m_ecl_sum == nullptr );
 
-    m_ecl_sum = RifEclipseSummaryTools::openEclSum( headerFileName, false );
+    m_ecl_sum = RifEclipseSummaryTools::openEclSum( headerFileName, true );
     if ( m_ecl_sum )
     {
         m_timeSteps.clear();


### PR DESCRIPTION
Fixed by including restart files in summary import.

Fixes #8899.