### PR TITLE
Avoid use of time_t when using sliders in GUI

### DIFF
--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicCreateDeclineCurvesFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicCreateDeclineCurvesFeature.cpp
@@ -102,7 +102,6 @@ RimSummaryDeclineCurve* RicCreateDeclineCurvesFeature::createDeclineCurveAndAddT
 
     RiaSummaryTools::copyCurveAxisData( *newCurve, *sourceCurve );
 
-    newCurve->updateDefaultValues();
     newCurve->loadDataAndUpdate( true );
     newCurve->updateConnectedEditors();
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
@@ -207,14 +207,14 @@ RimEnsembleCurveSet::RimEnsembleCurveSet()
     CAF_PDM_InitFieldNoDefault( &m_minDateRange, "MinDateRange", "From" );
     m_minDateRange.uiCapability()->setUiEditorTypeName( caf::PdmUiDateEditor::uiEditorTypeName() );
 
-    CAF_PDM_InitFieldNoDefault( &m_minTimeStep, "MinTimeStep", "" );
-    m_minTimeStep.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitField( &m_minTimeSliderPosition, "MinTimeSliderPosition", 0, "" );
+    m_minTimeSliderPosition.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
 
     CAF_PDM_InitFieldNoDefault( &m_maxDateRange, "MaxDateRange", "To" );
     m_maxDateRange.uiCapability()->setUiEditorTypeName( caf::PdmUiDateEditor::uiEditorTypeName() );
 
-    CAF_PDM_InitFieldNoDefault( &m_maxTimeStep, "MaxTimeStep", "" );
-    m_maxTimeStep.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitField( &m_maxTimeSliderPosition, "MaxTimeSliderPosition", 100, "" );
+    m_maxTimeSliderPosition.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
 
     // Time Step Selection
     CAF_PDM_InitFieldNoDefault( &m_timeStepFilter, "TimeStepFilter", "Available Time Steps" );
@@ -491,8 +491,8 @@ std::pair<time_t, time_t> RimEnsembleCurveSet::selectedTimeStepRange() const
 
     auto [min, max]  = fullTimeStepRange();
     auto range       = max - min;
-    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeStep / 100.0 ) );
-    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeStep / 100.0 ) );
+    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeSliderPosition / 100.0 ) );
+    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeSliderPosition / 100.0 ) );
 
     return { selectedMin, selectedMax };
 }
@@ -898,8 +898,8 @@ void RimEnsembleCurveSet::fieldChangedByUi( const caf::PdmFieldHandle* changedFi
                 summaryAddress->setAddress( m_yValuesSummaryAddress->address() );
                 m_objectiveValuesSummaryAddresses.push_back( summaryAddress );
                 updateAddressesUiField();
-                m_minTimeStep = 0;
-                m_maxTimeStep = 100;
+                m_minTimeSliderPosition = 0;
+                m_maxTimeSliderPosition = 100;
                 updateMaxMinAndDefaultValues();
             }
         }
@@ -924,7 +924,7 @@ void RimEnsembleCurveSet::fieldChangedByUi( const caf::PdmFieldHandle* changedFi
         updateObjectiveFunctionLegend();
         updateMaxMinAndDefaultValues();
     }
-    else if ( changedField == &m_minTimeStep || changedField == &m_maxTimeStep )
+    else if ( changedField == &m_minTimeSliderPosition || changedField == &m_maxTimeSliderPosition )
     {
         updateMaxMinAndDefaultValues();
         updateCurveColors();
@@ -941,8 +941,8 @@ void RimEnsembleCurveSet::fieldChangedByUi( const caf::PdmFieldHandle* changedFi
         maxTime      = std::clamp( maxTime, min, max );
 
         // Convert from date to normalized value between 0 and 100
-        m_minTimeStep = static_cast<int>( ( double( minTime - min ) / double( range ) ) * 100 );
-        m_maxTimeStep = static_cast<int>( ( double( maxTime - min ) / double( range ) ) * 100 );
+        m_minTimeSliderPosition = static_cast<int>( ( double( minTime - min ) / double( range ) ) * 100 );
+        m_maxTimeSliderPosition = static_cast<int>( ( double( maxTime - min ) / double( range ) ) * 100 );
 
         updateCurveColors();
         updateTimeAnnotations();
@@ -1046,8 +1046,8 @@ void RimEnsembleCurveSet::fieldChangedByUi( const caf::PdmFieldHandle* changedFi
                 setTimeSteps( indices );
             }
 
-            m_minTimeStep = 0;
-            m_maxTimeStep = 100;
+            m_minTimeSliderPosition = 0;
+            m_maxTimeSliderPosition = 100;
 
             updateLegendMappingMode();
             updateCurveColors();
@@ -1342,9 +1342,9 @@ void RimEnsembleCurveSet::appendColorGroup( caf::PdmUiOrdering& uiOrdering )
                    m_customObjectiveFunction()->weightContainsFunctionType( RimObjectiveFunction::FunctionType::F1 ) ) )
             {
                 timeSelectionGroup->add( &m_minDateRange );
-                timeSelectionGroup->add( &m_minTimeStep );
+                timeSelectionGroup->add( &m_minTimeSliderPosition );
                 timeSelectionGroup->add( &m_maxDateRange );
-                timeSelectionGroup->add( &m_maxTimeStep );
+                timeSelectionGroup->add( &m_maxTimeSliderPosition );
             }
             if ( m_objectiveFunction()->functionType() == RimObjectiveFunction::FunctionType::F2 ||
                  ( m_customObjectiveFunction() &&
@@ -1434,7 +1434,7 @@ void RimEnsembleCurveSet::defineEditorAttribute( const caf::PdmFieldHandle* fiel
         attrib->m_buttonText = "...";
     }
 
-    if ( field == &m_minTimeStep || field == &m_maxTimeStep )
+    if ( field == &m_minTimeSliderPosition || field == &m_maxTimeSliderPosition )
     {
         if ( auto* myAttr = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute ) )
         {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
@@ -209,7 +209,7 @@ private:
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
     QList<caf::PdmOptionItemInfo>          calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
-    std::set<time_t>                       allAvailableTimeSteps();
+    std::set<time_t>                       allAvailableTimeSteps() const;
     std::set<RimSummaryCase*>              timestepDefiningSourceCases();
     RiaSummaryCurveDefinitionAnalyser*     getOrCreateSelectedCurveDefAnalyser();
     std::vector<RiaSummaryCurveDefinition> curveDefinitions() const;
@@ -240,6 +240,9 @@ private:
     void onColorTagClicked( const SignalEmitter* emitter, size_t index );
 
     void setSummaryAddressX( RifEclipseSummaryAddress address );
+
+    std::pair<time_t, time_t> fullTimeStepRange() const;
+    std::pair<time_t, time_t> selectedTimeStepRange() const;
 
 private:
     caf::PdmField<bool>                       m_showCurves;
@@ -277,8 +280,8 @@ private:
     caf::PdmField<QString>                        m_objectiveValuesSummaryAddressesUiField;
     caf::PdmField<bool>                           m_objectiveValuesSelectSummaryAddressPushButton;
     caf::PdmPtrField<RimCustomObjectiveFunction*> m_customObjectiveFunction;
-    caf::PdmField<time_t>                         m_minTimeStep;
-    caf::PdmField<time_t>                         m_maxTimeStep;
+    caf::PdmField<int>                            m_minTimeStep;
+    caf::PdmField<int>                            m_maxTimeStep;
     caf::PdmField<QDate>                          m_minDateRange;
     caf::PdmField<QDate>                          m_maxDateRange;
     caf::PdmField<TimeStepFilterEnum>             m_timeStepFilter;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
@@ -280,8 +280,8 @@ private:
     caf::PdmField<QString>                        m_objectiveValuesSummaryAddressesUiField;
     caf::PdmField<bool>                           m_objectiveValuesSelectSummaryAddressPushButton;
     caf::PdmPtrField<RimCustomObjectiveFunction*> m_customObjectiveFunction;
-    caf::PdmField<int>                            m_minTimeStep;
-    caf::PdmField<int>                            m_maxTimeStep;
+    caf::PdmField<int>                            m_minTimeSliderPosition;
+    caf::PdmField<int>                            m_maxTimeSliderPosition;
     caf::PdmField<QDate>                          m_minDateRange;
     caf::PdmField<QDate>                          m_maxDateRange;
     caf::PdmField<TimeStepFilterEnum>             m_timeStepFilter;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.cpp
@@ -61,11 +61,11 @@ RimSummaryDeclineCurve::RimSummaryDeclineCurve()
     CAF_PDM_InitField( &m_hyperbolicDeclineConstant, "HyperbolicDeclineConstant", 0.5, "Decline Constant" );
     m_hyperbolicDeclineConstant.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
 
-    CAF_PDM_InitField( &m_minTimeStep, "MinTimeStep", 75, "From" );
-    m_minTimeStep.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitField( &m_minTimeSliderPosition, "MinTimeSliderPosition", 75, "From" );
+    m_minTimeSliderPosition.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
 
-    CAF_PDM_InitField( &m_maxTimeStep, "MaxTimeStep", 100, "To" );
-    m_maxTimeStep.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitField( &m_maxTimeSliderPosition, "MaxTimeSliderPosition", 100, "To" );
+    m_maxTimeSliderPosition.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_showTimeSelectionInPlot, "ShowTimeSelectionInPlot", true, "Show In Plot" );
 }
@@ -299,8 +299,8 @@ std::pair<time_t, time_t> RimSummaryDeclineCurve::selectedTimeStepRange() const
 
     auto [min, max]  = fullTimeStepRange();
     auto range       = max - min;
-    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeStep / 100.0 ) );
-    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeStep / 100.0 ) );
+    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeSliderPosition / 100.0 ) );
+    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeSliderPosition / 100.0 ) );
 
     return { selectedMin, selectedMax };
 }
@@ -355,8 +355,8 @@ void RimSummaryDeclineCurve::defineUiOrdering( QString uiConfigName, caf::PdmUiO
     }
 
     caf::PdmUiGroup* timeSelectionGroup = uiOrdering.addNewGroup( "Time Selection" );
-    timeSelectionGroup->add( &m_minTimeStep );
-    timeSelectionGroup->add( &m_maxTimeStep );
+    timeSelectionGroup->add( &m_minTimeSliderPosition );
+    timeSelectionGroup->add( &m_maxTimeSliderPosition );
     timeSelectionGroup->add( &m_showTimeSelectionInPlot );
 
     RimSummaryCurve::defineUiOrdering( uiConfigName, uiOrdering );
@@ -367,19 +367,19 @@ void RimSummaryDeclineCurve::defineUiOrdering( QString uiConfigName, caf::PdmUiO
 //--------------------------------------------------------------------------------------------------
 void RimSummaryDeclineCurve::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
-    if ( &m_minTimeStep == changedField && m_minTimeStep > m_maxTimeStep )
+    if ( &m_minTimeSliderPosition == changedField && m_minTimeSliderPosition > m_maxTimeSliderPosition )
     {
-        m_maxTimeStep = m_minTimeStep;
+        m_maxTimeSliderPosition = m_minTimeSliderPosition;
     }
 
-    if ( &m_maxTimeStep == changedField && m_maxTimeStep < m_minTimeStep )
+    if ( &m_maxTimeSliderPosition == changedField && m_maxTimeSliderPosition < m_minTimeSliderPosition )
     {
-        m_minTimeStep = m_maxTimeStep;
+        m_minTimeSliderPosition = m_maxTimeSliderPosition;
     }
 
     RimSummaryCurve::fieldChangedByUi( changedField, oldValue, newValue );
     if ( changedField == &m_declineCurveType || changedField == &m_predictionYears || changedField == &m_hyperbolicDeclineConstant ||
-         changedField == &m_minTimeStep || changedField == &m_maxTimeStep || changedField == &m_showTimeSelectionInPlot )
+         changedField == &m_minTimeSliderPosition || changedField == &m_maxTimeSliderPosition || changedField == &m_showTimeSelectionInPlot )
     {
         loadAndUpdateDataAndPlot();
         auto plot = firstAncestorOrThisOfTypeAsserted<RimSummaryPlot>();
@@ -413,7 +413,7 @@ void RimSummaryDeclineCurve::defineEditorAttribute( const caf::PdmFieldHandle* f
             myAttr->m_decimals = 2;
         }
     }
-    else if ( field == &m_minTimeStep || field == &m_maxTimeStep )
+    else if ( field == &m_minTimeSliderPosition || field == &m_maxTimeSliderPosition )
     {
         if ( auto* myAttr = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute ) )
         {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
@@ -100,8 +100,8 @@ private:
     caf::PdmField<double>                         m_hyperbolicDeclineConstant;
 
     // Time step range defined in the range [0..100] as time_t can hold values that do not fit into int used by QSpinBox
-    caf::PdmField<int> m_minTimeStep;
-    caf::PdmField<int> m_maxTimeStep;
+    caf::PdmField<int> m_minTimeSliderPosition;
+    caf::PdmField<int> m_maxTimeSliderPosition;
 
     caf::PdmField<bool> m_showTimeSelectionInPlot;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
@@ -56,8 +56,6 @@ public:
     // X Axis functions
     std::vector<double> valuesX() const override;
 
-    void updateDefaultValues();
-
 protected:
     void updateTimeAnnotations() override;
 
@@ -93,12 +91,19 @@ private:
 
     double computePredictedValue( double initialProductionRate, double initialDeclineRate, double timeSinceStart, bool isAccumulatedResult ) const;
 
+    std::pair<time_t, time_t> fullTimeStepRange() const;
+    std::pair<time_t, time_t> selectedTimeStepRange() const;
+
+private:
     caf::PdmField<caf::AppEnum<DeclineCurveType>> m_declineCurveType;
     caf::PdmField<int>                            m_predictionYears;
     caf::PdmField<double>                         m_hyperbolicDeclineConstant;
-    caf::PdmField<time_t>                         m_minTimeStep;
-    caf::PdmField<time_t>                         m_maxTimeStep;
-    caf::PdmField<bool>                           m_showTimeSelectionInPlot;
+
+    // Time step range defined in the range [0..100] as time_t can hold values that do not fit into int used by QSpinBox
+    caf::PdmField<int> m_minTimeStep;
+    caf::PdmField<int> m_maxTimeStep;
+
+    caf::PdmField<bool> m_showTimeSelectionInPlot;
 
     caf::PdmPointer<RimTimeAxisAnnotation> m_timeRangeAnnotation;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.cpp
@@ -107,11 +107,11 @@ RimSummaryRegressionAnalysisCurve::RimSummaryRegressionAnalysisCurve()
     CAF_PDM_InitField( &m_polynomialDegree, "PolynomialDegree", 3, "Degree" );
 
     CAF_PDM_InitFieldNoDefault( &m_timeRangeSelection, "TimeRangeSelection", "Time Range" );
-    CAF_PDM_InitFieldNoDefault( &m_minTimeStep, "MinTimeStep", "From" );
-    m_minTimeStep.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitFieldNoDefault( &m_minTimeSliderPosition, "MinTimeSliderPosition", "From" );
+    m_minTimeSliderPosition.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
 
-    CAF_PDM_InitFieldNoDefault( &m_maxTimeStep, "MaxTimeStep", "To" );
-    m_maxTimeStep.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitFieldNoDefault( &m_maxTimeSliderPosition, "MaxTimeSliderPosition", "To" );
+    m_maxTimeSliderPosition.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_showTimeSelectionInPlot, "ShowTimeSelectionInPlot", false, "Show In Plot" );
 
@@ -474,8 +474,8 @@ void RimSummaryRegressionAnalysisCurve::defineUiOrdering( QString uiConfigName, 
         timeSelectionGroup->add( &m_timeRangeSelection );
         if ( m_timeRangeSelection() == RangeType::USER_DEFINED_RANGE )
         {
-            timeSelectionGroup->add( &m_minTimeStep );
-            timeSelectionGroup->add( &m_maxTimeStep );
+            timeSelectionGroup->add( &m_minTimeSliderPosition );
+            timeSelectionGroup->add( &m_maxTimeSliderPosition );
         }
         timeSelectionGroup->add( &m_showTimeSelectionInPlot );
     }
@@ -512,14 +512,14 @@ void RimSummaryRegressionAnalysisCurve::fieldChangedByUi( const caf::PdmFieldHan
 {
     RimSummaryCurve::fieldChangedByUi( changedField, oldValue, newValue );
 
-    if ( &m_minTimeStep == changedField && m_minTimeStep > m_maxTimeStep )
+    if ( &m_minTimeSliderPosition == changedField && m_minTimeSliderPosition > m_maxTimeSliderPosition )
     {
-        m_maxTimeStep = m_minTimeStep;
+        m_maxTimeSliderPosition = m_minTimeSliderPosition;
     }
 
-    if ( &m_maxTimeStep == changedField && m_maxTimeStep < m_minTimeStep )
+    if ( &m_maxTimeSliderPosition == changedField && m_maxTimeSliderPosition < m_minTimeSliderPosition )
     {
-        m_minTimeStep = m_maxTimeStep;
+        m_minTimeSliderPosition = m_maxTimeSliderPosition;
     }
 
     loadAndUpdateDataAndPlot();
@@ -553,7 +553,7 @@ void RimSummaryRegressionAnalysisCurve::defineEditorAttribute( const caf::PdmFie
             lineEditorAttr->validator = new QIntValidator( 0, 50, nullptr );
         }
     }
-    else if ( field == &m_minTimeStep || field == &m_maxTimeStep )
+    else if ( field == &m_minTimeSliderPosition || field == &m_maxTimeSliderPosition )
     {
         if ( auto* myAttr = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute ) )
         {
@@ -736,8 +736,8 @@ std::pair<time_t, time_t> RimSummaryRegressionAnalysisCurve::selectedTimeStepRan
 
     auto [min, max]  = fullTimeStepRange();
     auto range       = max - min;
-    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeStep / 100.0 ) );
-    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeStep / 100.0 ) );
+    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeSliderPosition / 100.0 ) );
+    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeSliderPosition / 100.0 ) );
 
     return { selectedMin, selectedMax };
 }
@@ -882,8 +882,8 @@ void RimSummaryRegressionAnalysisCurve::updateDefaultValues()
 {
     if ( !m_sourceTimeStepsY.empty() && m_timeRangeSelection() == RangeType::FULL_RANGE )
     {
-        m_minTimeStep = 0;
-        m_maxTimeStep = 100;
+        m_minTimeSliderPosition = 0;
+        m_maxTimeSliderPosition = 100;
     }
 
     if ( !m_sourceValuesX.empty() && m_xRangeSelection() == RangeType::FULL_RANGE )

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.cpp
@@ -349,7 +349,8 @@ std::tuple<std::vector<time_t>, std::vector<double>, QString>
 {
     if ( values.empty() || timeSteps.empty() ) return { timeSteps, values, "" };
 
-    auto [timeStepsInRange, valuesInRange] = getInRangeValues( timeSteps, values, m_minTimeStep, m_maxTimeStep );
+    auto [minTimeStep, maxTimeStep]        = selectedTimeStepRange();
+    auto [timeStepsInRange, valuesInRange] = getInRangeValues( timeSteps, values, minTimeStep, maxTimeStep );
 
     if ( timeStepsInRange.empty() || valuesInRange.empty() ) return {};
 
@@ -556,12 +557,8 @@ void RimSummaryRegressionAnalysisCurve::defineEditorAttribute( const caf::PdmFie
     {
         if ( auto* myAttr = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute ) )
         {
-            auto timeSteps = m_sourceTimeStepsY;
-            if ( !timeSteps.empty() )
-            {
-                myAttr->m_minimum = *timeSteps.begin();
-                myAttr->m_maximum = *timeSteps.rbegin();
-            }
+            myAttr->m_minimum     = 0;
+            myAttr->m_maximum     = 100;
             myAttr->m_showSpinBox = false;
         }
     }
@@ -719,6 +716,35 @@ void RimSummaryRegressionAnalysisCurve::appendTimeSteps( std::vector<time_t>& de
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::pair<time_t, time_t> RimSummaryRegressionAnalysisCurve::fullTimeStepRange() const
+{
+    auto timeSteps = RimSummaryCurve::timeStepsY();
+    if ( !timeSteps.empty() )
+    {
+        return std::make_pair( *timeSteps.begin(), *timeSteps.rbegin() );
+    }
+
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::pair<time_t, time_t> RimSummaryRegressionAnalysisCurve::selectedTimeStepRange() const
+{
+    // Scale the slider values to the full time step range
+
+    auto [min, max]  = fullTimeStepRange();
+    auto range       = max - min;
+    auto selectedMin = min + static_cast<time_t>( range * ( m_minTimeStep / 100.0 ) );
+    auto selectedMax = min + static_cast<time_t>( range * ( m_maxTimeStep / 100.0 ) );
+
+    return { selectedMin, selectedMax };
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<time_t> RimSummaryRegressionAnalysisCurve::getOutputTimeSteps( const std::vector<time_t>& timeSteps,
                                                                            int                        forecastBackward,
                                                                            int                        forecastForward,
@@ -843,7 +869,8 @@ void RimSummaryRegressionAnalysisCurve::updateTimeAnnotations()
 
     if ( m_showTimeSelectionInPlot && isChecked() )
     {
-        m_timeRangeAnnotation = plot->addTimeRangeAnnotation( m_minTimeStep, m_maxTimeStep );
+        auto [minTimeStep, maxTimeStep] = selectedTimeStepRange();
+        m_timeRangeAnnotation           = plot->addTimeRangeAnnotation( minTimeStep, maxTimeStep );
         m_timeRangeAnnotation->setColor( color() );
     }
 }
@@ -855,8 +882,8 @@ void RimSummaryRegressionAnalysisCurve::updateDefaultValues()
 {
     if ( !m_sourceTimeStepsY.empty() && m_timeRangeSelection() == RangeType::FULL_RANGE )
     {
-        m_minTimeStep = m_sourceTimeStepsY.front();
-        m_maxTimeStep = m_sourceTimeStepsY.back();
+        m_minTimeStep = 0;
+        m_maxTimeStep = 100;
     }
 
     if ( !m_sourceValuesX.empty() && m_xRangeSelection() == RangeType::FULL_RANGE )

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.h
@@ -133,6 +133,9 @@ private:
 
     static void appendTimeSteps( std::vector<time_t>& destinationTimeSteps, const std::set<QDateTime>& sourceTimeSteps );
 
+    std::pair<time_t, time_t> fullTimeStepRange() const;
+    std::pair<time_t, time_t> selectedTimeStepRange() const;
+
 private:
     caf::PdmField<caf::AppEnum<DataSource>>                                      m_dataSourceForRegression;
     caf::PdmPtrField<RimEnsembleCurveSet*>                                       m_ensembleCurveSet;
@@ -141,8 +144,8 @@ private:
     caf::PdmField<caf::AppEnum<RegressionType>> m_regressionType;
 
     caf::PdmField<caf::AppEnum<RangeType>> m_timeRangeSelection;
-    caf::PdmField<time_t>                  m_minTimeStep;
-    caf::PdmField<time_t>                  m_maxTimeStep;
+    caf::PdmField<int>                     m_minTimeStep;
+    caf::PdmField<int>                     m_maxTimeStep;
     caf::PdmField<bool>                    m_showTimeSelectionInPlot;
 
     caf::PdmField<int>                        m_polynomialDegree;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.h
@@ -144,8 +144,8 @@ private:
     caf::PdmField<caf::AppEnum<RegressionType>> m_regressionType;
 
     caf::PdmField<caf::AppEnum<RangeType>> m_timeRangeSelection;
-    caf::PdmField<int>                     m_minTimeStep;
-    caf::PdmField<int>                     m_maxTimeStep;
+    caf::PdmField<int>                     m_minTimeSliderPosition;
+    caf::PdmField<int>                     m_maxTimeSliderPosition;
     caf::PdmField<bool>                    m_showTimeSelectionInPlot;
 
     caf::PdmField<int>                        m_polynomialDegree;


### PR DESCRIPTION
Use `int` as internal representation in sliders , as `time_t` can cause overflow. Never use `time_t`.

Closes #10706
