### PR TITLE
Cleanup macros used to initialize objects and fields

### DIFF
--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmScriptingBasicTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmScriptingBasicTest.cpp
@@ -74,8 +74,8 @@ public:
 #if 1
         m_proxyDouble.registerSetMethod( this, &SimpleObj::setDoubleMember );
         m_proxyDouble.registerGetMethod( this, &SimpleObj::doubleMember );
-        AddUiCapabilityToField( &m_proxyDouble );
-        AddXmlCapabilityToField( &m_proxyDouble );
+        addUiCapabilityToField( &m_proxyDouble );
+        addXmlCapabilityToField( &m_proxyDouble );
         CAF_PDM_InitFieldNoDefault( &m_proxyDouble, "ProxyDouble", "ProxyDouble" );
 #endif
     }

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmObject.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmObject.h
@@ -79,10 +79,10 @@ class PdmObjectCapability;
 
 #define CAF_PDM_InitObject( uiName, ... )                                                              \
     {                                                                                                  \
-        std::vector<QString> arguments = { __VA_ARGS__ };                                              \
-        QString              iconResourceName;                                                         \
-        QString              toolTip;                                                                  \
-        QString              whatsThis;                                                                \
+        const std::vector<QString> arguments = { __VA_ARGS__ };                                        \
+        QString                    iconResourceName;                                                   \
+        QString                    toolTip;                                                            \
+        QString                    whatsThis;                                                          \
         if ( arguments.size() > 0 ) iconResourceName = arguments[0];                                   \
         if ( arguments.size() > 1 ) toolTip = arguments[1];                                            \
         if ( arguments.size() > 2 ) whatsThis = arguments[2];                                          \
@@ -104,10 +104,10 @@ class PdmObjectCapability;
 
 #define CAF_PDM_InitField( field, keyword, default, uiName, ... )                                                                       \
     {                                                                                                                                   \
-        std::vector<QString> arguments = { __VA_ARGS__ };                                                                               \
-        QString              iconResourceName;                                                                                          \
-        QString              toolTip;                                                                                                   \
-        QString              whatsThis;                                                                                                 \
+        const std::vector<QString> arguments = { __VA_ARGS__ };                                                                         \
+        QString                    iconResourceName;                                                                                    \
+        QString                    toolTip;                                                                                             \
+        QString                    whatsThis;                                                                                           \
         if ( arguments.size() > 0 ) iconResourceName = arguments[0];                                                                    \
         if ( arguments.size() > 1 ) toolTip = arguments[1];                                                                             \
         if ( arguments.size() > 2 ) whatsThis = arguments[2];                                                                           \
@@ -115,13 +115,13 @@ class PdmObjectCapability;
                                                                                                                                         \
         static bool chekingThePresenceOfHeaderAndSourceInitMacros =                                                                     \
             Error_You_forgot_to_add_the_macro_CAF_PDM_XML_HEADER_INIT_and_or_CAF_PDM_XML_SOURCE_INIT_to_your_cpp_file_for_this_class(); \
-        Q_UNUSED( chekingThePresenceOfHeaderAndSourceInitMacros );                                                                      \
+        Q_UNUSED( chekingThePresenceOfHeaderAndSourceInitMacros )                                                                       \
         this->isInheritedFromPdmUiObject();                                                                                             \
         this->isInheritedFromPdmXmlSerializable();                                                                                      \
                                                                                                                                         \
-        AddXmlCapabilityToField( field );                                                                                               \
-        AddUiCapabilityToField( field );                                                                                                \
-        RegisterClassWithField( classKeyword(), field );                                                                                \
+        addXmlCapabilityToField( field );                                                                                               \
+        addUiCapabilityToField( field );                                                                                                \
+        registerClassWithField( classKeyword(), field );                                                                                \
                                                                                                                                         \
         static caf::PdmUiItemInfo objDescr( uiName, QString( iconResourceName ), toolTip, whatsThis, keyword );                         \
         addFieldUi( field, keyword, default, &objDescr );                                                                               \
@@ -133,24 +133,24 @@ class PdmObjectCapability;
 
 #define CAF_PDM_InitFieldNoDefault( field, keyword, uiName, ... )                                                                       \
     {                                                                                                                                   \
-        std::vector<QString> arguments = { __VA_ARGS__ };                                                                               \
-        QString              iconResourceName;                                                                                          \
-        QString              toolTip;                                                                                                   \
-        QString              whatsThis;                                                                                                 \
+        const std::vector<QString> arguments = { __VA_ARGS__ };                                                                         \
+        QString                    iconResourceName;                                                                                    \
+        QString                    toolTip;                                                                                             \
+        QString                    whatsThis;                                                                                           \
         if ( arguments.size() > 0 ) iconResourceName = arguments[0];                                                                    \
         if ( arguments.size() > 1 ) toolTip = arguments[1];                                                                             \
         if ( arguments.size() > 2 ) whatsThis = arguments[2];                                                                           \
         CAF_PDM_VERIFY_XML_KEYWORD( keyword )                                                                                           \
                                                                                                                                         \
-        static bool chekingThePresenceOfHeaderAndSourceInitMacros =                                                                     \
+        static bool checkingThePresenceOfHeaderAndSourceInitMacros =                                                                    \
             Error_You_forgot_to_add_the_macro_CAF_PDM_XML_HEADER_INIT_and_or_CAF_PDM_XML_SOURCE_INIT_to_your_cpp_file_for_this_class(); \
-        Q_UNUSED( chekingThePresenceOfHeaderAndSourceInitMacros );                                                                      \
+        Q_UNUSED( checkingThePresenceOfHeaderAndSourceInitMacros )                                                                      \
         this->isInheritedFromPdmUiObject();                                                                                             \
         this->isInheritedFromPdmXmlSerializable();                                                                                      \
                                                                                                                                         \
-        AddXmlCapabilityToField( field );                                                                                               \
-        AddUiCapabilityToField( field );                                                                                                \
-        RegisterClassWithField( classKeyword(), field );                                                                                \
+        addXmlCapabilityToField( field );                                                                                               \
+        addUiCapabilityToField( field );                                                                                                \
+        registerClassWithField( classKeyword(), field );                                                                                \
                                                                                                                                         \
         static caf::PdmUiItemInfo objDescr( uiName, QString( iconResourceName ), toolTip, whatsThis, keyword );                         \
         addFieldUiNoDefault( field, keyword, &objDescr );                                                                               \

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.h
@@ -78,7 +78,7 @@ public:
 };
 
 template <typename FieldType>
-void AddUiCapabilityToField( FieldType* field )
+void addUiCapabilityToField( FieldType* field )
 {
     if ( field->template capability<PdmFieldUiCap<FieldType>>() == NULL )
     {

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.h
@@ -188,7 +188,7 @@ private:
 };
 
 template <typename FieldType>
-void AddXmlCapabilityToField( FieldType* field )
+void addXmlCapabilityToField( FieldType* field )
 {
     if ( field->template capability<PdmFieldXmlCap<FieldType>>() == NULL )
     {
@@ -197,7 +197,7 @@ void AddXmlCapabilityToField( FieldType* field )
 }
 
 template <typename FieldType>
-void RegisterClassWithField( const QString& classKeyword, FieldType* field )
+void registerClassWithField( const QString& classKeyword, FieldType* field )
 {
     field->setOwnerClass( classKeyword );
 }

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandleMacros.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandleMacros.h
@@ -50,7 +50,7 @@ public:                                                                         
     bool ClassName::matchesClassKeyword( const QString& matchKeyword ) const                                                                   \
     {                                                                                                                                          \
         auto aliases = classKeywordAliases();                                                                                                  \
-        for ( auto alias : aliases )                                                                                                           \
+        for ( const auto& alias : aliases )                                                                                                    \
         {                                                                                                                                      \
             if ( alias == matchKeyword ) return true;                                                                                          \
         }                                                                                                                                      \
@@ -72,6 +72,6 @@ public:                                                                         
             Error_You_forgot_to_add_the_macro_CAF_PDM_XML_HEADER_INIT_and_or_CAF_PDM_XML_SOURCE_INIT_to_your_cpp_file_for_this_class(); \
         this->isInheritedFromPdmXmlSerializable();                                                                                      \
                                                                                                                                         \
-        AddXmlCapabilityToField( ( field ) );                                                                                           \
+        addXmlCapabilityToField( ( field ) );                                                                                           \
         addField( ( field ), ( keyword ) );                                                                                             \
     }

--- a/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/cafPdmBasicTest.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/cafPdmBasicTest.cpp
@@ -72,8 +72,8 @@ public:
 #if 1
         m_proxyDouble.registerSetMethod( this, &SimpleObj::setDoubleMember );
         m_proxyDouble.registerGetMethod( this, &SimpleObj::doubleMember );
-        AddUiCapabilityToField( &m_proxyDouble );
-        AddXmlCapabilityToField( &m_proxyDouble );
+        addUiCapabilityToField( &m_proxyDouble );
+        addXmlCapabilityToField( &m_proxyDouble );
         CAF_PDM_InitFieldNoDefault( &m_proxyDouble, "ProxyDouble", "ProxyDouble" );
 #endif
     }


### PR DESCRIPTION
Use lowercase for function names
Use const
Remove double '; '