### PR TITLE
9978 Improve UI for long drop-down lists, use tree selection more

### DIFF
--- a/ApplicationLibCode/Application/RiaMemoryCleanup.cpp
+++ b/ApplicationLibCode/Application/RiaMemoryCleanup.cpp
@@ -19,9 +19,11 @@
 #include "RiaMemoryCleanup.h"
 
 #include "RigCaseCellResultsData.h"
+#include "RigEclipseResultInfo.h"
 #include "RigFemPartResultsCollection.h"
 #include "RigFemResultAddress.h"
 #include "RigGeoMechCaseData.h"
+
 #include "Rim3dView.h"
 #include "RimEclipseCase.h"
 #include "RimEclipseResultDefinition.h"
@@ -29,8 +31,6 @@
 #include "RimGeoMechResultDefinition.h"
 #include "RimProject.h"
 
-#include "RigEclipseResultInfo.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
@@ -46,17 +46,15 @@ CAF_PDM_SOURCE_INIT( RiaMemoryCleanup, "RiaMemoryCleanup" );
 //--------------------------------------------------------------------------------------------------
 RiaMemoryCleanup::RiaMemoryCleanup()
 {
-    // clang-format off
-    CAF_PDM_InitFieldNoDefault(&m_case, "DataCase", "Case");
+    CAF_PDM_InitFieldNoDefault( &m_case, "DataCase", "Case" );
     m_case = nullptr;
 
-    CAF_PDM_InitFieldNoDefault(&m_resultsToDelete, "ResultsToDelete", "Results In Memory");
-    m_resultsToDelete.uiCapability()->setUiLabelPosition(caf::PdmUiItemInfo::TOP);
-    m_resultsToDelete.uiCapability()->setUiEditorTypeName(caf::PdmUiTreeSelectionEditor::uiEditorTypeName());
+    CAF_PDM_InitFieldNoDefault( &m_resultsToDelete, "ResultsToDelete", "Results In Memory" );
+    m_resultsToDelete.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
+    m_resultsToDelete.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
-    CAF_PDM_InitFieldNoDefault(&m_performDelete, "ClearSelectedData", "");
-    caf::PdmUiPushButtonEditor::configureEditorForField(&m_performDelete);
-    // clang-format on
+    CAF_PDM_InitFieldNoDefault( &m_performDelete, "ClearSelectedData", "" );
+    caf::PdmUiPushButtonEditor::configureEditorForField( &m_performDelete );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaPreferencesSummary.cpp
+++ b/ApplicationLibCode/Application/RiaPreferencesSummary.cpp
@@ -432,7 +432,7 @@ void RiaPreferencesSummary::defineEditorAttribute( const caf::PdmFieldHandle* fi
         auto attrib = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
         if ( attrib )
         {
-            attrib->m_heightHint = 30;
+            attrib->heightHint = 30;
         }
     }
 }

--- a/ApplicationLibCode/Commands/ExportCommands/RicExportEclipseSectorModelUi.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportEclipseSectorModelUi.cpp
@@ -33,8 +33,8 @@
 #include "cafPdmUiFilePathEditor.h"
 #include "cafPdmUiGroup.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiOrdering.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -251,10 +251,10 @@ void RicExportEclipseSectorModelUi::defineEditorAttribute( const caf::PdmFieldHa
     }
     else if ( field == &selectedKeywords )
     {
-        auto* myAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
+        auto myAttr = dynamic_cast<caf::PdmUiTreeSelectionEditorAttribute*>( attribute );
         if ( myAttr )
         {
-            myAttr->m_heightHint = 280;
+            myAttr->heightHint = 280;
         }
     }
     else if ( field == &refinementCountI || field == &refinementCountJ || field == &refinementCountK )

--- a/ApplicationLibCode/Commands/RicCreateEnsembleSurfaceUi.cpp
+++ b/ApplicationLibCode/Commands/RicCreateEnsembleSurfaceUi.cpp
@@ -22,8 +22,8 @@
 
 #include "cafPdmObject.h"
 #include "cafPdmUiCheckBoxEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiOrdering.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 CAF_PDM_SOURCE_INIT( RicCreateEnsembleSurfaceUi, "RicCreateEnsembleSurfaceUi" );
 
@@ -75,10 +75,10 @@ void RicCreateEnsembleSurfaceUi::defineEditorAttribute( const caf::PdmFieldHandl
 {
     if ( field == &m_layers )
     {
-        caf::PdmUiListEditorAttribute* myAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
+        auto myAttr = dynamic_cast<caf::PdmUiTreeSelectionEditorAttribute*>( attribute );
         if ( myAttr )
         {
-            myAttr->m_heightHint = 280;
+            myAttr->heightHint = 280;
         }
     }
 }

--- a/ApplicationLibCode/Commands/RicCreateEnsembleWellLogUi.cpp
+++ b/ApplicationLibCode/Commands/RicCreateEnsembleWellLogUi.cpp
@@ -34,7 +34,6 @@
 #include "cafPdmObject.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiFilePathEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiOrdering.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
@@ -66,7 +65,6 @@ RicCreateEnsembleWellLogUi::RicCreateEnsembleWellLogUi()
     CAF_PDM_InitFieldNoDefault( &m_wellPath, "WellPath", "Well Path" );
     CAF_PDM_InitFieldNoDefault( &m_wellFilePath, "WellFilePath", "Well File Path" );
     CAF_PDM_InitFieldNoDefault( &m_selectedKeywords, "SelectedProperties", "Selected Properties" );
-    m_selectedKeywords.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     m_tabNames << "Well"
                << "Properties";

--- a/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
@@ -53,7 +53,6 @@
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiGroup.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
 #include <cmath>

--- a/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterItem.cpp
+++ b/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimPlotDataFilterItem.cpp
@@ -19,19 +19,20 @@
 
 #include "RiaResultNames.h"
 
+#include "RifSummaryReaderInterface.h"
+
 #include "RimAnalysisPlot.h"
 #include "RimSummaryAddress.h"
+#include "RimSummaryCase.h"
 #include "RimSummaryCaseCollection.h"
 
-#include "RifSummaryReaderInterface.h"
-#include "RimSummaryCase.h"
-
-#include "QFontMetrics"
 #include "cafPdmUiActionPushButtonEditor.h"
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
+#include "cafPdmUiTreeSelectionEditor.h"
+
+#include <QFontMetrics>
 
 #include <limits>
 
@@ -116,7 +117,7 @@ RimPlotDataFilterItem::RimPlotDataFilterItem()
     CAF_PDM_InitFieldNoDefault( &m_ensembleParameterValueCategories, "EnsembleParameterValueCategories", "one of" );
     CAF_PDM_InitFieldNoDefault( &m_consideredTimestepsType, "ConsideredTimestepsType", "at the" );
     CAF_PDM_InitFieldNoDefault( &m_explicitlySelectedTimeSteps, "ExplicitlySelectedTimeSteps", "TimeSteps" );
-    m_explicitlySelectedTimeSteps.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_explicitlySelectedTimeSteps.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_explicitlySelectedTimeSteps.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
 
     setDeletable( true );

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFishbones.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFishbones.cpp
@@ -118,6 +118,7 @@ RimFishbones::RimFishbones()
                        "Orientation" );
 
     CAF_PDM_InitFieldNoDefault( &m_installationRotationAngles, "InstallationRotationAngles", "Installation Rotation Angles [deg]" );
+    m_installationRotationAngles.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
     m_installationRotationAngles.uiCapability()->setUiHidden( true );
     CAF_PDM_InitField( &m_fixedInstallationRotationAngle, "FixedInstallationRotationAngle", 0.0, "  Fixed Angle [deg]" );
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
@@ -23,11 +23,6 @@
 #include "RiaQDateTimeTools.h"
 #include "RiaStatisticsTools.h"
 #include "RiaSummaryCurveDefinition.h"
-#include "RiuPlotMainWindowTools.h"
-#include "RiuQwtLinearScaleEngine.h"
-#include "RiuQwtPlotItem.h"
-#include "RiuQwtPlotTools.h"
-#include "RiuQwtPlotWidget.h"
 
 #include "RifSummaryReaderInterface.h"
 
@@ -43,6 +38,12 @@
 #include "RimSummaryCase.h"
 #include "RimSummaryCaseCollection.h"
 #include "RimSummaryPlotAxisFormatter.h"
+
+#include "RiuPlotMainWindowTools.h"
+#include "RiuQwtLinearScaleEngine.h"
+#include "RiuQwtPlotItem.h"
+#include "RiuQwtPlotTools.h"
+#include "RiuQwtPlotWidget.h"
 
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiTreeOrdering.h"
@@ -163,7 +164,6 @@ RimCorrelationMatrixPlot::RimCorrelationMatrixPlot()
     CAF_PDM_InitFieldNoDefault( &m_legendConfig, "LegendConfig", "" );
     CAF_PDM_InitFieldNoDefault( &m_selectedParametersList, "SelectedParameters", "Select Parameters" );
     m_selectedParametersList.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
-    m_selectedParametersList.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     m_legendConfig = new RimRegularLegendConfig();
     m_legendConfig->setAutomaticRanges( -1.0, 1.0, -1.0, 1.0 );

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
@@ -42,7 +42,6 @@
 #include "RiuMainWindow.h"
 
 #include "cafPdmUiCheckBoxEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafUtils.h"
 
@@ -97,7 +96,6 @@ RimFlowCharacteristicsPlot::RimFlowCharacteristicsPlot()
     CAF_PDM_InitFieldNoDefault( &m_cellFilterView, "CellFilterView", "View" );
     CAF_PDM_InitField( &m_tracerFilter, "TracerFilter", QString(), "Tracer Filter" );
     CAF_PDM_InitFieldNoDefault( &m_selectedTracerNames, "SelectedTracerNames", " " );
-    m_selectedTracerNames.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
     CAF_PDM_InitFieldNoDefault( &m_showRegion, "ShowRegion", "" );
     caf::PdmUiPushButtonEditor::configureEditorForField( &m_showRegion );
 

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
@@ -152,10 +152,8 @@ RimWellConnectivityTable::RimWellConnectivityTable()
 
     // Producer/Injector tracer configuration
     CAF_PDM_InitFieldNoDefault( &m_selectedProducerTracersUiField, "SelectedProducerTracers", "Producer Tracers" );
-    m_selectedProducerTracersUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_selectedProducerTracersUiField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
     CAF_PDM_InitFieldNoDefault( &m_selectedInjectorTracersUiField, "SelectedInjectorTracers", "Injector Tracers" );
-    m_selectedInjectorTracersUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_selectedInjectorTracersUiField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
     CAF_PDM_InitField( &m_syncSelectedInjectorsFromProducerSelection, "SyncSelectedProdInj", false, "Synch Communicators ->" );
     m_syncSelectedInjectorsFromProducerSelection.uiCapability()->setUiEditorTypeName( caf::PdmUiToolButtonEditor::uiEditorTypeName() );

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftEnsembleCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftEnsembleCurveSet.cpp
@@ -26,10 +26,10 @@
 
 #include "RiuQwtPlotWidget.h"
 
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiObjectHandle.h"
 #include "cafPdmUiOrdering.h"
 #include "cafPdmUiTreeOrdering.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 #include <QFrame>
 
@@ -53,7 +53,7 @@ RimWellRftEnsembleCurveSet::RimWellRftEnsembleCurveSet()
     CAF_PDM_InitField( &m_ensembleColorMode, "ColorMode", ColorModeEnum( ColorMode::SINGLE_COLOR ), "Coloring Mode" );
 
     CAF_PDM_InitField( &m_ensembleParameter, "EnsembleParameter", QString( "" ), "Ensemble Parameter" );
-    m_ensembleParameter.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_ensembleParameter.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_ensembleLegendConfig, "LegendConfig", "" );
     m_ensembleLegendConfig = new RimRegularLegendConfig();

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp
@@ -64,7 +64,6 @@
 #include "RiuQwtPlotCurveDefines.h"
 #include "RiuQwtPlotWidget.h"
 
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechCase.cpp
@@ -54,7 +54,6 @@
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
 #include "cafPdmUiDoubleValueEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPropertyViewDialog.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeOrdering.h"
@@ -130,7 +129,6 @@ RimGeoMechCase::RimGeoMechCase()
     m_biotFixedCoefficient.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_biotResultAddress, "BiotResultAddress", QString( "" ), "Value" );
-    m_biotResultAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
 
     caf::AppEnum<InitialPermeabilityType> defaultInitialPermeabilityType = RimGeoMechCase::InitialPermeabilityType::INITIAL_PERMEABILITY_FIXED;
     CAF_PDM_InitField( &m_initialPermeabilityType, "InitialPermeabilityType", defaultInitialPermeabilityType, "Initial Permeability" );
@@ -138,7 +136,6 @@ RimGeoMechCase::RimGeoMechCase()
     m_initialPermeabilityFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_initialPermeabilityResultAddress, "InitialPermeabilityAddress", QString( "" ), "Value" );
-    m_initialPermeabilityResultAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_permeabilityExponent, "PermeabilityExponent", 1.0, "Permeability Exponent" );
     m_permeabilityExponent.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp
@@ -48,7 +48,7 @@
 #include "RimWellPath.h"
 
 #include "cafPdmUiDoubleValueEditor.h"
-#include "cafPdmUiListEditor.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 #include <QDoubleValidator>
 
@@ -99,7 +99,7 @@ RimGeoMechResultDefinition::RimGeoMechResultDefinition()
     CAF_PDM_InitField( &m_resultVariableUiField, "ResultVariableUI", QString( "" ), "Value" );
     m_resultVariableUiField.xmlCapability()->disableIO();
 
-    m_resultVariableUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_resultVariableUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_resultVariableUiField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
 
     CAF_PDM_InitField( &m_normalizeByHydrostaticPressure, "NormalizeByHSP", false, "Normalize by Hydrostatic Pressure" );

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
@@ -961,7 +961,7 @@ void RimExtrudedCurveIntersection::setBaseColor( bool enable, caf::PdmUiListEdit
 {
     if ( attribute )
     {
-        attribute->m_qssState = enable ? "ExternalInput" : QString();
+        attribute->qssState = enable ? "ExternalInput" : QString();
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimCellEdgeColors.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCellEdgeColors.cpp
@@ -31,7 +31,6 @@
 #include "RimRegularLegendConfig.h"
 #include "RimReservoirCellResultsStorage.h"
 
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
@@ -73,7 +72,6 @@ RimCellEdgeColors::RimCellEdgeColors()
     CAF_PDM_InitFieldNoDefault( &m_legendConfig, "LegendDefinition", "Color Legend", ":/Legend.png" );
 
     CAF_PDM_InitFieldNoDefault( &m_selectedKeywords, "SelectedProperties", "Selected Properties" );
-    m_selectedKeywords.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_showTextValuesIfItemIsUnchecked,
                        "ShowTextValuesIfItemIsUnchecked",
@@ -82,8 +80,6 @@ RimCellEdgeColors::RimCellEdgeColors()
                        "",
                        "Allow display of result values in Result Info window if the Cell Edge object is unchecked in "
                        "Property Editor." );
-
-    m_resultVariable.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
 
     m_legendConfig = new RimRegularLegendConfig();
 

--- a/ApplicationLibCode/ProjectDataModel/RimCustomObjectiveFunctionWeight.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCustomObjectiveFunctionWeight.cpp
@@ -29,7 +29,6 @@
 #include "RiuSummaryVectorSelectionDialog.h"
 
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
@@ -62,7 +61,7 @@ RimCustomObjectiveFunctionWeight::RimCustomObjectiveFunctionWeight()
     m_weightValue.uiCapability()->setUiEditorTypeName( caf::PdmUiLineEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_objectiveFunction, "ObjectiveFunction", "Objective Function" );
-    m_objectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_objectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     setDeletable( true );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp
@@ -147,6 +147,7 @@ RimEclipseResultDefinition::RimEclipseResultDefinition( caf::PdmUiItemInfo::Labe
     CAF_PDM_InitField( &m_resultVariableUiField, "MResultVariable", RiaResultNames::undefinedResultName(), "Result Property" );
     m_resultVariableUiField.xmlCapability()->disableIO();
     m_resultVariableUiField.uiCapability()->setUiLabelPosition( m_labelPosition );
+    m_resultVariableUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_inputPropertyFileName, "InputPropertyFileName", "File Name" );
     m_inputPropertyFileName.xmlCapability()->disableIO();

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp
@@ -66,7 +66,6 @@
 #endif
 
 #include "cafPdmFieldScriptingCapability.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiToolButtonEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 #include "cafUtils.h"
@@ -147,7 +146,6 @@ RimEclipseResultDefinition::RimEclipseResultDefinition( caf::PdmUiItemInfo::Labe
 
     CAF_PDM_InitField( &m_resultVariableUiField, "MResultVariable", RiaResultNames::undefinedResultName(), "Result Property" );
     m_resultVariableUiField.xmlCapability()->disableIO();
-    m_resultVariableUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
     m_resultVariableUiField.uiCapability()->setUiLabelPosition( m_labelPosition );
 
     CAF_PDM_InitFieldNoDefault( &m_inputPropertyFileName, "InputPropertyFileName", "File Name" );
@@ -166,17 +164,14 @@ RimEclipseResultDefinition::RimEclipseResultDefinition( caf::PdmUiItemInfo::Labe
 
     CAF_PDM_InitFieldNoDefault( &m_selectedInjectorTracersUiField, "MSelectedInjectorTracers", "Injector Tracers" );
     m_selectedInjectorTracersUiField.xmlCapability()->disableIO();
-    m_selectedInjectorTracersUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_selectedInjectorTracersUiField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
 
     CAF_PDM_InitFieldNoDefault( &m_selectedProducerTracersUiField, "MSelectedProducerTracers", "Producer Tracers" );
     m_selectedProducerTracersUiField.xmlCapability()->disableIO();
-    m_selectedProducerTracersUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_selectedProducerTracersUiField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
 
     CAF_PDM_InitFieldNoDefault( &m_selectedSouringTracersUiField, "MSelectedSouringTracers", "Tracers" );
     m_selectedSouringTracersUiField.xmlCapability()->disableIO();
-    m_selectedSouringTracersUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
     m_selectedSouringTracersUiField.uiCapability()->setUiLabelPosition( m_labelPosition );
 }
 
@@ -1592,29 +1587,13 @@ void RimEclipseResultDefinition::defineEditorAttribute( const caf::PdmFieldHandl
 {
     if ( m_resultTypeUiField() == RiaDefines::ResultCatType::FLOW_DIAGNOSTICS )
     {
-        if ( field == &m_resultVariableUiField )
-        {
-            caf::PdmUiListEditorAttribute* listEditAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
-            if ( listEditAttr )
-            {
-                listEditAttr->m_heightHint = 50;
-            }
-        }
-        else if ( field == &m_syncInjectorToProducerSelection || field == &m_syncProducerToInjectorSelection )
+        if ( field == &m_syncInjectorToProducerSelection || field == &m_syncProducerToInjectorSelection )
         {
             caf::PdmUiToolButtonEditorAttribute* toolButtonAttr = dynamic_cast<caf::PdmUiToolButtonEditorAttribute*>( attribute );
             if ( toolButtonAttr )
             {
                 toolButtonAttr->m_sizePolicy.setHorizontalPolicy( QSizePolicy::MinimumExpanding );
             }
-        }
-    }
-    if ( field == &m_resultVariableUiField )
-    {
-        caf::PdmUiListEditorAttribute* listEditAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
-        if ( listEditAttr )
-        {
-            listEditAttr->m_allowHorizontalScrollBar = false;
         }
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/RimElementVectorResult.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimElementVectorResult.cpp
@@ -32,7 +32,6 @@
 #include "RiuViewer.h"
 
 #include "cafAppEnum.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 
 CAF_PDM_SOURCE_INIT( RimElementVectorResult, "RimElementVectorResult" );

--- a/ApplicationLibCode/ProjectDataModel/RimMudWeightWindowParameters.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMudWeightWindowParameters.cpp
@@ -30,9 +30,9 @@
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
 #include "cafPdmUiDoubleValueEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPropertyViewDialog.h"
 #include "cafPdmUiTreeOrdering.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 CAF_PDM_SOURCE_INIT( RimMudWeightWindowParameters, "RimMudWeightWindowParameters" );
 
@@ -114,35 +114,35 @@ RimMudWeightWindowParameters::RimMudWeightWindowParameters()
     m_wellDeviationFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_wellDeviationAddress, "WellDeviationAddress", QString( "" ), "Value" );
-    m_wellDeviationAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_wellDeviationAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_wellAzimuthType, "WellAzimuthSourceType", defaultSourceType, "Well Azimuth" );
     CAF_PDM_InitField( &m_wellAzimuthFixed, "WellAzimuthFixed", 0.0, "Fixed Well Azimuth" );
     m_wellAzimuthFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_wellAzimuthAddress, "WellAzimuthAddress", QString( "" ), "Value" );
-    m_wellAzimuthAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_wellAzimuthAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_UCSType, "UCSSourceType", defaultSourceType, "UCS [Bar]" );
     CAF_PDM_InitField( &m_UCSFixed, "UCSFixed", 100.0, "Fixed UCS [Bar]" );
     m_UCSFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_UCSAddress, "UCSAddress", QString( "" ), "Value" );
-    m_UCSAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_UCSAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_poissonsRatioType, "PoissonsRatioSourceType", defaultSourceType, "Poisson's Ratio" );
     CAF_PDM_InitField( &m_poissonsRatioFixed, "PoissonsRatioFixed", 0.35, "Fixed Possion's Ratio" );
     m_poissonsRatioFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_poissonsRatioAddress, "PoissonsRatioAddress", QString( "" ), "Value" );
-    m_poissonsRatioAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_poissonsRatioAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_K0_FGType, "K0_FGSourceType", defaultSourceType, "K0 FG" );
     CAF_PDM_InitField( &m_K0_FGFixed, "K0_FGFixed", 0.75, "Fixed K0_FG" );
     m_K0_FGFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_K0_FGAddress, "K0_FGAddress", QString( "" ), "Value" );
-    m_K0_FGAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_K0_FGAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     caf::AppEnum<SourceType> defaultOBG0SourceType = RimMudWeightWindowParameters::SourceType::GRID;
     CAF_PDM_InitField( &m_obg0Type, "obg0SourceType", defaultOBG0SourceType, "Initial Overburden Gradient" );
@@ -150,7 +150,7 @@ RimMudWeightWindowParameters::RimMudWeightWindowParameters()
     m_obg0Fixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_obg0Address, "obg0Address", QString( "" ), "Value" );
-    m_obg0Address.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_obg0Address.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     m_parameterFields[RimMudWeightWindowParameters::ParameterType::WELL_DEVIATION] =
         std::make_tuple( &m_wellDeviationType, &m_wellDeviationFixed, &m_wellDeviationAddress );
@@ -190,7 +190,7 @@ RimMudWeightWindowParameters::RimMudWeightWindowParameters()
                        "" );
     CAF_PDM_InitField( &m_userDefinedPPNonReservoir, "UserPPNonReservoir", 1.0, "  Multiplier of hydrostatic PP" );
     CAF_PDM_InitField( &m_porePressureNonReservoirAddress, "PPNonReservoirAddress", QString( "" ), "Value" );
-    m_porePressureNonReservoirAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_porePressureNonReservoirAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_referenceLayer, "ReferenceLayer", -1, "Reference Layer" );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimMultipleEclipseResults.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMultipleEclipseResults.cpp
@@ -44,7 +44,6 @@ RimMultipleEclipseResults::RimMultipleEclipseResults()
 
     CAF_PDM_InitFieldNoDefault( &m_selectedKeywords, "SelectedProperties", "Properties" );
     m_selectedKeywords.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
-    m_selectedKeywords.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
@@ -49,9 +49,9 @@
 #include "RivReservoirViewPartMgr.h"
 
 #include "cafPdmUiCheckBoxTristateEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeOrdering.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 #include <set>
 
@@ -217,7 +217,7 @@ RimSimWellInViewCollection::RimSimWellInViewCollection()
     CAF_PDM_InitFieldNoDefault( &m_wellDiskSummaryCase, "WellDiskSummaryCase", "Summary Case" );
 
     CAF_PDM_InitField( &m_wellDiskQuantity, "WellDiskQuantity", QString( "WOPT" ), "Disk Quantity" );
-    m_wellDiskQuantity.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_wellDiskQuantity.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_wellDiskQuantity.uiCapability()->setAutoAddingOptionFromValue( false );
 
     CAF_PDM_InitFieldNoDefault( &m_wellDiskPropertyType, "WellDiskPropertyType", "Property Type" );

--- a/ApplicationLibCode/ProjectDataModel/RimTensorResults.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimTensorResults.cpp
@@ -28,8 +28,8 @@
 #include "RigGeoMechCaseData.h"
 
 #include "cafAppEnum.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiTreeOrdering.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 CAF_PDM_SOURCE_INIT( RimTensorResults, "RimTensorResults" );
 
@@ -92,7 +92,7 @@ RimTensorResults::RimTensorResults()
                        "Switches between automatic and user defined range",
                        "" );
 
-    m_resultFieldNameUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_resultFieldNameUiField.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
     m_resultFieldNameUiField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
 }
 
@@ -354,10 +354,10 @@ void RimTensorResults::defineEditorAttribute( const caf::PdmFieldHandle* field, 
 {
     if ( field == &m_resultFieldNameUiField )
     {
-        caf::PdmUiListEditorAttribute* listEditAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
-        if ( listEditAttr )
+        auto attr = dynamic_cast<caf::PdmUiTreeSelectionEditorAttribute*>( attribute );
+        if ( attr )
         {
-            listEditAttr->m_heightHint = 50;
+            attr->heightHint = 50;
         }
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/RimTimeStepFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimTimeStepFilter.cpp
@@ -32,7 +32,6 @@
 
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 
 #include <QDateTime>
@@ -83,7 +82,6 @@ RimTimeStepFilter::RimTimeStepFilter()
 
     CAF_PDM_InitFieldNoDefault( &m_filteredTimeStepsUi, "TimeStepIndicesUi", "Select From TimeSteps" );
     m_filteredTimeStepsUi.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
-    m_filteredTimeStepsUi.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
     m_filteredTimeStepsUi.xmlCapability()->disableIO();
 
     CAF_PDM_InitField( &m_readOnlyLastFrame, "OnlyLastFrame", false, "Load Only Last Frame Of Each Time Step" );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimAsciiDataCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimAsciiDataCurve.cpp
@@ -46,6 +46,8 @@ RimAsciiDataCurve::RimAsciiDataCurve()
     CAF_PDM_InitFieldNoDefault( &m_plotAxis, "PlotAxis", "Axis" );
     CAF_PDM_InitFieldNoDefault( &m_timeSteps, "TimeSteps", "Time Steps" );
     CAF_PDM_InitFieldNoDefault( &m_values, "Values", "Values" );
+    m_values.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+
     CAF_PDM_InitFieldNoDefault( &m_title, "Title", "Title" );
 
     setSymbolSkipDistance( 10.0f );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.cpp
@@ -34,8 +34,8 @@
 
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 #include <algorithm>
 
@@ -77,7 +77,7 @@ RimEnsembleCurveFilter::RimEnsembleCurveFilter()
     CAF_PDM_InitFieldNoDefault( &m_filterMode, "FilterMode", "Filter Mode" );
 
     CAF_PDM_InitFieldNoDefault( &m_ensembleParameterName, "EnsembleParameter", "Ensemble Parameter" );
-    m_ensembleParameterName.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_ensembleParameterName.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_objectiveValuesSummaryAddressesUiField, "SelectedObjectiveSummaryVar", "Vector" );
     m_objectiveValuesSummaryAddressesUiField.xmlCapability()->disableIO();
@@ -99,7 +99,7 @@ RimEnsembleCurveFilter::RimEnsembleCurveFilter()
     m_objectiveFunction->changed.connect( this, &RimEnsembleCurveFilter::onObjectionFunctionChanged );
 
     CAF_PDM_InitFieldNoDefault( &m_customObjectiveFunction, "CustomObjectiveFunction", "Custom Objective Function" );
-    m_customObjectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_customObjectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_minValue, "MinValue", m_lowerLimit, "Min" );
     m_minValue.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
@@ -70,7 +70,6 @@
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiItem.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiSliderEditor.h"
 #include "cafPdmUiTreeAttributes.h"
@@ -166,7 +165,7 @@ RimEnsembleCurveSet::RimEnsembleCurveSet()
     m_objectiveValuesSelectSummaryAddressPushButton = false;
 
     CAF_PDM_InitFieldNoDefault( &m_customObjectiveFunction, "CustomObjectiveFunction", "Objective Function" );
-    m_customObjectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_customObjectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_showObjectiveFunctionFormula, "ShowObjectiveFunctionFormula", true, "Show Text Box in Plot" );
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -54,7 +54,6 @@
 
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
@@ -45,7 +45,6 @@
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiItem.h"
 #include "cafPdmUiLabelEditor.h"
-#include "cafPdmUiListEditor.h"
 #include "cafPdmUiToolBarEditor.h"
 
 #include <QString>

--- a/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInView.cpp
@@ -80,7 +80,6 @@ RimWellMeasurementInView::RimWellMeasurementInView()
 
     CAF_PDM_InitFieldNoDefault( &m_qualityFilter, "QualityFilter", "Quality Filter" );
     m_qualityFilter.uiCapability()->setAutoAddingOptionFromValue( false );
-    m_qualityFilter.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_radiusScaleFactor, "RadiusScaleFactor", 2.5, "Radius Scale" );
     m_radiusScaleFactor.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LineEditAndPushButtons.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LineEditAndPushButtons.cpp
@@ -32,6 +32,7 @@ LineEditAndPushButtons::LineEditAndPushButtons()
     m_labelLongTextField.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_textListField, "TextListField", "Text List Field", "", "", "" );
+    m_textListField.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_pushButton_a, "PushButtonA", "Rotate", "", "", "" );
     m_pushButton_a.uiCapability()->setUiEditorTypeName( caf::PdmUiPushButtonEditor::uiEditorTypeName() );
@@ -139,6 +140,14 @@ void LineEditAndPushButtons::defineEditorAttribute( const caf::PdmFieldHandle* f
             myAttr->m_useSingleWidgetInsteadOfLabelAndEditorWidget = true;
         }
     }
+    else if ( field == &m_textListField )
+    {
+        auto myAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
+        if ( myAttr )
+        {
+            myAttr->heightHint = 150;
+        }
+    }
 
     {
         auto myAttr = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
@@ -172,7 +181,15 @@ void LineEditAndPushButtons::rotateContent()
     auto original = m_textListField.value();
 
     std::list<QString> newContent;
-    newContent.insert( newContent.begin(), original.begin(), original.end() );
+    if ( original.empty() )
+    {
+        newContent.push_back( "Item A" );
+        newContent.push_back( "Item B" );
+    }
+    else
+    {
+        newContent.insert( newContent.begin(), original.begin(), original.end() );
+    }
 
     auto firstItem = newContent.front();
     newContent.pop_front();

--- a/Fwk/AppFwk/cafTests/cafTestCvfApplication/TapCvfSpecialization.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestCvfApplication/TapCvfSpecialization.cpp
@@ -45,7 +45,7 @@ void TapCvfSpecialization::defineEditorAttribute( const caf::PdmFieldHandle* fie
         caf::PdmUiListEditorAttribute* myAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
         if ( myAttr )
         {
-            myAttr->m_baseColor.setRgbF( m_colorField().r(), m_colorField().g(), m_colorField().b() );
+            myAttr->baseColor.setRgbF( m_colorField().r(), m_colorField().g(), m_colorField().b() );
         }
     }
 }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDefaultObjectEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDefaultObjectEditor.cpp
@@ -47,6 +47,7 @@
 #include "cafPdmUiLineEditor.h"
 #include "cafPdmUiListEditor.h"
 #include "cafPdmUiTimeEditor.h"
+#include "cafPdmUiTreeSelectionEditor.h"
 
 #include <QGridLayout>
 
@@ -58,17 +59,19 @@ namespace caf
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiCheckBoxEditor, bool );
 
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiLineEditor, QString );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiDateEditor, QDate );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiDateEditor, QDateTime );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiTimeEditor, QTime );
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiLineEditor, int );
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiLineEditor, double );
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiLineEditor, float );
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiLineEditor, quint64 );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiListEditor, std::vector<QString> );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiListEditor, std::vector<int> );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiListEditor, std::vector<unsigned int> );
-CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiListEditor, std::vector<float> );
+
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiDateEditor, QDate );
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiDateEditor, QDateTime );
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiTimeEditor, QTime );
+
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiTreeSelectionEditor, std::vector<QString> );
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiTreeSelectionEditor, std::vector<int> );
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiTreeSelectionEditor, std::vector<unsigned int> );
+CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiTreeSelectionEditor, std::vector<float> );
 
 CAF_PDM_UI_REGISTER_DEFAULT_FIELD_EDITOR( PdmUiFilePathEditor, FilePath );
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiListEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiListEditor.cpp
@@ -176,13 +176,13 @@ void PdmUiListEditor::configureAndUpdateUi( const QString& uiConfigName )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );
 
-        m_listView->setHeightHint( attributes.m_heightHint );
-        if ( !attributes.m_allowHorizontalScrollBar )
+        m_listView->setHeightHint( attributes.heightHint );
+        if ( !attributes.allowHorizontalScrollBar )
         {
             m_listView->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
         }
 
-        m_listView->setProperty( "state", attributes.m_qssState );
+        m_listView->setProperty( "state", attributes.qssState );
         m_listView->style()->unpolish( m_listView );
         m_listView->style()->polish( m_listView );
     }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiListEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiListEditor.h
@@ -54,19 +54,19 @@ class PdmUiListEditorAttribute : public PdmUiEditorAttribute
 {
 public:
     PdmUiListEditorAttribute()
-        : m_heightHint( 2000 )
-        , m_allowHorizontalScrollBar( true )
+        : heightHint( 2000 )
+        , allowHorizontalScrollBar( true )
     {
         QPalette myPalette;
 
-        m_baseColor = myPalette.color( QPalette::Active, QPalette::Base );
+        baseColor = myPalette.color( QPalette::Active, QPalette::Base );
     }
 
 public:
-    QColor  m_baseColor;
-    QString m_qssState;
-    int     m_heightHint;
-    bool    m_allowHorizontalScrollBar;
+    QColor  baseColor;
+    QString qssState;
+    int     heightHint;
+    bool    allowHorizontalScrollBar;
 };
 
 //==================================================================================================

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
@@ -178,15 +178,6 @@ void PdmUiTreeSelectionEditor::configureAndUpdateUi( const QString& uiConfigName
         m_proxyModel->setFilterCaseSensitivity( Qt::CaseInsensitive );
 
         m_treeView->setModel( m_proxyModel );
-
-        if ( hasOnlyIntegers( m_model ) )
-        {
-            m_textFilterLineEdit->setPlaceholderText( "Integer filter eg. 1, 5-10" );
-        }
-        else
-        {
-            m_textFilterLineEdit->setPlaceholderText( "Type to filter items" );
-        }
     }
 
     QList<PdmOptionItemInfo> options = uiField()->valueOptions();
@@ -300,6 +291,16 @@ void PdmUiTreeSelectionEditor::configureAndUpdateUi( const QString& uiConfigName
                 }
             }
         }
+    }
+
+    // Set placeholder text based on content
+    if ( hasOnlyIntegers( m_model ) )
+    {
+        m_textFilterLineEdit->setPlaceholderText( "Integer filter e.g. 1, 5-10" );
+    }
+    else
+    {
+        m_textFilterLineEdit->setPlaceholderText( "Type to filter items" );
     }
 
     // It is required to use a timer here, as the layout of the widgets are handled by events
@@ -821,6 +822,14 @@ bool PdmUiTreeSelectionEditor::hasOnlyIntegers( const QAbstractItemModel* model 
 {
     if ( !model ) return false;
 
+    // Lambda function to check if a string is an integer
+    auto isInteger = []( const QString& s ) -> bool
+    {
+        bool ok;
+        s.toInt( &ok );
+        return ok;
+    };
+
     for ( int row = 0; row < model->rowCount(); ++row )
     {
         for ( int column = 0; column < model->columnCount(); ++column )
@@ -829,7 +838,7 @@ bool PdmUiTreeSelectionEditor::hasOnlyIntegers( const QAbstractItemModel* model 
             if ( index.isValid() )
             {
                 QVariant data = index.data();
-                if ( !data.canConvert<int>() )
+                if ( !data.canConvert<QString>() || !isInteger( data.toString() ) )
                 {
                     return false;
                 }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
@@ -535,10 +535,15 @@ void PdmUiTreeSelectionEditor::slotToggleAll()
     if ( m_toggleAllCheckBox->isChecked() )
     {
         checkAllItems();
+        return;
     }
-    else
+
+    unCheckAllItems();
+
+    // Apply integer filtering if the model contains only integers
+    if ( hasOnlyIntegers( m_model ) )
     {
-        unCheckAllItems();
+        setCheckedStateForIntegerItemsMatchingFilter();
     }
 }
 
@@ -572,7 +577,7 @@ void PdmUiTreeSelectionEditor::slotInvertCheckedStateOfAll()
 ///
 /// Mark matching items as checked
 //--------------------------------------------------------------------------------------------------
-void PdmUiTreeSelectionEditor::setCheckedStateForItemsMatchingFilter()
+void PdmUiTreeSelectionEditor::setCheckedStateForIntegerItemsMatchingFilter()
 {
 #if ( QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 ) )
     auto SkipEmptyParts = QString::SkipEmptyParts;
@@ -646,7 +651,7 @@ void PdmUiTreeSelectionEditor::slotTextFilterChanged()
 {
     if ( hasOnlyIntegers( m_model ) )
     {
-        setCheckedStateForItemsMatchingFilter();
+        setCheckedStateForIntegerItemsMatchingFilter();
 
         return;
     }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.h
@@ -129,7 +129,7 @@ private:
     void setCheckedStateForSubItemsOfSelected( bool checked );
     void checkAllItems();
     void unCheckAllItems();
-    void setCheckedStateForItemsMatchingFilter();
+    void setCheckedStateForIntegerItemsMatchingFilter();
 
     QModelIndexList allVisibleSourceModelIndices() const;
     void recursiveAppendVisibleSourceModelIndices( const QModelIndex& parent, QModelIndexList* sourceModelIndices ) const;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.h
@@ -47,6 +47,7 @@ class QLineEdit;
 class QSortFilterProxyModel;
 class QModelIndex;
 class QItemSelection;
+class QTreeViewHeightHint;
 
 namespace caf
 {
@@ -62,6 +63,7 @@ public:
     bool showToggleAllCheckbox;
     bool singleSelectionMode;
     bool setCurrentIndexWhenItemIsChecked;
+    int  heightHint;
 
     /// currentIndexFieldHandle is used to communicate the value of current item in the tree view
     /// This is useful when displaying a list of appEnums, and a dependent view is displaying content based on
@@ -76,6 +78,7 @@ public:
         showToggleAllCheckbox            = true;
         singleSelectionMode              = false;
         setCurrentIndexWhenItemIsChecked = false;
+        heightHint                       = -1;
 
         currentIndexFieldHandle = nullptr;
     }
@@ -130,15 +133,17 @@ private:
     void recursiveAppendVisibleSourceModelIndices( const QModelIndex& parent, QModelIndexList* sourceModelIndices ) const;
 
 private:
-    QPointer<QTreeView>       m_treeView;
-    QPointer<QShortenedLabel> m_label;
-    QPointer<QCheckBox>       m_toggleAllCheckBox;
-    QPointer<QLineEdit>       m_textFilterLineEdit;
+    QPointer<QTreeViewHeightHint> m_treeView;
+    QPointer<QShortenedLabel>     m_label;
+    QPointer<QCheckBox>           m_toggleAllCheckBox;
+    QPointer<QLineEdit>           m_textFilterLineEdit;
 
     PdmUiTreeSelectionQModel* m_model;
     QSortFilterProxyModel*    m_proxyModel;
 
     PdmUiTreeSelectionEditorAttribute m_attributes;
+
+    bool m_useSingleSelectionMode;
 };
 
 } // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.h
@@ -47,11 +47,12 @@ class QLineEdit;
 class QSortFilterProxyModel;
 class QModelIndex;
 class QItemSelection;
-class QTreeViewHeightHint;
 
 namespace caf
 {
 class PdmUiTreeSelectionQModel;
+class FilterLeafNodesOnlyProxyModel;
+class QTreeViewHeightHint;
 
 //==================================================================================================
 ///
@@ -128,9 +129,12 @@ private:
     void setCheckedStateForSubItemsOfSelected( bool checked );
     void checkAllItems();
     void unCheckAllItems();
+    void setCheckedStateForItemsMatchingFilter();
 
     QModelIndexList allVisibleSourceModelIndices() const;
     void recursiveAppendVisibleSourceModelIndices( const QModelIndex& parent, QModelIndexList* sourceModelIndices ) const;
+
+    static bool hasOnlyIntegers( const QAbstractItemModel* model );
 
 private:
     QPointer<QTreeViewHeightHint> m_treeView;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp
@@ -99,7 +99,7 @@ void caf::PdmUiTreeSelectionQModel::setCheckedStateForItems( const QModelIndexLi
         QVariant        fieldValue          = m_uiFieldHandle->uiField()->uiValue();
         QList<QVariant> fieldValueSelection = fieldValue.toList();
 
-        for ( auto v : fieldValueSelection )
+        for ( const auto& v : fieldValueSelection )
         {
             selectedIndices.insert( v.toUInt() );
         }
@@ -107,7 +107,7 @@ void caf::PdmUiTreeSelectionQModel::setCheckedStateForItems( const QModelIndexLi
 
     if ( checked )
     {
-        for ( auto mi : sourceModelIndices )
+        for ( const auto& mi : sourceModelIndices )
         {
             const caf::PdmOptionItemInfo* optionItemInfo = optionItem( mi );
             if ( !optionItemInfo->isReadOnly() )
@@ -118,7 +118,7 @@ void caf::PdmUiTreeSelectionQModel::setCheckedStateForItems( const QModelIndexLi
     }
     else
     {
-        for ( auto mi : sourceModelIndices )
+        for ( const auto& mi : sourceModelIndices )
         {
             const caf::PdmOptionItemInfo* optionItemInfo = optionItem( mi );
             if ( !optionItemInfo->isReadOnly() )
@@ -479,7 +479,7 @@ bool caf::PdmUiTreeSelectionQModel::setData( const QModelIndex& index, const QVa
             {
                 QList<QVariant> fieldValueSelection = fieldValue.toList();
 
-                for ( auto v : fieldValueSelection )
+                for ( const auto& v : fieldValueSelection )
                 {
                     selectedIndices.push_back( v.toUInt() );
                 }


### PR DESCRIPTION
Closes #9978

Example of updated UI
![image](https://github.com/OPM/ResInsight/assets/1793152/194d6348-fad9-4e35-9787-ea535a1e8380)


For models with integer values, the text string is used to define the items to be checked. Typing `1, 5-7` will mark items `1, 5, 6, 7` and set all other unchecked. This is useful for category results.

![image](https://github.com/OPM/ResInsight/assets/1793152/bde31301-d7c5-403b-b0d9-34b754a14b89)
