### PR TITLE
Roff: support import of N grid files and 1 grid file with N property files

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
@@ -74,11 +74,7 @@ bool RiaImportEclipseCaseTools::openEclipseCasesFromFile( const QStringList&    
                                                           std::shared_ptr<RifReaderSettings> readerSettings )
 {
     RimProject* project = RimProject::current();
-    if ( !project )
-    {
-        RiaLogging::error( "Failed to find project" );
-        return false;
-    }
+    if ( !project ) return false;
 
     // Get list of files to import
     RifSummaryCaseRestartSelector selector;
@@ -262,11 +258,7 @@ int RiaImportEclipseCaseTools::openEclipseInputCaseFromFileNames( const QStringL
     auto* rimInputReservoir = new RimEclipseInputCase();
 
     RimProject* project = RimProject::current();
-    if ( !project )
-    {
-        RiaLogging::error( "Failed to find project" );
-        return -1;
-    }
+    if ( !project ) return -1;
 
     project->assignCaseIdToCase( rimInputReservoir );
 
@@ -333,11 +325,7 @@ int RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl( const QStr
     rimResultReservoir->setReaderSettings( readerSettings );
 
     RimProject* project = RimProject::current();
-    if ( !project )
-    {
-        RiaLogging::error( "Failed to find project" );
-        return -1;
-    }
+    if ( !project ) return -1;
 
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
     if ( analysisModels == nullptr )
@@ -407,11 +395,7 @@ bool RiaImportEclipseCaseTools::addEclipseCases( const QStringList& fileNames, R
     RimIdenticalGridCaseGroup*    gridCaseGroup = nullptr;
 
     RimProject* project = RimProject::current();
-    if ( !project )
-    {
-        RiaLogging::error( "Failed to find project" );
-        return false;
-    }
+    if ( !project ) return false;
 
     {
         QString   firstFileName = fileNames[0];
@@ -507,11 +491,7 @@ std::vector<int> RiaImportEclipseCaseTools::openRoffCasesFromFileNames( const QS
     CAF_ASSERT( !fileNames.empty() );
 
     RimProject* project = RimProject::current();
-    if ( !project )
-    {
-        RiaLogging::error( "Failed to find project" );
-        return {};
-    }
+    if ( !project ) return {};
 
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
     if ( !analysisModels ) return {};
@@ -560,11 +540,7 @@ std::vector<int> RiaImportEclipseCaseTools::openRoffCasesFromFileNames( const QS
 RimRoffCase* RiaImportEclipseCaseTools::openRoffCaseFromFileName( const QString& fileName, bool createDefaultView )
 {
     RimProject* project = RimProject::current();
-    if ( !project )
-    {
-        RiaLogging::error( "Failed to find project" );
-        return nullptr;
-    }
+    if ( !project ) return nullptr;
 
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
     if ( !analysisModels ) return nullptr;

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
@@ -24,7 +24,6 @@
 #include "SummaryPlotCommands/RicNewSummaryCurveFeature.h"
 #include "SummaryPlotCommands/RicSummaryPlotFeatureImpl.h"
 
-#include "RiaApplication.h"
 #include "RiaGuiApplication.h"
 #include "RiaLogging.h"
 
@@ -74,8 +73,12 @@ bool RiaImportEclipseCaseTools::openEclipseCasesFromFile( const QStringList&    
                                                           bool                               noDialog,
                                                           std::shared_ptr<RifReaderSettings> readerSettings )
 {
-    RiaApplication* app     = RiaApplication::instance();
-    RimProject*     project = app->project();
+    RimProject* project = RimProject::current();
+    if ( !project )
+    {
+        RiaLogging::error( "Failed to find project" );
+        return false;
+    }
 
     // Get list of files to import
     RifSummaryCaseRestartSelector selector;
@@ -258,8 +261,12 @@ int RiaImportEclipseCaseTools::openEclipseInputCaseFromFileNames( const QStringL
 {
     auto* rimInputReservoir = new RimEclipseInputCase();
 
-    RiaApplication* app     = RiaApplication::instance();
-    RimProject*     project = app->project();
+    RimProject* project = RimProject::current();
+    if ( !project )
+    {
+        RiaLogging::error( "Failed to find project" );
+        return -1;
+    }
 
     project->assignCaseIdToCase( rimInputReservoir );
 
@@ -325,8 +332,12 @@ int RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl( const QStr
     rimResultReservoir->setCaseInfo( caseName, fileName );
     rimResultReservoir->setReaderSettings( readerSettings );
 
-    RiaApplication* app     = RiaApplication::instance();
-    RimProject*     project = app->project();
+    RimProject* project = RimProject::current();
+    if ( !project )
+    {
+        RiaLogging::error( "Failed to find project" );
+        return -1;
+    }
 
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
     if ( analysisModels == nullptr )
@@ -395,8 +406,12 @@ bool RiaImportEclipseCaseTools::addEclipseCases( const QStringList& fileNames, R
     std::vector<std::vector<int>> mainCaseGridDimensions;
     RimIdenticalGridCaseGroup*    gridCaseGroup = nullptr;
 
-    RiaApplication* app     = RiaApplication::instance();
-    RimProject*     project = app->project();
+    RimProject* project = RimProject::current();
+    if ( !project )
+    {
+        RiaLogging::error( "Failed to find project" );
+        return false;
+    }
 
     {
         QString   firstFileName = fileNames[0];
@@ -491,10 +506,13 @@ std::vector<int> RiaImportEclipseCaseTools::openRoffCasesFromFileNames( const QS
 {
     CAF_ASSERT( !fileNames.empty() );
 
-    RiaApplication* app = RiaApplication::instance();
-    if ( !app ) return {};
-    RimProject* project = app->project();
-    if ( !project ) return {};
+    RimProject* project = RimProject::current();
+    if ( !project )
+    {
+        RiaLogging::error( "Failed to find project" );
+        return {};
+    }
+
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
     if ( !analysisModels ) return {};
 
@@ -541,10 +559,13 @@ std::vector<int> RiaImportEclipseCaseTools::openRoffCasesFromFileNames( const QS
 //--------------------------------------------------------------------------------------------------
 RimRoffCase* RiaImportEclipseCaseTools::openRoffCaseFromFileName( const QString& fileName, bool createDefaultView )
 {
-    RiaApplication* app = RiaApplication::instance();
-    if ( !app ) return nullptr;
-    RimProject* project = app->project();
-    if ( !project ) return nullptr;
+    RimProject* project = RimProject::current();
+    if ( !project )
+    {
+        RiaLogging::error( "Failed to find project" );
+        return nullptr;
+    }
+
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
     if ( !analysisModels ) return nullptr;
 

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
@@ -26,6 +26,7 @@ class QString;
 class QStringList;
 
 class RimIdenticalGridCaseGroup;
+class RimRoffCase;
 class RifReaderSettings;
 
 //==================================================================================================
@@ -51,7 +52,8 @@ public:
 
     static int openEclipseCaseFromFile( const QString& fileName, bool createView, std::shared_ptr<RifReaderSettings> readerSettings = nullptr );
 
-    static std::vector<int> openRoffCaseFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static std::vector<int> openRoffCasesFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static RimRoffCase*     openRoffCaseFromFileName( const QString& fileName, bool createDefaultView );
 
 private:
     static int openEclipseCaseShowTimeStepFilterImpl( const QString&                     fileName,

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 class QString;
 class QStringList;
@@ -50,7 +51,7 @@ public:
 
     static int openEclipseCaseFromFile( const QString& fileName, bool createView, std::shared_ptr<RifReaderSettings> readerSettings = nullptr );
 
-    static int openRoffCaseFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static std::vector<int> openRoffCaseFromFileNames( const QStringList& fileNames, bool createDefaultView );
 
 private:
     static int openEclipseCaseShowTimeStepFilterImpl( const QString&                     fileName,

--- a/ApplicationLibCode/Commands/CMakeLists.txt
+++ b/ApplicationLibCode/Commands/CMakeLists.txt
@@ -129,6 +129,7 @@ set(LINK_LIBRARIES
     qwt
     ${QT_LIBRARIES}
     Eigen3::Eigen
+    roffcpp
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${LINK_LIBRARIES})

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
@@ -441,6 +441,8 @@ bool RicImportGeneralDataFeature::openRoffCaseAndPropertiesFromFileNames( const 
     auto* generatedRoffCase = RiaImportEclipseCaseTools::openRoffCaseFromFileName( *gridCaseItr, createDefaultView );
     if ( !generatedRoffCase ) return false;
 
+    createdCaseIds.push_back( generatedRoffCase->caseId() );
+
     QStringList propertyFileNames;
     for ( auto fileNameItr = fileNames.begin(); fileNameItr != fileNames.end(); ++fileNameItr )
     {

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
@@ -406,7 +406,7 @@ bool RicImportGeneralDataFeature::openRoffCasesFromFileNames( const QStringList&
     const size_t initialNumCases  = createdCaseIds.size();
     auto         generatedCaseIds = RiaImportEclipseCaseTools::openRoffCasesFromFileNames( fileNames, createDefaultView );
 
-    CAF_ASSERT( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) && "Expected to create one roff case per file provided!" );
+    CAF_ASSERT( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) && "Expected to create one roff case per file provided" );
 
     for ( int i = 0; i < fileNames.size(); ++i )
     {

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
@@ -373,7 +373,7 @@ bool RicImportGeneralDataFeature::openRoffFilesFromFileNames( const QStringList&
 {
     CAF_ASSERT( !fileNames.empty() );
 
-    auto numGridCases = static_cast<size_t>(
+    auto numGridCases = static_cast<int>(
         std::count_if( fileNames.begin(), fileNames.end(), []( const auto& fileName ) { return RifRoffFileTools::hasGridData( fileName ); } ) );
 
     if ( numGridCases != fileNames.size() && numGridCases != 1 )
@@ -406,14 +406,15 @@ bool RicImportGeneralDataFeature::openRoffCasesFromFileNames( const QStringList&
     const size_t initialNumCases  = createdCaseIds.size();
     auto         generatedCaseIds = RiaImportEclipseCaseTools::openRoffCasesFromFileNames( fileNames, createDefaultView );
 
-    CAF_ASSERT( fileNames.size() == generatedCaseIds.size() );
+    CAF_ASSERT( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) && "Expected to create one roff case per file provided!" );
 
-    for ( size_t i = 0; i < fileNames.size(); ++i )
+    for ( int i = 0; i < fileNames.size(); ++i )
     {
-        if ( generatedCaseIds[i] >= 0 )
+        const auto caseId = generatedCaseIds[static_cast<size_t>( i )];
+        if ( caseId >= 0 )
         {
             RiaApplication::instance()->addToRecentFiles( fileNames[i] );
-            createdCaseIds.push_back( generatedCaseIds[i] );
+            createdCaseIds.push_back( caseId );
         }
     }
     return initialNumCases != createdCaseIds.size();

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.h
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.h
@@ -76,5 +76,8 @@ protected:
                                               std::shared_ptr<RifReaderSettings> readerSettings );
     static bool openInputEclipseCaseFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
     static bool openSummaryCaseFromFileNames( const QStringList& fileNames, bool doCreateDefaultPlot = true );
-    static bool openRoffCaseFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
+
+    static bool openRoffFilesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
+    static bool openRoffCasesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
+    static bool openRoffCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
 };

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
@@ -523,6 +523,37 @@ std::pair<bool, std::map<QString, QString>> RifRoffFileTools::createInputPropert
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RifRoffFileTools::hasGridData( const QString& filename )
+{
+    // Check if arrayTypes contains grid info
+    // - Alt 1. Look for tag "cornerLines" and its data with keyword "cornerLines.data" - actual representation of grid data
+    // - Alt 2. Look for tag "filedata" and its filetype with keyword "filedata.filetype" - should be equal "grid" (not as robust, rather
+    // look for "cornerLines" which is grid representation)
+
+    std::ifstream stream( filename.toStdString(), std::ios::binary );
+    if ( !stream.good() )
+    {
+        RiaLogging::error( "Unable to open roff file" );
+        return false;
+    }
+
+    roff::Reader reader( stream );
+    reader.parse();
+
+    const std::vector<std::pair<std::string, roff::Token::Kind>> arrayTypes = reader.getNamedArrayTypes();
+
+    const std::string cornerLinesDataKeyword = "cornderLines.data";
+    auto              cornerLinesDataItr     = std::find_if( arrayTypes.begin(),
+                                            arrayTypes.end(),
+                                            [&cornerLinesDataKeyword]( const auto& arrayType )
+                                            { return arrayType.first == cornerLinesDataKeyword; } );
+
+    return cornerLinesDataItr != arrayTypes.end();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<double>
     RifRoffFileTools::readAndConvertToDouble( int nx, int ny, int nz, const std::string& keyword, roff::Token::Kind kind, roff::Reader& reader )
 {

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
@@ -43,6 +43,32 @@
 using namespace std::chrono;
 
 //--------------------------------------------------------------------------------------------------
+/// NOTE: Moved from header file due to compile header when using RifRoffFileTools from
+/// ApplicationLibCode/Commands
+//--------------------------------------------------------------------------------------------------
+template <typename IN, typename OUT>
+static void convertToReservoirIndexOrder( int nx, int ny, int nz, const std::vector<IN>& in, std::vector<OUT>& out )
+{
+    CAF_ASSERT( static_cast<size_t>( nx * ny * nz ) == in.size() );
+
+    out.resize( in.size(), -1 );
+
+    int outIdx = 0;
+    for ( int k = 0; k < nz; k++ )
+    {
+        for ( int j = 0; j < ny; j++ )
+        {
+            for ( int i = 0; i < nx; i++ )
+            {
+                int inIdx   = i * ny * nz + j * nz + ( nz - k - 1 );
+                out[outIdx] = static_cast<OUT>( in[inIdx] );
+                outIdx++;
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 /// Constructor
 //--------------------------------------------------------------------------------------------------
 RifRoffFileTools::RifRoffFileTools()
@@ -542,7 +568,7 @@ bool RifRoffFileTools::hasGridData( const QString& filename )
 
     const std::vector<std::pair<std::string, roff::Token::Kind>> arrayTypes = reader.getNamedArrayTypes();
 
-    const std::string cornerLinesDataKeyword = "cornderLines.data";
+    const std::string cornerLinesDataKeyword = "cornerLines.data";
     auto              cornerLinesDataItr     = std::find_if( arrayTypes.begin(),
                                             arrayTypes.end(),
                                             [&cornerLinesDataKeyword]( const auto& arrayType )

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.h
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.h
@@ -83,26 +83,4 @@ private:
                                               const std::string&  keyword,
                                               roff::Token::Kind   token,
                                               roff::Reader&       reader );
-
-    template <typename IN, typename OUT>
-    static void convertToReservoirIndexOrder( int nx, int ny, int nz, const std::vector<IN>& in, std::vector<OUT>& out )
-    {
-        CAF_ASSERT( static_cast<size_t>( nx * ny * nz ) == in.size() );
-
-        out.resize( in.size(), -1 );
-
-        int outIdx = 0;
-        for ( int k = 0; k < nz; k++ )
-        {
-            for ( int j = 0; j < ny; j++ )
-            {
-                for ( int i = 0; i < nx; i++ )
-                {
-                    int inIdx   = i * ny * nz + j * nz + ( nz - k - 1 );
-                    out[outIdx] = static_cast<OUT>( in[inIdx] );
-                    outIdx++;
-                }
-            }
-        }
-    }
 };

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.h
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.h
@@ -53,6 +53,8 @@ public:
 
     static std::pair<bool, std::map<QString, QString>> createInputProperties( const QString& fileName, RigEclipseCaseData* eclipseCase );
 
+    static bool hasGridData( const QString& filename );
+
 private:
     static void interpretSplitenzData( int                       nz,
                                        float                     zoffset,
@@ -85,7 +87,7 @@ private:
     template <typename IN, typename OUT>
     static void convertToReservoirIndexOrder( int nx, int ny, int nz, const std::vector<IN>& in, std::vector<OUT>& out )
     {
-        CAF_ASSERT( static_cast<size_t>( nx ) * ny * nz == in.size() );
+        CAF_ASSERT( static_cast<size_t>( nx * ny * nz ) == in.size() );
 
         out.resize( in.size(), -1 );
 


### PR DESCRIPTION
Adding support for loading of multiple roff grid files, or 1 single grid file with N corresponding property files.

----

Closes: #9713 and #9690