### PR TITLE
Add custom tickmark configuration for Summary Plot

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -1083,7 +1083,7 @@ void RimSummaryPlot::updateZoomForNumericalAxis( RimPlotAxisProperties* axisProp
 //--------------------------------------------------------------------------------------------------
 void RimSummaryPlot::updateZoomForTimeAxis( RimSummaryTimeAxisProperties* timeAxisProperties )
 {
-    if ( !timeAxisProperties ) return;
+    if ( !timeAxisProperties || !plotWidget() ) return;
 
     if ( timeAxisProperties->isAutoZoom() )
     {
@@ -1102,7 +1102,7 @@ void RimSummaryPlot::updateZoomForTimeAxis( RimSummaryTimeAxisProperties* timeAx
 //--------------------------------------------------------------------------------------------------
 void RimSummaryPlot::createAndSetCustomTimeAxisTickmarks( RimSummaryTimeAxisProperties* timeAxisProperties )
 {
-    if ( !timeAxisProperties ) return;
+    if ( !timeAxisProperties || !plotWidget() ) return;
 
     const auto [minValue, maxValue] = plotWidget()->axisRange( RiuPlotAxis::defaultBottom() );
     const auto tickmarkList =

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -95,6 +95,7 @@
 #include <QString>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <set>
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -22,6 +22,7 @@
 #include "RiaColorTools.h"
 #include "RiaDefines.h"
 #include "RiaFieldHandleTools.h"
+#include "RiaLogging.h"
 #include "RiaPlotDefines.h"
 #include "RiaPreferences.h"
 #include "RiaPreferencesSummary.h"
@@ -62,6 +63,7 @@
 #include "RimSummaryTimeAxisProperties.h"
 
 #include "RiuPlotAxis.h"
+#include "RiuPlotMainWindow.h"
 #include "RiuPlotMainWindowTools.h"
 #include "RiuQwtPlotCurve.h"
 #include "RiuQwtPlotItem.h"
@@ -79,6 +81,7 @@
 #include "cafPdmUiTreeOrdering.h"
 #include "cafSelectionManager.h"
 
+#include "qwt_date.h"
 #include "qwt_plot.h"
 #include "qwt_plot_curve.h"
 #include "qwt_plot_textlabel.h"
@@ -135,7 +138,7 @@ RimSummaryPlot::RimSummaryPlot( bool isCrossPlot )
     CAF_PDM_InitFieldNoDefault( &m_asciiDataCurves, "AsciiDataCurves", "" );
     m_asciiDataCurves.uiCapability()->setUiTreeHidden( true );
 
-    CAF_PDM_InitFieldNoDefault( &m_axisProperties, "AxisProperties", "Axes", ":/Axes16x16.png" );
+    CAF_PDM_InitFieldNoDefault( &m_axisPropertiesArray, "AxisProperties", "Axes", ":/Axes16x16.png" );
 
     if ( m_isCrossPlot )
     {
@@ -144,10 +147,10 @@ RimSummaryPlot::RimSummaryPlot( bool isCrossPlot )
     else
     {
         auto* timeAxisProperties = new RimSummaryTimeAxisProperties;
-        timeAxisProperties->settingsChanged.connect( this, &RimSummaryPlot::axisSettingsChanged );
-        timeAxisProperties->requestLoadDataAndUpdate.connect( this, &RimSummaryPlot::axisSettingsChangedReloadRequired );
+        timeAxisProperties->settingsChanged.connect( this, &RimSummaryPlot::timeAxisSettingsChanged );
+        timeAxisProperties->requestLoadDataAndUpdate.connect( this, &RimSummaryPlot::timeAxisSettingsChangedReloadRequired );
 
-        m_axisProperties.push_back( timeAxisProperties );
+        m_axisPropertiesArray.push_back( timeAxisProperties );
     }
 
     auto leftAxis = addNewAxisProperties( RiuPlotAxis::defaultLeft(), "Left" );
@@ -227,8 +230,8 @@ RimSummaryPlot::~RimSummaryPlot()
 //--------------------------------------------------------------------------------------------------
 void RimSummaryPlot::updateAxes()
 {
-    updateAxis( RiaDefines::PlotAxis::PLOT_AXIS_LEFT );
-    updateAxis( RiaDefines::PlotAxis::PLOT_AXIS_RIGHT );
+    updateNumericalAxis( RiaDefines::PlotAxis::PLOT_AXIS_LEFT );
+    updateNumericalAxis( RiaDefines::PlotAxis::PLOT_AXIS_RIGHT );
 
     if ( m_summaryPlot ) m_summaryPlot->clearAnnotationObjects();
 
@@ -245,7 +248,7 @@ void RimSummaryPlot::updateAxes()
 
     if ( m_isCrossPlot )
     {
-        updateAxis( RiaDefines::PlotAxis::PLOT_AXIS_BOTTOM );
+        updateNumericalAxis( RiaDefines::PlotAxis::PLOT_AXIS_BOTTOM );
     }
     else
     {
@@ -280,7 +283,7 @@ bool RimSummaryPlot::isCurveHighlightSupported() const
 RimSummaryTimeAxisProperties* RimSummaryPlot::timeAxisProperties()
 {
     // Find the first time axis (which is correct since there is only one).
-    for ( const auto& ap : m_axisProperties )
+    for ( const auto& ap : m_axisPropertiesArray )
     {
         auto* timeAxis = dynamic_cast<RimSummaryTimeAxisProperties*>( ap.p() );
         if ( timeAxis ) return timeAxis;
@@ -859,20 +862,22 @@ bool RimSummaryPlot::isNormalizationEnabled()
 
 //--------------------------------------------------------------------------------------------------
 ///
+/// Update regular axis with numerical axis values - i.e. not time axis.
+///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryPlot::updateAxis( RiaDefines::PlotAxis plotAxis )
+void RimSummaryPlot::updateNumericalAxis( RiaDefines::PlotAxis plotAxis )
 {
     if ( !plotWidget() ) return;
 
-    for ( RimPlotAxisPropertiesInterface* yAxisProperties : m_axisProperties )
+    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisPropertiesArray )
     {
-        RiuPlotAxis riuPlotAxis = yAxisProperties->plotAxisType();
+        RiuPlotAxis riuPlotAxis = axisProperties->plotAxisType();
         if ( riuPlotAxis.axis() == plotAxis )
         {
-            auto* axisProperties = dynamic_cast<RimPlotAxisProperties*>( yAxisProperties );
-            if ( axisProperties )
+            auto* axisProps = dynamic_cast<RimPlotAxisProperties*>( axisProperties );
+            if ( axisProps )
             {
-                if ( yAxisProperties->isActive() && hasVisibleCurvesForAxis( riuPlotAxis ) )
+                if ( axisProperties->isActive() && hasVisibleCurvesForAxis( riuPlotAxis ) )
                 {
                     plotWidget()->enableAxis( riuPlotAxis, true );
                 }
@@ -883,7 +888,7 @@ void RimSummaryPlot::updateAxis( RiaDefines::PlotAxis plotAxis )
 
                 if ( !hasVisibleCurvesForAxis( riuPlotAxis ) )
                 {
-                    axisProperties->setNameForUnusedAxis();
+                    axisProps->setNameForUnusedAxis();
                 }
                 else
                 {
@@ -910,7 +915,7 @@ void RimSummaryPlot::updateAxis( RiaDefines::PlotAxis plotAxis )
                         curveDefs.push_back( def );
                     }
 
-                    RimSummaryPlotAxisFormatter calc( axisProperties,
+                    RimSummaryPlotAxisFormatter calc( axisProps,
                                                       {},
                                                       curveDefs,
                                                       visibleAsciiDataCurvesForAxis( riuPlotAxis ),
@@ -920,11 +925,10 @@ void RimSummaryPlot::updateAxis( RiaDefines::PlotAxis plotAxis )
                 }
             }
 
-            plotWidget()->enableAxisNumberLabels( riuPlotAxis, axisProperties->showNumbers() );
+            plotWidget()->enableAxisNumberLabels( riuPlotAxis, axisProps->showNumbers() );
 
-            RimSummaryTimeAxisProperties::LegendTickmarkCount tickmarkCountEnum = axisProperties->majorTickmarkCount();
+            RimSummaryTimeAxisProperties::LegendTickmarkCount tickmarkCountEnum = axisProps->majorTickmarkCount();
             int maxTickmarkCount = RimPlotAxisPropertiesInterface::tickmarkCountFromEnum( tickmarkCountEnum );
-
             plotWidget()->setAutoTickIntervalCounts( riuPlotAxis, maxTickmarkCount, maxTickmarkCount );
         }
     }
@@ -933,17 +937,96 @@ void RimSummaryPlot::updateAxis( RiaDefines::PlotAxis plotAxis )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryPlot::updateZoomForAxis( RiuPlotAxis plotAxis )
+void RimSummaryPlot::updateTimeAxis( RimSummaryTimeAxisProperties* timeAxisProperties )
 {
-    RimPlotAxisPropertiesInterface* yAxisProps = axisPropertiesForPlotAxis( plotAxis );
-    if ( !yAxisProps ) return;
+    if ( !plotWidget() ) return;
 
-    if ( yAxisProps->isAutoZoom() )
+    if ( !timeAxisProperties->isActive() )
     {
-        if ( yAxisProps->isLogarithmicScaleEnabled() )
-        {
-            plotWidget()->setAxisScaleType( yAxisProps->plotAxisType(), RiuQwtPlotWidget::AxisScaleType::LOGARITHMIC );
+        plotWidget()->enableAxis( RiuPlotAxis::defaultBottom(), false );
 
+        return;
+    }
+
+    if ( timeAxisProperties->timeMode() == RimSummaryTimeAxisProperties::DATE )
+    {
+        RiaDefines::DateFormatComponents dateComponents = timeAxisProperties->dateComponents();
+        RiaDefines::TimeFormatComponents timeComponents = timeAxisProperties->timeComponents();
+
+        const QString& dateFormat = timeAxisProperties->dateFormat();
+        const QString& timeFormat = timeAxisProperties->timeFormat();
+
+        m_summaryPlot->useDateBasedTimeAxis( dateFormat, timeFormat, dateComponents, timeComponents );
+    }
+    else
+    {
+        m_summaryPlot->useTimeBasedTimeAxis();
+    }
+
+    plotWidget()->enableAxis( RiuPlotAxis::defaultBottom(), true );
+
+    {
+        Qt::AlignmentFlag alignment = Qt::AlignCenter;
+        if ( timeAxisProperties->titlePosition() == RimPlotAxisPropertiesInterface::AXIS_TITLE_END )
+        {
+            alignment = Qt::AlignRight;
+        }
+
+        plotWidget()->setAxisFontsAndAlignment( RiuPlotAxis::defaultBottom(),
+                                                timeAxisProperties->titleFontSize(),
+                                                timeAxisProperties->valuesFontSize(),
+                                                true,
+                                                alignment );
+        plotWidget()->setAxisTitleText( RiuPlotAxis::defaultBottom(), timeAxisProperties->title() );
+        plotWidget()->setAxisTitleEnabled( RiuPlotAxis::defaultBottom(), timeAxisProperties->showTitle );
+
+        if ( timeAxisProperties->tickmarkType() == RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_COUNT )
+        {
+            RimSummaryTimeAxisProperties::LegendTickmarkCount tickmarkCountEnum = timeAxisProperties->majorTickmarkCount();
+            int maxTickmarkCount = RimPlotAxisPropertiesInterface::tickmarkCountFromEnum( tickmarkCountEnum );
+
+            plotWidget()->setAxisMaxMajor( RiuPlotAxis::defaultBottom(), maxTickmarkCount );
+        }
+        else if ( timeAxisProperties->tickmarkType() == RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_CUSTOM )
+        {
+            createAndSetCustomTimeAxisTickmarks( timeAxisProperties );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryPlot::updateZoomForAxis( RimPlotAxisPropertiesInterface* axisProperties )
+{
+    RimSummaryTimeAxisProperties* timeAxisProps = dynamic_cast<RimSummaryTimeAxisProperties*>( axisProperties );
+    if ( timeAxisProps )
+    {
+        updateZoomForTimeAxis( timeAxisProps );
+        return;
+    }
+
+    RimPlotAxisProperties* axisProps = dynamic_cast<RimPlotAxisProperties*>( axisProperties );
+    if ( axisProps )
+    {
+        updateZoomForNumericalAxis( axisProps );
+        return;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryPlot::updateZoomForNumericalAxis( RimPlotAxisProperties* axisProperties )
+{
+    if ( !axisProperties ) return;
+
+    const auto plotAxis = axisProperties->plotAxisType();
+    if ( axisProperties->isAutoZoom() )
+    {
+        if ( axisProperties->isLogarithmicScaleEnabled() )
+        {
+            plotWidget()->setAxisScaleType( plotAxis, RiuQwtPlotWidget::AxisScaleType::LOGARITHMIC );
             std::vector<const RimPlotCurve*> plotCurves;
 
             for ( RimSummaryCurve* c : visibleSummaryCurvesForAxis( plotAxis ) )
@@ -965,33 +1048,104 @@ void RimSummaryPlot::updateZoomForAxis( RiuPlotAxis plotAxis )
             RimPlotAxisLogRangeCalculator calc( plotAxis.axis(), plotCurves );
             calc.computeAxisRange( &min, &max );
 
-            if ( yAxisProps->isAxisInverted() )
+            if ( axisProperties->isAxisInverted() )
             {
                 std::swap( min, max );
             }
 
-            plotWidget()->setAxisScale( yAxisProps->plotAxisType(), min, max );
+            plotWidget()->setAxisScale( axisProperties->plotAxisType(), min, max );
         }
         else if ( ( plotAxis.axis() == RiaDefines::PlotAxis::PLOT_AXIS_LEFT ||
                     plotAxis.axis() == RiaDefines::PlotAxis::PLOT_AXIS_RIGHT ) &&
                   isOnlyWaterCutCurvesVisible( plotAxis ) )
         {
-            plotWidget()->setAxisScale( yAxisProps->plotAxisType(), 0.0, 1.0 );
+            plotWidget()->setAxisScale( axisProperties->plotAxisType(), 0.0, 1.0 );
         }
         else
         {
-            plotWidget()->setAxisAutoScale( yAxisProps->plotAxisType(), true );
+            plotWidget()->setAxisAutoScale( axisProperties->plotAxisType(), true );
         }
     }
     else
     {
-        double min = yAxisProps->visibleRangeMin();
-        double max = yAxisProps->visibleRangeMax();
-        if ( yAxisProps->isAxisInverted() ) std::swap( min, max );
-        plotWidget()->setAxisScale( yAxisProps->plotAxisType(), min, max );
+        double min = axisProperties->visibleRangeMin();
+        double max = axisProperties->visibleRangeMax();
+        if ( axisProperties->isAxisInverted() ) std::swap( min, max );
+        plotWidget()->setAxisScale( axisProperties->plotAxisType(), min, max );
     }
 
-    plotWidget()->setAxisInverted( yAxisProps->plotAxisType(), yAxisProps->isAxisInverted() );
+    plotWidget()->setAxisInverted( axisProperties->plotAxisType(), axisProperties->isAxisInverted() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryPlot::updateZoomForTimeAxis( RimSummaryTimeAxisProperties* timeAxisProperties )
+{
+    if ( !timeAxisProperties ) return;
+
+    if ( timeAxisProperties->isAutoZoom() )
+    {
+        plotWidget()->setAxisAutoScale( timeAxisProperties->plotAxisType(), true );
+    }
+    else
+    {
+        double min = timeAxisProperties->visibleRangeMin();
+        double max = timeAxisProperties->visibleRangeMax();
+        plotWidget()->setAxisScale( timeAxisProperties->plotAxisType(), min, max );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryPlot::createAndSetCustomTimeAxisTickmarks( RimSummaryTimeAxisProperties* timeAxisProperties )
+{
+    if ( !timeAxisProperties ) return;
+
+    const auto [minValue, maxValue] = plotWidget()->axisRange( RiuPlotAxis::defaultBottom() );
+    const auto tickmarkList =
+        timeAxisProperties->createTickmarkList( QwtDate::toDateTime( minValue ), QwtDate::toDateTime( maxValue ) );
+
+    plotWidget()->setMajorTicksList( RiuPlotAxis::defaultBottom(), tickmarkList, minValue, maxValue );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryPlot::overrideTimeAxisSettingsIfTooManyCustomTickmarks( RimSummaryTimeAxisProperties* timeAxisProperties,
+                                                                       bool                          showMessageBox )
+{
+    if ( !timeAxisProperties ||
+         timeAxisProperties->tickmarkType() != RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_CUSTOM )
+    {
+        return;
+    }
+
+    const uint MAX_NUM_TICKS = 100;
+
+    // Prevent too large number of ticks by overriding time axis interval and step to
+    // prevent large number of tickmarks by accident.
+    const auto [minValue, maxValue] = plotWidget()->axisRange( RiuPlotAxis::defaultBottom() );
+    const double ticksInterval      = timeAxisProperties->getTickmarkIntervalDouble();
+    const uint   numTicks           = static_cast<uint>( std::ceil( ( maxValue - minValue ) / ticksInterval ) );
+    if ( numTicks > MAX_NUM_TICKS )
+    {
+        if ( showMessageBox )
+        {
+            QString errorTitle = "Too many custom tickmarks";
+            QString errorMessage =
+                QString( "The current configuration generates more than %1 number of custom tickmarks. "
+                         "To prevent slow response the configuration will be reset to default: \n\n"
+                         "Interval = Years and Interval Step = 1." )
+                    .arg( MAX_NUM_TICKS );
+            RiaLogging::errorInMessageBox( RiuPlotMainWindow::instance(), errorTitle, errorMessage );
+        }
+
+        timeAxisProperties->setTickmarkInterval( RimSummaryTimeAxisProperties::TickmarkInterval::YEARS );
+        timeAxisProperties->setTickmarkIntervalStep( 1 );
+        timeAxisProperties->updateConnectedEditors();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1100,7 +1254,7 @@ bool RimSummaryPlot::hasVisibleCurvesForAxis( RiuPlotAxis plotAxis ) const
 //--------------------------------------------------------------------------------------------------
 RimPlotAxisPropertiesInterface* RimSummaryPlot::axisPropertiesForPlotAxis( RiuPlotAxis plotAxis ) const
 {
-    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisProperties )
+    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisPropertiesArray )
     {
         if ( axisProperties->plotAxisType() == plotAxis ) return axisProperties;
     }
@@ -1148,61 +1302,6 @@ std::vector<RimAsciiDataCurve*> RimSummaryPlot::visibleAsciiDataCurvesForAxis( R
     }
 
     return curves;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimSummaryPlot::updateTimeAxis( RimSummaryTimeAxisProperties* timeAxisProperties )
-{
-    if ( !plotWidget() ) return;
-
-    if ( !timeAxisProperties->isActive() )
-    {
-        plotWidget()->enableAxis( RiuPlotAxis::defaultBottom(), false );
-
-        return;
-    }
-
-    if ( timeAxisProperties->timeMode() == RimSummaryTimeAxisProperties::DATE )
-    {
-        RiaDefines::DateFormatComponents dateComponents = timeAxisProperties->dateComponents();
-        RiaDefines::TimeFormatComponents timeComponents = timeAxisProperties->timeComponents();
-
-        const QString& dateFormat = timeAxisProperties->dateFormat();
-        const QString& timeFormat = timeAxisProperties->timeFormat();
-
-        m_summaryPlot->useDateBasedTimeAxis( dateFormat, timeFormat, dateComponents, timeComponents );
-    }
-    else
-    {
-        m_summaryPlot->useTimeBasedTimeAxis();
-    }
-
-    plotWidget()->enableAxis( RiuPlotAxis::defaultBottom(), true );
-
-    {
-        Qt::AlignmentFlag alignment = Qt::AlignCenter;
-        if ( timeAxisProperties->titlePosition() == RimPlotAxisPropertiesInterface::AXIS_TITLE_END )
-        {
-            alignment = Qt::AlignRight;
-        }
-
-        plotWidget()->setAxisFontsAndAlignment( RiuPlotAxis::defaultBottom(),
-                                                timeAxisProperties->titleFontSize(),
-                                                timeAxisProperties->valuesFontSize(),
-                                                true,
-                                                alignment );
-        plotWidget()->setAxisTitleText( RiuPlotAxis::defaultBottom(), timeAxisProperties->title() );
-        plotWidget()->setAxisTitleEnabled( RiuPlotAxis::defaultBottom(), timeAxisProperties->showTitle );
-
-        {
-            RimSummaryTimeAxisProperties::LegendTickmarkCount tickmarkCountEnum = timeAxisProperties->majorTickmarkCount();
-            int maxTickmarkCount = RimPlotAxisPropertiesInterface::tickmarkCountFromEnum( tickmarkCountEnum );
-
-            plotWidget()->setAxisMaxMajor( RiuPlotAxis::defaultBottom(), maxTickmarkCount );
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1560,7 +1659,7 @@ void RimSummaryPlot::updateStackedCurveData()
 bool RimSummaryPlot::updateStackedCurveDataForRelevantAxes()
 {
     bool anyStackedCurvesPresent = false;
-    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisProperties )
+    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisPropertiesArray )
     {
         if ( axisProperties->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_LEFT ||
              axisProperties->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_RIGHT )
@@ -1658,7 +1757,7 @@ void RimSummaryPlot::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrderin
 
     bool isPlotEditor = ( uiConfigName == RicSummaryPlotEditorUi::CONFIGURATION_NAME );
 
-    if ( !isPlotEditor ) uiTreeOrdering.add( &m_axisProperties );
+    if ( !isPlotEditor ) uiTreeOrdering.add( &m_axisPropertiesArray );
 
     for ( auto& curve : m_summaryCurveCollection->curves() )
     {
@@ -1730,14 +1829,27 @@ void RimSummaryPlot::updateZoomInParentPlot()
 {
     if ( !plotWidget() ) return;
 
-    for ( const auto& axisProperty : m_axisProperties )
+    for ( const auto& axisProperty : m_axisPropertiesArray )
     {
-        updateZoomForAxis( axisProperty->plotAxisType() );
+        updateZoomForAxis( axisProperty );
     }
 
     plotWidget()->updateAxes();
     updateZoomFromParentPlot();
     plotWidget()->updateZoomDependentCurveProperties();
+
+    // Must create and set new custom tickmarks for time axis after zoom update
+    auto* timeAxisProps = timeAxisProperties();
+    if ( timeAxisProps && timeAxisProps->tickmarkType() == RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_CUSTOM )
+    {
+        // Protection against too many custom tickmarks
+        const bool showErrorMessageBox = false;
+        overrideTimeAxisSettingsIfTooManyCustomTickmarks( timeAxisProps, showErrorMessageBox );
+
+        // Create and set tickmarks based on settings
+        createAndSetCustomTimeAxisTickmarks( timeAxisProps );
+    }
+
     scheduleReplotIfVisible();
 }
 
@@ -1748,7 +1860,7 @@ void RimSummaryPlot::updateZoomFromParentPlot()
 {
     if ( !plotWidget() ) return;
 
-    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisProperties )
+    for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisPropertiesArray )
     {
         if ( !axisProperties ) continue;
 
@@ -1877,7 +1989,37 @@ void RimSummaryPlot::axisSettingsChanged( const caf::SignalEmitter* emitter )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryPlot::axisSettingsChangedReloadRequired( const caf::SignalEmitter* emitter )
+void RimSummaryPlot::timeAxisSettingsChanged( const caf::SignalEmitter* emitter )
+{
+    axisChanged.send( this );
+
+    auto* timeAxisProps = timeAxisProperties();
+    if ( !timeAxisProps )
+    {
+        return;
+    }
+
+    if ( !timeAxisProps->isAutoZoom() && plotWidget() )
+    {
+        // If not auto zoom - the new date and time ranges must be set and axes updated
+        plotWidget()->setAxisScale( RiuPlotAxis::defaultBottom(),
+                                    timeAxisProps->visibleRangeMin(),
+                                    timeAxisProps->visibleRangeMax() );
+        plotWidget()->updateAxes();
+    }
+
+    // Protection against too many custom tickmarks
+    const bool showErrorMessageBox = true;
+    overrideTimeAxisSettingsIfTooManyCustomTickmarks( timeAxisProps, showErrorMessageBox );
+
+    updateTimeAxis( timeAxisProps );
+    scheduleReplotIfVisible();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryPlot::timeAxisSettingsChangedReloadRequired( const caf::SignalEmitter* emitter )
 {
     axisChangedReloadRequired.send( this );
 }
@@ -1907,7 +2049,7 @@ RimPlotAxisProperties* RimSummaryPlot::addNewAxisProperties( RiuPlotAxis plotAxi
 {
     auto* axisProperties = new RimPlotAxisProperties;
     axisProperties->setNameAndAxis( name, name, plotAxis.axis(), plotAxis.index() );
-    m_axisProperties.push_back( axisProperties );
+    m_axisPropertiesArray.push_back( axisProperties );
     connectAxisSignals( axisProperties );
 
     return axisProperties;
@@ -1976,7 +2118,7 @@ void RimSummaryPlot::axisPositionChanged( const caf::SignalEmitter* emitter,
         if ( oldPlotAxis != RiuPlotAxis::defaultLeft() && oldPlotAxis != RiuPlotAxis::defaultRight() )
         {
             auto oldAxisProperties = axisPropertiesForPlotAxis( oldPlotAxis );
-            if ( oldAxisProperties ) m_axisProperties.removeChild( oldAxisProperties );
+            if ( oldAxisProperties ) m_axisPropertiesArray.removeChild( oldAxisProperties );
             plotWidget()->moveAxis( oldPlotAxis, newPlotAxis );
         }
 
@@ -2407,6 +2549,8 @@ void RimSummaryPlot::onPlotZoomed()
 
     updateZoomFromParentPlot();
 
+    timeAxisSettingsChanged( nullptr );
+
     axisChanged.send( this );
 }
 
@@ -2489,7 +2633,7 @@ RiuPlotWidget* RimSummaryPlot::doCreatePlotViewWidget( QWidget* mainWindowParent
 
         QObject::connect( plotWidget(), SIGNAL( curveOrderNeedsUpdate() ), this, SLOT( onUpdateCurveOrder() ) );
 
-        for ( const auto& axisProperties : m_axisProperties )
+        for ( const auto& axisProperties : m_axisPropertiesArray )
         {
             plotWidget()->ensureAxisIsCreated( axisProperties->plotAxisType() );
         }
@@ -2571,7 +2715,7 @@ void RimSummaryPlot::initAfterRead()
             copyAxis( RiuPlotAxis::defaultBottom(), m_timeAxisProperties_OBSOLETE.v() );
     }
 
-    for ( const auto& axisProperties : m_axisProperties )
+    for ( const auto& axisProperties : m_axisPropertiesArray )
     {
         auto plotAxisProperties = dynamic_cast<RimPlotAxisProperties*>( axisProperties.p() );
         if ( plotAxisProperties )
@@ -2581,8 +2725,8 @@ void RimSummaryPlot::initAfterRead()
         auto* timeAxis = dynamic_cast<RimSummaryTimeAxisProperties*>( axisProperties.p() );
         if ( timeAxis )
         {
-            timeAxis->settingsChanged.connect( this, &RimSummaryPlot::axisSettingsChanged );
-            timeAxis->requestLoadDataAndUpdate.connect( this, &RimSummaryPlot::axisSettingsChangedReloadRequired );
+            timeAxis->settingsChanged.connect( this, &RimSummaryPlot::timeAxisSettingsChanged );
+            timeAxis->requestLoadDataAndUpdate.connect( this, &RimSummaryPlot::timeAxisSettingsChangedReloadRequired );
         }
     }
 
@@ -2834,7 +2978,7 @@ std::vector<caf::PdmFieldHandle*> RimSummaryPlot::fieldsToShowInToolbar()
 //--------------------------------------------------------------------------------------------------
 void RimSummaryPlot::setAutoScaleXEnabled( bool enabled )
 {
-    for ( const auto& ap : m_axisProperties )
+    for ( const auto& ap : m_axisPropertiesArray )
     {
         if ( ap->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_TOP ||
              ap->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_BOTTOM )
@@ -2849,7 +2993,7 @@ void RimSummaryPlot::setAutoScaleXEnabled( bool enabled )
 //--------------------------------------------------------------------------------------------------
 void RimSummaryPlot::setAutoScaleYEnabled( bool enabled )
 {
-    for ( const auto& ap : m_axisProperties )
+    for ( const auto& ap : m_axisPropertiesArray )
     {
         if ( ap->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_LEFT ||
              ap->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_RIGHT )
@@ -2883,7 +3027,7 @@ bool RimSummaryPlot::isDeletable() const
 std::vector<RimPlotAxisPropertiesInterface*> RimSummaryPlot::plotAxes() const
 {
     std::vector<RimPlotAxisPropertiesInterface*> axisProps;
-    for ( const auto& ap : m_axisProperties )
+    for ( const auto& ap : m_axisPropertiesArray )
     {
         axisProps.push_back( ap );
     }
@@ -2897,7 +3041,7 @@ std::vector<RimPlotAxisPropertiesInterface*> RimSummaryPlot::plotAxes() const
 std::vector<RimPlotAxisProperties*> RimSummaryPlot::plotYAxes() const
 {
     std::vector<RimPlotAxisProperties*> axisProps;
-    for ( const auto& ap : m_axisProperties )
+    for ( const auto& ap : m_axisPropertiesArray )
     {
         auto plotAxisProp = dynamic_cast<RimPlotAxisProperties*>( ap.p() );
         if ( plotAxisProp ) axisProps.push_back( plotAxisProp );
@@ -2969,7 +3113,7 @@ void RimSummaryPlot::assignPlotAxis( RimSummaryCurve* destinationCurve )
 
             if ( currentUnit == destinationUnit )
             {
-                for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisProperties )
+                for ( RimPlotAxisPropertiesInterface* axisProperties : m_axisPropertiesArray )
                 {
                     if ( axisProperties->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_LEFT ||
                          axisProperties->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_RIGHT )
@@ -3003,7 +3147,7 @@ void RimSummaryPlot::assignPlotAxis( RimSummaryCurve* destinationCurve )
     {
         size_t axisCountLeft  = 0;
         size_t axisCountRight = 0;
-        for ( const auto& ap : m_axisProperties )
+        for ( const auto& ap : m_axisPropertiesArray )
         {
             if ( ap->plotAxisType().axis() == RiaDefines::PlotAxis::PLOT_AXIS_LEFT )
                 axisCountLeft++;
@@ -3042,7 +3186,7 @@ void RimSummaryPlot::assignPlotAxis( RimSummaryCurve* destinationCurve )
 void RimSummaryPlot::onChildDeleted( caf::PdmChildArrayFieldHandle*      childArray,
                                      std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
-    if ( childArray == &m_axisProperties )
+    if ( childArray == &m_axisPropertiesArray )
     {
         for ( caf::PdmObjectHandle* reffingObj : referringObjects )
         {
@@ -3061,7 +3205,7 @@ void RimSummaryPlot::onChildDeleted( caf::PdmChildArrayFieldHandle*      childAr
         if ( plotWidget() )
         {
             std::set<RiuPlotAxis> usedPlotAxis;
-            for ( const auto& axisProperties : m_axisProperties )
+            for ( const auto& axisProperties : m_axisPropertiesArray )
             {
                 usedPlotAxis.insert( axisProperties->plotAxisType() );
             }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
@@ -266,11 +266,15 @@ private:
     bool                                  hasVisibleCurvesForAxis( RiuPlotAxis plotAxis ) const;
     std::vector<RimSummaryCurve*>         visibleStackedSummaryCurvesForAxis( RiuPlotAxis plotAxis );
 
-    void updateAxis( RiaDefines::PlotAxis plotAxis );
-
-    void updateZoomForAxis( RiuPlotAxis plotAxis );
-
+    void updateNumericalAxis( RiaDefines::PlotAxis plotAxis );
+    void updateZoomForAxis( RimPlotAxisPropertiesInterface* axisProperties );
+    void updateZoomForNumericalAxis( RimPlotAxisProperties* axisProperties );
     void updateTimeAxis( RimSummaryTimeAxisProperties* timeAxisProperties );
+    void updateZoomForTimeAxis( RimSummaryTimeAxisProperties* timeAxisProperties );
+
+    void createAndSetCustomTimeAxisTickmarks( RimSummaryTimeAxisProperties* timeAxisProperties );
+    void overrideTimeAxisSettingsIfTooManyCustomTickmarks( RimSummaryTimeAxisProperties* timeAxisProperties,
+                                                           bool                          showMessageBox );
 
     void deletePlotCurvesAndPlotWidget();
 
@@ -285,12 +289,14 @@ private:
 
     void connectAxisSignals( RimPlotAxisProperties* axis );
     void axisSettingsChanged( const caf::SignalEmitter* emitter );
-    void axisSettingsChangedReloadRequired( const caf::SignalEmitter* emitter );
     void axisLogarithmicChanged( const caf::SignalEmitter* emitter, bool isLogarithmic );
     void axisPositionChanged( const caf::SignalEmitter* emitter,
                               RimPlotAxisProperties*    axisProperties,
                               RiuPlotAxis               oldPlotAxis,
                               RiuPlotAxis               newPlotAxis );
+
+    void timeAxisSettingsChanged( const caf::SignalEmitter* emitter );
+    void timeAxisSettingsChangedReloadRequired( const caf::SignalEmitter* emitter );
 
     void assignPlotAxis( RimSummaryCurve* curve );
 
@@ -330,7 +336,7 @@ private:
     caf::PdmChildField<RimPlotAxisProperties*>        m_bottomAxisProperties_OBSOLETE;
     caf::PdmChildField<RimSummaryTimeAxisProperties*> m_timeAxisProperties_OBSOLETE;
 
-    caf::PdmChildArrayField<RimPlotAxisPropertiesInterface*> m_axisProperties;
+    caf::PdmChildArrayField<RimPlotAxisPropertiesInterface*> m_axisPropertiesArray;
 
     caf::PdmChildField<RimSummaryPlotFilterTextCurveSetEditor*> m_textCurveSetEditor;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTimeAxisProperties.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTimeAxisProperties.cpp
@@ -63,6 +63,25 @@ void caf::AppEnum<RimSummaryTimeAxisProperties::TimeUnitType>::setUp()
     setDefault( RimSummaryTimeAxisProperties::YEARS );
 }
 
+template <>
+void RimSummaryTimeAxisProperties::TickmarkTypeEnum::setUp()
+{
+    addItem( RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_COUNT, "COUNT", "Count" );
+    addItem( RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_CUSTOM, "CUSTOM", "Custom" );
+    setDefault( RimSummaryTimeAxisProperties::TickmarkType::TICKMARK_COUNT );
+}
+
+template <>
+void RimSummaryTimeAxisProperties::TickmarkIntervalEnum::setUp()
+{
+    addItem( RimSummaryTimeAxisProperties::TickmarkInterval::MINUTES, "MINUTES", "Minutes" );
+    addItem( RimSummaryTimeAxisProperties::TickmarkInterval::HOURS, "HOURS", "Hours" );
+    addItem( RimSummaryTimeAxisProperties::TickmarkInterval::DAYS, "DAYS", "Days" );
+    addItem( RimSummaryTimeAxisProperties::TickmarkInterval::MONTHS, "MONTHS", "Months" );
+    addItem( RimSummaryTimeAxisProperties::TickmarkInterval::YEARS, "YEARS", "Years" );
+    setDefault( RimSummaryTimeAxisProperties::TickmarkInterval::YEARS );
+}
+
 } // namespace caf
 
 CAF_PDM_SOURCE_INIT( RimSummaryTimeAxisProperties, "SummaryTimeAxisProperties" );
@@ -119,6 +138,14 @@ RimSummaryTimeAxisProperties::RimSummaryTimeAxisProperties()
     CAF_PDM_InitFieldNoDefault( &m_timeFormat, "TimeFormat", "Time Label Format" );
     m_timeFormat.uiCapability()->setUiEditorTypeName( caf::PdmUiComboBoxEditor::uiEditorTypeName() );
     m_timeFormat = RiaPreferences::current()->timeFormat();
+
+    CAF_PDM_InitFieldNoDefault( &m_tickmarkType, "TickmarkType", "Tickmark Type" );
+    m_tickmarkType.uiCapability()->enableAutoValueSupport( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_tickmarkInterval, "TickmarkInterval", "Tickmark Interval" );
+    m_tickmarkInterval.uiCapability()->enableAutoValueSupport( true );
+
+    CAF_PDM_InitField( &m_tickmarkIntervalStep, "TickmarkIntervalStep", 1, "Tickmark Interval Step" );
 
     CAF_PDM_InitFieldNoDefault( &m_majorTickmarkCount, "MajorTickmarkCount", "Major Tickmark Count" );
     m_majorTickmarkCount.uiCapability()->enableAutoValueSupport( true );
@@ -357,6 +384,160 @@ void RimSummaryTimeAxisProperties::setVisibleDateTimeMax( const QDateTime& dateT
 {
     m_visibleDateRangeMax = dateTime.date();
     m_visibleTimeRangeMax = dateTime.time();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryTimeAxisProperties::setTickmarkInterval( TickmarkInterval interval )
+{
+    m_tickmarkInterval = interval;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryTimeAxisProperties::setTickmarkIntervalStep( int step )
+{
+    m_tickmarkIntervalStep = step;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Create evenly distributed tickmarks between min and max with rounded values dependent on
+/// the currently active tickmark step.
+//--------------------------------------------------------------------------------------------------
+QList<double> RimSummaryTimeAxisProperties::createTickmarkList( const QDateTime& minDateTime,
+                                                                const QDateTime& maxDateTime ) const
+{
+    const auto& [tickmarkInterval, tickmarkStep] = tickmarkIntervalAndStep();
+
+    // Ensure no infinite loop
+    if ( tickmarkStep < 1 ) return {};
+
+    // Convert from list of QDateTime items to double values for Qwt
+    auto toDoubleList = []( const QList<QDateTime>& dateTimeList ) {
+        QList<double> output;
+        for ( const auto& elm : dateTimeList )
+        {
+            output.push_back( QwtDate::toDouble( elm ) );
+        }
+        return output;
+    };
+
+    QList<QDateTime> dateTimeList;
+    if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::YEARS )
+    {
+        dateTimeList = { QDateTime( QDate( minDateTime.date().year(), 1, 1 ), QTime( 0, 0 ), Qt::UTC ) };
+        while ( dateTimeList.back() < maxDateTime )
+        {
+            const auto nextYear = dateTimeList.back().addYears( tickmarkStep );
+            dateTimeList.push_back( nextYear );
+        }
+    }
+    else if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::MONTHS )
+    {
+        dateTimeList = { QDateTime( QDate( minDateTime.date().year(), 1, 1 ), QTime( 0, 0 ), Qt::UTC ) };
+        while ( dateTimeList.back() < maxDateTime )
+        {
+            const auto nextMonth = dateTimeList.back().addMonths( tickmarkStep );
+            dateTimeList.push_back( nextMonth );
+        }
+    }
+    else if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::DAYS )
+    {
+        dateTimeList = { QDateTime( QDate( minDateTime.date().year(), minDateTime.date().month(), minDateTime.date().day() ),
+                                    QTime( 0, 0 ),
+                                    Qt::UTC ) };
+        while ( dateTimeList.back() < maxDateTime )
+        {
+            const auto nextDay = dateTimeList.back().addDays( tickmarkStep );
+            dateTimeList.push_back( nextDay );
+        }
+    }
+    else if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::HOURS )
+    {
+        dateTimeList = { QDateTime( QDate( minDateTime.date().year(), minDateTime.date().month(), minDateTime.date().day() ),
+                                    QTime( minDateTime.time().hour(), 0 ),
+                                    Qt::UTC ) };
+        while ( dateTimeList.back() < maxDateTime )
+        {
+            const auto nextHour = dateTimeList.back().addSecs( static_cast<qint64>( tickmarkStep * 60 * 60 ) );
+            dateTimeList.push_back( nextHour );
+        }
+    }
+    else if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::MINUTES )
+    {
+        dateTimeList = { QDateTime( QDate( minDateTime.date().year(), minDateTime.date().month(), minDateTime.date().day() ),
+                                    QTime( minDateTime.time().hour(), minDateTime.time().minute() ),
+                                    Qt::UTC ) };
+        while ( dateTimeList.back() < maxDateTime )
+        {
+            const auto nextMinute = dateTimeList.back().addSecs( static_cast<qint64>( tickmarkStep * 60 ) );
+            dateTimeList.push_back( nextMinute );
+        }
+    }
+    else
+    {
+        CAF_ASSERT( "Tickmark interval type not handled!" );
+    }
+
+    return toDoubleList( dateTimeList );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimSummaryTimeAxisProperties::getTickmarkIntervalDouble()
+{
+    const auto& [tickmarkInterval, tickmarkStep] = tickmarkIntervalAndStep();
+
+    QDateTime initialInterval = QDateTime::fromMSecsSinceEpoch( 0 );
+    if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::YEARS )
+    {
+        auto interval = initialInterval.addYears( tickmarkStep );
+        return QwtDate::toDouble( interval );
+    }
+    if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::MONTHS )
+    {
+        auto interval = initialInterval.addMonths( tickmarkStep );
+        return QwtDate::toDouble( interval );
+    }
+    if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::DAYS )
+    {
+        auto interval = initialInterval.addDays( static_cast<qint64>( tickmarkStep ) );
+        return QwtDate::toDouble( interval );
+    }
+    if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::HOURS )
+    {
+        const qint64 secs     = static_cast<qint64>( tickmarkStep ) * 60 * 60;
+        auto         interval = initialInterval.addSecs( secs );
+        return QwtDate::toDouble( interval );
+    }
+    if ( tickmarkInterval == RimSummaryTimeAxisProperties::TickmarkInterval::MINUTES )
+    {
+        const qint64 secs     = static_cast<qint64>( tickmarkStep ) * 60;
+        auto         interval = initialInterval.addSecs( secs );
+        return QwtDate::toDouble( interval );
+    }
+
+    CAF_ASSERT( "Tickmark interval type not handled!" );
+    return 0.0;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSummaryTimeAxisProperties::TickmarkType RimSummaryTimeAxisProperties::tickmarkType() const
+{
+    return m_tickmarkType();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::pair<RimSummaryTimeAxisProperties::TickmarkInterval, int> RimSummaryTimeAxisProperties::tickmarkIntervalAndStep() const
+{
+    return std::pair<TickmarkInterval, int>( m_tickmarkInterval(), m_tickmarkIntervalStep() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -641,7 +822,16 @@ void RimSummaryTimeAxisProperties::defineUiOrdering( QString uiConfigName, caf::
     }
 
     timeGroup->add( &m_valuesFontSize );
-    timeGroup->add( &m_majorTickmarkCount );
+    timeGroup->add( &m_tickmarkType );
+    if ( m_tickmarkType == TickmarkType::TICKMARK_COUNT )
+    {
+        timeGroup->add( &m_majorTickmarkCount );
+    }
+    if ( m_tickmarkType == TickmarkType::TICKMARK_CUSTOM )
+    {
+        timeGroup->add( &m_tickmarkInterval );
+        timeGroup->add( &m_tickmarkIntervalStep );
+    }
 
     if ( m_timeMode() == DATE )
     {
@@ -727,8 +917,10 @@ void RimSummaryTimeAxisProperties::fieldChangedByUi( const caf::PdmFieldHandle* 
         requestLoadDataAndUpdate.send();
         return;
     }
-
-    rimSummaryPlot->updateAxes();
+    else if ( changedField == &m_tickmarkType && m_tickmarkType == TickmarkType::TICKMARK_CUSTOM )
+    {
+        m_isAutoZoom = false;
+    }
 
     settingsChanged.send();
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTimeAxisProperties.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTimeAxisProperties.cpp
@@ -823,11 +823,12 @@ void RimSummaryTimeAxisProperties::defineUiOrdering( QString uiConfigName, caf::
 
     timeGroup->add( &m_valuesFontSize );
     timeGroup->add( &m_tickmarkType );
-    if ( m_tickmarkType == TickmarkType::TICKMARK_COUNT )
+    m_tickmarkType.uiCapability()->setUiReadOnly( m_timeMode() == TIME_FROM_SIMULATION_START );
+    if ( m_tickmarkType() == TickmarkType::TICKMARK_COUNT )
     {
         timeGroup->add( &m_majorTickmarkCount );
     }
-    if ( m_tickmarkType == TickmarkType::TICKMARK_CUSTOM )
+    if ( m_tickmarkType() == TickmarkType::TICKMARK_CUSTOM && m_timeMode() == DATE )
     {
         timeGroup->add( &m_tickmarkInterval );
         timeGroup->add( &m_tickmarkIntervalStep );
@@ -910,8 +911,17 @@ void RimSummaryTimeAxisProperties::fieldChangedByUi( const caf::PdmFieldHandle* 
         updateDateVisibleRange();
         m_isAutoZoom = false;
     }
-    else if ( changedField == &m_timeMode || changedField == &m_timeUnit || changedField == &m_dateFormat ||
-              changedField == &m_timeFormat )
+    else if ( changedField == &m_timeMode )
+    {
+        if ( m_timeMode() == TimeModeType::TIME_FROM_SIMULATION_START )
+        {
+            m_tickmarkType = TickmarkType::TICKMARK_COUNT;
+        }
+        // Changing this setting requires a full update of the plot
+        requestLoadDataAndUpdate.send();
+        return;
+    }
+    else if ( changedField == &m_timeUnit || changedField == &m_dateFormat || changedField == &m_timeFormat )
     {
         // Changing these settings requires a full update of the plot
         requestLoadDataAndUpdate.send();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTimeAxisProperties.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTimeAxisProperties.h
@@ -57,6 +57,23 @@ public:
         YEARS
     };
 
+    enum class TickmarkType
+    {
+        TICKMARK_COUNT,
+        TICKMARK_CUSTOM,
+    };
+    using TickmarkTypeEnum = caf::AppEnum<TickmarkType>;
+
+    enum class TickmarkInterval
+    {
+        MINUTES,
+        HOURS,
+        DAYS,
+        MONTHS,
+        YEARS,
+    };
+    using TickmarkIntervalEnum = caf::AppEnum<TickmarkInterval>;
+
     typedef caf::AppEnum<RiaDefines::DateFormatComponents> DateFormatEnum;
     typedef caf::AppEnum<RiaDefines::TimeFormatComponents> TimeFormatEnum;
 
@@ -105,6 +122,14 @@ public:
 
     void setVisibleDateTimeMin( const QDateTime& dateTime );
     void setVisibleDateTimeMax( const QDateTime& dateTime );
+
+    void setTickmarkInterval( TickmarkInterval interval );
+    void setTickmarkIntervalStep( int step );
+
+    QList<double> createTickmarkList( const QDateTime& minDateTime, const QDateTime& maxDateTime ) const;
+    double        getTickmarkIntervalDouble();
+    TickmarkType  tickmarkType() const;
+    std::pair<TickmarkInterval, int> tickmarkIntervalAndStep() const;
 
     LegendTickmarkCount majorTickmarkCount() const override;
     void                setMajorTickmarkCount( LegendTickmarkCount count ) override;
@@ -155,6 +180,9 @@ private:
     caf::PdmField<TimeFormatEnum>                      m_timeComponents;
     caf::PdmField<QString>                             m_dateFormat;
     caf::PdmField<QString>                             m_timeFormat;
+    caf::PdmField<TickmarkTypeEnum>                    m_tickmarkType;
+    caf::PdmField<TickmarkIntervalEnum>                m_tickmarkInterval;
+    caf::PdmField<int>                                 m_tickmarkIntervalStep;
     caf::PdmField<LegendTickmarkCountEnum>             m_majorTickmarkCount;
     caf::PdmChildArrayField<RimPlotAxisAnnotation*>    m_annotations;
 };

--- a/ApplicationLibCode/UserInterface/RiuPlotWidget.h
+++ b/ApplicationLibCode/UserInterface/RiuPlotWidget.h
@@ -135,6 +135,8 @@ public:
 
     virtual void enableGridLines( RiuPlotAxis axis, bool majorGridLines, bool minorGridLines ) = 0;
 
+    virtual void
+                 setMajorTicksList( RiuPlotAxis axis, const QList<double>& majorTicks, double minValue, double maxValue ) = 0;
     virtual void setMajorAndMinorTickIntervals( RiuPlotAxis axis,
                                                 double      majorTickInterval,
                                                 double      minorTickInterval,

--- a/ApplicationLibCode/UserInterface/RiuQtChartsPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQtChartsPlotWidget.cpp
@@ -412,6 +412,14 @@ void RiuQtChartsPlotWidget::enableGridLines( RiuPlotAxis axis, bool majorGridLin
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RiuQtChartsPlotWidget::setMajorTicksList( RiuPlotAxis axis, const QList<double>& majorTicks, double minValue, double maxValue )
+{
+    CAF_ASSERT( "setMajorTicksList()-method not implemented for RiuQtChartsPlotWidget!" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RiuQtChartsPlotWidget::setMajorAndMinorTickIntervals( RiuPlotAxis axis,
                                                            double      majorTickInterval,
                                                            double      minorTickInterval,

--- a/ApplicationLibCode/UserInterface/RiuQtChartsPlotWidget.h
+++ b/ApplicationLibCode/UserInterface/RiuQtChartsPlotWidget.h
@@ -129,6 +129,8 @@ public:
 
     void enableGridLines( RiuPlotAxis axis, bool majorGridLines, bool minorGridLines ) override;
 
+    virtual void
+         setMajorTicksList( RiuPlotAxis axis, const QList<double>& majorTicks, double minValue, double maxValue ) override;
     void setMajorAndMinorTickIntervals( RiuPlotAxis axis,
                                         double      majorTickInterval,
                                         double      minorTickInterval,

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
@@ -389,18 +389,29 @@ void RiuQwtPlotWidget::enableGridLines( RiuPlotAxis axis, bool majorGridLines, b
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RiuQwtPlotWidget::setMajorTicksList( RiuPlotAxis axis, const QList<double>& majorTicks, double minValue, double maxValue )
+{
+    auto        qwtAxis = toQwtPlotAxis( axis );
+    QwtScaleDiv scaleDiv( minValue, maxValue );
+    scaleDiv.setTicks( QwtScaleDiv::TickType::MajorTick, majorTicks );
+    m_plot->setAxisScaleDiv( qwtAxis, scaleDiv );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RiuQwtPlotWidget::setMajorAndMinorTickIntervals( RiuPlotAxis axis,
                                                       double      majorTickInterval,
                                                       double      minorTickInterval,
                                                       double      minValue,
                                                       double      maxValue )
 {
-    auto  qwtAxis     = toQwtPlotAxis( axis );
-    auto* scaleEngine = dynamic_cast<RiuQwtLinearScaleEngine*>( m_plot->axisScaleEngine( qwtAxis ) );
-    if ( scaleEngine )
+    auto  qwtAxis           = toQwtPlotAxis( axis );
+    auto* linearScaleEngine = dynamic_cast<RiuQwtLinearScaleEngine*>( m_plot->axisScaleEngine( qwtAxis ) );
+    if ( linearScaleEngine )
     {
         QwtScaleDiv scaleDiv =
-            scaleEngine->divideScaleWithExplicitIntervals( minValue, maxValue, majorTickInterval, minorTickInterval );
+            linearScaleEngine->divideScaleWithExplicitIntervals( minValue, maxValue, majorTickInterval, minorTickInterval );
 
         m_plot->setAxisScaleDiv( qwtAxis, scaleDiv );
     }

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.h
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.h
@@ -118,6 +118,8 @@ public:
 
     void enableGridLines( RiuPlotAxis axis, bool majorGridLines, bool minorGridLines ) override;
 
+    virtual void
+         setMajorTicksList( RiuPlotAxis axis, const QList<double>& majorTicks, double minValue, double maxValue ) override;
     void setMajorAndMinorTickIntervals( RiuPlotAxis axis,
                                         double      majorTickInterval,
                                         double      minorTickInterval,


### PR DESCRIPTION
- Add custom tickmark configuration in time axis properties
- Refactor code to separate handling of time axis properties and regular axis properties in RimSummaryPlot
- Add method for setting major ticks by use of list for RiuPlotWidget interface.

---

Closes: #9790