### PR TITLE
Support copy of property filters to linked views

### DIFF
--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterFeatureImpl.cpp
@@ -61,7 +61,7 @@ std::vector<RimEclipsePropertyFilterCollection*> RicEclipsePropertyFilterFeature
 void RicEclipsePropertyFilterFeatureImpl::addPropertyFilter( RimEclipsePropertyFilterCollection* propertyFilterCollection )
 {
     RimEclipsePropertyFilter* propertyFilter = new RimEclipsePropertyFilter();
-    propertyFilterCollection->propertyFilters.push_back( propertyFilter );
+    propertyFilterCollection->propertyFiltersField().push_back( propertyFilter );
     setDefaults( propertyFilter );
 
     propertyFilterCollection->reservoirView()->scheduleGeometryRegen( PROPERTY_FILTERED );
@@ -80,7 +80,7 @@ void RicEclipsePropertyFilterFeatureImpl::insertPropertyFilter( RimEclipseProper
                                                                 size_t                              index )
 {
     RimEclipsePropertyFilter* propertyFilter = new RimEclipsePropertyFilter();
-    propertyFilterCollection->propertyFilters.insertAt( static_cast<int>( index ), propertyFilter );
+    propertyFilterCollection->propertyFiltersField().insertAt( static_cast<int>( index ), propertyFilter );
     setDefaults( propertyFilter );
 
     propertyFilterCollection->reservoirView()->scheduleGeometryRegen( PROPERTY_FILTERED );

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterFeatureImpl.cpp
@@ -69,6 +69,8 @@ void RicEclipsePropertyFilterFeatureImpl::addPropertyFilter( RimEclipsePropertyF
 
     propertyFilterCollection->updateConnectedEditors();
     Riu3DMainWindowTools::selectAsCurrentItem( propertyFilter, false );
+
+    propertyFilterCollection->onChildAdded( nullptr );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertExec.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertExec.cpp
@@ -59,8 +59,8 @@ void RicEclipsePropertyFilterInsertExec::redo()
     RimEclipsePropertyFilterCollection* propertyFilterCollection = nullptr;
     m_propertyFilter->firstAncestorOrThisOfTypeAsserted( propertyFilterCollection );
 
-    size_t index = propertyFilterCollection->propertyFilters.indexOf( m_propertyFilter );
-    CVF_ASSERT( index < propertyFilterCollection->propertyFilters.size() );
+    size_t index = propertyFilterCollection->propertyFiltersField().indexOf( m_propertyFilter );
+    CVF_ASSERT( index < propertyFilterCollection->propertyFilters().size() );
 
     RicEclipsePropertyFilterFeatureImpl::insertPropertyFilter( propertyFilterCollection, index );
 }

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterNewExec.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterNewExec.cpp
@@ -69,7 +69,7 @@ void RicEclipsePropertyFilterNewExec::redo()
 //--------------------------------------------------------------------------------------------------
 void RicEclipsePropertyFilterNewExec::undo()
 {
-    m_propertyFilterCollection->propertyFilters.erase( m_propertyFilterCollection->propertyFilters.size() - 1 );
+    m_propertyFilterCollection->propertyFiltersField().erase( m_propertyFilterCollection->propertyFilters().size() - 1 );
 
     m_propertyFilterCollection->updateConnectedEditors();
 }

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilter.h
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilter.h
@@ -44,6 +44,8 @@ public:
     void rangeValues( double* lower, double* upper ) const;
     bool isCategorySelectionActive() const;
 
+    void setIsDuplicatedFromLinkedView( bool isControlled );
+
     void setToDefaultValues();
     void updateFilterName();
     void computeResultValueRange();
@@ -63,6 +65,9 @@ private:
                                 caf::PdmUiEditorAttribute* attribute ) override;
 
 private:
+    void defineObjectEditorAttribute( QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
+
+private:
     friend class RimEclipsePropertyFilterCollection;
     friend class RicEclipsePropertyFilterFeatureImpl;
 
@@ -79,6 +84,7 @@ private:
     caf::PdmField<QString>                          m_rangeLabelText;
     caf::PdmField<double>                           m_lowerBound;
     caf::PdmField<double>                           m_upperBound;
+    caf::PdmField<bool>                             m_isDuplicatedFromLinkedView;
 
     caf::PdmField<bool> m_useCategorySelection;
 

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.cpp
@@ -64,6 +64,17 @@ RimEclipseView* RimEclipsePropertyFilterCollection::reservoirView()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimEclipsePropertyFilterCollection::setIsDuplicatedFromLinkedView()
+{
+    for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )
+    {
+        propertyFilter->setIsDuplicatedFromLinkedView( true );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimEclipsePropertyFilterCollection::loadAndInitializePropertyFilters()
 {
     for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.cpp
@@ -38,8 +38,8 @@ RimEclipsePropertyFilterCollection::RimEclipsePropertyFilterCollection()
 {
     CAF_PDM_InitObject( "Property Filters", ":/CellFilter_Values.png" );
 
-    CAF_PDM_InitFieldNoDefault( &propertyFilters, "PropertyFilters", "Property Filters" );
-    propertyFilters.uiCapability()->setUiTreeHidden( true );
+    CAF_PDM_InitFieldNoDefault( &m_propertyFilters, "PropertyFilters", "Property Filters" );
+    m_propertyFilters.uiCapability()->setUiTreeHidden( true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ RimEclipsePropertyFilterCollection::RimEclipsePropertyFilterCollection()
 //--------------------------------------------------------------------------------------------------
 RimEclipsePropertyFilterCollection::~RimEclipsePropertyFilterCollection()
 {
-    propertyFilters.deleteChildren();
+    m_propertyFilters.deleteChildren();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ RimEclipseView* RimEclipsePropertyFilterCollection::reservoirView()
 //--------------------------------------------------------------------------------------------------
 void RimEclipsePropertyFilterCollection::setIsDuplicatedFromLinkedView()
 {
-    for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )
+    for ( RimEclipsePropertyFilter* propertyFilter : m_propertyFilters )
     {
         propertyFilter->setIsDuplicatedFromLinkedView( true );
     }
@@ -75,9 +75,25 @@ void RimEclipsePropertyFilterCollection::setIsDuplicatedFromLinkedView()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<RimEclipsePropertyFilter*> RimEclipsePropertyFilterCollection::propertyFilters() const
+{
+    return m_propertyFilters.children();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::PdmChildArrayField<RimEclipsePropertyFilter*>& RimEclipsePropertyFilterCollection::propertyFiltersField()
+{
+    return m_propertyFilters;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimEclipsePropertyFilterCollection::loadAndInitializePropertyFilters()
 {
-    for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )
+    for ( RimEclipsePropertyFilter* propertyFilter : m_propertyFilters )
     {
         propertyFilter->resultDefinition()->setEclipseCase( reservoirView()->eclipseCase() );
         propertyFilter->initAfterRead();
@@ -104,7 +120,7 @@ bool RimEclipsePropertyFilterCollection::hasActiveFilters() const
 {
     if ( !isActive ) return false;
 
-    for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )
+    for ( RimEclipsePropertyFilter* propertyFilter : m_propertyFilters )
     {
         if ( propertyFilter->isActive() && propertyFilter->resultDefinition()->hasResult() ) return true;
     }
@@ -119,7 +135,7 @@ bool RimEclipsePropertyFilterCollection::hasActiveDynamicFilters() const
 {
     if ( !isActive ) return false;
 
-    for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )
+    for ( RimEclipsePropertyFilter* propertyFilter : m_propertyFilters )
     {
         if ( propertyFilter->isActive() && propertyFilter->resultDefinition()->hasDynamicResult() ) return true;
     }
@@ -134,7 +150,7 @@ bool RimEclipsePropertyFilterCollection::isUsingFormationNames() const
 {
     if ( !isActive ) return false;
 
-    for ( RimEclipsePropertyFilter* propertyFilter : propertyFilters )
+    for ( RimEclipsePropertyFilter* propertyFilter : m_propertyFilters )
     {
         if ( propertyFilter->isActive() &&
              propertyFilter->resultDefinition()->resultType() == RiaDefines::ResultCatType::FORMATION_NAMES &&
@@ -170,7 +186,7 @@ void RimEclipsePropertyFilterCollection::updateIconState()
 
     updateUiIconFromState( activeIcon );
 
-    for ( RimEclipsePropertyFilter* cellFilter : propertyFilters )
+    for ( RimEclipsePropertyFilter* cellFilter : m_propertyFilters )
     {
         cellFilter->updateActiveState();
         cellFilter->updateIconState();
@@ -182,7 +198,7 @@ void RimEclipsePropertyFilterCollection::updateIconState()
 //--------------------------------------------------------------------------------------------------
 void RimEclipsePropertyFilterCollection::updateFromCurrentTimeStep()
 {
-    for ( RimEclipsePropertyFilter* cellFilter : propertyFilters() )
+    for ( RimEclipsePropertyFilter* cellFilter : m_propertyFilters() )
     {
         cellFilter->updateFromCurrentTimeStep();
     }

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.h
@@ -42,10 +42,9 @@ public:
     RimEclipseView* reservoirView();
     void            setIsDuplicatedFromLinkedView();
 
-    // Fields:
-    caf::PdmChildArrayField<RimEclipsePropertyFilter*> propertyFilters;
+    std::vector<RimEclipsePropertyFilter*>              propertyFilters() const;
+    caf::PdmChildArrayField<RimEclipsePropertyFilter*>& propertyFiltersField();
 
-    // Methods
     bool hasActiveFilters() const override;
     bool hasActiveDynamicFilters() const override;
     bool isUsingFormationNames() const;
@@ -56,6 +55,8 @@ public:
     void updateFromCurrentTimeStep();
 
 protected:
-    // Overridden methods
     void initAfterRead() override;
+
+private:
+    caf::PdmChildArrayField<RimEclipsePropertyFilter*> m_propertyFilters;
 };

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimEclipsePropertyFilterCollection.h
@@ -40,6 +40,7 @@ public:
     ~RimEclipsePropertyFilterCollection() override;
 
     RimEclipseView* reservoirView();
+    void            setIsDuplicatedFromLinkedView();
 
     // Fields:
     caf::PdmChildArrayField<RimEclipsePropertyFilter*> propertyFilters;

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimPropertyFilterCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimPropertyFilterCollection.cpp
@@ -66,16 +66,21 @@ void RimPropertyFilterCollection::updateDisplayModelNotifyManagedViews( RimPrope
     view->scheduleCreateDisplayModelAndRedraw();
 }
 
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimPropertyFilterCollection::onChildDeleted( caf::PdmChildArrayFieldHandle*      childArray,
                                                   std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
-    Rim3dView* view = nullptr;
-    this->firstAncestorOrThisOfType( view );
-    CVF_ASSERT( view );
-    if ( !view ) return;
+    updateDisplayModelNotifyManagedViews( nullptr );
+}
 
-    view->scheduleGeometryRegen( PROPERTY_FILTERED );
-    view->scheduleCreateDisplayModelAndRedraw();
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimPropertyFilterCollection::onChildAdded( caf::PdmFieldHandle* containerForNewObject )
+{
+    updateDisplayModelNotifyManagedViews( nullptr );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimPropertyFilterCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimPropertyFilterCollection.h
@@ -48,6 +48,7 @@ public:
     virtual void updateIconState() = 0;
     void         onChildDeleted( caf::PdmChildArrayFieldHandle*      childArray,
                                  std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
+    void         onChildAdded( caf::PdmFieldHandle* containerForNewObject ) override;
 
 protected:
     // Overridden methods

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
@@ -543,7 +543,7 @@ void RimEclipseCase::updateFormationNamesData()
                     }
 
                     RimEclipsePropertyFilterCollection* eclFilColl = eclView->eclipsePropertyFilterCollection();
-                    for ( RimEclipsePropertyFilter* propFilter : eclFilColl->propertyFilters )
+                    for ( RimEclipsePropertyFilter* propFilter : eclFilColl->propertyFilters() )
                     {
                         if ( propFilter->resultDefinition()->resultType() == RiaDefines::ResultCatType::FORMATION_NAMES )
                         {
@@ -553,7 +553,7 @@ void RimEclipseCase::updateFormationNamesData()
                 }
 
                 RimEclipsePropertyFilterCollection* eclFilColl = eclView->eclipsePropertyFilterCollection();
-                for ( RimEclipsePropertyFilter* propFilter : eclFilColl->propertyFilters )
+                for ( RimEclipsePropertyFilter* propFilter : eclFilColl->propertyFilters() )
                 {
                     if ( propFilter->resultDefinition()->resultType() == RiaDefines::ResultCatType::FORMATION_NAMES )
                     {

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -1836,7 +1836,7 @@ void RimEclipseView::calculateCompletionTypeAndRedrawIfRequired()
         isDependingOnCompletionType = true;
     }
 
-    for ( const auto& propFilter : m_propertyFilterCollection()->propertyFilters )
+    for ( const auto& propFilter : m_propertyFilterCollection()->propertyFilters() )
     {
         if ( propFilter->isActive() &&
              propFilter->resultDefinition()->resultVariable() == RiaResultNames::completionTypeResultName() )
@@ -1859,7 +1859,7 @@ void RimEclipseView::calculateCompletionTypeAndRedrawIfRequired()
         }
     }
 
-    for ( const auto& propFilter : m_propertyFilterCollection()->propertyFilters )
+    for ( const auto& propFilter : m_propertyFilterCollection()->propertyFilters() )
     {
         if ( propFilter->isActive() &&
              propFilter->resultDefinition()->resultVariable() == RiaResultNames::completionTypeResultName() )

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
@@ -78,11 +78,6 @@ RimViewController::RimViewController()
     CAF_PDM_InitField( &m_syncCellResult, "SyncCellResult", false, "Cell Result" );
     CAF_PDM_InitField( &m_syncLegendDefinitions, "SyncLegendDefinitions", true, "   Color Legend" );
 
-    CAF_PDM_InitField( &m_syncVisibleCells, "SyncVisibleCells", false, "Visible Cells" );
-    /// We do not support this. Consider to remove sometime
-    m_syncVisibleCells.uiCapability()->setUiHidden( true );
-    m_syncVisibleCells.xmlCapability()->disableIO();
-
     CAF_PDM_InitField( &m_syncCellFilters, "SyncRangeFilters", false, "Cell Filters" );
     CAF_PDM_InitField( &m_syncPropertyFilters, "SyncPropertyFilters", false, "Property Filters" );
 
@@ -224,11 +219,6 @@ void RimViewController::fieldChangedByUi( const caf::PdmFieldHandle* changedFiel
         setManagedView( m_managedView() );
 
         m_name.uiCapability()->updateConnectedEditors();
-    }
-    else if ( &m_syncVisibleCells == changedField )
-    {
-        updateOptionSensitivity();
-        updateOverrides();
     }
 }
 
@@ -432,8 +422,6 @@ void RimViewController::updateOptionSensitivity()
         this->m_showCursor.uiCapability()->setUiReadOnly( true );
         this->m_showCursor = false;
     }
-
-    m_syncVisibleCells.uiCapability()->setUiReadOnly( !this->isMasterAndDepViewDifferentType() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -481,7 +469,6 @@ void RimViewController::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderi
     scriptGroup->add( &m_syncLegendDefinitions );
 
     caf::PdmUiGroup* visibleCells = uiOrdering.addNewGroup( "Link Cell Filters" );
-    visibleCells->add( &m_syncVisibleCells );
     visibleCells->add( &m_syncCellFilters );
     visibleCells->add( &m_syncPropertyFilters );
 }
@@ -781,16 +768,6 @@ bool RimViewController::isLegendDefinitionsControlled() const
 //--------------------------------------------------------------------------------------------------
 bool RimViewController::isVisibleCellsOveridden() const
 {
-    if ( isMasterAndDepViewDifferentType() )
-    {
-        if ( ownerViewLinker()->isActive() && this->m_isActive() )
-        {
-            return m_syncVisibleCells();
-        }
-
-        return false;
-    }
-
     return false;
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.h
@@ -69,6 +69,7 @@ public:
 
     bool isVisibleCellsOveridden() const;
     bool isPropertyFilterOveridden() const;
+    bool isPropertyFilterDuplicationActive() const;
 
     void scheduleCreateDisplayModelAndRedrawForDependentView() const;
     void scheduleGeometryRegenForDepViews( RivCellSetEnum geometryType ) const;
@@ -76,6 +77,7 @@ public:
     void updateOptionSensitivity();
     void removeOverrides();
     void updateDisplayNameAndIcon();
+    void updateDuplicatedPropertyFilters();
 
     void updateCellFilterOverrides( const RimCellFilter* changedFilter );
     void applyCellFilterCollectionByUserChoice();
@@ -118,12 +120,12 @@ private:
     caf::PdmField<bool> m_showCursor;
     caf::PdmField<bool> m_syncTimeStep;
 
-    // Overridden properties
     caf::PdmField<bool> m_syncCellResult;
     caf::PdmField<bool> m_syncLegendDefinitions;
 
     caf::PdmField<bool> m_syncCellFilters;
     caf::PdmField<bool> m_syncPropertyFilters;
+    caf::PdmField<bool> m_duplicatePropertyFilters;
 
     cvf::ref<RigCaseToCaseCellMapper> m_caseToCaseCellMapper;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimViewController.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.h
@@ -123,7 +123,6 @@ private:
     caf::PdmField<bool> m_syncLegendDefinitions;
 
     caf::PdmField<bool> m_syncCellFilters;
-    caf::PdmField<bool> m_syncVisibleCells;
     caf::PdmField<bool> m_syncPropertyFilters;
 
     cvf::ref<RigCaseToCaseCellMapper> m_caseToCaseCellMapper;

--- a/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp
@@ -112,13 +112,13 @@ void RimViewLinker::updateTimeStep( Rim3dView* sourceView, int timeStep )
         m_masterView->viewer()->setCurrentFrame( timeStep );
     }
 
-    for ( RimViewController* viewLink : m_viewControllers )
+    for ( RimViewController* viewController : m_viewControllers )
     {
-        if ( !viewLink->isTimeStepLinked() ) continue;
+        if ( !viewController->isTimeStepLinked() ) continue;
 
-        if ( viewLink->managedView() && viewLink->managedView() != sourceView && viewLink->managedView()->viewer() )
+        if ( viewController->managedView() && viewController->managedView() != sourceView && viewController->managedView()->viewer() )
         {
-            viewLink->managedView()->viewer()->setCurrentFrame( timeStep );
+            viewController->managedView()->viewer()->setCurrentFrame( timeStep );
         }
     }
 }
@@ -134,20 +134,20 @@ void RimViewLinker::updateCellResult()
     {
         RimEclipseResultDefinition* eclipseCellResultDefinition = masterEclipseView->cellResult();
 
-        for ( RimViewController* viewLink : m_viewControllers )
+        for ( RimViewController* viewController : m_viewControllers )
         {
-            if ( viewLink->managedView() )
+            if ( viewController->managedView() )
             {
-                Rim3dView*      managedView = viewLink->managedView();
+                Rim3dView*      managedView = viewController->managedView();
                 RimEclipseView* eclipseView = dynamic_cast<RimEclipseView*>( managedView );
                 if ( eclipseView )
                 {
-                    if ( viewLink->isResultColorControlled() )
+                    if ( viewController->isResultColorControlled() )
                     {
                         eclipseView->cellResult()->simpleCopy( eclipseCellResultDefinition );
                         eclipseView->cellResult()->loadResult();
 
-                        if ( viewLink->isLegendDefinitionsControlled() )
+                        if ( viewController->isLegendDefinitionsControlled() )
                         {
                             eclipseView->cellResult()->legendConfig()->setUiValuesFromLegendConfig(
                                 masterEclipseView->cellResult()->legendConfig() );
@@ -172,19 +172,19 @@ void RimViewLinker::updateCellResult()
     {
         RimGeoMechResultDefinition* geoMechResultDefinition = masterGeoView->cellResult();
 
-        for ( RimViewController* viewLink : m_viewControllers )
+        for ( RimViewController* viewController : m_viewControllers )
         {
-            if ( viewLink->managedView() )
+            if ( viewController->managedView() )
             {
-                Rim3dView*      managedView = viewLink->managedView();
+                Rim3dView*      managedView = viewController->managedView();
                 RimGeoMechView* geoView     = dynamic_cast<RimGeoMechView*>( managedView );
                 if ( geoView )
                 {
-                    if ( viewLink->isResultColorControlled() )
+                    if ( viewController->isResultColorControlled() )
                     {
                         geoView->cellResult()->setResultAddress( geoMechResultDefinition->resultAddress() );
 
-                        if ( viewLink->isLegendDefinitionsControlled() )
+                        if ( viewController->isLegendDefinitionsControlled() )
                         {
                             geoView->cellResult()->legendConfig()->setUiValuesFromLegendConfig(
                                 masterGeoView->cellResult()->legendConfig() );
@@ -207,9 +207,9 @@ void RimViewLinker::updateCellResult()
 //--------------------------------------------------------------------------------------------------
 void RimViewLinker::updateCellFilters( const RimCellFilter* changedFilter )
 {
-    for ( RimViewController* viewLink : m_viewControllers )
+    for ( RimViewController* viewController : m_viewControllers )
     {
-        viewLink->updateCellFilterOverrides( changedFilter );
+        viewController->updateCellFilterOverrides( changedFilter );
     }
 }
 
@@ -218,15 +218,15 @@ void RimViewLinker::updateCellFilters( const RimCellFilter* changedFilter )
 //--------------------------------------------------------------------------------------------------
 void RimViewLinker::updateOverrides()
 {
-    for ( RimViewController* viewLink : m_viewControllers )
+    for ( RimViewController* viewController : m_viewControllers )
     {
-        if ( viewLink->isActive() )
+        if ( viewController->isActive() )
         {
-            viewLink->updateOverrides();
+            viewController->updateOverrides();
         }
         else
         {
-            viewLink->removeOverrides();
+            viewController->removeOverrides();
         }
     }
 }
@@ -238,12 +238,23 @@ void RimViewLinker::updateWindowTitles()
 {
     if ( m_masterView ) m_masterView->updateMdiWindowTitle();
 
-    for ( RimViewController* viewLink : m_viewControllers )
+    for ( RimViewController* viewController : m_viewControllers )
     {
-        if ( auto view = viewLink->managedView() )
+        if ( auto view = viewController->managedView() )
         {
             view->updateMdiWindowTitle();
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimViewLinker::updateDuplicatedPropertyFilters()
+{
+    for ( RimViewController* viewController : m_viewControllers )
+    {
+        viewController->updateDuplicatedPropertyFilters();
     }
 }
 
@@ -271,11 +282,11 @@ void RimViewLinker::updateScaleWidgetVisibility()
 
     if ( masterView() ) masterView()->scheduleCreateDisplayModelAndRedraw();
 
-    for ( RimViewController* viewLink : m_viewControllers )
+    for ( RimViewController* viewController : m_viewControllers )
     {
-        if ( viewLink->managedView() )
+        if ( viewController->managedView() )
         {
-            viewLink->managedView()->scheduleCreateDisplayModelAndRedraw();
+            viewController->managedView()->scheduleCreateDisplayModelAndRedraw();
         }
     }
 }
@@ -312,6 +323,7 @@ void RimViewLinker::updateDependentViews()
     if ( m_viewControllers.empty() ) return;
 
     updateOverrides();
+    updateDuplicatedPropertyFilters();
     updateCellResult();
     updateScaleZ( m_masterView, m_masterView->scaleZ() );
     updateCamera( m_masterView );

--- a/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp
@@ -116,7 +116,8 @@ void RimViewLinker::updateTimeStep( Rim3dView* sourceView, int timeStep )
     {
         if ( !viewController->isTimeStepLinked() ) continue;
 
-        if ( viewController->managedView() && viewController->managedView() != sourceView && viewController->managedView()->viewer() )
+        if ( viewController->managedView() && viewController->managedView() != sourceView &&
+             viewController->managedView()->viewer() )
         {
             viewController->managedView()->viewer()->setCurrentFrame( timeStep );
         }

--- a/ApplicationLibCode/ProjectDataModel/RimViewLinker.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewLinker.h
@@ -68,6 +68,7 @@ public:
 
     void updateOverrides();
     void updateWindowTitles();
+    void updateDuplicatedPropertyFilters();
 
     void updateCamera( Rim3dView* sourceView );
     void updateTimeStep( Rim3dView* sourceView, int timeStep );


### PR DESCRIPTION
When a property filter is linked across grid model cases, the property filters must be duplicated and applied to each case individually.

Related to #9487