### PR TITLE
TESTING: Branch for testing concept of visualizing javascript in Qt

### DIFF
--- a/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
@@ -18,9 +18,17 @@ set(QRC_FILES ${QRC_FILES} textedit.qrc)
 find_package(
   Qt5
   COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL Svg WebEngineWidgets
+  REQUIRED
+  Core
+  Gui
+  Widgets
+  OpenGL
+  Svg
+  WebEngineWidgets
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg Qt5::WebEngineWidgets)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg
+                 Qt5::WebEngineWidgets
+)
 qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
 qt5_add_resources(QRC_FILES_CPP ${QRC_FILES})
 

--- a/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
@@ -18,9 +18,9 @@ set(QRC_FILES ${QRC_FILES} textedit.qrc)
 find_package(
   Qt5
   COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL Svg
+  REQUIRED Core Gui Widgets OpenGL Svg WebEngineWidgets
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg Qt5::WebEngineWidgets)
 qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
 qt5_add_resources(QRC_FILES_CPP ${QRC_FILES})
 

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -49,6 +49,7 @@
 #include <QMenuBar>
 #include <QTreeView>
 #include <QUndoView>
+#include <QWebEngineSettings>
 #include <QWebEngineView>
 
 class DemoPdmObjectGroup : public caf::PdmDocument
@@ -1184,11 +1185,18 @@ MainWindow::MainWindow()
     m_smallPlotLabel->setPixmap( pix.scaled( 1000, 500 ) );
 
     m_webView = new QWebEngineView( this );
-    m_webView->load( QUrl( "https://www.google.com" ) );
+    //m_webView->load( QUrl( "https://www.google.com" ) );
+    //m_webView->load( QUrl( "http://localhost:5173/" ) );
     /*m_webView->load( QUrl::fromLocalFile(
         "D:/Git/ResInsight/build/Fwk/AppFwk/cafTests/cafTestApplication/RelWithDebInfo/HTML-dist/index.html" ) );*/
+    m_webView->load( QUrl::fromLocalFile(
+        "D:/Git/ResInsight/build/Fwk/AppFwk/cafTests/cafTestApplication/RelWithDebInfo/HTML-dist-simple/index.html" ) );
     /*m_webView->load( QUrl::fromLocalFile(
         "D:/Git/ResInsight/build/Fwk/AppFwk/cafTests/cafTestApplication/RelWithDebInfo/HTML-dist/testIndex.html" ) );*/
+
+    /*QWebEngineSettings* settings = m_webView->settings();
+    settings->setAttribute( QWebEngineSettings::LocalContentCanAccessFileUrls, true );
+    settings->setAttribute( QWebEngineSettings::LocalContentCanAccessRemoteUrls, true );*/
 
     createActions();
     createDockPanels();

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -49,6 +49,7 @@
 #include <QMenuBar>
 #include <QTreeView>
 #include <QUndoView>
+#include <QWebEngineView>
 
 class DemoPdmObjectGroup : public caf::PdmDocument
 {
@@ -1180,7 +1181,14 @@ MainWindow::MainWindow()
     m_plotLabel->setPixmap( pix.scaled( 250, 100 ) );
 
     m_smallPlotLabel = new QLabel( this );
-    m_smallPlotLabel->setPixmap( pix.scaled( 100, 50 ) );
+    m_smallPlotLabel->setPixmap( pix.scaled( 1000, 500 ) );
+
+    m_webView = new QWebEngineView( this );
+    m_webView->load( QUrl( "https://www.google.com" ) );
+    /*m_webView->load( QUrl::fromLocalFile(
+        "D:/Git/ResInsight/build/Fwk/AppFwk/cafTests/cafTestApplication/RelWithDebInfo/HTML-dist/index.html" ) );*/
+    /*m_webView->load( QUrl::fromLocalFile(
+        "D:/Git/ResInsight/build/Fwk/AppFwk/cafTests/cafTestApplication/RelWithDebInfo/HTML-dist/testIndex.html" ) );*/
 
     createActions();
     createDockPanels();
@@ -1377,15 +1385,18 @@ void MainWindow::setPdmRoot( caf::PdmObjectHandle* pdmRoot )
     m_customObjectEditor->removeWidget( m_plotLabel );
     m_customObjectEditor->removeWidget( m_smallPlotLabel );
 
+    m_customObjectEditor->removeWidget( m_webView );
+
     if ( obj.size() == 1 )
     {
         m_customObjectEditor->setPdmObject( obj[0] );
 
-        m_customObjectEditor->defineGridLayout( 5, 4 );
+        m_customObjectEditor->defineGridLayout( 1, 1 );
 
-        m_customObjectEditor->addBlankCell( 0, 0 );
-        m_customObjectEditor->addWidget( m_plotLabel, 0, 1, 1, 2 );
-        m_customObjectEditor->addWidget( m_smallPlotLabel, 1, 2, 2, 1 );
+        //m_customObjectEditor->addBlankCell( 0, 0 );
+        //m_customObjectEditor->addWidget( m_plotLabel, 0, 1, 1, 2 );
+        //m_customObjectEditor->addWidget( m_smallPlotLabel, 1, 2, 2, 1 );
+        m_customObjectEditor->addWidget( m_webView, 0, 0, 1, 1 );
     }
     else
     {

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.h
@@ -3,6 +3,7 @@
 #include <QAbstractItemModel>
 #include <QItemSelection>
 #include <QMainWindow>
+#include <QWebEngineView>
 
 class DemoPdmObject;
 class DemoPdmObjectGroup;
@@ -68,4 +69,6 @@ private:
 
     QLabel* m_plotLabel;
     QLabel* m_smallPlotLabel;
+
+    QWebEngineView* m_webView;
 };


### PR DESCRIPTION
- Using QWebEngineView
- Visualizing HTML-data generated from repo: https://github.com/jorgenherje/webviz-components-for-qt

- Had to install Qt component (using `MaintenanceTool`): `Qt WebEngine`

---

`Group Tree` component from `webviz-subsurface-components` is placed in an app and bundled using `Vite`. The resulting HTML, js and css files in `dist` folder is used for ResInsight. The test application is used as testing application for proof of conecpt.

The HTML-code for testing is placed in the folder named `HTML-dist`.

The following .dll, .exe and folders are added to build directory for application:
![image](https://github.com/OPM/ResInsight/assets/82032112/ed5c6e1c-2683-48cf-9bb6-d98df954f238)



