### PR TITLE
Set minimum CMake version to 3.15 to avoid warnings on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 
 include(CheckCSourceCompiles)
 project(ResInsight)


### PR DESCRIPTION
Set CMake version on top level to avoid warnings on MSVC when warning level is set to something else than the default.

https://stackoverflow.com/questions/58708772/cmake-project-in-visual-studio-gives-flag-override-warnings-command-line-warnin