### PR TITLE
GRDECL: Import multiple grid files from dialog

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -249,7 +249,8 @@ void RiaApplication::createMockModelCustomized()
 void RiaApplication::createInputMockModel()
 {
     bool createView = true;
-    RiaImportEclipseCaseTools::openEclipseInputCaseFromFileNames( QStringList( RiaDefines::mockModelBasicInputCase() ), createView );
+    RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( QStringList( RiaDefines::mockModelBasicInputCase() ),
+                                                                               createView );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
@@ -253,10 +253,11 @@ bool RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilter( const QString
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-int RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView )
+RiaImportEclipseCaseTools::CaseFileNameAndId
+    RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView )
 {
     RimProject* project = RimProject::current();
-    if ( !project ) return -1;
+    if ( !project ) return { QString(), -1 };
 
     auto* rimInputReservoir = new RimEclipseInputCase();
     project->assignCaseIdToCase( rimInputReservoir );
@@ -266,11 +267,11 @@ int RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( c
     {
         RiaLogging::error( "Failed to import grid" );
         delete rimInputReservoir;
-        return -1;
+        return { QString(), -1 };
     }
 
     RimEclipseCaseCollection* analysisModels = project->activeOilField() ? project->activeOilField()->analysisModels() : nullptr;
-    if ( analysisModels == nullptr ) return false;
+    if ( analysisModels == nullptr ) return { QString(), -1 };
 
     analysisModels->cases.push_back( rimInputReservoir );
 
@@ -296,7 +297,7 @@ int RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( c
         Riu3DMainWindowTools::selectAsCurrentItem( eclipseView->cellResult() );
     }
 
-    return rimInputReservoir->caseId();
+    return { rimInputReservoir->gridFileName(), rimInputReservoir->caseId() };
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -308,8 +309,8 @@ std::vector<int> RiaImportEclipseCaseTools::openEclipseInputCasesFromFileNames( 
     for ( const auto& fileName : fileNames )
     {
         // Open with single file
-        auto eclipseCaseId = openEclipseInputCaseAndPropertiesFromFileNames( { fileName }, createDefaultView );
-        eclipseCaseIds.push_back( eclipseCaseId );
+        auto [caseFileName, caseId] = openEclipseInputCaseAndPropertiesFromFileNames( { fileName }, createDefaultView );
+        eclipseCaseIds.push_back( caseId );
     }
     return eclipseCaseIds;
 }

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp
@@ -302,6 +302,21 @@ int RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( c
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<int> RiaImportEclipseCaseTools::openEclipseInputCasesFromFileNames( const QStringList& fileNames, bool createDefaultView )
+{
+    std::vector<int> eclipseCaseIds;
+    for ( const auto& fileName : fileNames )
+    {
+        // Open with single file
+        auto eclipseCaseId = openEclipseInputCaseAndPropertiesFromFileNames( { fileName }, createDefaultView );
+        eclipseCaseIds.push_back( eclipseCaseId );
+    }
+    return eclipseCaseIds;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RiaImportEclipseCaseTools::openMockModel( const QString& name )
 {
     bool showTimeStepFilter = false;

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
@@ -45,7 +45,7 @@ public:
 
     static bool openEclipseCaseShowTimeStepFilter( const QString& fileName );
 
-    static int  openEclipseInputCaseFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static int  openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView );
     static bool openMockModel( const QString& name );
 
     static bool addEclipseCases( const QStringList& fileNames, RimIdenticalGridCaseGroup** resultingCaseGroup = nullptr );

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
@@ -45,7 +45,9 @@ public:
 
     static bool openEclipseCaseShowTimeStepFilter( const QString& fileName );
 
-    static int  openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static int              openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static std::vector<int> openEclipseInputCasesFromFileNames( const QStringList& fileNames, bool createDefaultView );
+
     static bool openMockModel( const QString& name );
 
     static bool addEclipseCases( const QStringList& fileNames, RimIdenticalGridCaseGroup** resultingCaseGroup = nullptr );

--- a/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 class QString;
@@ -35,7 +36,8 @@ class RifReaderSettings;
 class RiaImportEclipseCaseTools
 {
 public:
-    using FileCaseIdMap = std::map<QString, int>;
+    using CaseFileNameAndId = std::pair<QString, int>;
+    using FileCaseIdMap     = std::map<QString, int>;
 
     static bool openEclipseCasesFromFile( const QStringList&                 fileNames,
                                           bool                               createView,
@@ -45,8 +47,8 @@ public:
 
     static bool openEclipseCaseShowTimeStepFilter( const QString& fileName );
 
-    static int              openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView );
-    static std::vector<int> openEclipseInputCasesFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static CaseFileNameAndId openEclipseInputCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView );
+    static std::vector<int>  openEclipseInputCasesFromFileNames( const QStringList& fileNames, bool createDefaultView );
 
     static bool openMockModel( const QString& name );
 

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
@@ -357,7 +357,7 @@ bool RicImportGeneralDataFeature::openEclipseInputFilesFromFileNames( const QStr
                                                                       bool               createDefaultView,
                                                                       std::vector<int>&  createdCaseIds )
 {
-    CAF_ASSERT( !fileNames.empty() );
+    if ( fileNames.empty() ) return false;
 
     // For single file - assume grid and perform open - to prevent multiple read of grid files
     if ( fileNames.size() == 1 )
@@ -397,13 +397,15 @@ bool RicImportGeneralDataFeature::openGrdeclCasesFromFileNames( const QStringLis
                                                                 bool               createDefaultView,
                                                                 std::vector<int>&  createdCaseIds )
 {
-    CAF_ASSERT( !fileNames.empty() );
+    if ( fileNames.empty() ) return false;
 
     const size_t initialNumCases  = createdCaseIds.size();
     const auto   generatedCaseIds = RiaImportEclipseCaseTools::openEclipseInputCasesFromFileNames( fileNames, createDefaultView );
 
-    CAF_ASSERT( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) &&
-                "Expected to create one eclipse case per file provided" );
+    if ( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) )
+    {
+        RiaLogging::error( "Expected to create one eclipse case per file provided" );
+    }
 
     for ( int i = 0; i < fileNames.size(); ++i )
     {
@@ -425,13 +427,13 @@ bool RicImportGeneralDataFeature::openGrdeclCaseAndPropertiesFromFileNames( cons
                                                                             bool               createDefaultView,
                                                                             std::vector<int>&  createdCaseIds )
 {
-    CAF_ASSERT( !fileNames.empty() );
+    if ( fileNames.empty() ) return false;
 
-    const auto generatedCaseId = RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( fileNames, createDefaultView );
+    const auto [caseFileName, generatedCaseId] =
+        RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( fileNames, createDefaultView );
     if ( generatedCaseId >= 0 )
     {
-        // TODO: Consider retrieving name of eclipse grid file and add to recent files
-        if ( fileNames.size() == 1 ) RiaApplication::instance()->addToRecentFiles( fileNames[0] );
+        RiaApplication::instance()->addToRecentFiles( caseFileName );
         createdCaseIds.push_back( generatedCaseId );
         return true;
     }
@@ -443,7 +445,7 @@ bool RicImportGeneralDataFeature::openGrdeclCaseAndPropertiesFromFileNames( cons
 //--------------------------------------------------------------------------------------------------
 bool RicImportGeneralDataFeature::openRoffFilesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds )
 {
-    CAF_ASSERT( !fileNames.empty() );
+    if ( fileNames.empty() ) return false;
 
     auto numGridCases = static_cast<int>(
         std::count_if( fileNames.begin(), fileNames.end(), []( const auto& fileName ) { return RifRoffFileTools::hasGridData( fileName ); } ) );
@@ -473,12 +475,15 @@ bool RicImportGeneralDataFeature::openRoffFilesFromFileNames( const QStringList&
 //--------------------------------------------------------------------------------------------------
 bool RicImportGeneralDataFeature::openRoffCasesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds )
 {
-    CAF_ASSERT( !fileNames.empty() );
+    if ( fileNames.empty() ) return false;
 
     const size_t initialNumCases  = createdCaseIds.size();
     auto         generatedCaseIds = RiaImportEclipseCaseTools::openRoffCasesFromFileNames( fileNames, createDefaultView );
 
-    CAF_ASSERT( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) && "Expected to create one roff case per file provided" );
+    if ( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) )
+    {
+        RiaLogging::error( "Expected to create one roff case per file provided" );
+    }
 
     for ( int i = 0; i < fileNames.size(); ++i )
     {
@@ -499,7 +504,7 @@ bool RicImportGeneralDataFeature::openRoffCaseAndPropertiesFromFileNames( const 
                                                                           bool               createDefaultView,
                                                                           std::vector<int>&  createdCaseIds )
 {
-    CAF_ASSERT( !fileNames.empty() );
+    if ( fileNames.empty() ) return false;
 
     auto gridCaseItr =
         std::find_if( fileNames.begin(), fileNames.end(), []( const auto& fileName ) { return RifRoffFileTools::hasGridData( fileName ); } );

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp
@@ -25,6 +25,7 @@
 
 #include "RicImportSummaryCasesFeature.h"
 
+#include "RifEclipseInputFileTools.h"
 #include "RifRoffFileTools.h"
 
 #include "RimRoffCase.h"
@@ -93,7 +94,7 @@ RicImportGeneralDataFeature::OpenCaseResults
     }
     if ( !eclipseInputFiles.empty() )
     {
-        if ( !openInputEclipseCaseFromFileNames( eclipseInputFiles, createDefaultView, results.createdCaseIds ) )
+        if ( !openEclipseInputFilesFromFileNames( eclipseInputFiles, createDefaultView, results.createdCaseIds ) )
         {
             return OpenCaseResults();
         }
@@ -334,23 +335,6 @@ bool RicImportGeneralDataFeature::openEclipseCaseFromFileNames( const QStringLis
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RicImportGeneralDataFeature::openInputEclipseCaseFromFileNames( const QStringList& fileNames,
-                                                                     bool               createDefaultView,
-                                                                     std::vector<int>&  createdCaseIds )
-{
-    auto generatedCaseId = RiaImportEclipseCaseTools::openEclipseInputCaseFromFileNames( fileNames, createDefaultView );
-    if ( generatedCaseId >= 0 )
-    {
-        RiaApplication::instance()->addToRecentFiles( fileNames[0] );
-        createdCaseIds.push_back( generatedCaseId );
-        return true;
-    }
-    return false;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 bool RicImportGeneralDataFeature::openSummaryCaseFromFileNames( const QStringList& fileNames, bool doCreateDefaultPlot )
 {
     auto [isOk, newCases] = RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles( fileNames, doCreateDefaultPlot );
@@ -369,6 +353,94 @@ bool RicImportGeneralDataFeature::openSummaryCaseFromFileNames( const QStringLis
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicImportGeneralDataFeature::openEclipseInputFilesFromFileNames( const QStringList& fileNames,
+                                                                      bool               createDefaultView,
+                                                                      std::vector<int>&  createdCaseIds )
+{
+    CAF_ASSERT( !fileNames.empty() );
+
+    // For single file - assume grid and perform open - to prevent multiple read of grid files
+    if ( fileNames.size() == 1 )
+    {
+        return openGrdeclCaseAndPropertiesFromFileNames( fileNames, createDefaultView, createdCaseIds );
+    }
+
+    auto numGridCases =
+        static_cast<int>( std::count_if( fileNames.begin(),
+                                         fileNames.end(),
+                                         []( const auto& fileName ) { return RifEclipseInputFileTools::hasGridData( fileName ); } ) );
+
+    if ( numGridCases != fileNames.size() && numGridCases != 1 )
+    {
+        RiaLogging::error( "Select only grid case files or 1 grid case file with N property files" );
+        return false;
+    }
+
+    if ( numGridCases == 1 )
+    {
+        // Open single grid case and connected property files
+        return openGrdeclCaseAndPropertiesFromFileNames( fileNames, createDefaultView, createdCaseIds );
+    }
+    else
+    {
+        // Open multiple grid cases
+        return openGrdeclCasesFromFileNames( fileNames, createDefaultView, createdCaseIds );
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Assumes N files containing grid info - each file must be grid case
+//--------------------------------------------------------------------------------------------------
+bool RicImportGeneralDataFeature::openGrdeclCasesFromFileNames( const QStringList& fileNames,
+                                                                bool               createDefaultView,
+                                                                std::vector<int>&  createdCaseIds )
+{
+    CAF_ASSERT( !fileNames.empty() );
+
+    const size_t initialNumCases  = createdCaseIds.size();
+    const auto   generatedCaseIds = RiaImportEclipseCaseTools::openEclipseInputCasesFromFileNames( fileNames, createDefaultView );
+
+    CAF_ASSERT( fileNames.size() == static_cast<int>( generatedCaseIds.size() ) &&
+                "Expected to create one eclipse case per file provided" );
+
+    for ( int i = 0; i < fileNames.size(); ++i )
+    {
+        const auto caseId = generatedCaseIds[static_cast<size_t>( i )];
+        if ( caseId >= 0 )
+        {
+            RiaApplication::instance()->addToRecentFiles( fileNames[i] );
+            createdCaseIds.push_back( caseId );
+        }
+    }
+
+    return initialNumCases != createdCaseIds.size();
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Assuming 1 file with grid data and N files with property info for respective grid file
+//--------------------------------------------------------------------------------------------------
+bool RicImportGeneralDataFeature::openGrdeclCaseAndPropertiesFromFileNames( const QStringList& fileNames,
+                                                                            bool               createDefaultView,
+                                                                            std::vector<int>&  createdCaseIds )
+{
+    CAF_ASSERT( !fileNames.empty() );
+
+    const auto generatedCaseId = RiaImportEclipseCaseTools::openEclipseInputCaseAndPropertiesFromFileNames( fileNames, createDefaultView );
+    if ( generatedCaseId >= 0 )
+    {
+        // TODO: Consider retrieving name of eclipse grid file and add to recent files
+        if ( fileNames.size() == 1 ) RiaApplication::instance()->addToRecentFiles( fileNames[0] );
+        createdCaseIds.push_back( generatedCaseId );
+        return true;
+    }
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RicImportGeneralDataFeature::openRoffFilesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds )
 {
     CAF_ASSERT( !fileNames.empty() );
@@ -378,7 +450,7 @@ bool RicImportGeneralDataFeature::openRoffFilesFromFileNames( const QStringList&
 
     if ( numGridCases != fileNames.size() && numGridCases != 1 )
     {
-        RiaLogging::error( "Select only grid case files or 1 grid case file with N property files!" );
+        RiaLogging::error( "Select only grid case files or 1 grid case file with N property files" );
         return false;
     }
 

--- a/ApplicationLibCode/Commands/RicImportGeneralDataFeature.h
+++ b/ApplicationLibCode/Commands/RicImportGeneralDataFeature.h
@@ -74,8 +74,13 @@ protected:
                                               bool                               createDefaultView,
                                               std::vector<int>&                  createdCaseIds,
                                               std::shared_ptr<RifReaderSettings> readerSettings );
-    static bool openInputEclipseCaseFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
+
     static bool openSummaryCaseFromFileNames( const QStringList& fileNames, bool doCreateDefaultPlot = true );
+
+    static bool openEclipseInputFilesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
+    static bool openGrdeclCasesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
+    static bool
+        openGrdeclCaseAndPropertiesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
 
     static bool openRoffFilesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );
     static bool openRoffCasesFromFileNames( const QStringList& fileNames, bool createDefaultView, std::vector<int>& createdCaseIds );

--- a/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
@@ -1402,6 +1402,23 @@ cvf::StructGridInterface::FaceEnum RifEclipseInputFileTools::faceEnumFromText( c
 }
 
 //--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifEclipseInputFileTools::hasGridData( const QString& fileName )
+{
+    // Look for keyword "COORD" in file
+    // NOTE: If readKeywordAndValues is slow for large .GRDECL files, consider function in RifEclipseTextFileReader
+    // reading line for line and returns true on first hit of keyword. This prevents reading entire file on large cases
+
+    const auto keywordAndValues = RifEclipseTextFileReader::readKeywordAndValues( fileName.toStdString() );
+    auto       coordKeywordItr  = std::find_if( keywordAndValues.begin(),
+                                         keywordAndValues.end(),
+                                         []( const auto& keywordAndValue ) { return keywordAndValue.keyword == "COORD"; } );
+
+    return coordKeywordItr != keywordAndValues.end();
+}
+
+//--------------------------------------------------------------------------------------------------
 /// The file pointer is pointing at the line following the FAULTS keyword.
 /// Parse content of this keyword until end of file or
 /// end of keyword when a single line with '/' is found

--- a/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.h
@@ -122,6 +122,8 @@ public:
 
     static cvf::StructGridInterface::FaceEnum faceEnumFromText( const QString& faceString );
 
+    static bool hasGridData( const QString& fileName );
+
 private:
     static void readFaults( QFile& data, qint64 filePos, cvf::Collection<RigFault>* faults, bool* isEditKeywordDetected );
 

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
@@ -144,12 +144,9 @@ bool RimEclipseInputCase::openDataFileSet( const QStringList& fileNames )
 
     if ( this->eclipseCaseData()->mainGrid()->gridPointDimensions() == cvf::Vec3st( 0, 0, 0 ) )
     {
-        if ( !allErrorMessages.empty() )
+        for ( QString errorMessages : allErrorMessages )
         {
-            for ( QString errorMessages : allErrorMessages )
-            {
-                RiaLogging::error( errorMessages );
-            }
+            RiaLogging::error( errorMessages );
         }
         return false; // No grid present
     }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseInputCase.cpp
@@ -171,7 +171,10 @@ bool RimEclipseInputCase::openDataFileSet( const QStringList& fileNames )
         }
     }
 
-    RifInputPropertyLoader::loadAndSynchronizeInputProperties( m_inputPropertyCollection, this->eclipseCaseData(), filesToRead, importFaults );
+    if ( !filesToRead.empty() )
+    {
+        RifInputPropertyLoader::loadAndSynchronizeInputProperties( m_inputPropertyCollection, this->eclipseCaseData(), filesToRead, importFaults );
+    }
 
     if ( importFaults )
     {


### PR DESCRIPTION
Add import of multiple grid files

Note: Initial implementation utilizes existing code for opening and reading grdecl files. If performance becomes slow, consider creating new method looking for keyword in `RifEclipseTextFileReader`, utilized in `RifEclipseInputFileTools::hasGridData`. The new function can read grdecl file line for line and return true on first hit on keyword. This can prevent reading large amount of file data for a simple check.

---

Closes: #10125 