### PR TITLE
#10209 Plot: fix html axis title

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotAxisFormatter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotAxisFormatter.cpp
@@ -310,7 +310,7 @@ QString RimSummaryPlotAxisFormatter::autoAxisTitle() const
         {
             assembledYAxisText += QString::fromStdString( quantIt );
 
-            insertLineShift ? ( assembledYAxisText += "\n" ) : ( assembledYAxisText += " " );
+            insertLineShift ? ( assembledYAxisText += "<br>" ) : ( assembledYAxisText += " " );
         }
 
         if ( m_axisProperties->showUnitText() )


### PR DESCRIPTION
Qwt uses Qt::mightBeRichText to determine if the axis title is rich text or not. Qt::mightBeRichText is a simple heuristic which checks whether there is something that looks like a tag before the first line break. See: https://doc.qt.io/qt-6/qt-sub-qtgui.html#mightBeRichText

Fixed bug by using html br tag to have at least some html before breaking the line.

Fixes #10209.