### PR TITLE
Summary Restart: Add more guarding on empty strings

### DIFF
--- a/ThirdParty/Ert/lib/ecl/ecl_util.cpp
+++ b/ThirdParty/Ert/lib/ecl/ecl_util.cpp
@@ -378,6 +378,10 @@ static bool valid_base(const char * input_base, bool * upper_case) {
 
 static char * ecl_util_alloc_filename_static(const char * path, const char * base , ecl_file_enum file_type , bool fmt_file, int report_nr, bool must_exist) {
   bool upper_case;
+
+  if (base == NULL)
+    return NULL;
+
   if (!valid_base(base, &upper_case))
     return NULL;
 
@@ -877,7 +881,7 @@ bool ecl_util_alloc_summary_files(const char * path , const char * _base , const
   else
     base = (char *) _base;
 
-  if (ext != NULL) {
+  if (base != NULL && ext != NULL) {
     ecl_file_enum input_type;
 
     {


### PR DESCRIPTION
When trying to import a restart case, parsing of the restart path causes crash in some cases. Add more checking on NULL.

Closes #9844