### PR TITLE
Do not tag calculator results to be stored in cache

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
@@ -120,7 +120,8 @@ bool RimGridCalculation::calculate()
 
     if ( !eclipseCase->results( porosityModel )->ensureKnownResultLoaded( resAddr ) )
     {
-        eclipseCase->results( porosityModel )->createResultEntry( resAddr, true );
+        bool needsToBeStored = false;
+        eclipseCase->results( porosityModel )->createResultEntry( resAddr, needsToBeStored );
     }
 
     eclipseCase->results( porosityModel )->clearScalarResult( resAddr );


### PR DESCRIPTION
Grid calculator results was tagged to be stored in cache. No data was stored, but meta data for the result was added. These results are always recalculated when the project is loaded, and `needsToBeStored `is set to false

Related to #10489