### PR TITLE
Allow linking of contour map views

### DIFF
--- a/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp
@@ -414,12 +414,5 @@ void RicNewContourMapViewFeature::assignDefaultResultAndLegend( RimEclipseContou
         {
             contourMap->cellResult()->setResultVariable( "SOIL" );
         }
-
-        RimRegularLegendConfig* legendConfig = contourMap->cellResult()->legendConfig();
-        if ( legendConfig )
-        {
-            RimColorLegend* legend = legendConfig->mapToColorLegend( RimRegularLegendConfig::ColorRangesType::RAINBOW );
-            legendConfig->setColorLegend( legend );
-        }
     }
 }

--- a/ApplicationLibCode/Commands/ViewLink/RicDeleteAllLinkedViewsFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicDeleteAllLinkedViewsFeature.cpp
@@ -19,6 +19,7 @@
 
 #include "RicDeleteAllLinkedViewsFeature.h"
 
+#include "RimEclipseContourMapView.h"
 #include "RimGridView.h"
 #include "RimProject.h"
 #include "RimViewLinker.h"
@@ -75,9 +76,15 @@ void RicDeleteAllLinkedViewsFeature::onActionTriggered( bool isChecked )
         // viewLinkerCollection->viewLinker is a PdmChildField containing one RimViewLinker child object
         proj->viewLinkerCollection->viewLinker.removeChild( viewLinker );
 
-        viewLinker->applyCellFilterCollectionByUserChoice();
+        auto views = viewLinker->allViews();
 
+        viewLinker->applyCellFilterCollectionByUserChoice();
         delete viewLinker;
+
+        for ( auto v : views )
+        {
+            if ( dynamic_cast<RimEclipseContourMapView*>( v ) ) v->zoomAll();
+        }
 
         proj->uiCapability()->updateConnectedEditors();
     }

--- a/ApplicationLibCode/Commands/ViewLink/RicLinkViewFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicLinkViewFeature.cpp
@@ -24,8 +24,6 @@
 #include "RicLinkVisibleViewsFeature.h"
 
 #include "Rim3dView.h"
-#include "RimEclipseContourMapView.h"
-#include "RimGeoMechContourMapView.h"
 #include "RimGridView.h"
 #include "RimProject.h"
 #include "RimViewLinker.h"
@@ -57,8 +55,6 @@ public:
             // Link only the active view to an existing view link collection.
             RimGridView* activeView = RiaApplication::instance()->activeGridView();
             if ( !activeView ) return false;
-            if ( dynamic_cast<RimEclipseContourMapView*>( activeView ) ) return false;
-            if ( dynamic_cast<RimGeoMechContourMapView*>( activeView ) ) return false;
 
             if ( activeView->assosiatedViewLinker() ) return false;
 
@@ -73,18 +69,6 @@ public:
         for ( auto gridView : selectedGridViews )
         {
             if ( !gridView ) continue;
-
-            if ( dynamic_cast<RimEclipseContourMapView*>( gridView ) )
-            {
-                hasAnyUnlinkableViews = true;
-                break;
-            }
-
-            if ( dynamic_cast<RimGeoMechContourMapView*>( gridView ) )
-            {
-                hasAnyUnlinkableViews = true;
-                break;
-            }
 
             if ( !gridView->assosiatedViewLinker() )
             {

--- a/ApplicationLibCode/Commands/ViewLink/RicLinkViewFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicLinkViewFeature.cpp
@@ -65,7 +65,6 @@ public:
         std::vector<RimGridView*> selectedGridViews;
 
         caf::SelectionManager::instance()->objectsByTypeStrict( &selectedGridViews );
-        bool hasAnyUnlinkableViews = false;
         for ( auto gridView : selectedGridViews )
         {
             if ( !gridView ) continue;
@@ -76,7 +75,7 @@ public:
             }
         }
 
-        if ( !m_viewsToLink.empty() && !hasAnyUnlinkableViews )
+        if ( !m_viewsToLink.empty() )
         {
             return true;
         }

--- a/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp
@@ -57,7 +57,7 @@ bool RicLinkVisibleViewsFeature::isCommandEnabled()
 
     if ( proj->viewLinkerCollection() && proj->viewLinkerCollection()->viewLinker() )
     {
-        proj->viewLinkerCollection()->viewLinker()->allViews( linkedviews );
+        linkedviews = proj->viewLinkerCollection()->viewLinker()->allViews();
     }
 
     if ( visibleGridViews.size() >= 2 && ( linkedviews.size() < visibleGridViews.size() ) )

--- a/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp
@@ -21,8 +21,6 @@
 
 #include "RicLinkVisibleViewsFeatureUi.h"
 
-#include "RimEclipseContourMapView.h"
-#include "RimGeoMechContourMapView.h"
 #include "RimGridView.h"
 #include "RimProject.h"
 #include "RimViewController.h"
@@ -97,24 +95,9 @@ void RicLinkVisibleViewsFeature::setupActionLook( QAction* actionToSetup )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicLinkVisibleViewsFeature::allLinkedViews( std::vector<RimGridView*>& views )
-{
-    RimProject* proj = RimProject::current();
-    if ( proj->viewLinkerCollection()->viewLinker() )
-    {
-        proj->viewLinkerCollection()->viewLinker()->allViews( views );
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void RicLinkVisibleViewsFeature::findLinkableVisibleViews( std::vector<RimGridView*>& views )
 {
     RimProject* proj = RimProject::current();
-
-    std::vector<RimGridView*> alreadyLinkedViews;
-    allLinkedViews( alreadyLinkedViews );
 
     std::vector<RimGridView*> visibleGridViews;
     proj->allVisibleGridViews( visibleGridViews );
@@ -122,8 +105,6 @@ void RicLinkVisibleViewsFeature::findLinkableVisibleViews( std::vector<RimGridVi
     for ( auto gridView : visibleGridViews )
     {
         if ( !gridView ) continue;
-        if ( dynamic_cast<RimEclipseContourMapView*>( gridView ) ) continue;
-        if ( dynamic_cast<RimGeoMechContourMapView*>( gridView ) ) continue;
         if ( gridView->assosiatedViewLinker() ) continue;
 
         views.push_back( gridView );

--- a/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.h
+++ b/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.h
@@ -43,5 +43,4 @@ protected:
 
 private:
     void findLinkableVisibleViews( std::vector<RimGridView*>& views );
-    void allLinkedViews( std::vector<RimGridView*>& views );
 };

--- a/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeatureUi.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeatureUi.cpp
@@ -23,7 +23,6 @@
 #include "RiaOptionItemFactory.h"
 
 #include "RimCase.h"
-#include "RimEclipseContourMapView.h"
 #include "RimGridView.h"
 #include "RimViewLinker.h"
 
@@ -79,17 +78,7 @@ RimGridView* RicLinkVisibleViewsFeatureUi::masterView()
 //--------------------------------------------------------------------------------------------------
 std::vector<RimGridView*> RicLinkVisibleViewsFeatureUi::masterViewCandidates() const
 {
-    std::vector<RimGridView*> masterCandidates;
-    // Set Active view as master view if the active view isn't a contour map.
-    for ( size_t i = 0; i < m_allViews.size(); i++ )
-    {
-        RimEclipseContourMapView* contourMap = dynamic_cast<RimEclipseContourMapView*>( m_allViews[i] );
-        if ( contourMap == nullptr )
-        {
-            masterCandidates.push_back( m_allViews[i] );
-        }
-    }
-    return masterCandidates;
+    return m_allViews;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/ViewLink/RicShowAllLinkedViewsFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicShowAllLinkedViewsFeature.cpp
@@ -47,23 +47,21 @@ void RicShowAllLinkedViewsFeature::onActionTriggered( bool isChecked )
 
     std::vector<RimViewController*> managedViews;
     caf::SelectionManager::instance()->objectsByType( &managedViews );
-    for ( size_t i = 0; i < managedViews.size(); i++ )
+    for ( auto& managedView : managedViews )
     {
         RimViewLinker* rimLinked = nullptr;
-        managedViews[i]->firstAncestorOrThisOfType( rimLinked );
+        managedView->firstAncestorOrThisOfType( rimLinked );
         CVF_ASSERT( rimLinked );
 
         linkedViews.push_back( rimLinked );
     }
 
-    for ( size_t i = 0; i < linkedViews.size(); i++ )
+    for ( auto& linkedView : linkedViews )
     {
-        std::vector<RimGridView*> views;
-        linkedViews[i]->allViews( views );
-
-        for ( size_t j = 0; j < views.size(); j++ )
+        auto views = linkedView->allViews();
+        for ( auto& view : views )
         {
-            views[j]->forceShowWindowOn();
+            view->forceShowWindowOn();
         }
     }
 }

--- a/ApplicationLibCode/Commands/ViewLink/RicUnLinkViewFeature.cpp
+++ b/ApplicationLibCode/Commands/ViewLink/RicUnLinkViewFeature.cpp
@@ -22,15 +22,16 @@
 #include "RiaApplication.h"
 
 #include "Rim3dView.h"
+#include "RimEclipseContourMapView.h"
 #include "RimGridView.h"
 #include "RimProject.h"
 #include "RimViewController.h"
 #include "RimViewLinker.h"
+#include "RimViewLinkerCollection.h"
 
 #include "cafCmdFeatureManager.h"
 #include "cafSelectionManager.h"
 
-#include "RimViewLinkerCollection.h"
 #include <QAction>
 
 CAF_CMD_SOURCE_INIT( RicUnLinkViewFeature, "RicUnLinkViewFeature" );
@@ -68,8 +69,9 @@ void RicUnLinkViewFeature::onActionTriggered( bool isChecked )
     {
         viewController->applyCellFilterCollectionByUserChoice();
         delete viewController;
-        viewLinker->removeViewController( nullptr ); // Remove the slots in the vector that was set to nullptr by the
-                                                     // destructor
+
+        // Remove the slots in the vector that was set to nullptr by the destructor
+        viewLinker->removeViewController( nullptr );
     }
     else if ( viewLinker )
     {
@@ -93,6 +95,8 @@ void RicUnLinkViewFeature::onActionTriggered( bool isChecked )
         }
         activeView->updateAutoName();
     }
+
+    if ( dynamic_cast<RimEclipseContourMapView*>( activeView ) ) activeView->zoomAll();
 
     RimProject::current()->viewLinkerCollection.uiCapability()->updateConnectedEditors();
     RimProject::current()->uiCapability()->updateConnectedEditors();

--- a/ApplicationLibCode/ModelVisualization/RivContourMapProjectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivContourMapProjectionPartMgr.cpp
@@ -479,6 +479,9 @@ std::vector<cvf::ref<cvf::Drawable>>
                     {
                         for ( const cvf::BoundingBox& existingBBox : boxVector )
                         {
+                            // Assert on invalid bounding box seen on Linux
+                            if ( !displayBBox.isValid() || !existingBBox.isValid() ) continue;
+
                             double dist = ( displayBBox.center() - existingBBox.center() ).length();
                             if ( dist < segment.length() || existingBBox.intersects( displayBBox ) )
                             {

--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
@@ -331,6 +331,8 @@ QWidget* Rim3dView::createViewWidget( QWidget* mainWindowParent )
 //--------------------------------------------------------------------------------------------------
 void Rim3dView::updateViewWidgetAfterCreation()
 {
+    if ( !m_viewer ) return;
+
     m_viewer->setDefaultPerspectiveNearPlaneDistance( 10 );
 
     this->onResetLegendsInViewer();

--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.h
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.h
@@ -230,8 +230,6 @@ protected:
     virtual cvf::Transform* scaleTransform()         = 0;
 
 protected:
-    // Overridden PdmObject methods:
-
     caf::PdmFieldHandle* userDescriptionField() override;
     caf::PdmFieldHandle* backgroundColorField();
 
@@ -242,9 +240,10 @@ protected:
 
     void setupBeforeSave() override;
 
-    // Overridden ViewWindow methods:
     void     updateViewWidgetAfterCreation() override;
     QWidget* createViewWidget( QWidget* mainWindowParent ) override;
+
+    void setCameraPosition( const cvf::Mat4d& cameraPosition ) override;
 
 protected:
     // Timestep Field. Children clamps this differently
@@ -271,8 +270,6 @@ private:
     void performAutoNameUpdate() final;
 
     // Implementation of RiuViewerToViewInterface
-
-    void setCameraPosition( const cvf::Mat4d& cameraPosition ) override;
     void setCameraPointOfInterest( const cvf::Vec3d& cameraPointOfInterest ) override;
 
     void endAnimation() override;

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.cpp
@@ -72,7 +72,7 @@ RimEclipseContourMapView::RimEclipseContourMapView()
 
     m_contourMapProjectionPartMgr = new RivContourMapProjectionPartMgr( contourMapProjection(), this );
 
-    ( (RiuViewerToViewInterface*)this )->setCameraPosition( sm_defaultViewMatrix );
+    setCameraPosition( sm_defaultViewMatrix );
 
     cellResult()->setTernaryEnabled( false );
     cellResult()->legendConfigChanged.connect( this, &RimEclipseContourMapView::onLegendConfigChanged );
@@ -568,4 +568,19 @@ RimSurfaceInViewCollection* RimEclipseContourMapView::surfaceInViewCollection() 
 {
     // Surfaces should not be shown in contour map.
     return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEclipseContourMapView::zoomAll()
+{
+    setCameraPosition( sm_defaultViewMatrix );
+    isPerspectiveView = false;
+
+    // If a 3D view has been used as the primary linked view, a contour map can be rotated in 3D. Use the following
+    // function to make sure view is reset to original state, with correct rotation and grid box configuration.
+    updateViewWidgetAfterCreation();
+
+    RimEclipseView::zoomAll();
 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.cpp
@@ -35,6 +35,7 @@
 #include "RimGridCollection.h"
 #include "RimRegularLegendConfig.h"
 #include "RimSimWellInViewCollection.h"
+#include "RimViewLinker.h"
 #include "RimViewNameConfig.h"
 
 #include "cafPdmUiTreeOrdering.h"
@@ -410,7 +411,22 @@ void RimEclipseContourMapView::onUpdateLegends()
             }
         }
 
-        nativeOrOverrideViewer()->showScaleLegend( m_showScaleLegend() );
+        // Hide the scale widget if any 3D views are present, as the display of the scale widget is only working for
+        // default rotation. The update is triggered in RimViewLinker::updateScaleWidgetVisibility()
+
+        bool any3DViewsLinked = false;
+
+        if ( auto viewLinker = assosiatedViewLinker() )
+        {
+            auto views = viewLinker->allViews();
+            for ( auto v : views )
+            {
+                if ( dynamic_cast<RimEclipseContourMapView*>( v ) ) continue;
+                any3DViewsLinked = true;
+            }
+        }
+
+        nativeOrOverrideViewer()->showScaleLegend( any3DViewsLinked ? false : m_showScaleLegend() );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseContourMapView.h
@@ -41,6 +41,7 @@ public:
     void    updatePickPointAndRedraw();
 
     RimSurfaceInViewCollection* surfaceInViewCollection() const override;
+    void                        zoomAll() override;
 
 protected:
     void initAfterRead() override;

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -755,7 +755,7 @@ void RimProject::allNotLinkedViews( std::vector<RimGridView*>& views )
     std::vector<RimGridView*> alreadyLinkedViews;
     if ( viewLinkerCollection->viewLinker() )
     {
-        viewLinkerCollection->viewLinker()->allViews( alreadyLinkedViews );
+        alreadyLinkedViews = viewLinkerCollection->viewLinker()->allViews();
     }
 
     for ( size_t caseIdx = 0; caseIdx < cases.size(); caseIdx++ )

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
@@ -422,16 +422,6 @@ void RimViewController::updateOptionSensitivity()
         }
     }
 
-    if ( isCameraControlPossible() )
-    {
-        this->m_syncCamera.uiCapability()->setUiReadOnly( false );
-    }
-    else
-    {
-        this->m_syncCamera.uiCapability()->setUiReadOnly( true );
-        this->m_syncCamera = false;
-    }
-
     if ( isPropertyFilterControlPossible() )
     {
         this->m_syncPropertyFilters.uiCapability()->setUiReadOnly( false );
@@ -677,16 +667,6 @@ const RigCaseToCaseCellMapper* RimViewController::cellMapper()
 RimGridView* RimViewController::masterView() const
 {
     return ownerViewLinker()->masterView();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-bool RimViewController::isCameraControlPossible() const
-{
-    RimEclipseContourMapView* contourMapMasterView  = dynamic_cast<RimEclipseContourMapView*>( masterView() );
-    RimEclipseContourMapView* contourMapManagedView = dynamic_cast<RimEclipseContourMapView*>( managedEclipseView() );
-    return !( contourMapMasterView || contourMapManagedView );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
@@ -60,34 +60,31 @@ CAF_PDM_SOURCE_INIT( RimViewController, "ViewController" );
 //--------------------------------------------------------------------------------------------------
 RimViewController::RimViewController()
 {
-    // clang-format off
+    CAF_PDM_InitObject( "View Link" );
 
-    CAF_PDM_InitObject("View Link");
-
-    CAF_PDM_InitField(&m_isActive, "Active", true, "Active");
-    m_isActive.uiCapability()->setUiHidden(true);
+    CAF_PDM_InitField( &m_isActive, "Active", true, "Active" );
+    m_isActive.uiCapability()->setUiHidden( true );
 
     QString defaultName = "View Config: Empty view";
-    CAF_PDM_InitField(&m_name, "Name", defaultName, "Managed View Name");
-    m_name.uiCapability()->setUiHidden(true);
+    CAF_PDM_InitField( &m_name, "Name", defaultName, "Managed View Name" );
+    m_name.uiCapability()->setUiHidden( true );
 
-    CAF_PDM_InitFieldNoDefault(&m_managedView, "ManagedView", "Linked View");
-    m_managedView.uiCapability()->setUiTreeChildrenHidden(true);
+    CAF_PDM_InitFieldNoDefault( &m_managedView, "ManagedView", "Linked View" );
+    m_managedView.uiCapability()->setUiTreeChildrenHidden( true );
 
-    CAF_PDM_InitField(&m_syncCamera,            "SyncCamera", true,             "Camera");
-    CAF_PDM_InitField(&m_showCursor,            "ShowCursor", true,             "   Show Cursor");
-    CAF_PDM_InitField(&m_syncTimeStep,          "SyncTimeStep", true,           "Time Step");
-    CAF_PDM_InitField(&m_syncCellResult,        "SyncCellResult", false,        "Cell Result");
-    CAF_PDM_InitField(&m_syncLegendDefinitions, "SyncLegendDefinitions", true,  "   Color Legend");
-    
-    CAF_PDM_InitField(&m_syncVisibleCells,    "SyncVisibleCells", false,  "Visible Cells");
+    CAF_PDM_InitField( &m_syncCamera, "SyncCamera", true, "Camera" );
+    CAF_PDM_InitField( &m_showCursor, "ShowCursor", true, "   Show Cursor" );
+    CAF_PDM_InitField( &m_syncTimeStep, "SyncTimeStep", true, "Time Step" );
+    CAF_PDM_InitField( &m_syncCellResult, "SyncCellResult", false, "Cell Result" );
+    CAF_PDM_InitField( &m_syncLegendDefinitions, "SyncLegendDefinitions", true, "   Color Legend" );
+
+    CAF_PDM_InitField( &m_syncVisibleCells, "SyncVisibleCells", false, "Visible Cells" );
     /// We do not support this. Consider to remove sometime
-    m_syncVisibleCells.uiCapability()->setUiHidden(true);
+    m_syncVisibleCells.uiCapability()->setUiHidden( true );
     m_syncVisibleCells.xmlCapability()->disableIO();
 
-    CAF_PDM_InitField(&m_syncCellFilters,    "SyncRangeFilters", false,   "Cell Filters");
-    CAF_PDM_InitField(&m_syncPropertyFilters, "SyncPropertyFilters", false,"Property Filters");
-    // clang-format on
+    CAF_PDM_InitField( &m_syncCellFilters, "SyncRangeFilters", false, "Cell Filters" );
+    CAF_PDM_InitField( &m_syncPropertyFilters, "SyncPropertyFilters", false, "Property Filters" );
 
     setDeletable( true );
 }
@@ -466,7 +463,6 @@ void RimViewController::setManagedView( RimGridView* view )
     m_managedView = view;
 
     updateOptionSensitivity();
-    updateDefaultOptions();
     updateOverrides();
     updateResultColorsControl();
     updateCameraLink();
@@ -562,16 +558,6 @@ void RimViewController::updateLegendDefinitions()
 
     RimViewLinker* viewLinker = ownerViewLinker();
     viewLinker->updateCellResult();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimViewController::updateDefaultOptions()
-{
-    m_syncCellResult      = isCellResultControlAdvisable();
-    m_syncCellFilters     = isCellFilterControlAdvisable();
-    m_syncPropertyFilters = isPropertyFilterControlAdvisable();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -872,7 +858,7 @@ bool RimViewController::isCellResultControlAdvisable() const
 {
     bool contourMapMasterView  = dynamic_cast<RimEclipseContourMapView*>( masterView() ) != nullptr;
     bool contourMapManagedView = dynamic_cast<RimEclipseContourMapView*>( managedEclipseView() ) != nullptr;
-    return !isMasterAndDepViewDifferentType() && contourMapMasterView != contourMapManagedView;
+    return !isMasterAndDepViewDifferentType() && ( contourMapMasterView != contourMapManagedView );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -892,7 +878,7 @@ bool RimViewController::isPropertyFilterControlAdvisable() const
 {
     bool contourMapMasterView  = dynamic_cast<RimEclipseContourMapView*>( masterView() ) != nullptr;
     bool contourMapManagedView = dynamic_cast<RimEclipseContourMapView*>( managedEclipseView() ) != nullptr;
-    return isPropertyFilterControlPossible() && contourMapMasterView != contourMapManagedView;
+    return isPropertyFilterControlPossible() && ( contourMapMasterView != contourMapManagedView );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1096,7 +1082,19 @@ void RimViewController::applyCellFilterCollectionByUserChoice()
         return;
     }
 
-    bool restoreOriginal = askUserToRestoreOriginalCellFilterCollection( m_managedView->name() );
+    RimViewLinker* viewLinker = ownerViewLinker();
+    RimGridView*   masterView = viewLinker->masterView();
+
+    bool restoreOriginal = true;
+
+    bool anyActiveFilter = !masterView->cellFilterCollection()->filters().empty() ||
+                           masterView->propertyFilterCollection()->hasActiveFilters();
+
+    if ( anyActiveFilter )
+    {
+        restoreOriginal = askUserToRestoreOriginalCellFilterCollection( m_managedView->name() );
+    }
+
     if ( restoreOriginal )
     {
         m_managedView->setOverrideCellFilterCollection( nullptr );

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.h
@@ -95,8 +95,6 @@ private:
     void updateResultColorsControl();
     void updateLegendDefinitions();
 
-    void updateDefaultOptions();
-
     bool isMasterAndDepViewDifferentType() const;
     bool isPropertyFilterControlPossible() const;
     bool isCellFilterMappingApplicable() const;

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.h
@@ -97,7 +97,6 @@ private:
 
     void updateDefaultOptions();
 
-    bool isCameraControlPossible() const;
     bool isMasterAndDepViewDifferentType() const;
     bool isPropertyFilterControlPossible() const;
     bool isCellFilterMappingApplicable() const;

--- a/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp
@@ -266,6 +266,25 @@ void RimViewLinker::removeOverrides()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimViewLinker::updateScaleWidgetVisibility()
+{
+    // Create new display model that will call RimEclipseContourMapView::onUpdateLegends() where the visibility of scale
+    // widgets is controlled
+
+    if ( masterView() ) masterView()->scheduleCreateDisplayModelAndRedraw();
+
+    for ( RimViewController* viewLink : m_viewControllers )
+    {
+        if ( viewLink->managedView() )
+        {
+            viewLink->managedView()->scheduleCreateDisplayModelAndRedraw();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimViewLinker::allViewsForCameraSync( const RimGridView* source, std::vector<RimGridView*>& views ) const
 {
     if ( !isActive() ) return;
@@ -349,8 +368,10 @@ RimGridView* RimViewLinker::masterView() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimViewLinker::allViews( std::vector<RimGridView*>& views ) const
+std::vector<RimGridView*> RimViewLinker::allViews() const
 {
+    std::vector<RimGridView*> views;
+
     views.push_back( m_masterView() );
 
     for ( const auto& viewController : m_viewControllers )
@@ -360,6 +381,8 @@ void RimViewLinker::allViews( std::vector<RimGridView*>& views ) const
             views.push_back( viewController->managedView() );
         }
     }
+
+    return views;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -535,6 +558,8 @@ void RimViewLinker::onChildDeleted( caf::PdmChildArrayFieldHandle*      childArr
     RimViewLinkerCollection* viewLinkerCollection = nullptr;
     this->firstAncestorOrThisOfType( viewLinkerCollection );
     if ( viewLinkerCollection ) viewLinkerCollection->updateConnectedEditors();
+
+    updateScaleWidgetVisibility();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -644,6 +669,8 @@ void RimViewLinker::addDependentView( RimGridView* view )
 
         viewContr->setManagedView( view );
     }
+
+    updateScaleWidgetVisibility();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimViewLinker.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewLinker.h
@@ -83,7 +83,7 @@ public:
     void scheduleGeometryRegenForDepViews( RivCellSetEnum geometryType );
     void scheduleCreateDisplayModelAndRedrawForDependentViews();
 
-    void allViews( std::vector<RimGridView*>& views ) const;
+    std::vector<RimGridView*> allViews() const;
 
     void updateUiNameAndIcon();
 
@@ -113,6 +113,7 @@ private:
     void allViewsForCameraSync( const RimGridView* source, std::vector<RimGridView*>& views ) const;
 
     void removeOverrides();
+    void updateScaleWidgetVisibility();
 
 private:
     caf::PdmChildArrayField<RimViewController*> m_viewControllers;

--- a/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
@@ -46,7 +46,6 @@
 #include "RimContextCommandBuilder.h"
 #include "RimEclipseCase.h"
 #include "RimEclipseCellColors.h"
-#include "RimEclipseContourMapView.h"
 #include "RimEclipseFaultColors.h"
 #include "RimEclipseView.h"
 #include "RimEllipseFractureTemplate.h"
@@ -56,7 +55,6 @@
 #include "RimFracture.h"
 #include "RimGeoMechCase.h"
 #include "RimGeoMechCellColors.h"
-#include "RimGeoMechContourMapView.h"
 #include "RimGeoMechView.h"
 #include "RimIntersectionResultDefinition.h"
 #include "RimLegendConfig.h"
@@ -108,7 +106,6 @@
 #include "cvfPart.h"
 #include "cvfRay.h"
 #include "cvfScene.h"
-#include "cvfTransform.h"
 
 #include <QMenu>
 #include <QMouseEvent>
@@ -133,6 +130,7 @@ RiuViewerCommands::RiuViewerCommands( RiuViewer* ownerViewer )
     , m_currentCellIndex( -1 )
     , m_currentFaceIndex( cvf::StructGridInterface::NO_FACE )
     , m_currentPickPositionInDomainCoords( cvf::Vec3d::UNDEFINED )
+    , m_isCurrentPickInComparisonView( false )
     , m_viewer( ownerViewer )
 {
     if ( sm_defaultPickEventHandlers.empty() )
@@ -172,8 +170,6 @@ void RiuViewerCommands::addCompareToViewMenu( caf::CmdFeatureMenuBuilder* menuBu
         for ( auto view : views )
         {
             if ( !dynamic_cast<RimGridView*>( view ) ) continue;
-            if ( dynamic_cast<RimEclipseContourMapView*>( view ) ) continue;
-            if ( dynamic_cast<RimGeoMechContourMapView*>( view ) ) continue;
 
             if ( view != mainGridView )
             {
@@ -181,7 +177,7 @@ void RiuViewerCommands::addCompareToViewMenu( caf::CmdFeatureMenuBuilder* menuBu
             }
         }
 
-        if ( validComparisonViews.size() )
+        if ( !validComparisonViews.empty() )
         {
             menuBuilder->subMenuStart( "Compare To ...", QIcon( ":/ComparisonView16x16.png" ) );
             for ( auto view : validComparisonViews )
@@ -223,7 +219,7 @@ void RiuViewerCommands::displayContextMenu( QMouseEvent* event )
     uint             firstPartTriangleIndex = cvf::UNDEFINED_UINT;
     m_currentPickPositionInDomainCoords     = cvf::Vec3d::UNDEFINED;
 
-    if ( pickItemInfos.size() )
+    if ( !pickItemInfos.empty() )
     {
         cvf::Vec3d globalIntersectionPoint = pickItemInfos[0].globalPickedPoint();
 
@@ -711,7 +707,7 @@ void RiuViewerCommands::handlePickAction( int winPosX, int winPosY, Qt::Keyboard
 
     // Make pickEventHandlers do their stuff
 
-    if ( pickItemInfos.size() )
+    if ( !pickItemInfos.empty() )
     {
         Ric3dPickEvent viewerEventObject( pickItemInfos, mainOrComparisonView, keyboardModifiers );
 
@@ -739,7 +735,7 @@ void RiuViewerCommands::handlePickAction( int winPosX, int winPosY, Qt::Keyboard
         uint             firstPartTriangleIndex = cvf::UNDEFINED_UINT;
         cvf::Vec3d       globalIntersectionPoint( cvf::Vec3d::ZERO );
 
-        if ( pickItemInfos.size() )
+        if ( !pickItemInfos.empty() )
         {
             size_t indexToFirstNoneNncItem     = cvf::UNDEFINED_SIZE_T;
             size_t indexToNncItemNearFirstItem = cvf::UNDEFINED_SIZE_T;
@@ -1129,7 +1125,7 @@ void RiuViewerCommands::findFirstItems( Rim3dView*                          main
                                         size_t*                             indexToFirstNoneNncItem,
                                         size_t*                             indexToNncItemNearFirsItem )
 {
-    CVF_ASSERT( pickItemInfos.size() > 0 );
+    CVF_ASSERT( !pickItemInfos.empty() );
     CVF_ASSERT( indexToFirstNoneNncItem );
     CVF_ASSERT( indexToNncItemNearFirsItem );
 


### PR DESCRIPTION
Closes #8632

Allow linking of a contour map and a 3D view. If the 3D view is primary view, the contour map can be rotated in 3D. When the contour map is unlinked, use `Zoom All` to reset the contour map to the default settings.