### PR TITLE
More RFT fixes

### DIFF
--- a/ApplicationLibCode/Application/RiaRftDefines.h
+++ b/ApplicationLibCode/Application/RiaRftDefines.h
@@ -30,4 +30,12 @@ QString segmentNumberResultName();
 QString allBranches();
 QString segmentBranchNumberResultName();
 
+enum class RftBranchType
+{
+    RFT_TUBING,
+    RFT_ANNULAR,
+    RFT_DEVICE,
+    RFT_UNKNOWN
+};
+
 }; // namespace RiaDefines

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
@@ -317,7 +317,7 @@ QList<caf::PdmOptionItemInfo> RiaSummaryTools::optionsForSummaryCases( const std
 
     for ( RimSummaryCase* c : cases )
     {
-        options.push_back( caf::PdmOptionItemInfo( c->displayCaseName(), c ) );
+        options.push_back( caf::PdmOptionItemInfo( c->displayCaseName(), c, false, c->uiIconProvider() ) );
     }
 
     return options;

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
@@ -299,3 +299,26 @@ RimSummaryCaseCollection* RiaSummaryTools::ensembleById( int ensembleId )
 
     return nullptr;
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RiaSummaryTools::optionsForAllSummaryCases()
+{
+    return optionsForSummaryCases( RimProject::current()->allSummaryCases() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RiaSummaryTools::optionsForSummaryCases( const std::vector<RimSummaryCase*>& cases )
+{
+    QList<caf::PdmOptionItemInfo> options;
+
+    for ( RimSummaryCase* c : cases )
+    {
+        options.push_back( caf::PdmOptionItemInfo( c->displayCaseName(), c ) );
+    }
+
+    return options;
+}

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
@@ -40,7 +40,8 @@ class QStringList;
 namespace caf
 {
 class PdmObject;
-}
+class PdmOptionItemInfo;
+} // namespace caf
 
 //==================================================================================================
 //
@@ -75,4 +76,7 @@ public:
 
     static RimSummaryCase*           summaryCaseById( int caseId );
     static RimSummaryCaseCollection* ensembleById( int ensembleId );
+
+    static QList<caf::PdmOptionItemInfo> optionsForAllSummaryCases();
+    static QList<caf::PdmOptionItemInfo> optionsForSummaryCases( const std::vector<RimSummaryCase*>& cases );
 };

--- a/ApplicationLibCode/Commands/PlotTemplateCommands/RicSelectCaseOrEnsembleUi.cpp
+++ b/ApplicationLibCode/Commands/PlotTemplateCommands/RicSelectCaseOrEnsembleUi.cpp
@@ -18,6 +18,8 @@
 
 #include "RicSelectCaseOrEnsembleUi.h"
 
+#include "RiaSummaryTools.h"
+
 #include "RimProject.h"
 #include "RimSummaryCase.h"
 #include "RimSummaryCaseCollection.h"
@@ -78,14 +80,7 @@ QList<caf::PdmOptionItemInfo>
 
     if ( fieldNeedingOptions == &m_selectedSummaryCase )
     {
-        RimProject* proj = RimProject::current();
-
-        std::vector<RimSummaryCase*> cases = proj->allSummaryCases();
-
-        for ( RimSummaryCase* rimCase : cases )
-        {
-            options.push_back( caf::PdmOptionItemInfo( rimCase->displayCaseName(), rimCase ) );
-        }
+        options = RiaSummaryTools::optionsForAllSummaryCases();
     }
     else if ( fieldNeedingOptions == &m_selectedEnsemble )
     {

--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -29,6 +29,7 @@
 #include "RimEclipseResultCase.h"
 #include "RimProject.h"
 #include "RimSimWellInView.h"
+#include "RimSummaryCase.h"
 #include "RimWellLogCurveCommonDataSource.h"
 #include "RimWellLogExtractionCurve.h"
 #include "RimWellLogFile.h"
@@ -376,6 +377,23 @@ RimWellLogRftCurve*
         {
             auto wellName = *( wellNames.begin() );
             curve->setDefaultAddress( wellName );
+        }
+    }
+    else
+    {
+        auto sumCases = RimProject::current()->allSummaryCases();
+
+        for ( auto sc : sumCases )
+        {
+            if ( sc->rftReader() )
+            {
+                auto rftReader = sc->rftReader();
+
+                curve->setSummaryCase( sc );
+
+                auto addresses = rftReader->eclipseRftAddresses();
+                if ( !addresses.empty() ) curve->setRftAddress( *addresses.begin() );
+            }
         }
     }
 

--- a/ApplicationLibCode/FileInterface/RifReaderOpmRft.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmRft.cpp
@@ -156,6 +156,9 @@ std::set<QDateTime>
     RifReaderOpmRft::availableTimeSteps( const QString&                                     wellName,
                                          const RifEclipseRftAddress::RftWellLogChannelType& wellLogChannelName )
 {
+    if ( wellLogChannelName == RifEclipseRftAddress::RftWellLogChannelType::SEGMENT_VALUES )
+        return m_rftSegmentTimeSteps;
+
     std::set<QDateTime> timeSteps;
 
     for ( const auto& address : m_addresses )
@@ -300,6 +303,8 @@ void RifReaderOpmRft::buildMetaData()
         int d = std::get<2>( reportDate );
 
         auto dt = RiaQDateTimeTools::createUtcDateTime( QDate( y, m, d ) );
+
+        m_rftSegmentTimeSteps.insert( dt );
 
         auto segmentCount = segmentData.topology().size();
 

--- a/ApplicationLibCode/FileInterface/RifReaderOpmRft.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmRft.cpp
@@ -503,7 +503,7 @@ void RifReaderOpmRft::buildSegmentBranchTypes( const RftSegmentKey& segmentKey )
 
             double length = maximumMD - minimumMD;
 
-            segmentRef.setBranchLenght( id, length );
+            segmentRef.setBranchLength( id, length );
 
             const double              tubingThreshold = 1.0;
             RiaDefines::RftBranchType branchType      = RiaDefines::RftBranchType::RFT_UNKNOWN;

--- a/ApplicationLibCode/FileInterface/RifReaderOpmRft.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmRft.cpp
@@ -91,7 +91,7 @@ void RifReaderOpmRft::values( const RifEclipseRftAddress& rftAddress, std::vecto
         }
         else if ( rftAddress.segmentResultName() == RiaDefines::segmentBranchNumberResultName() )
         {
-            auto branchNumbers = segment.branchIds();
+            auto branchNumbers = segment.tubingBranchIds();
             for ( const auto& branchNumber : branchNumbers )
             {
                 values->push_back( branchNumber );
@@ -399,9 +399,10 @@ void RifReaderOpmRft::buildSegmentData()
                 }
             }
 
-            auto wellDateKey = std::make_pair( wellName, date );
-
+            auto wellDateKey                   = std::make_pair( wellName, date );
             m_rftWellDateSegments[wellDateKey] = segment;
+
+            buildSegmentBranchTypes( wellDateKey );
         }
     }
 }
@@ -447,6 +448,69 @@ void RifReaderOpmRft::importWellNames()
     for ( const auto& w : names )
     {
         m_wellNames.insert( QString::fromStdString( w ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RifReaderOpmRft::buildSegmentBranchTypes( const RftSegmentKey& segmentKey )
+{
+    auto           wellName   = segmentKey.first;
+    auto           date       = segmentKey.second;
+    RifRftSegment& segmentRef = m_rftWellDateSegments[segmentKey];
+
+    int y = std::get<0>( date );
+    int m = std::get<1>( date );
+    int d = std::get<2>( date );
+
+    auto dt = RiaQDateTimeTools::createUtcDateTime( QDate( y, m, d ) );
+
+    std::vector<double> seglenstValues;
+    std::vector<double> seglenenValues;
+    {
+        auto resultName =
+            RifEclipseRftAddress::createSegmentAddress( QString::fromStdString( wellName ), dt, "SEGLENST", -1 );
+
+        values( resultName, &seglenstValues );
+
+        if ( seglenstValues.size() > 2 )
+        {
+            seglenstValues[0] = seglenstValues[1];
+        }
+    }
+    {
+        auto resultName =
+            RifEclipseRftAddress::createSegmentAddress( QString::fromStdString( wellName ), dt, "SEGLENEN", -1 );
+
+        values( resultName, &seglenenValues );
+    }
+
+    if ( !seglenenValues.empty() && !seglenstValues.empty() )
+    {
+        auto branchIds = segmentRef.branchIds();
+        for ( auto id : branchIds )
+        {
+            double minimumMD = std::numeric_limits<double>::max();
+            double maximumMD = std::numeric_limits<double>::min();
+
+            auto indices = segmentRef.indicesForBranchNumber( id );
+            for ( auto i : indices )
+            {
+                minimumMD = std::min( minimumMD, seglenstValues[i] );
+                maximumMD = std::max( maximumMD, seglenenValues[i] );
+            }
+
+            double length = maximumMD - minimumMD;
+
+            segmentRef.setBranchLenght( id, length );
+
+            const double              tubingThreshold = 1.0;
+            RiaDefines::RftBranchType branchType      = RiaDefines::RftBranchType::RFT_UNKNOWN;
+            if ( length > tubingThreshold ) branchType = RiaDefines::RftBranchType::RFT_TUBING;
+
+            segmentRef.setBranchType( id, branchType );
+        }
     }
 }
 

--- a/ApplicationLibCode/FileInterface/RifReaderOpmRft.h
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmRft.h
@@ -63,6 +63,7 @@ private:
     void segmentDataDebugLog() const;
     bool isOpen() const;
     void importWellNames();
+    void buildSegmentBranchTypes( const RftSegmentKey& segmentKey );
 
     std::vector<int> importWellData( const std::string& wellName, const std::string& propertyName, const RftDate& date ) const;
 

--- a/ApplicationLibCode/FileInterface/RifReaderOpmRft.h
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmRft.h
@@ -77,4 +77,5 @@ private:
     std::set<QString>              m_wellNames;
 
     std::map<RftSegmentKey, RifRftSegment> m_rftWellDateSegments;
+    std::set<QDateTime>                    m_rftSegmentTimeSteps;
 };

--- a/ApplicationLibCode/FileInterface/RifRftSegment.cpp
+++ b/ApplicationLibCode/FileInterface/RifRftSegment.cpp
@@ -113,6 +113,27 @@ std::vector<Opm::EclIO::EclFile::EclEntry> RifRftSegment::resultNameAndSize() co
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<int> RifRftSegment::tubingBranchIds() const
+{
+    std::vector<int> filteredBranchIds;
+
+    for ( auto branchId : branchIds() )
+    {
+        if ( m_branchType.count( branchId ) )
+        {
+            if ( m_branchType.at( branchId ) == RiaDefines::RftBranchType::RFT_TUBING )
+            {
+                filteredBranchIds.push_back( branchId );
+            }
+        }
+    }
+
+    return filteredBranchIds;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<int> RifRftSegment::branchIds() const
 {
     std::unordered_set<int> s;
@@ -126,6 +147,22 @@ std::vector<int> RifRftSegment::branchIds() const
     std::sort( v.begin(), v.end() );
 
     return v;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RifRftSegment::setBranchLenght( int branchId, double length )
+{
+    m_branchLength[branchId] = length;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RifRftSegment::setBranchType( int branchId, RiaDefines::RftBranchType branchType )
+{
+    m_branchType[branchId] = branchType;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifRftSegment.cpp
+++ b/ApplicationLibCode/FileInterface/RifRftSegment.cpp
@@ -152,7 +152,7 @@ std::vector<int> RifRftSegment::branchIds() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RifRftSegment::setBranchLenght( int branchId, double length )
+void RifRftSegment::setBranchLength( int branchId, double length )
 {
     m_branchLength[branchId] = length;
 }

--- a/ApplicationLibCode/FileInterface/RifRftSegment.h
+++ b/ApplicationLibCode/FileInterface/RifRftSegment.h
@@ -22,6 +22,7 @@
 #include <tuple>
 #include <vector>
 
+#include "RiaRftDefines.h"
 #include "opm/io/eclipse/EclFile.hpp"
 
 class RifRftSegmentData
@@ -52,11 +53,18 @@ public:
     void addResultNameAndSize( const Opm::EclIO::EclFile::EclEntry& resultNameAndSize );
     std::vector<Opm::EclIO::EclFile::EclEntry> resultNameAndSize() const;
 
+    std::vector<int> tubingBranchIds() const;
     std::vector<int> branchIds() const;
+
+    void setBranchLenght( int branchId, double length );
+    void setBranchType( int branchId, RiaDefines::RftBranchType branchType );
 
     std::vector<size_t> indicesForBranchNumber( int branchNumber ) const;
 
 private:
     std::vector<RifRftSegmentData>             m_topology;
     std::vector<Opm::EclIO::EclFile::EclEntry> m_resultNameAndSize;
+
+    std::map<int, double>                    m_branchLength;
+    std::map<int, RiaDefines::RftBranchType> m_branchType;
 };

--- a/ApplicationLibCode/FileInterface/RifRftSegment.h
+++ b/ApplicationLibCode/FileInterface/RifRftSegment.h
@@ -56,7 +56,7 @@ public:
     std::vector<int> tubingBranchIds() const;
     std::vector<int> branchIds() const;
 
-    void setBranchLenght( int branchId, double length );
+    void setBranchLength( int branchId, double length );
     void setBranchType( int branchId, RiaDefines::RftBranchType branchType );
 
     std::vector<size_t> indicesForBranchNumber( int branchNumber ) const;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
@@ -29,6 +29,7 @@
 #include "RifProjectSummaryDataWriter.h"
 #include "RifReaderEclipseRft.h"
 #include "RifReaderEclipseSummary.h"
+#include "RifReaderOpmRft.h"
 #include "RifSummaryReaderMultipleFiles.h"
 
 #include "RimProject.h"
@@ -185,7 +186,7 @@ RifSummaryReaderInterface* RimFileSummaryCase::findRelatedFilesAndCreateReader( 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RifReaderEclipseRft* RimFileSummaryCase::findRftDataAndCreateReader( const QString& headerFileName )
+RifReaderOpmRft* RimFileSummaryCase::findRftDataAndCreateReader( const QString& headerFileName )
 {
     QFileInfo fileInfo( headerFileName );
     QString   folder = fileInfo.absolutePath();
@@ -195,8 +196,7 @@ RifReaderEclipseRft* RimFileSummaryCase::findRftDataAndCreateReader( const QStri
 
     if ( rftFileInfo.exists() )
     {
-        std::unique_ptr<RifReaderEclipseRft> rftReader( new RifReaderEclipseRft( rftFileInfo.filePath() ) );
-        return rftReader.release();
+        return new RifReaderOpmRft( rftFileInfo.filePath() );
     }
 
     return nullptr;
@@ -211,7 +211,7 @@ void RimFileSummaryCase::defineEditorAttribute( const caf::PdmFieldHandle* field
 {
     if ( field == &m_additionalSummaryFilePath )
     {
-        caf::PdmUiFilePathEditorAttribute* myAttr = dynamic_cast<caf::PdmUiFilePathEditorAttribute*>( attribute );
+        auto* myAttr = dynamic_cast<caf::PdmUiFilePathEditorAttribute*>( attribute );
         if ( myAttr )
         {
             myAttr->m_selectSaveFileName = true;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.h
@@ -23,7 +23,7 @@
 #include "cvfObject.h"
 
 class RifReaderRftInterface;
-class RifReaderEclipseRft;
+class RifReaderOpmRft;
 class RifReaderEclipseSummary;
 class RiaThreadSafeLogger;
 class RifOpmCommonEclipseSummary;
@@ -61,8 +61,6 @@ public:
                                                                        bool                 includeRestartFiles,
                                                                        RiaThreadSafeLogger* threadSafeLogger );
 
-    static RifReaderEclipseRft* findRftDataAndCreateReader( const QString& headerFileName );
-
 protected:
     void defineEditorAttribute( const caf::PdmFieldHandle* field,
                                 QString                    uiConfigName,
@@ -73,10 +71,12 @@ private:
     QString        additionalSummaryDataFilePath() const;
     static QString createAdditionalSummaryFileName();
 
+    static RifReaderOpmRft* findRftDataAndCreateReader( const QString& headerFileName );
+
 private:
     cvf::ref<RifSummaryReaderInterface> m_fileSummaryReader;
     cvf::ref<RifMultipleSummaryReaders> m_multiSummaryReader;
-    cvf::ref<RifReaderEclipseRft>       m_summaryEclipseRftReader;
+    cvf::ref<RifReaderOpmRft>           m_summaryEclipseRftReader;
     caf::PdmField<bool>                 m_includeRestartFiles;
 
     caf::PdmField<caf::FilePath>         m_additionalSummaryFilePath;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -484,10 +484,7 @@ QList<caf::PdmOptionItemInfo> RimSummaryCurve::calculateValueOptions( const caf:
 
         cases.push_back( proj->calculationCollection->calculationSummaryCase() );
 
-        for ( RimSummaryCase* rimCase : cases )
-        {
-            options.push_back( caf::PdmOptionItemInfo( rimCase->displayCaseName(), rimCase ) );
-        }
+        options = RiaSummaryTools::optionsForSummaryCases( cases );
 
         if ( options.size() > 0 )
         {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurveCommonDataSource.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurveCommonDataSource.h
@@ -33,6 +33,8 @@ class RimWellLogCurve;
 class RimWellLogPlot;
 class RimWellLogTrack;
 class RimWellPath;
+class RimSummaryCase;
+class RifReaderRftInterface;
 
 //==================================================================================================
 ///
@@ -56,20 +58,22 @@ public:
 
     void setCaseType( RiaDefines::CaseType caseType );
 
-    RimCase*      caseToApply() const;
-    void          setCaseToApply( RimCase* val );
-    int           trajectoryTypeToApply() const;
-    void          setTrajectoryTypeToApply( int val );
-    RimWellPath*  wellPathToApply() const;
-    void          setWellPathToApply( RimWellPath* val );
-    int           branchIndexToApply() const;
-    void          setBranchIndexToApply( int val );
-    caf::Tristate branchDetectionToApply() const;
-    void          setBranchDetectionToApply( caf::Tristate::State val );
-    caf::Tristate wbsSmoothingToApply() const;
-    void          setWbsSmoothingToApply( caf::Tristate::State val );
-    double        wbsSmoothingThreshold() const;
-    void          setWbsSmoothingThreshold( double smoothingThreshold );
+    RimCase*        caseToApply() const;
+    void            setCaseToApply( RimCase* val );
+    RimSummaryCase* summaryCaseToApply() const;
+    void            setSummaryCaseToApply( RimSummaryCase* val );
+    int             trajectoryTypeToApply() const;
+    void            setTrajectoryTypeToApply( int val );
+    RimWellPath*    wellPathToApply() const;
+    void            setWellPathToApply( RimWellPath* val );
+    int             branchIndexToApply() const;
+    void            setBranchIndexToApply( int val );
+    caf::Tristate   branchDetectionToApply() const;
+    void            setBranchDetectionToApply( caf::Tristate::State val );
+    caf::Tristate   wbsSmoothingToApply() const;
+    void            setWbsSmoothingToApply( caf::Tristate::State val );
+    double          wbsSmoothingThreshold() const;
+    void            setWbsSmoothingThreshold( double smoothingThreshold );
 
     QString simWellNameToApply() const;
     void    setSimWellNameToApply( const QString& val );
@@ -93,7 +97,7 @@ public:
 
     static QString smoothingUiOrderinglabel();
 
-protected:
+private:
     void                          fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
     void                          defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
@@ -102,24 +106,28 @@ protected:
                                                          caf::PdmUiEditorAttribute* attribute ) override;
     void                          modifyCurrentIndex( caf::PdmValueField* field, int indexOffset );
 
+    RifReaderRftInterface* rftReader();
+
 private:
     RiaDefines::CaseType m_caseType;
 
-    caf::PdmPtrField<RimCase*>     m_case;
-    caf::PdmField<int>             m_trajectoryType;
-    caf::PdmPtrField<RimWellPath*> m_wellPath;
-    caf::PdmField<QString>         m_simWellName;
-    caf::PdmField<int>             m_branchIndex;
-    caf::PdmField<caf::Tristate>   m_branchDetection;
-    caf::PdmField<int>             m_timeStep;
-    caf::PdmField<caf::Tristate>   m_wbsSmoothing;
-    caf::PdmField<double>          m_wbsSmoothingThreshold;
+    caf::PdmPtrField<RimCase*>        m_case;
+    caf::PdmPtrField<RimSummaryCase*> m_summaryCase;
+    caf::PdmField<int>                m_trajectoryType;
+    caf::PdmPtrField<RimWellPath*>    m_wellPath;
+    caf::PdmField<QString>            m_simWellName;
+    caf::PdmField<int>                m_branchIndex;
+    caf::PdmField<caf::Tristate>      m_branchDetection;
+    caf::PdmField<int>                m_timeStep;
+    caf::PdmField<caf::Tristate>      m_wbsSmoothing;
+    caf::PdmField<double>             m_wbsSmoothingThreshold;
 
     caf::PdmField<QDateTime> m_rftTimeStep;
     caf::PdmField<QString>   m_rftWellName;
     caf::PdmField<int>       m_rftSegmentBranchId;
 
     std::set<RimCase*>                 m_uniqueCases;
+    std::set<RimSummaryCase*>          m_uniqueSummaryCases;
     std::set<int>                      m_uniqueTrajectoryTypes;
     std::set<RimWellPath*>             m_uniqueWellPaths;
     std::set<QString>                  m_uniqueWellNames;

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -1104,6 +1104,12 @@ std::vector<double> RimWellLogRftCurve::measuredDepthValues()
                                                                             segmentBranchId() );
 
             reader->values( depthAddress, &values );
+
+            // Special handling of first segment
+            if ( values.size() > 2 && values.front() < 0.001 )
+            {
+                values[0] = values[1];
+            }
         }
         return values;
     }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -308,8 +308,9 @@ RimObservedFmuRftData* RimWellLogRftCurve::observedFmuRftData() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogRftCurve::setRftAddress( RifEclipseRftAddress address )
 {
-    m_timeStep = address.timeStep();
-    m_wellName = address.wellName();
+    m_timeStep           = address.timeStep();
+    m_wellName           = address.wellName();
+    m_wellLogChannelName = address.wellLogChannel();
 
     if ( address.wellLogChannel() == RifEclipseRftAddress::RftWellLogChannelType::SEGMENT_VALUES )
     {
@@ -319,8 +320,7 @@ void RimWellLogRftCurve::setRftAddress( RifEclipseRftAddress address )
     }
     else
     {
-        m_rftDataType        = RftDataType::RFT_DATA;
-        m_wellLogChannelName = address.wellLogChannel();
+        m_rftDataType = RftDataType::RFT_DATA;
     }
 }
 
@@ -736,7 +736,10 @@ QList<caf::PdmOptionItemInfo> RimWellLogRftCurve::calculateValueOptions( const c
     }
     else if ( fieldNeedingOptions == &m_timeStep )
     {
-        options = RimRftTools::timeStepOptions( reader, m_wellName, m_wellLogChannelName() );
+        if ( m_rftDataType == RimWellLogRftCurve::RftDataType::RFT_SEGMENT_DATA )
+            options = RimRftTools::segmentTimeStepOptions( reader, m_wellName );
+        else
+            options = RimRftTools::timeStepOptions( reader, m_wellName, m_wellLogChannelName() );
     }
     else if ( fieldNeedingOptions == &m_branchIndex )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -509,7 +509,7 @@ void RimWellLogRftCurve::onLoadDataAndUpdate( bool updateParentPlot )
 
         if ( values.empty() || values.size() != tvDepthVector.size() )
         {
-            this->detach();
+            this->detach( true );
             return;
         }
 

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -24,6 +24,7 @@
 #include "RiaResultNames.h"
 #include "RiaRftDefines.h"
 #include "RiaSimWellBranchTools.h"
+#include "RiaSummaryTools.h"
 
 #include "RifEclipseRftAddress.h"
 #include "RifReaderEclipseRft.h"
@@ -676,6 +677,7 @@ void RimWellLogRftCurve::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
 
     caf::PdmUiGroup* curveDataGroup = uiOrdering.addNewGroup( "Curve Data" );
     curveDataGroup->add( &m_eclipseResultCase );
+    curveDataGroup->add( &m_summaryCase );
     curveDataGroup->add( &m_wellName );
     curveDataGroup->add( &m_timeStep );
     curveDataGroup->add( &m_rftDataType );
@@ -725,6 +727,10 @@ QList<caf::PdmOptionItemInfo> RimWellLogRftCurve::calculateValueOptions( const c
         RimTools::caseOptionItems( &options );
 
         options.push_front( caf::PdmOptionItemInfo( "None", nullptr ) );
+    }
+    else if ( fieldNeedingOptions == &m_summaryCase )
+    {
+        options = RiaSummaryTools::optionsForSummaryCases( RimProject::current()->allSummaryCases() );
     }
     else if ( fieldNeedingOptions == &m_wellName )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -731,6 +731,7 @@ QList<caf::PdmOptionItemInfo> RimWellLogRftCurve::calculateValueOptions( const c
     else if ( fieldNeedingOptions == &m_summaryCase )
     {
         options = RiaSummaryTools::optionsForSummaryCases( RimProject::current()->allSummaryCases() );
+        options.push_front( caf::PdmOptionItemInfo( "None", nullptr ) );
     }
     else if ( fieldNeedingOptions == &m_wellName )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogTrack.cpp
@@ -1338,6 +1338,8 @@ void RimWellLogTrack::onLoadDataAndUpdate()
     m_explicitTickIntervals.uiCapability()->setUiReadOnly( emptyRange );
     m_propertyValueAxisGridVisibility.uiCapability()->setUiReadOnly( emptyRange );
 
+    updateDepthZoom();
+
     updateLegend();
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogTrack.cpp
@@ -1008,13 +1008,10 @@ QString RimWellLogTrack::asciiDataForPlotExport() const
 
         const std::vector<double>& allDepths = curveMerger.allXValues();
         curveDepths                          = allDepths;
-        for ( size_t depthIdx = 0; depthIdx < allDepths.size(); depthIdx++ )
+        for ( size_t curveIdx = 0; curveIdx < curveMerger.curveCount(); ++curveIdx )
         {
-            for ( size_t curveIdx = 0; curveIdx < curveMerger.curveCount(); ++curveIdx )
-            {
-                const std::vector<double>& curveValues = curveMerger.lookupYValuesForAllXValues( curveIdx );
-                curvesPlotXValues.push_back( curveValues );
-            }
+            const std::vector<double>& curveValues = curveMerger.lookupYValuesForAllXValues( curveIdx );
+            curvesPlotXValues.push_back( curveValues );
         }
     }
 

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogTrack.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogTrack.h
@@ -298,6 +298,8 @@ private:
 
     std::pair<double, double> adjustXRange( double minValue, double maxValue, double tickInterval );
 
+    std::pair<double, double> extendMinMaxRange( double minValue, double maxValue, double factor );
+
     void updateWellPathAttributesCollection();
 
     RimDepthTrackPlot* parentWellLogPlot() const;
@@ -324,6 +326,7 @@ private:
 
     caf::PdmField<bool>                         m_isAutoScalePropertyValuesEnabled;
     caf::PdmField<bool>                         m_isLogarithmicScaleEnabled;
+    caf::PdmField<bool>                         m_invertPropertyValueAxis;
     caf::PdmField<RimWellLogPlot::AxisGridEnum> m_propertyValueAxisGridVisibility;
 
     caf::PdmField<bool>   m_explicitTickIntervals;
@@ -373,5 +376,4 @@ private:
     double m_availablePropertyValueRangeMax;
     double m_availableDepthRangeMin;
     double m_availableDepthRangeMax;
-
 };


### PR DESCRIPTION
- Make sure start MD is at correct position
- Use summary case as data source for RFT data
- Well Log Plot: Invert data range 
- Add some more space to default depth zoom range
- When plotting RFT segment data, use time steps where segment data is available
- RFT-data: Show Plot data multiplies pressure data in table #8898
- Create categories for branches(tubing, annular, device) Set tubing if length is longer than 1.0
- Show tubing branches in drop down list


Closes #9046 
Closes #9051
Closes #8898