### PR TITLE
Do not replace '.' with the current project path

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -482,11 +482,6 @@ void RimProject::setProjectFileNameAndUpdateDependencies( const QString& project
         std::vector<QString> searchedPaths;
 
         QString filePathCandidate = filePath->path();
-        if ( filePathCandidate.startsWith( '.' ) )
-        {
-            filePathCandidate = filePathCandidate.right( filePathCandidate.size() - 1 );
-            filePathCandidate = newProjectPath + filePathCandidate;
-        }
 
         QString newFilePath = RimTools::relocateFile( filePathCandidate, newProjectPath, oldProjectPath, &foundFile, &searchedPaths );
         filePath->setPath( newFilePath );


### PR DESCRIPTION
When starting resinsight from a working folder, the project file paths can be relative to this folder (current working folder). If files are referenced relative to current working folder, the file references can start with either '..' or '.'  Make sure that these paths are left unchanged.

Closes #10002 