### PR TITLE
Update ResInsightWithCache.yml

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -68,7 +68,7 @@ jobs:
         run: echo "PYTHON_EXECUTABLE=$(python -c 'import sys; import pathlib; print (pathlib.PurePath(sys.executable).as_posix())')" >> $GITHUB_OUTPUT
 
       - name: Print Python path
-        run: echo ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }}
+        run: echo "${{ steps.python-path.outputs.PYTHON_EXECUTABLE }}"
 
       - name: Install dependencies
         # Make sure protobuf version is compatible with grpc - https://github.com/OPM/ResInsight/issues/9304

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -109,9 +109,9 @@ jobs:
         id: cache_timestamp_string
         shell: pwsh
         run: |
-        "timestep<<EOF" >> $env:GITHUB_ENV
-        Get-Date -Format "yyyy-MM-dd" >> $GITHUB_OUTPUT
-        "EOF" >> $env:GITHUB_ENV
+          "timestamp<<EOF" >> $env:GITHUB_ENV
+          Get-Date -Format "yyyy-MM-dd" >> $GITHUB_OUTPUT
+          "EOF" >> $env:GITHUB_ENV
       - name: Cache Buildcache
         id: cache-buildcache
         uses: actions/cache@v3

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -107,10 +107,11 @@ jobs:
 
       - name: Prepare cache timestamp
         id: cache_timestamp_string
-        shell: cmake -P {0}
+        shell: pwsh
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        "timestep<<EOF" >> $env:GITHUB_ENV
+        Get-Date -Format "yyyy-MM-dd" >> $GITHUB_OUTPUT
+        "EOF" >> $env:GITHUB_ENV
       - name: Cache Buildcache
         id: cache-buildcache
         uses: actions/cache@v3

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Get Python executable path
         id: python-path
-        run: echo "::set-output name=PYTHON_EXECUTABLE::$(python -c 'import sys; import pathlib; print (pathlib.PurePath(sys.executable).as_posix())')"
+        run: echo "PYTHON_EXECUTABLE=$(python -c 'import sys; import pathlib; print (pathlib.PurePath(sys.executable).as_posix())')" >> $GITHUB_OUTPUT
 
       - name: Print Python path
         run: echo ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }}

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -64,6 +64,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Get Python executable path
+        shell: bash
         id: python-path
         run: echo "PYTHON_EXECUTABLE=$(python -c 'import sys; import pathlib; print (pathlib.PurePath(sys.executable).as_posix())')" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Use `$GITHUB_OUTPUT` to communicate variables to be used in later steps.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/