### PR TITLE
Avoid update connected editors

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -174,11 +174,6 @@ void RiuPlotMainWindow::initializeGuiNewProjectLoaded()
     setPdmRoot( RimProject::current() );
     restoreTreeViewState();
 
-    if ( m_pdmUiPropertyView && m_pdmUiPropertyView->currentObject() )
-    {
-        m_pdmUiPropertyView->currentObject()->uiCapability()->updateConnectedEditors();
-    }
-
     auto sumPlotManager = dynamic_cast<RimSummaryPlotManager*>( m_summaryPlotManager.get() );
     if ( sumPlotManager )
     {


### PR DESCRIPTION
The call to updateConnectedEditors is very time consuming for summary models with many vectors. Testing indicates that this update is not required.

Closes #10508