### PR TITLE
#10720 Summary Import: support upper/lower case mismatch between file…

### DIFF
--- a/ThirdParty/Ert/lib/ecl/ecl_util.cpp
+++ b/ThirdParty/Ert/lib/ecl/ecl_util.cpp
@@ -457,11 +457,6 @@ static char * ecl_util_alloc_filename_static(const char * path, const char * bas
     ext        = NULL;
   }
 
-  if (!upper_case) {
-    for (size_t i=0; i < strlen(ext); i++)
-      ext[i] = tolower(ext[i]);
-  }
-
   filename = util_alloc_filename(path , base , ext);
   free(ext);
 
@@ -661,11 +656,6 @@ int ecl_util_select_filelist( const char * path , const char * base , ecl_file_e
 
     char * ext_pattern = util_alloc_string_copy(ecl_util_get_file_pattern( file_type , fmt_file ));
     char * file_pattern;
-
-    if (!upper_case) {
-      for (size_t i=0; i < strlen(ext_pattern); i++)
-        ext_pattern[i] = tolower(ext_pattern[i]);
-    }
 
     if (base)
       file_pattern = util_alloc_filename(NULL , base, ext_pattern);


### PR DESCRIPTION
…name and extension.

Importing files with different casing in base name and extension would fail when using libecl summary reader. E.g "norne_atw2013.SMSPEC" would fail since libecl forces the extension to be lower case even though it is given the actual extension.

Removing the lowercasing allows more flexibility in the file naming.

The problem only occurs when the libecl summary reader is used, the opm-common can already import these files.

Fixes #10720.
Fixes #10617.