### PR TITLE
Add support for field of std::pair<bool, double> 

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafInternalPdmValueFieldSpecializations.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafInternalPdmValueFieldSpecializations.h
@@ -135,6 +135,47 @@ public:
 };
 
 //==================================================================================================
+/// Partial specialization for std::pair
+//==================================================================================================
+template <typename T, typename U>
+class PdmValueFieldSpecialization<std::pair<T, U>>
+{
+public:
+    static QVariant convert( const std::pair<T, U>& value )
+    {
+        QList<QVariant> returnList;
+
+        returnList.push_back( PdmValueFieldSpecialization<T>::convert( value.first ) );
+        returnList.push_back( PdmValueFieldSpecialization<U>::convert( value.second ) );
+
+        return returnList;
+    }
+
+    static void setFromVariant( const QVariant& variantValue, std::pair<T, U>& value )
+    {
+        if ( variantValue.canConvert<QList<QVariant>>() )
+        {
+            QList<QVariant> lst = variantValue.toList();
+            if ( lst.size() == 2 )
+            {
+                T first;
+                PdmValueFieldSpecialization<T>::setFromVariant( lst[0], first );
+
+                U second;
+                PdmValueFieldSpecialization<U>::setFromVariant( lst[1], second );
+
+                value = std::make_pair( first, second );
+            }
+        }
+    }
+
+    static bool isEqual( const QVariant& variantValue, const QVariant& variantValue2 )
+    {
+        return variantValue == variantValue2;
+    }
+};
+
+//==================================================================================================
 /// Partial specialization for caf::FilePath
 //==================================================================================================
 template <>

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmFieldTypeSpecializations.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmFieldTypeSpecializations.h
@@ -179,6 +179,41 @@ public:
     }
 };
 
+template <typename T, typename U>
+class PdmUiFieldSpecialization<std::pair<T, U>>
+{
+public:
+    /// Convert the field value into a QVariant
+    static QVariant convert( const std::pair<T, U>& value )
+    {
+        return PdmValueFieldSpecialization<std::pair<T, U>>::convert( value );
+    }
+
+    /// Set the field value from a QVariant
+    static void setFromVariant( const QVariant& variantValue, std::pair<T, U>& value )
+    {
+        PdmValueFieldSpecialization<std::pair<T, U>>::setFromVariant( variantValue, value );
+    }
+
+    static bool isDataElementEqual( const QVariant& variantValue, const QVariant& variantValue2 )
+    {
+        return variantValue == variantValue2;
+    }
+
+    /// Methods to get a list of options for a field, specialized for AppEnum
+    static QList<PdmOptionItemInfo> valueOptions( const std::pair<T, U>& )
+    {
+        QList<PdmOptionItemInfo> optionList;
+
+        return optionList;
+    }
+
+    /// Methods to retrieve the possible PdmObject pointed to by a field
+    static void childObjects( const PdmDataValueField<caf::AppEnum<T>>& field, std::vector<PdmObjectHandle*>* objects )
+    {
+    }
+};
+
 //==================================================================================================
 /// Partial specialization for FilePath
 //==================================================================================================

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldSpecialization.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldSpecialization.h
@@ -27,11 +27,17 @@ template <typename T>
 class PdmUiFieldSpecialization
 {
 public:
-    /// Convert the field value into a QVariant
-    static QVariant convert( const T& value ) { return QVariant::fromValue( value ); }
+    static QVariant convert( const T& value )
+    {
+        /// Convert the field value into a QVariant
+        return QVariant::fromValue( value );
+    }
 
-    /// Set the field value from a QVariant
-    static void setFromVariant( const QVariant& variantValue, T& value ) { value = variantValue.value<T>(); }
+    static void setFromVariant( const QVariant& variantValue, T& value )
+    {
+        /// Set the field value from a QVariant
+        value = variantValue.value<T>();
+    }
 
     /// Check equality between QVariants that carries a Field Value.
     /// The == operator will normally work, but does not support custom types in the QVariant

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
@@ -64,11 +64,11 @@ QTextStream& operator>>( QTextStream& str, std::vector<T>& sobj )
 }
 
 //==================================================================================================
-/// QTextStream Stream operator overloading for std::pair<bool, T>
+/// QTextStream Stream operator overloading for std::pair<T, U>
 //==================================================================================================
 
 template <typename T, typename U>
-QTextStream& operator<<( QTextStream& str, const std::pair<U, T>& sobj )
+QTextStream& operator<<( QTextStream& str, const std::pair<T, U>& sobj )
 {
     str << sobj.first;
     str << " ";
@@ -78,10 +78,10 @@ QTextStream& operator<<( QTextStream& str, const std::pair<U, T>& sobj )
 }
 
 template <typename T, typename U>
-QTextStream& operator>>( QTextStream& str, std::pair<U, T>& sobj )
+QTextStream& operator>>( QTextStream& str, std::pair<T, U>& sobj )
 {
-    U first;
-    T second;
+    T first;
+    U second;
 
     str >> first;
     str >> second;

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
@@ -81,10 +81,27 @@ template <typename T, typename U>
 QTextStream& operator>>( QTextStream& str, std::pair<T, U>& sobj )
 {
     T first;
-    U second;
 
     str >> first;
-    str >> second;
+
+    QString restOfString;
+    while ( str.status() == QTextStream::Ok )
+    {
+        // Using the >> operator will parse a string word by word. Multiple spaces between words will be replaced by a
+        // single space.
+
+        QString tmp;
+        str >> tmp;
+
+        if ( !tmp.isEmpty() )
+        {
+            if ( !restOfString.isEmpty() ) restOfString += " ";
+            restOfString += tmp;
+        }
+    }
+
+    QVariant v      = restOfString;
+    U        second = v.value<U>();
 
     sobj = std::make_pair( first, second );
 

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
@@ -62,3 +62,31 @@ QTextStream& operator>>( QTextStream& str, std::vector<T>& sobj )
     }
     return str;
 }
+
+//==================================================================================================
+/// QTextStream Stream operator overloading for std::pair<bool, T>
+//==================================================================================================
+
+template <typename T, typename U>
+QTextStream& operator<<( QTextStream& str, const std::pair<U, T>& sobj )
+{
+    str << sobj.first;
+    str << " ";
+    str << sobj.second;
+
+    return str;
+}
+
+template <typename T, typename U>
+QTextStream& operator>>( QTextStream& str, std::pair<U, T>& sobj )
+{
+    U first( U() );
+    T second( T() );
+
+    str >> first;
+    str >> second;
+
+    sobj = std::make_pair( first, second );
+
+    return str;
+}

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmStreamOperators.h
@@ -80,8 +80,8 @@ QTextStream& operator<<( QTextStream& str, const std::pair<U, T>& sobj )
 template <typename T, typename U>
 QTextStream& operator>>( QTextStream& str, std::pair<U, T>& sobj )
 {
-    U first( U() );
-    T second( T() );
+    U first;
+    T second;
 
     str >> first;
     str >> second;

--- a/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/AggregatedTypesInField.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/AggregatedTypesInField.cpp
@@ -1,0 +1,102 @@
+//##################################################################################################
+//
+//   Custom Visualization Core library
+//   Copyright (C) 2011-2013 Ceetron AS
+//
+//   This library may be used under the terms of either the GNU General Public License or
+//   the GNU Lesser General Public License as follows:
+//
+//   GNU General Public License Usage
+//   This library is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU General Public License at <<http://www.gnu.org/licenses/gpl.html>>
+//   for more details.
+//
+//   GNU Lesser General Public License Usage
+//   This library is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU Lesser General Public License as published by
+//   the Free Software Foundation; either version 2.1 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
+//   for more details.
+//
+//##################################################################################################
+
+#include "gtest/gtest.h"
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+
+#include <utility>
+
+class AggregatedTypes : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    AggregatedTypes()
+    {
+        CAF_PDM_InitObject( "SimpleObj" );
+
+        auto pair = std::make_pair( false, 12.0 );
+        CAF_PDM_InitField( &m_checkableDouble, "CheckableDouble", pair, "label text" );
+    }
+
+    ~AggregatedTypes() {}
+
+    caf::PdmField<std::pair<bool, double>> m_checkableDouble;
+};
+CAF_PDM_SOURCE_INIT( AggregatedTypes, "AggregatedTypes" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( AggregatedTypes, AggregatedTypes )
+{
+    AggregatedTypes obj;
+    EXPECT_EQ( obj.m_checkableDouble().first, false );
+    EXPECT_EQ( obj.m_checkableDouble().second, 12.0 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( AggregatedTypeTest, MyTest )
+{
+    QString          xml;
+    QXmlStreamWriter xmlStream( &xml );
+    xmlStream.setAutoFormatting( true );
+
+    const double testValue = 0.0012;
+
+    {
+        AggregatedTypes myObj;
+
+        auto testPair           = std::make_pair( true, testValue );
+        myObj.m_checkableDouble = testPair;
+        xml                     = myObj.writeObjectToXmlString();
+    }
+
+    {
+        AggregatedTypes myObj;
+
+        myObj.readObjectFromXmlString( xml, caf::PdmDefaultObjectFactory::instance() );
+
+        auto fieldValue = myObj.m_checkableDouble();
+
+        ASSERT_TRUE( fieldValue.first );
+        ASSERT_DOUBLE_EQ( testValue, fieldValue.second );
+    }
+}

--- a/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/AggregatedTypesInField.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/AggregatedTypesInField.cpp
@@ -1,7 +1,7 @@
 //##################################################################################################
 //
 //   Custom Visualization Core library
-//   Copyright (C) 2011-2013 Ceetron AS
+//   Copyright (C) 2013 Ceetron Solutions AS
 //
 //   This library may be used under the terms of either the GNU General Public License or
 //   the GNU Lesser General Public License as follows:

--- a/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(
   COMPONENTS
   REQUIRED Core Xml Gui
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Xml Qt5::Gui)
+set(QT_LIBRARIES Qt5::Core Qt5::Xml Qt5::Gui Qt5::Widgets)
 
 if(MSVC AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.11))
   # VS 2017 : Disable warnings from from gtest code, using deprecated code
@@ -20,7 +20,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 )
 
 set(PROJECT_FILES cafPdmBasicTest.cpp cafProjectDataModel_UnitTests.cpp
-                  Child.cpp Parent.cpp TestObj.cpp
+                  Child.cpp Parent.cpp TestObj.cpp AggregatedTypesInField.cpp
 )
 
 # add the executable

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -130,7 +130,9 @@ public:
                           "Text tooltip",
                           "This is a place you can enter a small integer value if you want");
 
-        CAF_PDM_InitFieldNoDefault(&m_booleanAndDoubleField, "BooleanAndDoubleField", "Boolean and text");
+        CAF_PDM_InitFieldNoDefault(&m_booleanAndDoubleField, "BooleanAndDoubleField", "Checkable double");
+        CAF_PDM_InitFieldNoDefault(&m_booleanAndTextField, "BooleanAndTextField", "Checkable text");
+        m_booleanAndTextField.uiCapability()->setUiEditorTypeName(caf::PdmUiCheckBoxAndTextEditor::uiEditorTypeName());
 
         m_proxyDoubleField.registerSetMethod(this, &SmallDemoPdmObject::setDoubleMember);
         m_proxyDoubleField.registerGetMethod(this, &SmallDemoPdmObject::doubleMember);
@@ -167,7 +169,8 @@ public:
     caf::PdmField<int>     m_intField;
     caf::PdmField<QString> m_textField;
 
-    caf::PdmField<std::pair<bool, double>> m_booleanAndDoubleField;
+    caf::PdmField<std::pair<bool, double>>  m_booleanAndDoubleField;
+    caf::PdmField<std::pair<bool, QString>> m_booleanAndTextField;
 
     caf::PdmChildArrayField<ColorTriplet*> m_colorTriplets;
 
@@ -285,6 +288,8 @@ protected:
     void defineUiOrdering(QString uiConfigName, caf::PdmUiOrdering& uiOrdering) override
     {
         uiOrdering.add(&m_booleanAndDoubleField);
+        uiOrdering.add(&m_booleanAndTextField);
+
         uiOrdering.add(&m_doubleField);
         uiOrdering.add(&m_intField);
         QString dynamicGroupName = QString("Dynamic Group Text (%1)").arg(m_intField);

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -131,7 +131,6 @@ public:
                           "This is a place you can enter a small integer value if you want");
 
         CAF_PDM_InitFieldNoDefault(&m_booleanAndDoubleField, "BooleanAndDoubleField", "Boolean and text");
-        m_booleanAndDoubleField.uiCapability()->setUiEditorTypeName(caf::PdmUiCheckBoxAndTextEditor::uiEditorTypeName());
 
         m_proxyDoubleField.registerSetMethod(this, &SmallDemoPdmObject::setDoubleMember);
         m_proxyDoubleField.registerGetMethod(this, &SmallDemoPdmObject::doubleMember);

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -26,6 +26,7 @@
 #include "cafPdmProxyValueField.h"
 #include "cafPdmPtrField.h"
 #include "cafPdmReferenceHelper.h"
+#include "cafPdmUiCheckBoxAndTextEditor.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiColorEditor.h"
 #include "cafPdmUiComboBoxEditor.h"
@@ -129,6 +130,9 @@ public:
                           "Text tooltip",
                           "This is a place you can enter a small integer value if you want");
 
+        CAF_PDM_InitFieldNoDefault(&m_booleanAndDoubleField, "BooleanAndDoubleField", "Boolean and text");
+        m_booleanAndDoubleField.uiCapability()->setUiEditorTypeName(caf::PdmUiCheckBoxAndTextEditor::uiEditorTypeName());
+
         m_proxyDoubleField.registerSetMethod(this, &SmallDemoPdmObject::setDoubleMember);
         m_proxyDoubleField.registerGetMethod(this, &SmallDemoPdmObject::doubleMember);
         CAF_PDM_InitFieldNoDefault(&m_proxyDoubleField, "ProxyDouble", "Proxy Double");
@@ -163,6 +167,8 @@ public:
     caf::PdmField<double>  m_doubleField;
     caf::PdmField<int>     m_intField;
     caf::PdmField<QString> m_textField;
+
+    caf::PdmField<std::pair<bool, double>> m_booleanAndDoubleField;
 
     caf::PdmChildArrayField<ColorTriplet*> m_colorTriplets;
 
@@ -279,6 +285,7 @@ protected:
     //--------------------------------------------------------------------------------------------------
     void defineUiOrdering(QString uiConfigName, caf::PdmUiOrdering& uiOrdering) override
     {
+        uiOrdering.add(&m_booleanAndDoubleField);
         uiOrdering.add(&m_doubleField);
         uiOrdering.add(&m_intField);
         QString dynamicGroupName = QString("Dynamic Group Text (%1)").arg(m_intField);

--- a/Fwk/AppFwk/cafUserInterface/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/CMakeLists.txt
@@ -51,6 +51,7 @@ set(MOC_HEADER_FILES
     cafPdmDoubleStringValidator.h
     cafPdmUiPickableLineEditor.h
     cafPdmUiLabelEditor.h
+    cafPdmUiCheckBoxAndTextEditor.h
 )
 
 find_package(
@@ -105,6 +106,8 @@ set(PROJECT_FILES
     cafPdmUiFieldEditorHelper.h
     cafPdmUiFieldEditorHelper.cpp
     cafPdmUiLabelEditor.cpp
+    cafPdmUiCheckBoxAndTextEditor.h
+    cafPdmUiCheckBoxAndTextEditor.cpp
     # object editors
     cafPdmUiDefaultObjectEditor.cpp
     cafPdmUiDefaultObjectEditor.h

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
@@ -40,13 +40,13 @@
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
+#include "cafPdmUiLineEditor.h"
 #include "cafPdmUiOrdering.h"
 #include "cafQShortenedLabel.h"
 
-#include <QIntValidator>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QTextEdit>
-#include <QVBoxLayout>
 
 namespace caf
 {
@@ -57,26 +57,26 @@ CAF_PDM_UI_FIELD_EDITOR_SOURCE_INIT( PdmUiCheckBoxAndTextEditor );
 //--------------------------------------------------------------------------------------------------
 void PdmUiCheckBoxAndTextEditor::configureAndUpdateUi( const QString& uiConfigName )
 {
-    CAF_ASSERT( !m_textEdit.isNull() );
+    CAF_ASSERT( !m_lineEdit.isNull() );
     CAF_ASSERT( !m_label.isNull() );
 
     PdmUiFieldEditorHandle::updateLabelFromField( m_label, uiConfigName );
 
-    m_textEdit->setReadOnly( uiField()->isUiReadOnly( uiConfigName ) );
-    // m_textEdit->setEnabled(!field()->isUiReadOnly(uiConfigName)); // Neccesary ?
-    m_textEdit->setToolTip( uiField()->uiToolTip( uiConfigName ) );
+    m_lineEdit->setReadOnly( uiField()->isUiReadOnly( uiConfigName ) );
+    m_lineEdit->setToolTip( uiField()->uiToolTip( uiConfigName ) );
 
-    connect( m_textEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
+    connect( m_lineEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
 
     std::pair<bool, double> pairValue;
     pairValue = uiField()->uiValue().value<std::pair<bool, double>>();
 
-    m_textEdit->blockSignals( true );
-    m_textEdit->setText( QString( "%1" ).arg( pairValue.second ) );
-    m_textEdit->blockSignals( false );
-
+    m_lineEdit->blockSignals( true );
     m_checkBox->blockSignals( true );
+
+    m_lineEdit->setText( QString( "%1" ).arg( pairValue.second ) );
     m_checkBox->setChecked( pairValue.first );
+
+    m_lineEdit->blockSignals( false );
     m_checkBox->blockSignals( false );
 }
 
@@ -85,18 +85,18 @@ void PdmUiCheckBoxAndTextEditor::configureAndUpdateUi( const QString& uiConfigNa
 //--------------------------------------------------------------------------------------------------
 QWidget* PdmUiCheckBoxAndTextEditor::createEditorWidget( QWidget* parent )
 {
-    QWidget* containerWidget = new QWidget( parent );
+    auto* containerWidget = new QWidget( parent );
 
-    m_textEdit = new QLineEdit( containerWidget );
-    connect( m_textEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
+    m_lineEdit = new PdmUiLineEdit( containerWidget );
+    connect( m_lineEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
 
     m_checkBox = new QCheckBox( "", containerWidget );
     connect( m_checkBox, SIGNAL( clicked() ), this, SLOT( slotSetValueToField() ) );
 
-    QHBoxLayout* layout = new QHBoxLayout;
+    auto* layout = new QHBoxLayout;
 
     layout->addWidget( m_checkBox );
-    layout->addWidget( m_textEdit );
+    layout->addWidget( m_lineEdit );
     layout->setMargin( 0 );
 
     containerWidget->setLayout( layout );
@@ -120,7 +120,7 @@ void PdmUiCheckBoxAndTextEditor::slotSetValueToField()
 {
     bool isChecked = m_checkBox->checkState() == Qt::CheckState::Checked;
 
-    double   value     = m_textEdit->text().toDouble();
+    double   value     = m_lineEdit->text().toDouble();
     auto     pairValue = std::make_pair( isChecked, value );
     QVariant v         = QVariant::fromValue( pairValue );
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
@@ -1,0 +1,129 @@
+//##################################################################################################
+//
+//   Custom Visualization Core library
+//   Copyright (C) 2011-2013 Ceetron AS
+//
+//   This library may be used under the terms of either the GNU General Public License or
+//   the GNU Lesser General Public License as follows:
+//
+//   GNU General Public License Usage
+//   This library is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU General Public License at <<http://www.gnu.org/licenses/gpl.html>>
+//   for more details.
+//
+//   GNU Lesser General Public License Usage
+//   This library is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU Lesser General Public License as published by
+//   the Free Software Foundation; either version 2.1 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
+//   for more details.
+//
+//##################################################################################################
+
+#include "cafPdmUiCheckBoxAndTextEditor.h"
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+#include "cafPdmUiDefaultObjectEditor.h"
+#include "cafPdmUiFieldEditorHandle.h"
+#include "cafPdmUiOrdering.h"
+#include "cafQShortenedLabel.h"
+
+#include <QIntValidator>
+#include <QLabel>
+#include <QTextEdit>
+#include <QVBoxLayout>
+
+namespace caf
+{
+CAF_PDM_UI_FIELD_EDITOR_SOURCE_INIT( PdmUiCheckBoxAndTextEditor );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiCheckBoxAndTextEditor::configureAndUpdateUi( const QString& uiConfigName )
+{
+    CAF_ASSERT( !m_textEdit.isNull() );
+    CAF_ASSERT( !m_label.isNull() );
+
+    PdmUiFieldEditorHandle::updateLabelFromField( m_label, uiConfigName );
+
+    m_textEdit->setReadOnly( uiField()->isUiReadOnly( uiConfigName ) );
+    // m_textEdit->setEnabled(!field()->isUiReadOnly(uiConfigName)); // Neccesary ?
+    m_textEdit->setToolTip( uiField()->uiToolTip( uiConfigName ) );
+
+    connect( m_textEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
+
+    std::pair<bool, QString> pairValue;
+    pairValue = uiField()->uiValue().value<std::pair<bool, QString>>();
+
+    m_textEdit->blockSignals( true );
+    m_textEdit->setText( pairValue.second );
+    m_textEdit->blockSignals( false );
+
+    m_checkBox->blockSignals( true );
+    m_checkBox->setChecked( pairValue.first );
+    m_checkBox->blockSignals( false );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QWidget* PdmUiCheckBoxAndTextEditor::createEditorWidget( QWidget* parent )
+{
+    QWidget* containerWidget = new QWidget( parent );
+
+    m_textEdit = new QLineEdit( containerWidget );
+    connect( m_textEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
+
+    m_checkBox = new QCheckBox( "", containerWidget );
+    connect( m_checkBox, SIGNAL( clicked() ), this, SLOT( slotSetValueToField() ) );
+
+    QHBoxLayout* layout = new QHBoxLayout;
+
+    layout->addWidget( m_checkBox );
+    layout->addWidget( m_textEdit );
+    layout->setMargin( 0 );
+
+    containerWidget->setLayout( layout );
+
+    return containerWidget;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QWidget* PdmUiCheckBoxAndTextEditor::createLabelWidget( QWidget* parent )
+{
+    m_label = new QShortenedLabel( parent );
+    return m_label;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiCheckBoxAndTextEditor::slotSetValueToField()
+{
+    bool isChecked = m_checkBox->checkState() == Qt::CheckState::Checked;
+
+    auto     pairValue = std::make_pair( isChecked, m_textEdit->text() );
+    QVariant v         = QVariant::fromValue( pairValue );
+
+    this->setValueToField( v );
+}
+
+} // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
@@ -1,7 +1,7 @@
 //##################################################################################################
 //
 //   Custom Visualization Core library
-//   Copyright (C) 2011-2013 Ceetron AS
+//   Copyright (C) 2023 Ceetron Solutions AS
 //
 //   This library may be used under the terms of either the GNU General Public License or
 //   the GNU Lesser General Public License as follows:

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
@@ -62,10 +62,7 @@ void PdmUiCheckBoxAndTextEditor::configureAndUpdateUi( const QString& uiConfigNa
 
     PdmUiFieldEditorHandle::updateLabelFromField( m_label, uiConfigName );
 
-    m_lineEdit->setReadOnly( uiField()->isUiReadOnly( uiConfigName ) );
     m_lineEdit->setToolTip( uiField()->uiToolTip( uiConfigName ) );
-
-    connect( m_lineEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
 
     std::pair<bool, double> pairValue;
     pairValue = uiField()->uiValue().value<std::pair<bool, double>>();
@@ -78,6 +75,10 @@ void PdmUiCheckBoxAndTextEditor::configureAndUpdateUi( const QString& uiConfigNa
 
     m_lineEdit->blockSignals( false );
     m_checkBox->blockSignals( false );
+
+    bool isReadOnly = uiField()->isUiReadOnly( uiConfigName );
+    if ( !pairValue.first ) isReadOnly = true;
+    m_lineEdit->setDisabled( isReadOnly );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -87,7 +88,10 @@ QWidget* PdmUiCheckBoxAndTextEditor::createEditorWidget( QWidget* parent )
 {
     auto* containerWidget = new QWidget( parent );
 
-    m_lineEdit = new PdmUiLineEdit( containerWidget );
+    auto lineEditWidget = new PdmUiLineEdit( containerWidget );
+    lineEditWidget->setAvoidSendingEnterEventToParentWidget( true );
+
+    m_lineEdit = lineEditWidget;
     connect( m_lineEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
 
     m_checkBox = new QCheckBox( "", containerWidget );
@@ -119,6 +123,9 @@ QWidget* PdmUiCheckBoxAndTextEditor::createLabelWidget( QWidget* parent )
 void PdmUiCheckBoxAndTextEditor::slotSetValueToField()
 {
     bool isChecked = m_checkBox->checkState() == Qt::CheckState::Checked;
+
+    auto myObj = sender();
+    auto txt   = myObj->objectName();
 
     double   value     = m_lineEdit->text().toDouble();
     auto     pairValue = std::make_pair( isChecked, value );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.cpp
@@ -68,11 +68,11 @@ void PdmUiCheckBoxAndTextEditor::configureAndUpdateUi( const QString& uiConfigNa
 
     connect( m_textEdit, SIGNAL( editingFinished() ), this, SLOT( slotSetValueToField() ) );
 
-    std::pair<bool, QString> pairValue;
-    pairValue = uiField()->uiValue().value<std::pair<bool, QString>>();
+    std::pair<bool, double> pairValue;
+    pairValue = uiField()->uiValue().value<std::pair<bool, double>>();
 
     m_textEdit->blockSignals( true );
-    m_textEdit->setText( pairValue.second );
+    m_textEdit->setText( QString( "%1" ).arg( pairValue.second ) );
     m_textEdit->blockSignals( false );
 
     m_checkBox->blockSignals( true );
@@ -120,7 +120,8 @@ void PdmUiCheckBoxAndTextEditor::slotSetValueToField()
 {
     bool isChecked = m_checkBox->checkState() == Qt::CheckState::Checked;
 
-    auto     pairValue = std::make_pair( isChecked, m_textEdit->text() );
+    double   value     = m_textEdit->text().toDouble();
+    auto     pairValue = std::make_pair( isChecked, value );
     QVariant v         = QVariant::fromValue( pairValue );
 
     this->setValueToField( v );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.h
@@ -1,0 +1,76 @@
+//##################################################################################################
+//
+//   Custom Visualization Core library
+//   Copyright (C) 2011-2013 Ceetron AS
+//
+//   This library may be used under the terms of either the GNU General Public License or
+//   the GNU Lesser General Public License as follows:
+//
+//   GNU General Public License Usage
+//   This library is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU General Public License at <<http://www.gnu.org/licenses/gpl.html>>
+//   for more details.
+//
+//   GNU Lesser General Public License Usage
+//   This library is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU Lesser General Public License as published by
+//   the Free Software Foundation; either version 2.1 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
+//   for more details.
+//
+//##################################################################################################
+
+#pragma once
+#include "cafPdmUiFieldEditorHandle.h"
+#include <QCheckBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPointer>
+#include <QString>
+#include <QWidget>
+
+class QGridLayout;
+
+namespace caf
+{
+//==================================================================================================
+///
+//==================================================================================================
+class PdmUiCheckBoxAndTextEditor : public PdmUiFieldEditorHandle
+{
+    Q_OBJECT
+    CAF_PDM_UI_FIELD_EDITOR_HEADER_INIT;
+
+public:
+    PdmUiCheckBoxAndTextEditor() {}
+    ~PdmUiCheckBoxAndTextEditor() override {}
+
+protected:
+    QWidget* createEditorWidget( QWidget* parent ) override;
+    QWidget* createLabelWidget( QWidget* parent ) override;
+    void     configureAndUpdateUi( const QString& uiConfigName ) override;
+
+protected slots:
+    void slotSetValueToField();
+
+private:
+    QPointer<QLineEdit>       m_textEdit;
+    QPointer<QCheckBox>       m_checkBox;
+    QPointer<QShortenedLabel> m_label;
+};
+
+} // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.h
@@ -1,7 +1,7 @@
 //##################################################################################################
 //
 //   Custom Visualization Core library
-//   Copyright (C) 2011-2013 Ceetron AS
+//   Copyright (C) 2023 Ceetron Solutions AS
 //
 //   This library may be used under the terms of either the GNU General Public License or
 //   the GNU Lesser General Public License as follows:

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxAndTextEditor.h
@@ -35,15 +35,15 @@
 //##################################################################################################
 
 #pragma once
+
 #include "cafPdmUiFieldEditorHandle.h"
+
 #include <QCheckBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPointer>
 #include <QString>
 #include <QWidget>
-
-class QGridLayout;
 
 namespace caf
 {
@@ -68,7 +68,7 @@ protected slots:
     void slotSetValueToField();
 
 private:
-    QPointer<QLineEdit>       m_textEdit;
+    QPointer<QLineEdit>       m_lineEdit;
     QPointer<QCheckBox>       m_checkBox;
     QPointer<QShortenedLabel> m_label;
 };

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDefaultObjectEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDefaultObjectEditor.cpp
@@ -39,6 +39,7 @@
 #include "cafFilePath.h"
 #include "cafPdmField.h"
 #include "cafPdmProxyValueField.h"
+#include "cafPdmUiCheckBoxAndTextEditor.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiDateEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -48,6 +49,8 @@
 #include "cafPdmUiTimeEditor.h"
 
 #include <QGridLayout>
+
+#include <utility>
 
 namespace caf
 {
@@ -68,6 +71,15 @@ CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiListEditor, std::vector<unsigned 
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiListEditor, std::vector<float> );
 
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiFilePathEditor, FilePath );
+
+// As the macro CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR() is not working correctly for std::pair<bool, double> the
+// registration of this type in the factory has to be written directly
+static bool myPdmUiCheckBoxAndTextEditor73 =
+    caf::Factory<caf::PdmUiFieldEditorHandle, QString>::instance()->registerCreator<PdmUiCheckBoxAndTextEditor>(
+        QString( typeid( caf::PdmField<std::pair<bool, double>> ).name() ) );
+static bool my2PdmUiCheckBoxAndTextEditor73 =
+    caf::Factory<caf::PdmUiFieldEditorHandle, QString>::instance()->registerCreator<PdmUiCheckBoxAndTextEditor>(
+        QString( typeid( caf::PdmProxyValueField<std::pair<bool, double>> ).name() ) );
 
 //--------------------------------------------------------------------------------------------------
 ///


### PR DESCRIPTION
Add support for field of `std::pair<T, U>`. Add UI editor with a check box and a line edit based on conversion to `std::pair<bool, QString>`. 

Add tests for `caf::PdmField<std::pair<bool, double>>` and `caf::PdmField<std::pair<bool, QString>>`

Closes #10030