### PR TITLE
Look Up Time Step Object Exactly Once

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimeCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimeCollection.cpp
@@ -48,10 +48,11 @@ RimWellAllocationOverTimeCollection::RimWellAllocationOverTimeCollection(
     QDateTime prevValidTimeStep;
     for ( auto it = m_timeStepDates.rbegin(); it != m_timeStepDates.rend(); ++it )
     {
-        const QDateTime& timeStep = *it;
-        if ( timeStepAndCalculatorPairs.contains( timeStep ) )
+        const QDateTime& timeStep             = *it;
+        auto             timeStepCalculatorIt = timeStepAndCalculatorPairs.find( timeStep );
+        if ( timeStepCalculatorIt != timeStepAndCalculatorPairs.end() )
         {
-            m_timeStepAndCalculatorPairs.emplace( timeStep, timeStepAndCalculatorPairs.at( timeStep ) );
+            m_timeStepAndCalculatorPairs.emplace( timeStep, timeStepCalculatorIt->second );
             prevValidTimeStep = timeStep;
         }
         else if ( prevValidTimeStep.isValid() )


### PR DESCRIPTION
Using `.contains()` followed by `.at()` with the same argument will perform the same map lookup twice.

The `.contains()` member function is most appropriate when we make decisions based on the presence/absence of an element.  If we additionally need the actual element, then `.find()` is typically the better tool.