### PR TITLE
Fix bug in color mapping when changing mapping mode for Tables

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
@@ -103,6 +103,14 @@ void AppEnum<RimWellConnectivityTable::TimeStepRangeFilterMode>::setUp()
     addItem( RimWellConnectivityTable::TimeStepRangeFilterMode::TIME_STEP_COUNT, "TIME_STEP_COUNT", "Time Step Count" );
     setDefault( RimWellConnectivityTable::TimeStepRangeFilterMode::TIME_STEP_COUNT );
 }
+
+template <>
+void AppEnum<RimWellConnectivityTable::RangeType>::setUp()
+{
+    addItem( RimWellConnectivityTable::RangeType::AUTOMATIC, "AUTOMATIC", "Min and Max in Table" );
+    addItem( RimWellConnectivityTable::RangeType::USER_DEFINED, "USER_DEFINED_MAX_MIN", "User Defined Range" );
+    setDefault( RimWellConnectivityTable::RangeType::AUTOMATIC );
+}
 } // namespace caf
 
 //--------------------------------------------------------------------------------------------------
@@ -177,6 +185,9 @@ RimWellConnectivityTable::RimWellConnectivityTable()
     m_legendConfig->setShowLegend( true );
     m_legendConfig->setAutomaticRanges( 0.0, 100.0, 0.0, 100.0 );
     m_legendConfig->setColorLegend( RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::HEAT_MAP ) );
+
+    CAF_PDM_InitFieldNoDefault( &m_mappingType, "MappingType", "Mapping Type" );
+    CAF_PDM_InitFieldNoDefault( &m_rangeType, "RangeType", "Range Type" );
 
     setLegendsVisible( true );
     setAsPlotMdiWindow();
@@ -405,6 +416,23 @@ void RimWellConnectivityTable::fieldChangedByUi( const caf::PdmFieldHandle* chan
     {
         m_matrixPlotWidget->setValueFontSize( valueLabelFontSize() );
     }
+    else if ( changedField == &m_rangeType && m_legendConfig )
+    {
+        auto rangeMode = m_rangeType == RangeType::AUTOMATIC ? RimLegendConfig::RangeModeType::AUTOMATIC_ALLTIMESTEPS
+                                                             : RimLegendConfig::RangeModeType::USER_DEFINED;
+        m_legendConfig->setRangeMode( rangeMode );
+        m_legendConfig->updateTickCountAndUserDefinedRange();
+        onLoadDataAndUpdate();
+    }
+    else if ( changedField == &m_mappingType && m_legendConfig )
+    {
+        m_legendConfig->setMappingMode( m_mappingType() );
+        if ( m_rangeType == RangeType::AUTOMATIC )
+        {
+            m_legendConfig->updateTickCountAndUserDefinedRange();
+        }
+        onLoadDataAndUpdate();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -472,7 +500,10 @@ void RimWellConnectivityTable::defineUiOrdering( QString uiConfigName, caf::PdmU
 
     caf::PdmUiGroup* tableSettingsGroup = uiOrdering.addNewGroup( "Table Settings" );
     tableSettingsGroup->add( &m_showValueLabels );
-    m_legendConfig->uiOrdering( "FlagColorsAndMappingModeOnly", *tableSettingsGroup );
+    m_legendConfig->uiOrdering( "FlagAndColorsOnly", *tableSettingsGroup );
+    tableSettingsGroup->add( &m_mappingType );
+    tableSettingsGroup->add( &m_rangeType );
+    m_legendConfig->uiOrdering( "UserDefinedMinMaxOnly", *tableSettingsGroup );
 
     caf::PdmUiGroup* fontGroup = uiOrdering.addNewGroup( "Fonts" );
     fontGroup->setCollapsedByDefault();
@@ -605,6 +636,7 @@ void RimWellConnectivityTable::onLoadDataAndUpdate()
     // Fill matrix plot widget with filtered rows/columns
     double maxValue = 0.0;
     m_matrixPlotWidget->setColumnHeaders( filteredColumnHeaders );
+    double posClosestToZeroValue = std::numeric_limits<double>::max();
     for ( const auto& [rowName, rowValues] : filteredRows )
     {
         // Add columns with values above threshold
@@ -615,6 +647,11 @@ void RimWellConnectivityTable::onLoadDataAndUpdate()
 
             maxValue = maxValue < rowValues[i] ? rowValues[i] : maxValue;
             columns.push_back( rowValues[i] );
+
+            if ( rowValues[i] > 0.0 && rowValues[i] < posClosestToZeroValue )
+            {
+                posClosestToZeroValue = rowValues[i];
+            }
         }
 
         m_matrixPlotWidget->setRowValues( rowName, columns );
@@ -625,6 +662,7 @@ void RimWellConnectivityTable::onLoadDataAndUpdate()
     {
         const auto [min, max] = createLegendMinMaxValues( maxValue );
         m_legendConfig->setAutomaticRanges( min, max, 0.0, 0.0 );
+        m_legendConfig->setClosestToZeroValues( posClosestToZeroValue, -posClosestToZeroValue, posClosestToZeroValue, -posClosestToZeroValue );
     }
 
     // Set titles and font sizes
@@ -712,6 +750,17 @@ QList<caf::PdmOptionItemInfo> RimWellConnectivityTable::calculateValueOptions( c
               fieldNeedingOptions == &m_valueLabelFontSize )
     {
         options = caf::FontTools::relativeSizeValueOptions( RiaPreferences::current()->defaultPlotFontSize() );
+    }
+    else if ( fieldNeedingOptions == &m_mappingType )
+    {
+        std::vector<RimRegularLegendConfig::MappingType> mappingTypes = { RimRegularLegendConfig::MappingType::LINEAR_DISCRETE,
+                                                                          RimRegularLegendConfig::MappingType::LINEAR_CONTINUOUS,
+                                                                          RimRegularLegendConfig::MappingType::LOG10_CONTINUOUS,
+                                                                          RimRegularLegendConfig::MappingType::LOG10_DISCRETE };
+        for ( const auto mappingType : mappingTypes )
+        {
+            options.push_back( caf::PdmOptionItemInfo( caf::AppEnum<RimRegularLegendConfig::MappingType>::uiText( mappingType ), mappingType ) );
+        }
     }
     return options;
 }

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.h
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.h
@@ -22,6 +22,8 @@
 
 #include "RigFlowDiagResultAddress.h"
 
+#include "RimRegularLegendConfig.h"
+
 #include "cafPdmField.h"
 #include "cafPdmPtrField.h"
 
@@ -77,6 +79,12 @@ public:
     {
         NONE,
         TIME_STEP_COUNT,
+    };
+
+    enum class RangeType
+    {
+        AUTOMATIC,
+        USER_DEFINED
     };
 
 public:
@@ -185,6 +193,9 @@ private:
     caf::PdmField<bool>                 m_syncSelectedProducersFromInjectorSelection;
     caf::PdmField<bool>                 m_syncSelectedInjectorsFromProducerSelection;
     caf::PdmField<bool>                 m_applySelectedInectorProducerTracers;
+
+    caf::PdmField<RimRegularLegendConfig::MappingEnum> m_mappingType;
+    caf::PdmField<caf::AppEnum<RangeType>>             m_rangeType;
 
     caf::PdmField<caf::FontTools::RelativeSizeEnum> m_axisTitleFontSize;
     caf::PdmField<caf::FontTools::RelativeSizeEnum> m_axisLabelFontSize;

--- a/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -1244,11 +1244,24 @@ void RimRegularLegendConfig::defineUiOrdering( QString uiConfigName, caf::PdmUiO
         uiOrdering.add( &m_colorLegend );
         uiOrdering.skipRemainingFields( true );
     }
-    else if ( uiConfigName == "FlagColorsAndMappingModeOnly" )
+    else if ( uiConfigName == "FlagAndColorsOnly" )
     {
         uiOrdering.add( &m_showLegend );
         uiOrdering.add( &m_colorLegend );
-        uiOrdering.add( &m_mappingMode );
+        uiOrdering.skipRemainingFields( true );
+    }
+    else if ( uiConfigName == "UserDefinedMinMaxOnly" )
+    {
+        uiOrdering.add( &m_userDefinedMaxValue );
+        uiOrdering.add( &m_userDefinedMinValue );
+        uiOrdering.skipRemainingFields( true );
+    }
+    else if ( uiConfigName == "RangeModeAndUserDefinedMinMaxOnly" )
+    {
+        // TODO: DELETE!!!
+        uiOrdering.add( &m_rangeMode );
+        uiOrdering.add( &m_userDefinedMaxValue );
+        uiOrdering.add( &m_userDefinedMinValue );
         uiOrdering.skipRemainingFields( true );
     }
     else

--- a/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.h
+++ b/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.h
@@ -174,6 +174,8 @@ public:
 
     void defineUiOrderingColorOnly( caf::PdmUiOrdering* colorGroup );
 
+    void updateTickCountAndUserDefinedRange();
+
 private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void sendChangedSignal( const caf::PdmFieldHandle* changedField );
@@ -189,7 +191,6 @@ private:
 
     void updateCategoryItems();
     void configureCategoryMapper();
-    void updateTickCountAndUserDefinedRange();
 
     friend class RimViewLinker;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTable.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTable.h
@@ -24,6 +24,7 @@
 
 #include "RifEclipseSummaryAddress.h"
 
+#include "RimRegularLegendConfig.h"
 #include "RimSummaryTableTools.h"
 
 #include "cafPdmField.h"
@@ -44,6 +45,13 @@ class RiuMatrixPlotWidget;
 class RimSummaryTable : public RimPlotWindow
 {
     CAF_PDM_HEADER_INIT;
+
+public:
+    enum class RangeType
+    {
+        AUTOMATIC,
+        USER_DEFINED
+    };
 
 public:
     RimSummaryTable();
@@ -119,6 +127,9 @@ private:
     caf::PdmField<caf::FontTools::RelativeSizeEnum> m_axisLabelFontSize;
     caf::PdmField<caf::FontTools::RelativeSizeEnum> m_valueLabelFontSize;
     caf::PdmField<bool>                             m_showValueLabels;
+
+    caf::PdmField<RimRegularLegendConfig::MappingEnum> m_mappingType;
+    caf::PdmField<caf::AppEnum<RangeType>>             m_rangeType;
 
 private:
     using VectorData = RimSummaryTableTools::VectorData;

--- a/ApplicationLibCode/UserInterface/RiuMatrixPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMatrixPlotWidget.cpp
@@ -25,6 +25,7 @@
 #include "RimViewWindow.h"
 
 #include "RiuAbstractLegendFrame.h"
+#include "RiuCategoryLegendFrame.h"
 #include "RiuQwtLinearScaleEngine.h"
 #include "RiuQwtPlotItem.h"
 #include "RiuQwtPlotTools.h"
@@ -176,9 +177,18 @@ void RiuMatrixPlotWidget::createPlot()
     createMatrixCells();
     scheduleReplot();
 
-    auto frame = dynamic_cast<RiuScalarMapperLegendFrame*>( m_legendFrame.data() );
-    frame->updateTickValues();
-    frame->update();
+    auto scalarMapperFrame = dynamic_cast<RiuScalarMapperLegendFrame*>( m_legendFrame.data() );
+    auto categoryFrame     = dynamic_cast<RiuCategoryLegendFrame*>( m_legendFrame.data() );
+    if ( scalarMapperFrame )
+    {
+        scalarMapperFrame->setScalarMapper( m_legendConfig->scalarMapper() );
+        scalarMapperFrame->updateTickValues();
+        scalarMapperFrame->update();
+    }
+    if ( categoryFrame )
+    {
+        categoryFrame->update();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuScalarMapperLegendFrame.cpp
+++ b/ApplicationLibCode/UserInterface/RiuScalarMapperLegendFrame.cpp
@@ -80,6 +80,14 @@ void RiuScalarMapperLegendFrame::updateTickValues()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RiuScalarMapperLegendFrame::setScalarMapper( cvf::ScalarMapper* scalarMapper )
+{
+    m_scalarMapper = scalarMapper;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RiuScalarMapperLegendFrame::layoutInfo( LayoutInfo* layout ) const
 {
     QFontMetrics fontMetrics( this->font() );

--- a/ApplicationLibCode/UserInterface/RiuScalarMapperLegendFrame.h
+++ b/ApplicationLibCode/UserInterface/RiuScalarMapperLegendFrame.h
@@ -47,6 +47,7 @@ public:
     void setTickPrecision( int precision );
     void setTickFormat( NumberFormat format );
     void updateTickValues();
+    void setScalarMapper( cvf::ScalarMapper* scalarMapper );
 
 private:
     void    layoutInfo( LayoutInfo* layout ) const override;


### PR DESCRIPTION
Fix bug in color mapping when changing mapping mode for `RimSummaryTable` and `RimWellConnectivityTable`.

Closes: #10371