### PR TITLE
Avoid calling performUpdate() in showEvent()

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
@@ -805,6 +805,8 @@ void RimMultiPlot::onLoadDataAndUpdate()
     RiuPlotMainWindowTools::refreshToolbars();
 
     m_showPlotLegends = originalShowState;
+
+    if ( m_viewer ) m_viewer->forcePerformUpdate();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMultiPlotBook.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMultiPlotBook.cpp
@@ -399,7 +399,6 @@ void RiuMultiPlotBook::showEvent( QShowEvent* event )
     m_goToPageAfterUpdate = true;
     QWidget::showEvent( event );
 
-    performUpdate( RiaDefines::MultiPlotPageUpdateType::ALL );
     if ( m_previewMode )
     {
         applyPagePreviewBookSize( width() );
@@ -536,6 +535,14 @@ void RiuMultiPlotBook::updatePageTitles()
     {
         m_pages[0]->setPlotTitle( QString( "%1" ).arg( m_plotTitle ) );
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMultiPlotBook::forcePerformUpdate()
+{
+    performUpdate( RiaDefines::MultiPlotPageUpdateType::ALL );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMultiPlotBook.h
+++ b/ApplicationLibCode/UserInterface/RiuMultiPlotBook.h
@@ -93,6 +93,11 @@ public:
 
     void keepCurrentPageAfterUpdate();
 
+    // https://github.com/OPM/ResInsight/issues/10349
+    // This function is used to force an update of the plot book. It is intended to be used from RimMultiPlot::onLoadDataAndUpdate()
+    // The code used to be called from RiuMultiPlotBook::showEvent(), but this caused a crash when a dock widget was hidden and shown again.
+    void forcePerformUpdate();
+
 protected:
     void contextMenuEvent( QContextMenuEvent* ) override;
 


### PR DESCRIPTION
When a dock widget in a dock widget tab group is activated, a show event is triggered in `RimMultiPlotBook::showEvent`. This causes a crash if performUpdate is called in showEvent. Make sure the performUpdate is called from `RimMultiPlot::onLoadDataAndUpdate()`

Closes #10349