### PR TITLE
#9833: Add extra check based on value/cell count

### DIFF
--- a/ApplicationLibCode/FileInterface/RifActiveCellsReader.h
+++ b/ApplicationLibCode/FileInterface/RifActiveCellsReader.h
@@ -32,7 +32,8 @@ class RifActiveCellsReader
 public:
     static std::vector<std::vector<int>> activeCellsFromActnumKeyword( const ecl_file_type* ecl_file );
 
-    static std::vector<std::vector<int>> activeCellsFromPorvKeyword( const ecl_file_type* ecl_file, bool dualPorosity );
+    static std::vector<std::vector<int>>
+        activeCellsFromPorvKeyword( const ecl_file_type* ecl_file, bool dualPorosity, const int cellCountMainGrid );
 
     static void applyActiveCellsToAllGrids( ecl_grid_type*                       ecl_main_grid,
                                             const std::vector<std::vector<int>>& activeCellsForAllGrids );

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -840,8 +840,10 @@ bool RifReaderEclipseOutput::readActiveCellInfo()
                 ecl_file_open( RiaStringEncodingTools::toNativeEncoded( initFileName ).data(), ECL_FILE_CLOSE_STREAM );
             if ( ecl_file )
             {
-                bool isDualPorosity = m_eclipseCase->mainGrid()->isDualPorosity();
-                actnumValuesPerGrid = RifActiveCellsReader::activeCellsFromPorvKeyword( ecl_file, isDualPorosity );
+                bool isDualPorosity    = m_eclipseCase->mainGrid()->isDualPorosity();
+                int  cellCountMainGrid = static_cast<int>( m_eclipseCase->mainGrid()->cellCount() );
+                actnumValuesPerGrid =
+                    RifActiveCellsReader::activeCellsFromPorvKeyword( ecl_file, isDualPorosity, cellCountMainGrid );
                 ecl_file_close( ecl_file );
             }
         }
@@ -2330,8 +2332,10 @@ ecl_grid_type* RifReaderEclipseOutput::loadAllGrids() const
         // TODO : ecl_grid_alloc() will automatically read ACTNUM from EGRID file, and reading of active cell
         // information can be skipped if PORV is available
 
-        bool isDualPorosity = ecl_grid_dual_grid( mainEclGrid );
-        auto activeCells    = RifActiveCellsReader::activeCellsFromPorvKeyword( m_ecl_init_file, isDualPorosity );
+        bool isDualPorosity    = ecl_grid_dual_grid( mainEclGrid );
+        auto cellCountMainGrid = ecl_grid_get_global_size( mainEclGrid );
+        auto activeCells =
+            RifActiveCellsReader::activeCellsFromPorvKeyword( m_ecl_init_file, isDualPorosity, cellCountMainGrid );
 
         if ( !activeCells.empty() )
         {

--- a/ApplicationLibCode/UnitTests/RifActiveCellsReader-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifActiveCellsReader-Test.cpp
@@ -65,7 +65,8 @@ TEST( RifActiveCellsReaderTest, BasicTest10k )
         ecl_file_type* initFile =
             ecl_file_open( RiaStringEncodingTools::toNativeEncoded( filePath ).data(), ECL_FILE_CLOSE_STREAM );
 
-        activeCellsFromPorv = RifActiveCellsReader::activeCellsFromPorvKeyword( initFile, false );
+        int cellCountMainGrid = 0;
+        activeCellsFromPorv   = RifActiveCellsReader::activeCellsFromPorvKeyword( initFile, false, cellCountMainGrid );
         EXPECT_EQ( 2, (int)activeCellsFromPorv.size() );
 
         ecl_file_close( initFile );


### PR DESCRIPTION
Some models do not have the dual porosity flag set correctly. Add additional check to set the dual porosity flag if the number of active cells is the double of main grid cell count.