### PR TITLE
Fix automatic part id detection for Fault Reactivation Result, and resampling bug in RigWellLogCurveData

### DIFF
--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.cpp
@@ -125,6 +125,37 @@ const int* RigFemPart::connectivities( size_t elementIdx ) const
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Returns state of success for fill element coordinates
+//--------------------------------------------------------------------------------------------------
+bool RigFemPart::fillElementCoordinates( size_t elementIdx, std::array<cvf::Vec3d, 8>& coordinates ) const
+{
+    const auto elemType         = elementType( elementIdx );
+    const int* elemConnectivity = connectivities( elementIdx );
+    const auto nodeCount        = RigFemTypes::elementNodeCount( elemType );
+
+    // Only handle element of hex for now - false success
+    if ( nodeCount != 8 ) return false;
+
+    // Retrieve the node indices
+    std::vector<int> nodeIndices;
+    for ( int i = 0; i < nodeCount; ++i )
+    {
+        const int nodeIdx = elemConnectivity[i];
+        nodeIndices.push_back( nodeIdx );
+    }
+
+    // Fill coordinates for each node
+    const auto& partNodes = nodes();
+    for ( int i = 0; i < nodeIndices.size(); ++i )
+    {
+        coordinates[i].set( partNodes.coordinates[nodeIndices[i]] );
+    }
+
+    // Return true success
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 size_t RigFemPart::elementNodeResultIdx( int elementIdx, int elmLocalNodeIdx ) const

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.h
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.h
@@ -27,6 +27,7 @@
 #include "cvfBoundingBox.h"
 #include "cvfObject.h"
 #include "cvfVector3.h"
+#include <array>
 #include <string>
 #include <vector>
 
@@ -63,6 +64,8 @@ public:
     RigElementType elementType( size_t elementIdx ) const;
     bool           isHexahedron( size_t elementIdx ) const;
     const int*     connectivities( size_t elementIdx ) const;
+
+    bool fillElementCoordinates( size_t elementIdx, std::array<cvf::Vec3d, 8>& coordinates ) const;
 
     size_t elementNodeResultIdx( int elementIdx, int elmLocalNodeIdx ) const;
     size_t elementNodeResultCount() const;

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -337,10 +337,6 @@ void RimWellAllocationPlot::updateFromWell()
                     accFlow = ( m_flowType == ACCUMULATED ? wfCalculator->accumulatedTracerFlowPrConnection( tracerName, brIdx )
                                                           : wfCalculator->tracerFlowPrConnection( tracerName, brIdx ) );
 
-                    // Insert the first depth position again, to add a <maxdepth, 0.0> value pair
-                    curveDepthValues.insert( curveDepthValues.begin(), curveDepthValues[0] );
-                    accFlow.insert( accFlow.begin(), 0.0 );
-
                     if ( m_flowType == ACCUMULATED && brIdx == 0 && !accFlow.empty() ) // Add fictitious point to -1
                                                                                        // for first branch
                     {
@@ -473,6 +469,8 @@ void RimWellAllocationPlot::addStackedCurve( const QString&             tracerNa
     {
         curve->setColor( getTracerColor( tracerName ) );
     }
+
+    curve->setInterpolation( RiuQwtPlotCurveDefines::CurveInterpolationEnum::INTERPOLATION_STEP_LEFT );
 
     plotTrack->addCurve( curve );
 

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechFaultReactivationResult.h
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechFaultReactivationResult.h
@@ -77,4 +77,6 @@ private:
 
     caf::PdmField<int> m_faceAWellPathPartIndex;
     caf::PdmField<int> m_faceBWellPathPartIndex;
+
+    const double m_defaultDistanceFromIntersection = 1.0; // [m] Default value from intersection and into each part
 };

--- a/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.h
@@ -82,15 +82,19 @@ public:
     cvf::ref<RigWellLogCurveData> calculateResampledCurveData( double newMeasuredDepthStepSize ) const;
     cvf::ref<RigWellLogCurveData> calculateResampledCurveData( RiaDefines::DepthTypeEnum  resamplingDepthType,
                                                                const std::vector<double>& depths ) const;
-    static void                   interpolateSegment( RiaDefines::DepthTypeEnum                                       resamplingDepthType,
-                                                      std::vector<double>&                                            resampledValues,
-                                                      std::map<RiaDefines::DepthTypeEnum, std::vector<double>>&       resampledDepths,
-                                                      double                                                          targetDepthValue,
-                                                      size_t                                                          firstIndex,
-                                                      const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
-                                                      const std::vector<double>&                                      propertyValues,
-                                                      double                                                          eps );
 
+    // Made static due to unit testing
+    static void createAndAddInterpolatedSegmentValueAndDepths( std::vector<double>&                                      resampledValues,
+                                                               std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& resampledDepths,
+                                                               RiaDefines::DepthTypeEnum resamplingDepthType,
+                                                               double                    targetDepthValue,
+                                                               size_t                    firstIndex,
+                                                               size_t                    secondIndex,
+                                                               const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+                                                               const std::vector<double>& propertyValues,
+                                                               double                     eps );
+
+    // Made static due to unit testing
     static std::pair<std::vector<double>, std::map<RiaDefines::DepthTypeEnum, std::vector<double>>>
         createResampledValuesAndDepths( RiaDefines::DepthTypeEnum                                       resamplingDepthType,
                                         const std::vector<double>&                                      targetDepths,

--- a/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigWellLogCurveData.h
@@ -82,12 +82,20 @@ public:
     cvf::ref<RigWellLogCurveData> calculateResampledCurveData( double newMeasuredDepthStepSize ) const;
     cvf::ref<RigWellLogCurveData> calculateResampledCurveData( RiaDefines::DepthTypeEnum  resamplingDepthType,
                                                                const std::vector<double>& depths ) const;
-    void                          interpolateSegment( RiaDefines::DepthTypeEnum                                 resamplingDepthType,
-                                                      double                                                    depthValue,
-                                                      size_t                                                    firstIndex,
-                                                      std::vector<double>&                                      xValues,
-                                                      std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& resampledDepths,
-                                                      const double                                              eps ) const;
+    static void                   interpolateSegment( RiaDefines::DepthTypeEnum                                       resamplingDepthType,
+                                                      std::vector<double>&                                            resampledValues,
+                                                      std::map<RiaDefines::DepthTypeEnum, std::vector<double>>&       resampledDepths,
+                                                      double                                                          targetDepthValue,
+                                                      size_t                                                          firstIndex,
+                                                      const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+                                                      const std::vector<double>&                                      propertyValues,
+                                                      double                                                          eps );
+
+    static std::pair<std::vector<double>, std::map<RiaDefines::DepthTypeEnum, std::vector<double>>>
+        createResampledValuesAndDepths( RiaDefines::DepthTypeEnum                                       resamplingDepthType,
+                                        const std::vector<double>&                                      targetDepths,
+                                        const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+                                        const std::vector<double>&                                      propertyValues );
 
 private:
     void calculateIntervalsOfContinousValidValues();

--- a/ApplicationLibCode/UnitTests/CMakeLists_files.cmake
+++ b/ApplicationLibCode/UnitTests/CMakeLists_files.cmake
@@ -93,6 +93,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigDeclineCurveCalculator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifReaderFmuRft-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryRegressionAnalysisCurve-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigWellLogCurveData-Test.cpp
 )
 
 if(RESINSIGHT_ENABLE_GRPC)

--- a/ApplicationLibCode/UnitTests/CMakeLists_files.cmake
+++ b/ApplicationLibCode/UnitTests/CMakeLists_files.cmake
@@ -93,6 +93,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigDeclineCurveCalculator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifReaderFmuRft-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryRegressionAnalysisCurve-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCalculatedCurve-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellLogCurveData-Test.cpp
 )
 

--- a/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
@@ -61,14 +61,14 @@ TEST( RigWellLogCurveData, interpolateSegment_first )
                                              eps );
 
     // Check the results
-    ASSERT_EQ( resampledValues.size(), 1 );
+    ASSERT_EQ( resampledValues.size(), size_t( 1 ) );
     ASSERT_DOUBLE_EQ( resampledValues[0], 50.0 );
 
-    ASSERT_EQ( resampledDepths.size(), 2 );
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), 1 );
+    ASSERT_EQ( resampledDepths.size(), size_t( 2 ) );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), size_t( 1 ) );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), 1 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), size_t( 1 ) );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 20.0 );
 }
 
@@ -117,16 +117,16 @@ TEST( RigWellLogCurveData, interpolateSegment_second )
                                              eps );
 
     // Check the results
-    ASSERT_EQ( resampledValues.size(), 2 );
+    ASSERT_EQ( resampledValues.size(), size_t( 2 ) );
     ASSERT_DOUBLE_EQ( resampledValues[0], 50.0 );
     ASSERT_DOUBLE_EQ( resampledValues[1], 125.0 );
 
-    ASSERT_EQ( resampledDepths.size(), 2 );
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), 2 );
+    ASSERT_EQ( resampledDepths.size(), size_t( 2 ) );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), size_t( 2 ) );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][1], 45.0 );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), 2 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), size_t( 2 ) );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 20.0 );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][1], 60.0 );
 }

--- a/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
@@ -31,7 +31,7 @@
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RigWellLogCurveData, interpolateSegment_first )
+TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_first )
 {
     // Input data
     const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
@@ -49,22 +49,28 @@ TEST( RigWellLogCurveData, interpolateSegment_first )
     // Target data (resampling with MEASURED_DEPTH)
     const double targetDepthValue = 10.0; // Halfway between index 0 and 1 for MEASURED_DEPTH in originalDepths
     const size_t firstIndex       = 0;
+    const size_t secondIndex      = firstIndex + 1;
 
     // Call the function under test
-    RigWellLogCurveData::interpolateSegment( resamplingDepthType,
-                                             resampledValues,
-                                             resampledDepths,
-                                             targetDepthValue,
-                                             firstIndex,
-                                             originalDepths,
-                                             propertyValues,
-                                             eps );
+    RigWellLogCurveData::createAndAddInterpolatedSegmentValueAndDepths( resampledValues,
+                                                                        resampledDepths,
+                                                                        resamplingDepthType,
+                                                                        targetDepthValue,
+                                                                        firstIndex,
+                                                                        secondIndex,
+                                                                        originalDepths,
+                                                                        propertyValues,
+                                                                        eps );
 
     // Check the results
     ASSERT_EQ( resampledValues.size(), size_t( 1 ) );
     ASSERT_DOUBLE_EQ( resampledValues[0], 50.0 );
 
-    ASSERT_EQ( resampledDepths.size(), size_t( 2 ) );
+    ASSERT_EQ( resampledDepths.size(), size_t( 3 ) );
+
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH].size(), size_t( 1 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][0], 10.0 );
+
     ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), size_t( 1 ) );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
 
@@ -75,7 +81,7 @@ TEST( RigWellLogCurveData, interpolateSegment_first )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RigWellLogCurveData, interpolateSegment_second )
+TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second )
 {
     // Input data
     const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
@@ -95,33 +101,41 @@ TEST( RigWellLogCurveData, interpolateSegment_second )
     const double secondTargetDepthValue = 30.0; // Halfway between index 1 and 2 for MEASURED_DEPTH in originalDepths
     const size_t firstIndex             = 0;
     const size_t secondIndex            = 1;
+    const size_t thirdIndex             = 2;
 
-    // Call the function under test with first index and target value
-    RigWellLogCurveData::interpolateSegment( resamplingDepthType,
-                                             resampledValues,
-                                             resampledDepths,
-                                             firstTargetDepthValue,
-                                             firstIndex,
-                                             originalDepths,
-                                             propertyValues,
-                                             eps );
+    // Call the function under test with interpolating between first and second index
+    RigWellLogCurveData::createAndAddInterpolatedSegmentValueAndDepths( resampledValues,
+                                                                        resampledDepths,
+                                                                        resamplingDepthType,
+                                                                        firstTargetDepthValue,
+                                                                        firstIndex,
+                                                                        firstIndex + 1,
+                                                                        originalDepths,
+                                                                        propertyValues,
+                                                                        eps );
 
-    // Call the function under test with second index and target value
-    RigWellLogCurveData::interpolateSegment( resamplingDepthType,
-                                             resampledValues,
-                                             resampledDepths,
-                                             secondTargetDepthValue,
-                                             secondIndex,
-                                             originalDepths,
-                                             propertyValues,
-                                             eps );
+    // Call the function under test with interpolating between second and third index
+    RigWellLogCurveData::createAndAddInterpolatedSegmentValueAndDepths( resampledValues,
+                                                                        resampledDepths,
+                                                                        resamplingDepthType,
+                                                                        secondTargetDepthValue,
+                                                                        secondIndex,
+                                                                        thirdIndex,
+                                                                        originalDepths,
+                                                                        propertyValues,
+                                                                        eps );
 
     // Check the results
     ASSERT_EQ( resampledValues.size(), size_t( 2 ) );
     ASSERT_DOUBLE_EQ( resampledValues[0], 50.0 );
     ASSERT_DOUBLE_EQ( resampledValues[1], 125.0 );
 
-    ASSERT_EQ( resampledDepths.size(), size_t( 2 ) );
+    ASSERT_EQ( resampledDepths.size(), size_t( 3 ) );
+
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH].size(), size_t( 2 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][0], 10.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][1], 30.0 );
+
     ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), size_t( 2 ) );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
     ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][1], 45.0 );

--- a/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
@@ -1,0 +1,183 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2023- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RiaDefines.h"
+
+#include "RigWellLogCurveData.h"
+
+#include "cvfVector3.h"
+
+#include <vector>
+
+#include <iostream>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigWellLogCurveData, interpolateSegment_first )
+{
+    // Input data
+    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
+        { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, { 0.0, 20.0, 40.0 } },
+          { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, { 0.0, 30.0, 60.0 } },
+          { RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, { 0.0, 40.0, 80.0 } } };
+    const std::vector<double> propertyValues = { 0.0, 100.0, 150.0 };
+    const double              eps            = 1e-6;
+
+    // Output data
+    const auto                                               resamplingDepthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    std::vector<double>                                      resampledValues;
+    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths;
+
+    // Target data (resampling with MEASURED_DEPTH)
+    const double targetDepthValue = 10.0; // Halfway between index 0 and 1 for MEASURED_DEPTH in originalDepths
+    const size_t firstIndex       = 0;
+
+    // Call the function under test
+    RigWellLogCurveData::interpolateSegment( resamplingDepthType,
+                                             resampledValues,
+                                             resampledDepths,
+                                             targetDepthValue,
+                                             firstIndex,
+                                             originalDepths,
+                                             propertyValues,
+                                             eps );
+
+    // Check the results
+    ASSERT_EQ( resampledValues.size(), 1 );
+    ASSERT_DOUBLE_EQ( resampledValues[0], 50.0 );
+
+    ASSERT_EQ( resampledDepths.size(), 2 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), 1 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
+
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), 1 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 20.0 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigWellLogCurveData, interpolateSegment_second )
+{
+    // Input data
+    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
+        { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, { 0.0, 20.0, 40.0 } },
+          { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, { 0.0, 30.0, 60.0 } },
+          { RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, { 0.0, 40.0, 80.0 } } };
+    const std::vector<double> propertyValues = { 0.0, 100.0, 150.0 };
+    const double              eps            = 1e-6;
+
+    // Output data
+    const auto                                               resamplingDepthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    std::vector<double>                                      resampledValues;
+    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths;
+
+    // Target data (resampling with MEASURED_DEPTH)
+    const double firstTargetDepthValue  = 10.0; // Halfway between index 0 and 1 for MEASURED_DEPTH in originalDepths
+    const double secondTargetDepthValue = 30.0; // Halfway between index 1 and 2 for MEASURED_DEPTH in originalDepths
+    const size_t firstIndex             = 0;
+    const size_t secondIndex            = 1;
+
+    // Call the function under test with first index and target value
+    RigWellLogCurveData::interpolateSegment( resamplingDepthType,
+                                             resampledValues,
+                                             resampledDepths,
+                                             firstTargetDepthValue,
+                                             firstIndex,
+                                             originalDepths,
+                                             propertyValues,
+                                             eps );
+
+    // Call the function under test with second index and target value
+    RigWellLogCurveData::interpolateSegment( resamplingDepthType,
+                                             resampledValues,
+                                             resampledDepths,
+                                             secondTargetDepthValue,
+                                             secondIndex,
+                                             originalDepths,
+                                             propertyValues,
+                                             eps );
+
+    // Check the results
+    ASSERT_EQ( resampledValues.size(), 2 );
+    ASSERT_DOUBLE_EQ( resampledValues[0], 50.0 );
+    ASSERT_DOUBLE_EQ( resampledValues[1], 125.0 );
+
+    ASSERT_EQ( resampledDepths.size(), 2 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), 2 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][1], 45.0 );
+
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), 2 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 20.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][1], 60.0 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigWellLogCurveData, CreateResampledValuesAndDepthsTest )
+{
+    // Input data
+    RiaDefines::DepthTypeEnum                                      resamplingDepthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    const std::vector<double>                                      targetDepths        = { 0.0, 5.0, 10.0, 15.0 };
+    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
+        { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, { 0.0, 10.0, 20.0 } },
+          { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, { 0.0, 20.0, 40.0 } },
+          { RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, { 0.0, 30.0, 60.0 } } };
+    const std::vector<double> propertyValues = { 0.0, 100.0, 200.0 };
+
+    // Call the function under test
+    auto result = RigWellLogCurveData::createResampledValuesAndDepths( resamplingDepthType, targetDepths, originalDepths, propertyValues );
+
+    // Check the results
+    std::vector<double>&                                      resampledPropertyValues = result.first;
+    std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& resampledDepths         = result.second;
+    const auto                                                expectedSize            = targetDepths.size();
+
+    ASSERT_EQ( resampledDepths.size(), originalDepths.size() );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH].size(), expectedSize );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), expectedSize );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), expectedSize );
+
+    ASSERT_EQ( resampledPropertyValues.size(), expectedSize );
+
+    // Example assertions for the specific values
+    ASSERT_DOUBLE_EQ( resampledPropertyValues[0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledPropertyValues[1], 50.0 );
+    ASSERT_DOUBLE_EQ( resampledPropertyValues[2], 100.0 );
+    ASSERT_DOUBLE_EQ( resampledPropertyValues[3], 150.0 );
+
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][1], 5.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][2], 10.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][3], 15.0 );
+
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][1], 10.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][2], 20.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][3], 30.0 );
+
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][1], 15.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][2], 30.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][3], 45.0 );
+}

--- a/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
@@ -97,8 +97,8 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second 
     std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths;
 
     // Target data (resampling with MEASURED_DEPTH)
-    const double firstTargetDepthValue  = 10.0; // Halfway between index 0 and 1 for MEASURED_DEPTH in originalDepths
-    const double secondTargetDepthValue = 30.0; // Halfway between index 1 and 2 for MEASURED_DEPTH in originalDepths
+    const double firstTargetDepthValue  = 10.0; // Halfway between first and second index for MEASURED_DEPTH in originalDepths
+    const double secondTargetDepthValue = 30.0; // Halfway between second and third index for MEASURED_DEPTH in originalDepths
     const size_t firstIndex             = 0;
     const size_t secondIndex            = 1;
     const size_t thirdIndex             = 2;
@@ -109,7 +109,7 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second 
                                                                         resamplingDepthType,
                                                                         firstTargetDepthValue,
                                                                         firstIndex,
-                                                                        firstIndex + 1,
+                                                                        secondIndex,
                                                                         originalDepths,
                                                                         propertyValues,
                                                                         eps );


### PR DESCRIPTION
- `RimGeoMechFaultReactivationResult`:
    - Fix automatic detection of part id

- `RigWellLogCurveData`:
    - Fixes resampling bug
    - Refactored code for testability
    - Added unit tests

---

Closes: #10391
Closes: #10241