### PR TITLE
clang-tidy: Run on dev and main

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -2,6 +2,9 @@ name: clang-tidy
 
 on:
   push:
+    branches:
+      - main
+      - dev
     paths:
       - '**.clang-tidy'
   workflow_dispatch:


### PR DESCRIPTION
Make it possible to have temporary code violating clang-tidy fixes in work-in-progress branches

Closes #10428