### PR TITLE
Opm Parser: Include PATHS when importing WSEGLINK

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RiaOpmParserTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RiaOpmParserTools.cpp
@@ -25,6 +25,7 @@
 #include "opm/input/eclipse/Parser/ParseContext.hpp"
 #include "opm/input/eclipse/Parser/Parser.hpp"
 #include "opm/input/eclipse/Parser/ParserKeywords/I.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/P.hpp"
 #include "opm/input/eclipse/Parser/ParserKeywords/V.hpp"
 #include "opm/input/eclipse/Parser/ParserKeywords/W.hpp"
 
@@ -130,12 +131,15 @@ std::map<std::string, std::vector<std::pair<int, int>>> RiaOpmParserTools::extra
 {
     if ( !std::filesystem::exists( filename ) ) return {};
 
-    Opm::Parser                         parser( false );
+    Opm::Parser parser( false );
+
     const Opm::ParserKeywords::WSEGLINK kw1;
     const Opm::ParserKeywords::INCLUDE  kw2;
+    const Opm::ParserKeywords::PATHS    kw3;
 
     parser.addParserKeyword( kw1 );
     parser.addParserKeyword( kw2 );
+    parser.addParserKeyword( kw3 );
 
     std::stringstream ss;
     Opm::ParseContext parseContext( Opm::InputError::Action::WARN );

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,7 +385,9 @@ list(APPEND OPM_LIBRARIES custom-opm-flowdiagnostics custom-opm-flowdiag-app
      custom-opm-common
 )
 
-set_property(TARGET ${OPM_LIBRARIES} PROPERTY FOLDER "Thirdparty/OPM")
+set_property(
+  TARGET ${OPM_LIBRARIES} opm-parser-tests PROPERTY FOLDER "Thirdparty/OPM"
+)
 
 # ##############################################################################
 # NRLib

--- a/ThirdParty/custom-opm-common/custom-opm-parser-tests/TestData/mysubfolder/test_wseglink_subfolder.DATA
+++ b/ThirdParty/custom-opm-common/custom-opm-parser-tests/TestData/mysubfolder/test_wseglink_subfolder.DATA
@@ -4,27 +4,12 @@
 -- If either item #2 or #3 is undefined, all segment links are removed for the well and segment given.
 --
 
-PATHS
- 'E' 'mysubfolder' /
-/
-
 
 WSEGLINK
-  PROD  22 30 /
-  PROD2 25 37 /
+  PROD_N  20 30 /
 /
 
 WSEGLINK
-  PROD_A  20 30 /
+  PROD_M  20  /
 /
 
-WSEGLINK
-  PROD_A  20  /
-/
-
-WSEGLINK
-  PROD_A   /
-/
-
-INCLUDE
- '$E/test_wseglink_subfolder.DATA ' /

--- a/ThirdParty/custom-opm-common/custom-opm-parser-tests/opm-parser-BasicTest.cpp
+++ b/ThirdParty/custom-opm-common/custom-opm-parser-tests/opm-parser-BasicTest.cpp
@@ -13,6 +13,7 @@
 #include "opm/input/eclipse/Parser/ParserKeywords/W.hpp"
 #include "opm/input/eclipse/Parser/ParserKeywords/I.hpp"
 #include "opm/input/eclipse/Parser/ParserKeywords/S.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/P.hpp"
 
 #include "OpmTestDataDirectory.h"
 
@@ -92,9 +93,11 @@ TEST(OpmParserTest, ReadAndParseWSEGLINK)
 
     const Opm::ParserKeywords::WSEGLINK kw1;
     const Opm::ParserKeywords::INCLUDE  kw2;
+    const Opm::ParserKeywords::PATHS    kw3;
 
     parser.addParserKeyword(kw1);
     parser.addParserKeyword(kw2);
+    parser.addParserKeyword(kw3);
 
     std::string testFilePath = std::string(TEST_DATA_DIR) + "/test_wseglink.DATA";
     


### PR DESCRIPTION
Add PATHS to supported keywords to be able to use include files with alias in file path.