### PR TITLE
Ensemble: Disable auto name for old projects

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseCollection.cpp
@@ -1065,6 +1065,8 @@ void RimSummaryCaseCollection::initAfterRead()
     {
         summaryCase->nameChanged.connect( this, &RimSummaryCaseCollection::onCaseNameChanged );
     }
+
+    if ( RimProject::current()->isProjectFileVersionEqualOrOlderThan( "2022.06.2" ) ) m_autoName = false;
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Set auto name to false to be able to use the stored name in project files.