### PR TITLE
Rename RimWellLogDiffCurve to RimWellLogCalculatedCurve and additional improvements

### DIFF
--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -30,8 +30,8 @@
 #include "RimProject.h"
 #include "RimSimWellInView.h"
 #include "RimSummaryCase.h"
+#include "RimWellLogCalculatedCurve.h"
 #include "RimWellLogCurveCommonDataSource.h"
-#include "RimWellLogDiffCurve.h"
 #include "RimWellLogExtractionCurve.h"
 #include "RimWellLogFile.h"
 #include "RimWellLogFileChannel.h"
@@ -586,12 +586,12 @@ RimWellMeasurementCurve* RicWellLogTools::addWellMeasurementCurve( RimWellLogTra
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimWellLogDiffCurve* RicWellLogTools::addWellLogDiffCurve( RimWellLogTrack* plotTrack, bool showPlotWindow )
+RimWellLogCalculatedCurve* RicWellLogTools::addWellLogCalculatedCurve( RimWellLogTrack* plotTrack, bool showPlotWindow )
 {
     CVF_ASSERT( plotTrack );
 
-    RimWellLogDiffCurve* curve      = new RimWellLogDiffCurve();
-    const cvf::Color3f   curveColor = RicWellLogPlotCurveFeatureImpl::curveColorFromTable( plotTrack->curveCount() );
+    RimWellLogCalculatedCurve* curve      = new RimWellLogCalculatedCurve();
+    const cvf::Color3f         curveColor = RicWellLogPlotCurveFeatureImpl::curveColorFromTable( plotTrack->curveCount() );
     curve->setColor( curveColor );
 
     plotTrack->addCurve( curve );

--- a/ApplicationLibCode/Commands/RicWellLogTools.h
+++ b/ApplicationLibCode/Commands/RicWellLogTools.h
@@ -38,7 +38,7 @@ class RimWellPath;
 class RimWellMeasurementCurve;
 class RimSummaryCase;
 class RimWellLogCurve;
-class RimWellLogDiffCurve;
+class RimWellLogCalculatedCurve;
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -73,7 +73,7 @@ public:
                                                           bool             showPlotWindow = true );
     static RimWellMeasurementCurve*
         addWellMeasurementCurve( RimWellLogTrack* plotTrack, RimWellPath* wellPath, const QString& measurementName, bool showPlotWindow = true );
-    static RimWellLogDiffCurve* addWellLogDiffCurve( RimWellLogTrack* plotTrack, bool showPlotWindow = true );
+    static RimWellLogCalculatedCurve* addWellLogCalculatedCurve( RimWellLogTrack* plotTrack, bool showPlotWindow = true );
 
     static RimWellLogCurve*    addSummaryRftCurve( RimWellLogTrack* plotTrack, RimSummaryCase* rimCase );
     static RimWellLogRftCurve* addSummaryRftSegmentCurve( RimWellLogTrack*          plotTrack,

--- a/ApplicationLibCode/Commands/WellLogCommands/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/WellLogCommands/CMakeLists_files.cmake
@@ -30,7 +30,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicNewRftWellLogPlotFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicNewRftSegmentWellLogPlotFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicNewMultiPhaseRftSegmentPlotFeature.h
-    ${CMAKE_CURRENT_LIST_DIR}/RicNewWellLogDiffCurveFeature.h
+    ${CMAKE_CURRENT_LIST_DIR}/RicNewWellLogCalculatedCurveFeature.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -65,7 +65,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicNewRftWellLogPlotFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicNewRftSegmentWellLogPlotFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicNewMultiPhaseRftSegmentPlotFeature.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/RicNewWellLogDiffCurveFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicNewWellLogCalculatedCurveFeature.cpp
 )
 
 list(APPEND COMMAND_CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogCalculatedCurveFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogCalculatedCurveFeature.cpp
@@ -16,12 +16,12 @@
 //
 /////////////////////////////////////////////////////////////////////////////////
 
-#include "RicNewWellLogDiffCurveFeature.h"
+#include "RicNewWellLogCalculatedCurveFeature.h"
 
 #include "RicWellLogTools.h"
 
+#include "RimWellLogCalculatedCurve.h"
 #include "RimWellLogCurve.h"
-#include "RimWellLogDiffCurve.h"
 #include "RimWellLogTrack.h"
 
 #include "RiuPlotMainWindowTools.h"
@@ -33,12 +33,12 @@
 
 #include <vector>
 
-CAF_CMD_SOURCE_INIT( RicNewWellLogDiffCurveFeature, "RicNewWellLogDiffCurveFeature" );
+CAF_CMD_SOURCE_INIT( RicNewWellLogCalculatedCurveFeature, "RicNewWellLogCalculatedCurveFeature" );
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RicNewWellLogDiffCurveFeature::isCommandEnabled()
+bool RicNewWellLogCalculatedCurveFeature::isCommandEnabled()
 {
     std::vector<RimWellLogCurve*> wellLogCurves;
     caf::SelectionManager::instance()->objectsByType( &wellLogCurves );
@@ -49,12 +49,12 @@ bool RicNewWellLogDiffCurveFeature::isCommandEnabled()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicNewWellLogDiffCurveFeature::onActionTriggered( bool isChecked )
+void RicNewWellLogCalculatedCurveFeature::onActionTriggered( bool isChecked )
 {
     RimWellLogTrack* wellLogTrack = caf::SelectionManager::instance()->selectedItemOfType<RimWellLogTrack>();
     if ( wellLogTrack )
     {
-        RicWellLogTools::addWellLogDiffCurve( wellLogTrack );
+        RicWellLogTools::addWellLogCalculatedCurve( wellLogTrack );
     }
     else
     {
@@ -65,7 +65,7 @@ void RicNewWellLogDiffCurveFeature::onActionTriggered( bool isChecked )
         RimWellLogTrack* wellLogTrack = wellLogCurves[0]->firstAncestorOrThisOfType<RimWellLogTrack>();
         if ( !wellLogTrack ) return;
 
-        RimWellLogDiffCurve* newCurve = RicWellLogTools::addWellLogDiffCurve( wellLogTrack );
+        RimWellLogCalculatedCurve* newCurve = RicWellLogTools::addWellLogCalculatedCurve( wellLogTrack );
         newCurve->setWellLogCurves( wellLogCurves[0], wellLogCurves[1] );
         newCurve->updateConnectedEditors();
     }
@@ -75,8 +75,8 @@ void RicNewWellLogDiffCurveFeature::onActionTriggered( bool isChecked )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicNewWellLogDiffCurveFeature::setupActionLook( QAction* actionToSetup )
+void RicNewWellLogCalculatedCurveFeature::setupActionLook( QAction* actionToSetup )
 {
-    actionToSetup->setText( "New Well Log Diff Curve" );
+    actionToSetup->setText( "New Well Log Calculated Curve" );
     actionToSetup->setIcon( QIcon( ":/WellLogCurve16x16.png" ) );
 }

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogCalculatedCurveFeature.h
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogCalculatedCurveFeature.h
@@ -23,7 +23,7 @@
 //==================================================================================================
 ///
 //==================================================================================================
-class RicNewWellLogDiffCurveFeature : public caf::CmdFeature
+class RicNewWellLogCalculatedCurveFeature : public caf::CmdFeature
 {
     CAF_CMD_HEADER_INIT;
 

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechFaultReactivationResult.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechFaultReactivationResult.cpp
@@ -35,7 +35,7 @@
 #include "RimIntersectionCollection.h"
 #include "RimMainPlotCollection.h"
 #include "RimModeledWellPath.h"
-#include "RimWellLogDiffCurve.h"
+#include "RimWellLogCalculatedCurve.h"
 #include "RimWellLogExtractionCurve.h"
 #include "RimWellLogPlotCollection.h"
 #include "RimWellLogPlotNameConfig.h"
@@ -286,8 +286,8 @@ void RimGeoMechFaultReactivationResult::createWellLogCurves()
     const bool       doUpdateAfter = true;
     RimWellLogTrack* wellLogExtractionDisplacementTrack =
         RicNewWellLogPlotFeatureImpl::createWellLogPlotTrack( doUpdateAfter, QString( "Fault Reactivation Displacement Curves" ), newPlot );
-    RimWellLogTrack* wellLogDiffTrack =
-        RicNewWellLogPlotFeatureImpl::createWellLogPlotTrack( doUpdateAfter, QString( "Fault Reactivation Displacement Diff" ), newPlot );
+    RimWellLogTrack* wellLogCalculatedTrack =
+        RicNewWellLogPlotFeatureImpl::createWellLogPlotTrack( doUpdateAfter, QString( "Fault Reactivation Displacement Difference" ), newPlot );
     RimWellLogTrack* wellLogExtractionFaultmobTrack =
         RicNewWellLogPlotFeatureImpl::createWellLogPlotTrack( doUpdateAfter, QString( "Fault Reactivation Faultmob Curves" ), newPlot );
 
@@ -308,11 +308,12 @@ void RimGeoMechFaultReactivationResult::createWellLogCurves()
         return;
     }
 
-    // Create well log diff curve for m_faceAWellPath and m_faceBWellPath
-    RimWellLogDiffCurve* faceWellLogDiffCurve = RicWellLogTools::addWellLogDiffCurve( wellLogDiffTrack );
-    faceWellLogDiffCurve->setWellLogCurves( faceADisplacementCurve, faceBDisplacementCurve );
-    faceWellLogDiffCurve->loadDataAndUpdate( true );
-    faceWellLogDiffCurve->updateConnectedEditors();
+    // Create well log calculated curve for m_faceAWellPath and m_faceBWellPath
+    RimWellLogCalculatedCurve* wellLogCalculatedCurve = RicWellLogTools::addWellLogCalculatedCurve( wellLogCalculatedTrack );
+    wellLogCalculatedCurve->setOperator( RimWellLogCalculatedCurve::Operators::SUBTRACT );
+    wellLogCalculatedCurve->setWellLogCurves( faceADisplacementCurve, faceBDisplacementCurve );
+    wellLogCalculatedCurve->loadDataAndUpdate( true );
+    wellLogCalculatedCurve->updateConnectedEditors();
 
     // Well log extraction faultmob curves
     RigFemResultAddress wellLogExtractionFaultmobResult( RigFemResultPosEnum::RIG_ELEMENT_NODAL_FACE, "SE", "FAULTMOB" );

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -639,7 +639,7 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
             menuBuilder << "RicNewWellLogRftCurveFeature";
             menuBuilder << "RicNewWellLogFileCurveFeature";
             menuBuilder << "RicNewWellMeasurementCurveFeature";
-            menuBuilder << "RicNewWellLogDiffCurveFeature";
+            menuBuilder << "RicNewWellLogCalculatedCurveFeature";
             menuBuilder << "RicNewEnsembleWellLogCurveSetFeature";
             menuBuilder << "Separator";
             menuBuilder << "RicDeleteSubPlotFeature";
@@ -1245,7 +1245,7 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         }
         else if ( dynamic_cast<RimWellLogCurve*>( firstUiItem ) || dynamic_cast<RimWellLogTrack*>( firstUiItem ) )
         {
-            menuBuilder << "RicNewWellLogDiffCurveFeature";
+            menuBuilder << "RicNewWellLogCalculatedCurveFeature";
             menuBuilder << "RicExportToLasFileFeature";
             menuBuilder << "RicChangeDataSourceFeature";
         }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/CMakeLists_files.cmake
@@ -26,7 +26,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimRftTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RimRftTopologyCurve.h
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCurveInfoTextProvider.h
-    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogDiffCurve.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCalculatedCurve.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -57,7 +57,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimRftTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimRftTopologyCurve.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCurveInfoTextProvider.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogDiffCurve.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCalculatedCurve.cpp
 )
 
 list(APPEND CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.cpp
@@ -231,7 +231,7 @@ void RimWellLogCalculatedCurve::setAutomaticName()
 //--------------------------------------------------------------------------------------------------
 void RimWellLogCalculatedCurve::onWellLogCurveChanged( const SignalEmitter* emitter )
 {
-    onLoadDataAndUpdate( true );
+    loadDataAndUpdate( true );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.cpp
@@ -273,7 +273,7 @@ double RimWellLogCalculatedCurve::calculateValue( double firstValue, double seco
     }
     if ( operatorValue == Operators::DIVIDE )
     {
-        return firstValue / secondValue;
+        return secondValue == 0.0 ? std::numeric_limits<double>::infinity() : firstValue / secondValue;
     }
     return 0.0;
 }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
@@ -30,20 +30,32 @@ class RimWellPath;
 ///
 ///
 //==================================================================================================
-class RimWellLogDiffCurve : public RimWellLogCurve
+class RimWellLogCalculatedCurve : public RimWellLogCurve
 {
     CAF_PDM_HEADER_INIT;
 
 public:
-    RimWellLogDiffCurve();
-    ~RimWellLogDiffCurve() override;
+    enum class Operators
+    {
+        ADD,
+        SUBTRACT,
+        DIVIDE,
+        MULTIPLY
+    };
 
+public:
+    RimWellLogCalculatedCurve();
+    ~RimWellLogCalculatedCurve() override;
+
+    void setOperator( Operators operatorValue );
     void setWellLogCurves( RimWellLogCurve* firstWellLogCurve, RimWellLogCurve* secondWellLogCurve );
 
     // Inherited via RimWellLogCurve
     QString wellName() const override;
     QString wellLogChannelUiName() const override;
     QString wellLogChannelUnits() const override;
+
+    static double calculateValue( double firstValue, double secondValue, Operators operatorValue );
 
 protected:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
@@ -64,6 +76,8 @@ private:
 
 private:
     caf::PdmPtrField<RimCase*> m_case;
+
+    caf::PdmField<caf::AppEnum<Operators>> m_operator;
 
     caf::PdmPtrField<RimWellLogCurve*> m_firstWellLogCurve;
     caf::PdmPtrField<RimWellLogCurve*> m_secondWellLogCurve;

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
@@ -42,6 +42,12 @@ public:
         DIVIDE,
         MULTIPLY
     };
+    enum class DepthSource
+    {
+        FIRST,
+        SECOND,
+        UNION
+    };
 
 public:
     RimWellLogCalculatedCurve();
@@ -56,6 +62,7 @@ public:
     QString wellLogChannelUnits() const override;
 
     static double calculateValue( double firstValue, double secondValue, Operators operatorValue );
+    static std::vector<double> unionDepthValuesFromVectors( const std::vector<double>& firstDepths, const std::vector<double>& secondDepths );
 
 protected:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
@@ -74,10 +81,14 @@ private:
     void connectWellLogCurveChangedToSlots( RimWellLogCurve* wellLogCurve );
     void disconnectWellLogCurveChangedFromSlots( RimWellLogCurve* wellLogCurve );
 
+    std::vector<double> depthValuesFromSource( RiaDefines::DepthTypeEnum depthType ) const;
+    std::vector<double> unionDepthValuesFromCurves( RiaDefines::DepthTypeEnum depthType ) const;
+
 private:
     caf::PdmPtrField<RimCase*> m_case;
 
-    caf::PdmField<caf::AppEnum<Operators>> m_operator;
+    caf::PdmField<caf::AppEnum<Operators>>   m_operator;
+    caf::PdmField<caf::AppEnum<DepthSource>> m_depthSource;
 
     caf::PdmPtrField<RimWellLogCurve*> m_firstWellLogCurve;
     caf::PdmPtrField<RimWellLogCurve*> m_secondWellLogCurve;

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
@@ -62,7 +62,8 @@ public:
     QString wellLogChannelUnits() const override;
 
     static double calculateValue( double firstValue, double secondValue, Operators operatorValue );
-    static std::vector<double> unionDepthValuesFromVectors( const std::vector<double>& firstDepths, const std::vector<double>& secondDepths );
+    static std::vector<double>
+        unionDepthValuesFromVectors( const std::vector<double>& firstDepths, const std::vector<double>& secondDepths, double threshold );
 
 protected:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;

--- a/ApplicationLibCode/UnitTests/CMakeLists_files.cmake
+++ b/ApplicationLibCode/UnitTests/CMakeLists_files.cmake
@@ -92,6 +92,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaEnsembleNameTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigDeclineCurveCalculator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellLogCurveData-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCalculatedCurve-Test.cpp
 )
 
 if(RESINSIGHT_ENABLE_GRPC)

--- a/ApplicationLibCode/UnitTests/RimWellLogCalculatedCurve-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellLogCalculatedCurve-Test.cpp
@@ -27,12 +27,14 @@ TEST( RimWellLogCalculatedCurve, unionDepthValuesFromVectors_singleValuesInDepth
     // Depth vectors without duplicates
     const std::vector<double> depthValues1 = { 1.0, 2.0, 3.0, 4.0 };
     const std::vector<double> depthValues2 = { 2.0, 3.0, 4.0, 5.0 };
+    const double              threshold    = 0.1;
 
     // Expected duplicate occurrence of common depth values
-    const std::vector<double> expectedUnionDepthValues = { 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0 };
+    const std::vector<double> expectedUnionDepthValues = { 1.0, 2.0, 3.0, 4.0, 5.0 };
 
     // Call the function under test
-    const std::vector<double> unionDepthValues = RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2 );
+    const std::vector<double> unionDepthValues =
+        RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2, threshold );
 
     ASSERT_EQ( unionDepthValues, expectedUnionDepthValues );
 }
@@ -43,14 +45,36 @@ TEST( RimWellLogCalculatedCurve, unionDepthValuesFromVectors_singleValuesInDepth
 TEST( RimWellLogCalculatedCurve, unionDepthValuesFromVectors_duplicateValuesInDepthVectors )
 {
     // Depth vectors with duplicates
-    const std::vector<double> depthValues1 = { 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 };
-    const std::vector<double> depthValues2 = { 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0 };
+    const std::vector<double> depthValues1 = { 0.0, 0.5, 0.5, 1.0, 1.0, 1.5, 1.5 };
+    const std::vector<double> depthValues2 = { 1.5, 1.5, 2.0, 2.0, 2.5, 2.5, 3.0 };
+    const double              threshold    = 0.1;
 
-    // Expected maximum 2 duplicate occurrences of common depth values
-    const std::vector<double> expectedUnionDepthValues = { 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0 };
+    // Expected no duplicate occurrences of depth values
+    const std::vector<double> expectedUnionDepthValues = { 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0 };
 
     // Call the function under test
-    const std::vector<double> unionDepthValues = RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2 );
+    const std::vector<double> unionDepthValues =
+        RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2, threshold );
+
+    ASSERT_EQ( unionDepthValues, expectedUnionDepthValues );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellLogCalculatedCurve, unionDepthValuesFromVectors_thresholdVerification )
+{
+    // Depth vectors with duplicates
+    const std::vector<double> depthValues1 = { 0.0, 0.5, 1.0, 1.5 };
+    const std::vector<double> depthValues2 = { 2.0, 2.5, 3.0, 4.0 };
+    const double              threshold    = 0.6;
+
+    // Expected every second value to be skipped due to threshold
+    const std::vector<double> expectedUnionDepthValues = { 0.0, 1.0, 2.0, 3.0, 4.0 };
+
+    // Call the function under test
+    const std::vector<double> unionDepthValues =
+        RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2, threshold );
 
     ASSERT_EQ( unionDepthValues, expectedUnionDepthValues );
 }

--- a/ApplicationLibCode/UnitTests/RimWellLogCalculatedCurve-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellLogCalculatedCurve-Test.cpp
@@ -64,4 +64,8 @@ TEST( RimWellLogCalculatedCurve, calculateValue )
     ASSERT_DOUBLE_EQ( 3.0, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::SUBTRACT ) );
     ASSERT_DOUBLE_EQ( 2.5, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::DIVIDE ) );
     ASSERT_DOUBLE_EQ( 10.0, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::MULTIPLY ) );
+
+    // Divide by zero
+    ASSERT_DOUBLE_EQ( std::numeric_limits<double>::infinity(),
+                      RimWellLogCalculatedCurve::calculateValue( 5.0, 0.0, RimWellLogCalculatedCurve::Operators::DIVIDE ) );
 }

--- a/ApplicationLibCode/UnitTests/RimWellLogCalculatedCurve-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellLogCalculatedCurve-Test.cpp
@@ -1,0 +1,67 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2023- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+
+#include "gtest/gtest.h"
+
+#include "RimWellLogCalculatedCurve.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellLogCalculatedCurve, unionDepthValuesFromVectors_singleValuesInDepthVectors )
+{
+    // Depth vectors without duplicates
+    const std::vector<double> depthValues1 = { 1.0, 2.0, 3.0, 4.0 };
+    const std::vector<double> depthValues2 = { 2.0, 3.0, 4.0, 5.0 };
+
+    // Expected duplicate occurrence of common depth values
+    const std::vector<double> expectedUnionDepthValues = { 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0 };
+
+    // Call the function under test
+    const std::vector<double> unionDepthValues = RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2 );
+
+    ASSERT_EQ( unionDepthValues, expectedUnionDepthValues );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellLogCalculatedCurve, unionDepthValuesFromVectors_duplicateValuesInDepthVectors )
+{
+    // Depth vectors with duplicates
+    const std::vector<double> depthValues1 = { 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 };
+    const std::vector<double> depthValues2 = { 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0 };
+
+    // Expected maximum 2 duplicate occurrences of common depth values
+    const std::vector<double> expectedUnionDepthValues = { 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0 };
+
+    // Call the function under test
+    const std::vector<double> unionDepthValues = RimWellLogCalculatedCurve::unionDepthValuesFromVectors( depthValues1, depthValues2 );
+
+    ASSERT_EQ( unionDepthValues, expectedUnionDepthValues );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellLogCalculatedCurve, calculateValue )
+{
+    ASSERT_DOUBLE_EQ( 7.0, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::ADD ) );
+    ASSERT_DOUBLE_EQ( 3.0, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::SUBTRACT ) );
+    ASSERT_DOUBLE_EQ( 2.5, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::DIVIDE ) );
+    ASSERT_DOUBLE_EQ( 10.0, RimWellLogCalculatedCurve::calculateValue( 5.0, 2.0, RimWellLogCalculatedCurve::Operators::MULTIPLY ) );
+}


### PR DESCRIPTION
- Renaming
- Add math operators
- Add option to select which curve to use as "base" for resampling, or to use union of depth values from both curves

Closes: #10296