### PR TITLE
Remove test code related to producer/injector table plots

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -393,7 +393,6 @@ void RimRegularLegendConfig::updateLegend()
 {
     m_significantDigitsInData = m_precision;
 
-    updateTickCountAndUserDefinedRange();
     if ( m_resetUserDefinedValues && m_globalAutoMax != cvf::UNDEFINED_DOUBLE )
     {
         updateTickCountAndUserDefinedRange();


### PR DESCRIPTION
This code caused legend config to be reset to 1 number of levels.