### PR TITLE
#10536 Observed data: fix handling of data with error bars when impor…

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressCollection.cpp
@@ -184,8 +184,11 @@ void RimSummaryAddressCollection::updateFolderStructure( const std::set<RifEclip
     auto* imported      = getOrCreateSubfolder( CollectionContentType::IMPORTED );
 
     // Sort addresses to have calculated results last per category
-    std::vector<RifEclipseSummaryAddress> sortedAddresses( addresses.size() );
-    std::copy( addresses.begin(), addresses.end(), sortedAddresses.begin() );
+    std::vector<RifEclipseSummaryAddress> sortedAddresses;
+    std::copy_if( addresses.begin(),
+                  addresses.end(),
+                  std::back_inserter( sortedAddresses ),
+                  []( RifEclipseSummaryAddress x ) { return !x.isErrorResult(); } );
     std::sort( sortedAddresses.begin(),
                sortedAddresses.end(),
                []( const RifEclipseSummaryAddress& a, const RifEclipseSummaryAddress& b ) -> bool
@@ -202,6 +205,7 @@ void RimSummaryAddressCollection::updateFolderStructure( const std::set<RifEclip
                    if ( a.cellI() != b.cellI() ) return a.cellI() < b.cellI();
                    if ( a.wellSegmentNumber() != b.wellSegmentNumber() ) return a.wellSegmentNumber() < b.wellSegmentNumber();
                    if ( a.aquiferNumber() != b.aquiferNumber() ) return a.aquiferNumber() < b.aquiferNumber();
+                   if ( a.isErrorResult() != b.isErrorResult() ) return !a.isErrorResult();
 
                    // Calculated results are sorted last.
                    if ( a.isCalculated() != b.isCalculated() ) return a.isCalculated() < b.isCalculated();


### PR DESCRIPTION
…ting

Observed summary data with error bar results have two addresses: one for the data, and one for the error data. When creating the RimSummaryAddress objects in the "Data Sources" tree the error data address would occasionally be used instead of the data address (due to lack of sorting and filtering).

Plots created from the error RimSummaryAddress would display the error data twice in the "Show Plot Data" view.

Fixed by filtering out the error addresses and improving the sorting criteria.

Fixes #10536.