### PR TITLE
Fix warning for conversion from std::vector to QStringList

### DIFF
--- a/ApplicationLibCode/ProjectDataModelCommands/RimcEclipseCase.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcEclipseCase.cpp
@@ -66,7 +66,8 @@ caf::PdmObjectHandle* RimcEclipseCase_importProperties::execute()
         }
     }
 
-    const QStringList propertyFileNames = QStringList::fromVector( QVector<QString>::fromStdVector( absolutePaths ) );
+    QStringList propertyFileNames;
+    std::copy( absolutePaths.begin(), absolutePaths.end(), std::back_inserter( propertyFileNames ) );
 
     auto eclipseCase = self<RimEclipseCase>();
     eclipseCase->importAsciiInputProperties( propertyFileNames );


### PR DESCRIPTION
Minor build warning in conversion from std::vector<QString> to QStringList in windows