### PR TITLE
Refactor menu building for main windows

### DIFF
--- a/ApplicationLibCode/UserInterface/CMakeLists_files.cmake
+++ b/ApplicationLibCode/UserInterface/CMakeLists_files.cmake
@@ -107,6 +107,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiuQssSyntaxHighlighter.h
     ${CMAKE_CURRENT_LIST_DIR}/RiuQwtDateScaleWrapper.h
     ${CMAKE_CURRENT_LIST_DIR}/RiuMatrixPlotWidget.h
+    ${CMAKE_CURRENT_LIST_DIR}/RiuMenuBarBuildTools.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -215,6 +216,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiuQwtLegendOverlayContentFrame.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuQwtDateScaleWrapper.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuMatrixPlotWidget.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiuMenuBarBuildTools.cpp
 )
 
 if(RESINSIGHT_USE_QT_CHARTS)

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -54,6 +54,7 @@
 #include "RiuDockWidgetTools.h"
 #include "RiuMdiArea.h"
 #include "RiuMdiSubWindow.h"
+#include "RiuMenuBarBuildTools.h"
 #include "RiuMessagePanel.h"
 #include "RiuMohrsCirclePlot.h"
 #include "RiuProcessMonitor.h"
@@ -434,60 +435,13 @@ void RiuMainWindow::createMenus()
     CVF_ASSERT( cmdFeatureMgr );
 
     // File menu
-    QMenu* fileMenu = new RiuToolTipMenu( menuBar() );
-    fileMenu->setTitle( "&File" );
-
-    menuBar()->addMenu( fileMenu );
-
-    fileMenu->addAction( cmdFeatureMgr->action( "RicOpenProjectFeature" ) );
-    fileMenu->addAction( cmdFeatureMgr->action( "RicOpenLastUsedFileFeature" ) );
+    QMenu* fileMenu = RiuMenuBarBuildTools::createDefaultFileMenu( menuBar() );
     fileMenu->addSeparator();
 
-    QMenu* importMenu = fileMenu->addMenu( "&Import" );
+    // Import menu actions
+    RiuMenuBarBuildTools::addImportMenuWithActions( this, fileMenu );
 
-    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Eclipse Cases" );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCasesFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseTimeStepFilterFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportInputEclipseCaseFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicCreateGridCaseGroupFromFilesFeature" ) );
-
-    QMenu* importRoffMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Roff Grid Models" );
-    importRoffMenu->addAction( cmdFeatureMgr->action( "RicImportRoffCaseFeature" ) );
-
-    importMenu->addSeparator();
-    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
-
-#ifdef USE_ODB_API
-    importMenu->addSeparator();
-    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Cases" );
-    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseFeature" ) );
-    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseTimeStepFilterFeature" ) );
-    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportElementPropertyFeature" ) );
-#endif
-
-    importMenu->addSeparator();
-    QMenu* importWellMenu = importMenu->addMenu( QIcon( ":/Well.svg" ), "Well Data" );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportSsihubFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellLogsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathFormationsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicImportWellMeasurementsFeature" ) );
-
-    importMenu->addSeparator();
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportSurfacesFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportSeismicFeature" ) );
-
-    RiuTools::enableAllActionsOnShow( this, importMenu );
-
+    // Export menu actions
     QMenu* exportMenu = fileMenu->addMenu( "&Export" );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
     exportMenu->addAction( m_snapshotAllViewsToFile );
@@ -498,9 +452,9 @@ void RiuMainWindow::createMenus()
     exportMenu->addAction( cmdFeatureMgr->action( "RicExportCompletionsForVisibleWellPathsFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicExportVisibleWellPathsFeature" ) );
 
+    // Save menu actions
     fileMenu->addSeparator();
-    fileMenu->addAction( cmdFeatureMgr->action( "RicSaveProjectFeature" ) );
-    fileMenu->addAction( cmdFeatureMgr->action( "RicSaveProjectAsFeature" ) );
+    RiuMenuBarBuildTools::addSaveProjectActions( fileMenu );
 
     std::vector<QAction*> recentFileActions = RiaGuiApplication::instance()->recentFileActions();
     for ( auto act : recentFileActions )
@@ -511,33 +465,24 @@ void RiuMainWindow::createMenus()
     fileMenu->addSeparator();
     QMenu* testMenu = fileMenu->addMenu( "&Testing" );
 
+    // Close and Exit actions
     fileMenu->addSeparator();
-    fileMenu->addAction( cmdFeatureMgr->action( "RicCloseProjectFeature" ) );
-    fileMenu->addSeparator();
-    fileMenu->addAction( cmdFeatureMgr->action( "RicExitApplicationFeature" ) );
+    RiuMenuBarBuildTools::addCloseAndExitActions( fileMenu );
 
     connect( fileMenu, SIGNAL( aboutToShow() ), SLOT( slotRefreshFileActions() ) );
 
     // Edit menu
-    QMenu* editMenu = menuBar()->addMenu( "&Edit" );
-    editMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToClipboardFeature" ) );
-    editMenu->addSeparator();
-    editMenu->addAction( cmdFeatureMgr->action( "RicShowMemoryCleanupDialogFeature" ) );
-    editMenu->addSeparator();
-    editMenu->addAction( cmdFeatureMgr->action( "RicEditPreferencesFeature" ) );
-
+    QMenu* editMenu = RiuMenuBarBuildTools::createDefaultEditMenu( menuBar() );
     if ( RiaPreferences::current()->useUndoRedo() )
     {
         editMenu->addSeparator();
         editMenu->addAction( m_undoAction );
         editMenu->addAction( m_redoAction );
     }
-
     connect( editMenu, SIGNAL( aboutToShow() ), SLOT( slotRefreshUndoRedoActions() ) );
 
     // View menu
-    QMenu* viewMenu = menuBar()->addMenu( "&View" );
-    viewMenu->addAction( cmdFeatureMgr->action( "RicViewZoomAllFeature" ) );
+    QMenu* viewMenu = RiuMenuBarBuildTools::createDefaultViewMenu( menuBar() );
     viewMenu->addSeparator();
     viewMenu->addAction( m_viewFromSouth );
     viewMenu->addAction( m_viewFromNorth );
@@ -548,6 +493,7 @@ void RiuMainWindow::createMenus()
 
     connect( viewMenu, SIGNAL( aboutToShow() ), SLOT( slotRefreshViewActions() ) );
 
+    // Test menu
     testMenu->addAction( m_mockModelAction );
     testMenu->addAction( m_mockResultsModelAction );
     testMenu->addAction( m_mockLargeResultsModelAction );
@@ -565,12 +511,10 @@ void RiuMainWindow::createMenus()
     testMenu->addAction( cmdFeatureMgr->action( "RicExecuteLastUsedScriptFeature" ) );
 
     testMenu->addSeparator();
-
     testMenu->addAction( cmdFeatureMgr->action( "RicHoloLensExportToFolderFeature" ) );
     testMenu->addAction( cmdFeatureMgr->action( "RicHoloLensCreateDummyFiledBackedSessionFeature" ) );
 
     testMenu->addSeparator();
-
     testMenu->addAction( cmdFeatureMgr->action( "RicThemeColorEditorFeature" ) );
 
     // Windows menu
@@ -578,16 +522,7 @@ void RiuMainWindow::createMenus()
     connect( m_windowMenu, SIGNAL( aboutToShow() ), SLOT( slotBuildWindowActions() ) );
 
     // Help menu
-    QMenu* helpMenu = menuBar()->addMenu( "&Help" );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpAboutFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpCommandLineFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpSummaryCommandLineFeature" ) );
-    helpMenu->addSeparator();
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpOpenUsersGuideFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicSearchHelpFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicSearchIssuesHelpFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicCreateNewIssueHelpFeature" ) );
-
+    QMenu* helpMenu = RiuMenuBarBuildTools::createDefaultHelpMenu( menuBar() );
     connect( helpMenu, SIGNAL( aboutToShow() ), SLOT( slotRefreshHelpActions() ) );
 }
 

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -1,0 +1,184 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2023- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RiuMenuBarBuildTools.h"
+
+#include "cafCmdFeatureManager.h"
+
+#include "cvfAssert.h"
+
+#include "RiuToolTipMenu.h"
+#include "RiuTools.h"
+
+#include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QMenu* RiuMenuBarBuildTools::createDefaultFileMenu( QMenuBar* menuBar )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+    CVF_ASSERT( menuBar && cmdFeatureMgr );
+
+    QMenu* fileMenu = new RiuToolTipMenu( menuBar );
+    fileMenu->setTitle( "&File" );
+
+    menuBar->addMenu( fileMenu );
+
+    fileMenu->addAction( cmdFeatureMgr->action( "RicOpenProjectFeature" ) );
+    fileMenu->addAction( cmdFeatureMgr->action( "RicOpenLastUsedFileFeature" ) );
+
+    return fileMenu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QMenu* RiuMenuBarBuildTools::createDefaultEditMenu( QMenuBar* menuBar )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+    CVF_ASSERT( menuBar && cmdFeatureMgr );
+
+    QMenu* editMenu = menuBar->addMenu( "&Edit" );
+    editMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToClipboardFeature" ) );
+    editMenu->addSeparator();
+    editMenu->addAction( cmdFeatureMgr->action( "RicShowMemoryCleanupDialogFeature" ) );
+    editMenu->addSeparator();
+    editMenu->addAction( cmdFeatureMgr->action( "RicEditPreferencesFeature" ) );
+
+    return editMenu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QMenu* RiuMenuBarBuildTools::createDefaultViewMenu( QMenuBar* menuBar )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+    CVF_ASSERT( menuBar && cmdFeatureMgr );
+
+    QMenu* viewMenu = menuBar->addMenu( "&View" );
+    viewMenu->addAction( cmdFeatureMgr->action( "RicViewZoomAllFeature" ) );
+
+    return viewMenu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QMenu* RiuMenuBarBuildTools::createDefaultHelpMenu( QMenuBar* menuBar )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+    CVF_ASSERT( menuBar && cmdFeatureMgr );
+
+    QMenu* helpMenu = menuBar->addMenu( "&Help" );
+    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpAboutFeature" ) );
+    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpCommandLineFeature" ) );
+    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpSummaryCommandLineFeature" ) );
+    helpMenu->addSeparator();
+    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpOpenUsersGuideFeature" ) );
+    helpMenu->addAction( cmdFeatureMgr->action( "RicSearchHelpFeature" ) );
+    helpMenu->addAction( cmdFeatureMgr->action( "RicSearchIssuesHelpFeature" ) );
+    helpMenu->addAction( cmdFeatureMgr->action( "RicCreateNewIssueHelpFeature" ) );
+
+    return helpMenu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMenuBarBuildTools::addImportMenuWithActions( QObject* parent, QMenu* menu )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+
+    if ( !parent || !menu || !cmdFeatureMgr ) return;
+
+    QMenu* importMenu = menu->addMenu( "&Import" );
+
+    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Eclipse Cases" );
+    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseFeature" ) );
+    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCasesFeature" ) );
+    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseTimeStepFilterFeature" ) );
+    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportInputEclipseCaseFeature" ) );
+    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicCreateGridCaseGroupFromFilesFeature" ) );
+
+    QMenu* importRoffMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Roff Grid Models" );
+    importRoffMenu->addAction( cmdFeatureMgr->action( "RicImportRoffCaseFeature" ) );
+
+    importMenu->addSeparator();
+    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
+
+#ifdef USE_ODB_API
+    importMenu->addSeparator();
+    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Cases" );
+    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseFeature" ) );
+    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseTimeStepFilterFeature" ) );
+    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportElementPropertyFeature" ) );
+#endif
+
+    importMenu->addSeparator();
+    QMenu* importWellMenu = importMenu->addMenu( QIcon( ":/Well.svg" ), "Well Data" );
+    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportFileFeature" ) );
+    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportSsihubFeature" ) );
+    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellLogsImportFileFeature" ) );
+    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathFormationsImportFileFeature" ) );
+    importWellMenu->addAction( cmdFeatureMgr->action( "RicImportWellMeasurementsFeature" ) );
+
+    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportSurfacesFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportSeismicFeature" ) );
+
+    RiuTools::enableAllActionsOnShow( parent, importMenu );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMenuBarBuildTools::addSaveProjectActions( QMenu* menu )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+
+    if ( !menu || !cmdFeatureMgr ) return;
+
+    menu->addAction( cmdFeatureMgr->action( "RicSaveProjectFeature" ) );
+    menu->addAction( cmdFeatureMgr->action( "RicSaveProjectAsFeature" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMenuBarBuildTools::addCloseAndExitActions( QMenu* menu )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+
+    if ( !menu || !cmdFeatureMgr ) return;
+
+    menu->addAction( cmdFeatureMgr->action( "RicCloseProjectFeature" ) );
+    menu->addSeparator();
+    menu->addAction( cmdFeatureMgr->action( "RicExitApplicationFeature" ) );
+}

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.h
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.h
@@ -1,0 +1,40 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2023- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <QObject>
+
+class QMenu;
+class QMenuBar;
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+namespace RiuMenuBarBuildTools
+{
+QMenu* createDefaultFileMenu( QMenuBar* menuBar );
+QMenu* createDefaultEditMenu( QMenuBar* menuBar );
+QMenu* createDefaultViewMenu( QMenuBar* menuBar );
+QMenu* createDefaultHelpMenu( QMenuBar* menuBar );
+
+void addImportMenuWithActions( QObject* parent, QMenu* menu );
+void addSaveProjectActions( QMenu* menu );
+void addCloseAndExitActions( QMenu* menu );
+
+}; // namespace RiuMenuBarBuildTools

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -52,6 +52,7 @@
 #include "RiuDragDrop.h"
 #include "RiuMdiArea.h"
 #include "RiuMdiSubWindow.h"
+#include "RiuMenuBarBuildTools.h"
 #include "RiuMessagePanel.h"
 #include "RiuMultiPlotPage.h"
 #include "RiuToolTipMenu.h"
@@ -293,65 +294,25 @@ void RiuPlotMainWindow::keyPressEvent( QKeyEvent* keyEvent )
 void RiuPlotMainWindow::createMenus()
 {
     caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+    CVF_ASSERT( cmdFeatureMgr );
 
     // File menu
-    QMenu* fileMenu = new RiuToolTipMenu( menuBar() );
-    fileMenu->setTitle( "&File" );
-
-    menuBar()->addMenu( fileMenu );
-
-    fileMenu->addAction( cmdFeatureMgr->action( "RicOpenProjectFeature" ) );
-    fileMenu->addAction( cmdFeatureMgr->action( "RicOpenLastUsedFileFeature" ) );
+    QMenu* fileMenu = RiuMenuBarBuildTools::createDefaultFileMenu( menuBar() );
     fileMenu->addSeparator();
 
-    QMenu* importMenu = fileMenu->addMenu( "&Import" );
+    // Import menu actions
+    RiuMenuBarBuildTools::addImportMenuWithActions( this, fileMenu );
 
-    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case24x24.png" ), "Eclipse Cases" );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCasesFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicImportInputEclipseCaseFeature" ) );
-    importEclipseMenu->addAction( cmdFeatureMgr->action( "RicCreateGridCaseGroupFromFilesFeature" ) );
-
-#ifdef USE_ODB_API
-    importMenu->addSeparator();
-    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Cases" );
-    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseFeature" ) );
-    importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportElementPropertyFeature" ) );
-#endif
-
-    importMenu->addSeparator();
-    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
-
-    importMenu->addSeparator();
-    QMenu* importWellMenu = importMenu->addMenu( QIcon( ":/Well.svg" ), "Well Data" );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathsImportSsihubFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellLogsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathFormationsImportFileFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleWellLogsFeature" ) );
-
-    importMenu->addSeparator();
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );
-
-    RiuTools::enableAllActionsOnShow( this, importMenu );
-
+    // Export menu actions
     QMenu* exportMenu = fileMenu->addMenu( "&Export" );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToPdfFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotAllPlotsToFileFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSaveEclipseInputActiveVisibleCellsFeature" ) );
 
+    // Save menu actions
     fileMenu->addSeparator();
-    fileMenu->addAction( cmdFeatureMgr->action( "RicSaveProjectFeature" ) );
-    fileMenu->addAction( cmdFeatureMgr->action( "RicSaveProjectAsFeature" ) );
+    RiuMenuBarBuildTools::addSaveProjectActions( fileMenu );
 
     std::vector<QAction*> recentFileActions = RiaGuiApplication::instance()->recentFileActions();
     for ( auto act : recentFileActions )
@@ -359,47 +320,29 @@ void RiuPlotMainWindow::createMenus()
         fileMenu->addAction( act );
     }
 
+    // Close and Exit actions
     fileMenu->addSeparator();
-    fileMenu->addAction( cmdFeatureMgr->action( "RicCloseProjectFeature" ) );
-    fileMenu->addSeparator();
-    fileMenu->addAction( cmdFeatureMgr->action( "RicExitApplicationFeature" ) );
+    RiuMenuBarBuildTools::addCloseAndExitActions( fileMenu );
 
     // Edit menu
-    QMenu* editMenu = menuBar()->addMenu( "&Edit" );
-    editMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToClipboardFeature" ) );
-    editMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
-    editMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToPdfFeature" ) );
-    editMenu->addSeparator();
-    editMenu->addAction( cmdFeatureMgr->action( "RicEditPreferencesFeature" ) );
-
+    QMenu* editMenu = RiuMenuBarBuildTools::createDefaultEditMenu( menuBar() );
     if ( RiaPreferences::current()->useUndoRedo() )
     {
         editMenu->addSeparator();
         editMenu->addAction( m_undoAction );
         editMenu->addAction( m_redoAction );
     }
-
     connect( editMenu, SIGNAL( aboutToShow() ), SLOT( slotRefreshUndoRedoActions() ) );
 
     // View menu
-    QMenu* viewMenu = menuBar()->addMenu( "&View" );
-    viewMenu->addAction( cmdFeatureMgr->action( "RicViewZoomAllFeature" ) );
+    RiuMenuBarBuildTools::createDefaultViewMenu( menuBar() );
 
     // Windows menu
     m_windowMenu = menuBar()->addMenu( "&Windows" );
     connect( m_windowMenu, SIGNAL( aboutToShow() ), SLOT( slotBuildWindowActions() ) );
 
     // Help menu
-    QMenu* helpMenu = menuBar()->addMenu( "&Help" );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpAboutFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpCommandLineFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpSummaryCommandLineFeature" ) );
-    helpMenu->addSeparator();
-    helpMenu->addAction( cmdFeatureMgr->action( "RicHelpOpenUsersGuideFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicSearchHelpFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicSearchIssuesHelpFeature" ) );
-    helpMenu->addAction( cmdFeatureMgr->action( "RicCreateNewIssueHelpFeature" ) );
-
+    QMenu* helpMenu = RiuMenuBarBuildTools::createDefaultHelpMenu( menuBar() );
     connect( helpMenu, SIGNAL( aboutToShow() ), SLOT( slotRefreshHelpActions() ) );
 }
 


### PR DESCRIPTION
- Create RiuMenuBarBuildTools with utilities for building default/common menus for menubar.
- Synch menu options/actions to have as common as possible setup between MainWindow and PlotMainWindow

Note: Added Roff case import for plot main window
----

Closes: #10040
