### PR TITLE
Use more size_t instead of int in interface

### DIFF
--- a/ApplicationLibCode/FileInterface/RifThermalFractureReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifThermalFractureReader.cpp
@@ -51,7 +51,7 @@ std::pair<std::shared_ptr<RigThermalFractureDefinition>, QString>
     QString separator = ",";
 
     auto appendPropertyValues =
-        [definition]( int nodeIndex, int valueOffset, const QStringList& values, double conductivityFactor ) {
+        [definition]( size_t nodeIndex, int valueOffset, const QStringList& values, double conductivityFactor ) {
             CAF_ASSERT( valueOffset <= values.size() );
             for ( int i = valueOffset; i < values.size(); i++ )
             {
@@ -59,7 +59,7 @@ std::pair<std::shared_ptr<RigThermalFractureDefinition>, QString>
                 double value = values[i].toDouble( &isOk );
                 if ( isOk )
                 {
-                    int propertyIndex = i - valueOffset;
+                    size_t propertyIndex = static_cast<size_t>( i - valueOffset );
 
                     // Convert conductivity from Darcy to milliDarcy
                     if ( definition->getPropertyIndex( "Conductivity" ) == propertyIndex )

--- a/ApplicationLibCode/FileInterface/RifThermalFractureTemplateSurfaceExporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifThermalFractureTemplateSurfaceExporter.cpp
@@ -48,7 +48,7 @@ bool RifThermalFractureTemplateSurfaceExporter::writeToFile( gsl::not_null<RimTh
         out.setRealNumberPrecision( 16 );
 
         auto nameAndUnits  = fractureData->getPropertyNamesUnits();
-        int  numProperties = nameAndUnits.size();
+        auto numProperties = nameAndUnits.size();
 
         for ( auto [name, unit] : nameAndUnits )
         {
@@ -59,7 +59,7 @@ bool RifThermalFractureTemplateSurfaceExporter::writeToFile( gsl::not_null<RimTh
 
         for ( int nodeIndex = 0; nodeIndex < static_cast<int>( numNodes ); nodeIndex++ )
         {
-            for ( int propertyIndex = 0; propertyIndex < numProperties; propertyIndex++ )
+            for ( size_t propertyIndex = 0; propertyIndex < numProperties; propertyIndex++ )
             {
                 double value = fractureData->getPropertyValue( propertyIndex, nodeIndex, timeStepIndex );
                 out << value;

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimThermalFractureTemplate.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimThermalFractureTemplate.cpp
@@ -168,13 +168,13 @@ void RimThermalFractureTemplate::loadDataAndUpdate()
     if ( m_fractureDefinitionData )
     {
         auto addInjectivityFactor = []( std::shared_ptr<RigThermalFractureDefinition> def ) {
-            int     leakoffPressureDropIndex  = def->getPropertyIndex( RiaDefines::leakoffPressureDropResultName() );
-            int     filtratePressureDropIndex = def->getPropertyIndex( RiaDefines::filtratePressureDropResultName() );
+            size_t  leakoffPressureDropIndex  = def->getPropertyIndex( RiaDefines::leakoffPressureDropResultName() );
+            size_t  filtratePressureDropIndex = def->getPropertyIndex( RiaDefines::filtratePressureDropResultName() );
             QString injectivityValueTag       = RiaDefines::injectivityFactorResultName();
             def->addProperty( injectivityValueTag,
                               RiaDefines::getExpectedThermalFractureUnit( injectivityValueTag, def->unitSystem() ) );
 
-            int injectivityFactorIndex = def->getPropertyIndex( injectivityValueTag );
+            size_t injectivityFactorIndex = def->getPropertyIndex( injectivityValueTag );
 
             for ( size_t nodeIndex = 0; nodeIndex < def->numNodes(); nodeIndex++ )
             {
@@ -192,14 +192,14 @@ void RimThermalFractureTemplate::loadDataAndUpdate()
         };
 
         auto addFilterCakeMobility = []( std::shared_ptr<RigThermalFractureDefinition> def ) {
-            int     leakoffPressureDropIndex   = def->getPropertyIndex( RiaDefines::leakoffPressureDropResultName() );
-            int     filtratePressureDropIndex  = def->getPropertyIndex( RiaDefines::filtratePressureDropResultName() );
-            int     leakoffMobilityIndex       = def->getPropertyIndex( RiaDefines::leakoffMobilityResultName() );
+            size_t  leakoffPressureDropIndex   = def->getPropertyIndex( RiaDefines::leakoffPressureDropResultName() );
+            size_t  filtratePressureDropIndex  = def->getPropertyIndex( RiaDefines::filtratePressureDropResultName() );
+            size_t  leakoffMobilityIndex       = def->getPropertyIndex( RiaDefines::leakoffMobilityResultName() );
             QString filterCakeMobilityValueTag = RiaDefines::filterCakeMobilityResultName();
             def->addProperty( filterCakeMobilityValueTag,
                               RiaDefines::getExpectedThermalFractureUnit( filterCakeMobilityValueTag, def->unitSystem() ) );
 
-            int filterCakeMobilityIndex = def->getPropertyIndex( filterCakeMobilityValueTag );
+            size_t filterCakeMobilityIndex = def->getPropertyIndex( filterCakeMobilityValueTag );
 
             for ( size_t nodeIndex = 0; nodeIndex < def->numNodes(); nodeIndex++ )
             {

--- a/ApplicationLibCode/ReservoirDataModel/RigThermalFractureDefinition.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigThermalFractureDefinition.cpp
@@ -127,10 +127,9 @@ std::vector<std::pair<QString, QString>> RigThermalFractureDefinition::getProper
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigThermalFractureDefinition::appendPropertyValue( int propertyIndex, int nodeIndex, double value )
+void RigThermalFractureDefinition::appendPropertyValue( size_t propertyIndex, size_t nodeIndex, double value )
 {
-    CAF_ASSERT( propertyIndex >= 0 );
-    CAF_ASSERT( propertyIndex < static_cast<int>( m_results.size() ) );
+    CAF_ASSERT( propertyIndex < m_results.size() );
 
     m_results[propertyIndex].appendValue( nodeIndex, value );
 }
@@ -138,48 +137,51 @@ void RigThermalFractureDefinition::appendPropertyValue( int propertyIndex, int n
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-double RigThermalFractureDefinition::getPropertyValue( int propertyIndex, int nodeIndex, int timeStepIndex ) const
+double RigThermalFractureDefinition::getPropertyValue( size_t propertyIndex, size_t nodeIndex, size_t timeStepIndex ) const
 {
+    CAF_ASSERT( propertyIndex < m_results.size() );
+
     return m_results[propertyIndex].getValue( nodeIndex, timeStepIndex );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-int RigThermalFractureDefinition::getPropertyIndex( const QString& name ) const
+size_t RigThermalFractureDefinition::getPropertyIndex( const QString& name ) const
 {
     for ( size_t i = 0; i < m_results.size(); i++ )
-        if ( name == m_results[i].name() ) return static_cast<int>( i );
+        if ( name == m_results[i].name() ) return i;
 
-    return -1;
+    return std::numeric_limits<size_t>::max();
 };
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<cvf::Vec3d> RigThermalFractureDefinition::relativeCoordinates( int timeStepIndex ) const
+std::vector<cvf::Vec3d> RigThermalFractureDefinition::relativeCoordinates( size_t timeStepIndex ) const
 {
     std::vector<cvf::Vec3d> relCoords;
 
-    int xIndex = getPropertyIndex( "XCoord" );
-    int yIndex = getPropertyIndex( "YCoord" );
-    int zIndex = getPropertyIndex( "ZCoord" );
-    if ( xIndex == -1 || yIndex == -1 || zIndex == -1 )
+    auto xIndex = getPropertyIndex( "XCoord" );
+    auto yIndex = getPropertyIndex( "YCoord" );
+    auto zIndex = getPropertyIndex( "ZCoord" );
+    if ( xIndex == std::numeric_limits<size_t>::max() || yIndex == std::numeric_limits<size_t>::max() ||
+         zIndex == std::numeric_limits<size_t>::max() )
     {
         return relCoords;
     }
 
     // The first node is the center node
-    int        centerNodeIndex = 0;
+    size_t     centerNodeIndex = 0;
     cvf::Vec3d centerNode( getPropertyValue( xIndex, centerNodeIndex, timeStepIndex ),
                            getPropertyValue( yIndex, centerNodeIndex, timeStepIndex ),
                            getPropertyValue( zIndex, centerNodeIndex, timeStepIndex ) );
 
     for ( size_t nodeIndex = 0; nodeIndex < numNodes(); nodeIndex++ )
     {
-        cvf::Vec3d nodePos( getPropertyValue( xIndex, static_cast<int>( nodeIndex ), timeStepIndex ),
-                            getPropertyValue( yIndex, static_cast<int>( nodeIndex ), timeStepIndex ),
-                            getPropertyValue( zIndex, static_cast<int>( nodeIndex ), timeStepIndex ) );
+        cvf::Vec3d nodePos( getPropertyValue( xIndex, nodeIndex, timeStepIndex ),
+                            getPropertyValue( yIndex, nodeIndex, timeStepIndex ),
+                            getPropertyValue( zIndex, nodeIndex, timeStepIndex ) );
         relCoords.push_back( nodePos - centerNode );
     }
 
@@ -191,17 +193,18 @@ std::vector<cvf::Vec3d> RigThermalFractureDefinition::relativeCoordinates( int t
 //--------------------------------------------------------------------------------------------------
 cvf::Vec3d RigThermalFractureDefinition::centerPosition() const
 {
-    int xIndex = getPropertyIndex( "XCoord" );
-    int yIndex = getPropertyIndex( "YCoord" );
-    int zIndex = getPropertyIndex( "ZCoord" );
-    if ( xIndex == -1 || yIndex == -1 || zIndex == -1 )
+    auto xIndex = getPropertyIndex( "XCoord" );
+    auto yIndex = getPropertyIndex( "YCoord" );
+    auto zIndex = getPropertyIndex( "ZCoord" );
+    if ( xIndex == std::numeric_limits<size_t>::max() || yIndex == std::numeric_limits<size_t>::max() ||
+         zIndex == std::numeric_limits<size_t>::max() )
     {
         return cvf::Vec3d::UNDEFINED;
     }
 
     // The first node is the center node
-    int        centerNodeIndex = 0;
-    int        timeStepIndex   = 0;
+    size_t     centerNodeIndex = 0;
+    size_t     timeStepIndex   = 0;
     cvf::Vec3d centerNode( getPropertyValue( xIndex, centerNodeIndex, timeStepIndex ),
                            getPropertyValue( yIndex, centerNodeIndex, timeStepIndex ),
                            getPropertyValue( zIndex, centerNodeIndex, timeStepIndex ) );
@@ -211,25 +214,26 @@ cvf::Vec3d RigThermalFractureDefinition::centerPosition() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::BoundingBox RigThermalFractureDefinition::getBoundingBox( int timeStepIndex ) const
+cvf::BoundingBox RigThermalFractureDefinition::getBoundingBox( size_t timeStepIndex ) const
 {
     std::vector<cvf::Vec3d> coords;
 
     cvf::BoundingBox bb;
 
-    int xIndex = getPropertyIndex( "XCoord" );
-    int yIndex = getPropertyIndex( "YCoord" );
-    int zIndex = getPropertyIndex( "ZCoord" );
-    if ( xIndex == -1 || yIndex == -1 || zIndex == -1 )
+    auto xIndex = getPropertyIndex( "XCoord" );
+    auto yIndex = getPropertyIndex( "YCoord" );
+    auto zIndex = getPropertyIndex( "ZCoord" );
+    if ( xIndex == std::numeric_limits<size_t>::max() || yIndex == std::numeric_limits<size_t>::max() ||
+         zIndex == std::numeric_limits<size_t>::max() )
     {
         return bb;
     }
 
     for ( size_t nodeIndex = 0; nodeIndex < numNodes(); nodeIndex++ )
     {
-        cvf::Vec3d nodePos( getPropertyValue( xIndex, static_cast<int>( nodeIndex ), timeStepIndex ),
-                            getPropertyValue( yIndex, static_cast<int>( nodeIndex ), timeStepIndex ),
-                            getPropertyValue( zIndex, static_cast<int>( nodeIndex ), timeStepIndex ) );
+        cvf::Vec3d nodePos( getPropertyValue( xIndex, nodeIndex, timeStepIndex ),
+                            getPropertyValue( yIndex, nodeIndex, timeStepIndex ),
+                            getPropertyValue( zIndex, nodeIndex, timeStepIndex ) );
         bb.add( nodePos );
     }
 
@@ -239,7 +243,7 @@ cvf::BoundingBox RigThermalFractureDefinition::getBoundingBox( int timeStepIndex
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-double RigThermalFractureDefinition::minDepth( int timeStepIndex ) const
+double RigThermalFractureDefinition::minDepth( size_t timeStepIndex ) const
 {
     return getBoundingBox( timeStepIndex ).min().z();
 }
@@ -247,7 +251,7 @@ double RigThermalFractureDefinition::minDepth( int timeStepIndex ) const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-double RigThermalFractureDefinition::maxDepth( int timeStepIndex ) const
+double RigThermalFractureDefinition::maxDepth( size_t timeStepIndex ) const
 {
     return getBoundingBox( timeStepIndex ).max().z();
 }

--- a/ApplicationLibCode/ReservoirDataModel/RigThermalFractureDefinition.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigThermalFractureDefinition.h
@@ -51,25 +51,25 @@ public:
 
     std::vector<std::pair<QString, QString>> getPropertyNamesUnits() const;
 
-    void appendPropertyValue( int propertyIndex, int nodeIndex, double value );
+    void appendPropertyValue( size_t propertyIndex, size_t nodeIndex, double value );
 
-    double getPropertyValue( int propertyIndex, int nodeIndex, int timeStepIndex ) const;
+    double getPropertyValue( size_t propertyIndex, size_t nodeIndex, size_t timeStepIndex ) const;
 
-    int getPropertyIndex( const QString& name ) const;
+    size_t getPropertyIndex( const QString& name ) const;
 
-    std::vector<cvf::Vec3d> relativeCoordinates( int timeStepIndex ) const;
+    std::vector<cvf::Vec3d> relativeCoordinates( size_t timeStepIndex ) const;
 
     cvf::Vec3d centerPosition() const;
 
-    double minDepth( int timeStepIndex ) const;
-    double maxDepth( int timeStepIndex ) const;
+    double minDepth( size_t timeStepIndex ) const;
+    double maxDepth( size_t timeStepIndex ) const;
 
     void setUnitSystem( RiaDefines::EclipseUnitSystem unitSystem );
 
     RiaDefines::EclipseUnitSystem unitSystem() const;
 
 private:
-    cvf::BoundingBox getBoundingBox( int timeStepIndex ) const;
+    cvf::BoundingBox getBoundingBox( size_t timeStepIndex ) const;
 
     QString m_name;
 

--- a/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResult.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResult.cpp
@@ -46,9 +46,9 @@ QString RigThermalFractureResult::unit() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigThermalFractureResult::appendValue( int nodeIndex, double value )
+void RigThermalFractureResult::appendValue( size_t nodeIndex, double value )
 {
-    if ( nodeIndex >= static_cast<int>( m_parameterValues.size() ) )
+    if ( nodeIndex >= m_parameterValues.size() )
         m_parameterValues.push_back( { value } );
     else
         m_parameterValues[nodeIndex].push_back( value );
@@ -57,7 +57,7 @@ void RigThermalFractureResult::appendValue( int nodeIndex, double value )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-double RigThermalFractureResult::getValue( int nodeIndex, int timeStepIndex ) const
+double RigThermalFractureResult::getValue( size_t nodeIndex, size_t timeStepIndex ) const
 {
     return m_parameterValues[nodeIndex][timeStepIndex];
 }

--- a/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResult.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResult.h
@@ -37,8 +37,8 @@ public:
     QString name() const;
     QString unit() const;
 
-    void   appendValue( int nodeIndex, double value );
-    double getValue( int nodeIndex, int timeStepIndex ) const;
+    void   appendValue( size_t nodeIndex, double value );
+    double getValue( size_t nodeIndex, size_t timeStepIndex ) const;
 
     size_t numNodes() const;
 

--- a/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResultUtil.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResultUtil.cpp
@@ -59,8 +59,8 @@ std::vector<std::vector<double>>
 {
     std::vector<std::vector<double>> vec;
 
-    int propertyIndex = fractureDefinition->getPropertyIndex( resultName );
-    if ( propertyIndex < 0 ) return vec;
+    size_t propertyIndex = fractureDefinition->getPropertyIndex( resultName );
+    if ( propertyIndex == std::numeric_limits<size_t>::max() ) return vec;
 
     std::vector<cvf::Vec3d> relativePos = getRelativeCoordinates( fractureDefinition, timeStepIndex );
 
@@ -430,13 +430,13 @@ void RigThermalFractureResultUtil::appendDataToResultStatistics( std::shared_ptr
                                                                  MinMaxAccumulator& minMaxAccumulator,
                                                                  PosNegAccumulator& posNegAccumulator )
 {
-    int propertyIndex = fractureDefinition->getPropertyIndex( resultName );
-    if ( propertyIndex < 0 ) return;
+    size_t propertyIndex = fractureDefinition->getPropertyIndex( resultName );
+    if ( propertyIndex == std::numeric_limits<size_t>::max() ) return;
 
-    int maxTs = static_cast<int>( fractureDefinition->timeSteps().size() );
-    for ( int ts = 0; ts < maxTs; ts++ )
+    size_t maxTs = fractureDefinition->timeSteps().size();
+    for ( size_t ts = 0; ts < maxTs; ts++ )
     {
-        for ( int nodeIndex = 0; nodeIndex < static_cast<int>( fractureDefinition->numNodes() ); nodeIndex++ )
+        for ( size_t nodeIndex = 0; nodeIndex < fractureDefinition->numNodes(); nodeIndex++ )
         {
             double value = fractureDefinition->getPropertyValue( propertyIndex, nodeIndex, ts );
             minMaxAccumulator.addValue( value );
@@ -589,7 +589,7 @@ std::pair<cvf::Vec3d, cvf::Vec3d> RigThermalFractureResultUtil::computePositionA
 double RigThermalFractureResultUtil::interpolateProperty( const cvf::Vec3d&                                   position,
                                                           const std::vector<cvf::Vec3d>&                      points,
                                                           std::shared_ptr<const RigThermalFractureDefinition> fractureDefinition,
-                                                          int    propertyIndex,
+                                                          size_t propertyIndex,
                                                           size_t timeStepIndex )
 {
     // Compute the distance to the other points

--- a/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResultUtil.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigThermalFractureResultUtil.h
@@ -109,7 +109,7 @@ private:
     static double interpolateProperty( const cvf::Vec3d&                                   position,
                                        const std::vector<cvf::Vec3d>&                      points,
                                        std::shared_ptr<const RigThermalFractureDefinition> fractureDefinition,
-                                       int                                                 propertyIndex,
+                                       size_t                                              propertyIndex,
                                        size_t                                              timeStepIndex );
 
     static const int NUM_SAMPLES_X = 50;


### PR DESCRIPTION
Fix some type conversion errors. Use `size_t` instead of `int` where possible.