### PR TITLE
Adjustments to UI

### DIFF
--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
@@ -75,6 +75,6 @@ void RicImportEclipseCaseFeature::onActionTriggered( bool isChecked )
 //--------------------------------------------------------------------------------------------------
 void RicImportEclipseCaseFeature::setupActionLook( QAction* actionToSetup )
 {
-    actionToSetup->setIcon( QIcon( ":/Case48x48.png" ) );
+    actionToSetup->setIcon( QIcon( ":/Case.svg" ) );
     actionToSetup->setText( "Import Eclipse Case" );
 }

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
@@ -201,10 +201,9 @@ QStringList RicImportGeneralDataFeature::getEclipseFileNamesWithDialog( RiaDefin
 
     QString defaultDir = RiaApplication::instance()->lastUsedDialogDirectory( defaultDirectoryLabel( fileType ) );
 
-    QStringList fileNames = RiuFileDialogTools::getOpenFileNames( Riu3DMainWindowTools::mainWindowWidget(),
-                                                                  "Import Data File",
-                                                                  defaultDir,
-                                                                  fullPattern );
+    // Use nullptr as parent to this dialog, as this function is called from both plot window and main window
+    QStringList fileNames = RiuFileDialogTools::getOpenFileNames( nullptr, "Import Data File", defaultDir, fullPattern );
+
     return fileNames;
 }
 

--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -475,19 +475,21 @@ RimWellLogCurve* RicWellLogTools::addSummaryRftCurve( RimWellLogTrack* plotTrack
 
     curve->setSummaryCase( rimCase );
     auto rftReader = rimCase->rftReader();
+    if ( rftReader )
+    {
+        QString wellName;
+        auto    wellNames = rftReader->wellNames();
+        if ( !wellNames.empty() ) wellName = *wellNames.begin();
 
-    QString wellName;
-    auto    wellNames = rftReader->wellNames();
-    if ( !wellNames.empty() ) wellName = *wellNames.begin();
+        QDateTime dateTime;
 
-    QDateTime dateTime;
+        auto timeSteps = rftReader->availableTimeSteps( wellName );
+        if ( !timeSteps.empty() ) dateTime = *timeSteps.rbegin();
 
-    auto timeSteps = rftReader->availableTimeSteps( wellName );
-    if ( !timeSteps.empty() ) dateTime = *timeSteps.rbegin();
-
-    RifEclipseRftAddress adr =
-        RifEclipseRftAddress::createAddress( wellName, dateTime, RifEclipseRftAddress::RftWellLogChannelType::PRESSURE );
-    curve->setRftAddress( adr );
+        RifEclipseRftAddress adr =
+            RifEclipseRftAddress::createAddress( wellName, dateTime, RifEclipseRftAddress::RftWellLogChannelType::PRESSURE );
+        curve->setRftAddress( adr );
+    }
 
     plotTrack->addCurve( curve );
 
@@ -506,20 +508,23 @@ RimWellLogRftCurve* RicWellLogTools::addSummaryRftSegmentCurve( RimWellLogTrack*
     auto curve = new RimWellLogRftCurve();
 
     curve->setSummaryCase( rimCase );
+
     auto rftReader = rimCase->rftReader();
+    if ( rftReader )
+    {
+        QDateTime dateTime;
 
-    QDateTime dateTime;
+        auto timeSteps = rftReader->availableTimeSteps( wellName );
+        if ( !timeSteps.empty() ) dateTime = *timeSteps.rbegin();
 
-    auto timeSteps = rftReader->availableTimeSteps( wellName );
-    if ( !timeSteps.empty() ) dateTime = *timeSteps.rbegin();
+        RifEclipseRftAddress adr =
+            RifEclipseRftAddress::createBranchSegmentAddress( wellName, dateTime, resultName, 1, branchType );
+        curve->setRftAddress( adr );
+        curve->assignColorFromResultName( resultName );
+        curve->setLineThickness( 4 );
 
-    RifEclipseRftAddress adr =
-        RifEclipseRftAddress::createBranchSegmentAddress( wellName, dateTime, resultName, 1, branchType );
-    curve->setRftAddress( adr );
-    curve->assignColorFromResultName( resultName );
-    curve->setLineThickness( 4 );
-
-    curve->setInterpolation( RiuQwtPlotCurveDefines::CurveInterpolationEnum::INTERPOLATION_STEP_LEFT );
+        curve->setInterpolation( RiuQwtPlotCurveDefines::CurveInterpolationEnum::INTERPOLATION_STEP_LEFT );
+    }
 
     plotTrack->addCurve( curve );
 
@@ -535,6 +540,7 @@ bool RicWellLogTools::hasData( const QString&            resultName,
                                RimSummaryCase*           rimCase )
 {
     auto rftReader = rimCase->rftReader();
+    if ( rftReader ) return false;
 
     QDateTime dateTime;
 

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewMultiPhaseRftSegmentPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewMultiPhaseRftSegmentPlotFeature.cpp
@@ -24,6 +24,7 @@
 #include "RicWellLogTools.h"
 
 #include "RiaApplication.h"
+#include "RiaLogging.h"
 #include "RiaPlotWindowRedrawScheduler.h"
 #include "RiaRftDefines.h"
 
@@ -64,16 +65,19 @@ void RicNewMultiPhaseRftSegmentPlotFeature::onActionTriggered( bool isChecked )
     rftCase->firstAncestorOfType( summaryCase );
     if ( !summaryCase ) return;
 
+    auto rftReader = summaryCase->rftReader();
+    if ( !rftReader )
+    {
+        RiaLogging::error( "Could not open RFT file or no RFT file present. " );
+        return;
+    }
+
     auto plot = RicNewWellLogPlotFeatureImpl::createHorizontalWellLogPlot();
 
     QString wellName = "Unknown";
 
-    auto rftReader = summaryCase->rftReader();
-    if ( rftReader )
-    {
-        auto wellNames = rftReader->wellNames();
-        if ( !wellNames.empty() ) wellName = *wellNames.begin();
-    }
+    auto wellNames = rftReader->wellNames();
+    if ( !wellNames.empty() ) wellName = *wellNames.begin();
 
     appendTrackAndCurveForBranchType( plot,
                                       "Connection Rates",

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewRftSegmentWellLogPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewRftSegmentWellLogPlotFeature.cpp
@@ -24,6 +24,7 @@
 
 #include "RiaApplication.h"
 #include "RiaColorTools.h"
+#include "RiaLogging.h"
 #include "RiaPlotWindowRedrawScheduler.h"
 #include "RiaRftDefines.h"
 
@@ -64,16 +65,18 @@ void RicNewRftSegmentWellLogPlotFeature::onActionTriggered( bool isChecked )
     rftCase->firstAncestorOfType( summaryCase );
     if ( !summaryCase ) return;
 
+    auto rftReader = summaryCase->rftReader();
+    if ( !rftReader )
+    {
+        RiaLogging::error( "Could not open RFT file or no RFT file present. " );
+        return;
+    }
+
     auto plot = RicNewWellLogPlotFeatureImpl::createHorizontalWellLogPlot();
 
-    QString wellName = "Unknown";
-
-    auto rftReader = summaryCase->rftReader();
-    if ( rftReader )
-    {
-        auto wellNames = rftReader->wellNames();
-        if ( !wellNames.empty() ) wellName = *wellNames.begin();
-    }
+    QString wellName  = "Unknown";
+    auto    wellNames = rftReader->wellNames();
+    if ( !wellNames.empty() ) wellName = *wellNames.begin();
 
     {
         RimWellLogTrack* plotTrack = new RimWellLogTrack();
@@ -197,15 +200,14 @@ void RicNewRftSegmentWellLogPlotFeature::appendTopologyTrack( RimWellLogPlot* pl
                                                               const QString&  wellName,
                                                               RimSummaryCase* summaryCase )
 {
+    auto rftReader = dynamic_cast<RifReaderOpmRft*>( summaryCase->rftReader() );
+    if ( !rftReader ) return;
+
     QDateTime dateTime;
     int       branchIndex = 1;
 
-    auto rftReader = dynamic_cast<RifReaderOpmRft*>( summaryCase->rftReader() );
-    if ( rftReader )
-    {
-        auto timeSteps = rftReader->availableTimeSteps( wellName );
-        if ( !timeSteps.empty() ) dateTime = *timeSteps.rbegin();
-    }
+    auto timeSteps = rftReader->availableTimeSteps( wellName );
+    if ( !timeSteps.empty() ) dateTime = *timeSteps.rbegin();
 
     auto track = new RimWellLogTrack();
     track->setDescription( "Topology" );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
@@ -269,7 +269,12 @@ void RimFileSummaryCase::defineEditorAttribute( const caf::PdmFieldHandle* field
 void RimFileSummaryCase::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName /*= "" */ )
 {
     RimSummaryCase::defineUiTreeOrdering( uiTreeOrdering, uiConfigName );
-    uiTreeOrdering.add( m_rftCase() );
+
+    if ( rftReader() )
+    {
+        uiTreeOrdering.add( m_rftCase() );
+    }
+    uiTreeOrdering.skipRemainingChildren();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -594,7 +594,7 @@ void RiuMainWindow::createToolBars()
     {
         QToolBar* toolbar = addToolBar( tr( "Standard" ) );
         toolbar->setObjectName( toolbar->windowTitle() );
-        toolbar->addAction( cmdFeatureMgr->action( "RicImportGeneralDataFeature" ) );
+        toolbar->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseFeature" ) );
         toolbar->addAction( cmdFeatureMgr->action( "RicOpenProjectFeature" ) );
         toolbar->addAction( cmdFeatureMgr->action( "RicSaveProjectFeature" ) );
     }

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -405,7 +405,7 @@ QStringList RiuPlotMainWindow::toolbarCommandIds( const QString& toolbarName )
 
     if ( toolbarName.isEmpty() || toolbarName == "Standard" )
     {
-        commandIds << "RicImportGeneralDataFeature";
+        commandIds << "RicImportEclipseCaseFeature";
         commandIds << "RicImportSummaryCaseFeature";
         commandIds << "RicImportEnsembleFeature";
         commandIds << "RicOpenProjectFeature";


### PR DESCRIPTION
Show RFT tree node only when RFT file is present
Guard null pointer use for RFT data
Avoid opening of 3D view when importing summary data
Use specific grid import feature instead of general import feature

Closes #9551 