### PR TITLE
Regression Test: Fix parsing of string lists from command file

### DIFF
--- a/Fwk/AppFwk/cafPdmScripting/cafPdmFieldScriptingCapability.h
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmFieldScriptingCapability.h
@@ -278,7 +278,7 @@ struct PdmFieldScriptingCapabilityIOHandler<std::vector<T>>
                 PdmFieldScriptingCapabilityIOHandler<T>::writeToField( singleValue,
                                                                        singleValueStream,
                                                                        errorMessageContainer,
-                                                                       false );
+                                                                       stringsAreQuoted );
                 fieldValue.push_back( singleValue );
             }
         }

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(
   COMPONENTS
   REQUIRED Core Xml Gui
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Xml Qt5::Gui)
+set(QT_LIBRARIES Qt5::Core Qt5::Xml Qt5::Gui Qt5::Widgets)
 
 if(MSVC AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.11))
   # VS 2017 : Disable warnings from from gtest code, using deprecated code
@@ -20,6 +20,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 add_executable(
   ${PROJECT_NAME} cafPdmScripting_UnitTests.cpp gtest/gtest-all.cpp
                   cafPdmScriptingBasicTest.cpp
+                  cafPdmFieldSerializationTest.cpp
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
@@ -19,8 +19,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 # add the executable
 add_executable(
   ${PROJECT_NAME} cafPdmScripting_UnitTests.cpp gtest/gtest-all.cpp
-                  cafPdmScriptingBasicTest.cpp
-                  cafPdmFieldSerializationTest.cpp
+                  cafPdmScriptingBasicTest.cpp cafPdmFieldSerializationTest.cpp
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
@@ -1,0 +1,98 @@
+//##################################################################################################
+//
+//   Custom Visualization Core library
+//   Copyright (C) Ceetron Solutions AS
+//
+//   This library may be used under the terms of either the GNU General Public License or
+//   the GNU Lesser General Public License as follows:
+//
+//   GNU General Public License Usage
+//   This library is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU General Public License at <<http://www.gnu.org/licenses/gpl.html>>
+//   for more details.
+//
+//   GNU Lesser General Public License Usage
+//   This library is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU Lesser General Public License as published by
+//   the Free Software Foundation; either version 2.1 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
+//   for more details.
+//
+//##################################################################################################
+
+#include "gtest/gtest.h"
+
+#include "cafPdmFieldScriptingCapability.h"
+#include "cafPdmScriptIOMessages.h"
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmFieldSerialization, Strings )
+{
+    QString     source = "This is a string";
+    QTextStream stream( &source );
+    QString     destination;
+
+    caf::PdmScriptIOMessages messages;
+    bool                     stringsAreQuoted = false;
+
+    caf::PdmFieldScriptingCapabilityIOHandler<QString>::writeToField( destination, stream, &messages, stringsAreQuoted );
+    EXPECT_STREQ( source.toStdString().data(), destination.toStdString().data() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmFieldSerialization, StringList )
+{
+    // Items in a string list is not quoted when coming from Python
+    QString              source = "[Here, are, four, strings]";
+    QTextStream          stream( &source );
+    std::vector<QString> destination;
+
+    caf::PdmScriptIOMessages messages;
+    bool                     stringsAreQuoted = false;
+
+    caf::PdmFieldScriptingCapabilityIOHandler<std::vector<QString>>::writeToField( destination,
+                                                                                   stream,
+                                                                                   &messages,
+                                                                                   stringsAreQuoted );
+
+    EXPECT_EQ( 4, destination.size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmFieldSerialization, StringListQuoted )
+{
+    // Items in a string list are quoted when coming from command file
+    QString source = R"(["B-2H", "B-4H"])";
+
+    QTextStream          stream( &source );
+    std::vector<QString> destination;
+
+    caf::PdmScriptIOMessages messages;
+    bool                     stringsAreQuoted = true;
+
+    caf::PdmFieldScriptingCapabilityIOHandler<std::vector<QString>>::writeToField( destination,
+                                                                                   stream,
+                                                                                   &messages,
+                                                                                   stringsAreQuoted );
+
+    EXPECT_EQ( 2, destination.size() );
+    EXPECT_STREQ( "B-2H", destination[0].toStdString().c_str() );
+    EXPECT_STREQ( "B-4H", destination[1].toStdString().c_str() );
+}


### PR DESCRIPTION
The strings in a string list in a command file are quoted