### PR TITLE
Remove obsolete code

### DIFF
--- a/ApplicationLibCode/Commands/PlotTemplateCommands/RicSaveMultiPlotTemplateFeature.cpp
+++ b/ApplicationLibCode/Commands/PlotTemplateCommands/RicSaveMultiPlotTemplateFeature.cpp
@@ -166,7 +166,7 @@ QString RicSaveMultiPlotTemplateFeature::createTextFromObject( RimSummaryMultiPl
             std::set<QString> sourceStrings;
 
             const QString summaryFieldKeyword = RicSummaryPlotTemplateTools::summaryCaseFieldKeyword();
-            for ( const auto& curve : summaryPlot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS ) )
+            for ( const auto& curve : summaryPlot->allCurves() )
             {
                 auto fieldHandle = curve->findField( summaryFieldKeyword );
                 if ( fieldHandle )
@@ -186,7 +186,7 @@ QString RicSaveMultiPlotTemplateFeature::createTextFromObject( RimSummaryMultiPl
             std::set<QString> sourceStrings;
 
             const QString summaryFieldKeyword = RicSummaryPlotTemplateTools::summaryCaseXFieldKeyword();
-            for ( const auto& curve : summaryPlot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS ) )
+            for ( const auto& curve : summaryPlot->allCurves() )
             {
                 if ( curve->axisTypeX() != RiaDefines::HorizontalAxisType::SUMMARY_VECTOR ) continue;
 

--- a/ApplicationLibCode/Commands/PlotTemplateCommands/RicSummaryPlotTemplateTools.cpp
+++ b/ApplicationLibCode/Commands/PlotTemplateCommands/RicSummaryPlotTemplateTools.cpp
@@ -247,7 +247,7 @@ void RicSummaryPlotTemplateTools::setValuesForPlaceholders( RimSummaryPlot*     
     {
         // Replace single summary curves data sources
 
-        auto summaryCurves = summaryPlot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS );
+        auto summaryCurves = summaryPlot->allCurves();
         for ( const auto& curve : summaryCurves )
         {
             auto summaryCaseHandle = curve->findField( RicSummaryPlotTemplateTools::summaryCaseFieldKeyword() );

--- a/ApplicationLibCode/ProjectDataModel/RimMainPlotCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMainPlotCollection.cpp
@@ -210,7 +210,7 @@ void RimMainPlotCollection::initAfterRead()
         auto summaryPlot = new RimSummaryPlot;
         summaryMultiPlot->addPlot( summaryPlot );
 
-        for ( auto curve : crossPlot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS ) )
+        for ( auto curve : crossPlot->allCurves() )
         {
             crossPlot->removeCurve( curve );
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp
@@ -51,7 +51,6 @@ RimEnsembleCurveSetCollection::RimEnsembleCurveSetCollection()
 
     CAF_PDM_InitFieldNoDefault( &m_ySourceStepping, "YSourceStepping", "" );
     m_ySourceStepping = new RimSummaryPlotSourceStepping;
-    m_ySourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::Y_AXIS );
     m_ySourceStepping.uiCapability()->setUiTreeHidden( true );
     m_ySourceStepping.uiCapability()->setUiTreeChildrenHidden( true );
     m_ySourceStepping.xmlCapability()->disableIO();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressModifier.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressModifier.cpp
@@ -56,7 +56,7 @@ std::vector<RimSummaryAddressModifier> RimSummaryAddressModifier::createAddressM
             mods.emplace_back( RimSummaryAddressModifier( curveSet ) );
         }
 
-        auto curves = summaryPlot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS );
+        auto curves = summaryPlot->allCurves();
         for ( auto c : curves )
         {
             mods.emplace_back( RimSummaryAddressModifier( c ) );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.cpp
@@ -65,24 +65,9 @@ RimSummaryCurveCollection::RimSummaryCurveCollection()
 
     CAF_PDM_InitFieldNoDefault( &m_ySourceStepping, "YSourceStepping", "" );
     m_ySourceStepping = new RimSummaryPlotSourceStepping;
-    m_ySourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::Y_AXIS );
     m_ySourceStepping.uiCapability()->setUiTreeHidden( true );
     m_ySourceStepping.uiCapability()->setUiTreeChildrenHidden( true );
     m_ySourceStepping.xmlCapability()->disableIO();
-
-    CAF_PDM_InitFieldNoDefault( &m_xSourceStepping, "XSourceStepping", "" );
-    m_xSourceStepping = new RimSummaryPlotSourceStepping;
-    m_xSourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::X_AXIS );
-    m_xSourceStepping.uiCapability()->setUiTreeHidden( true );
-    m_xSourceStepping.uiCapability()->setUiTreeChildrenHidden( true );
-    m_xSourceStepping.xmlCapability()->disableIO();
-
-    CAF_PDM_InitFieldNoDefault( &m_unionSourceStepping, "UnionSourceStepping", "" );
-    m_unionSourceStepping = new RimSummaryPlotSourceStepping;
-    m_unionSourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::UNION_X_Y_AXIS );
-    m_unionSourceStepping.uiCapability()->setUiTreeHidden( true );
-    m_unionSourceStepping.uiCapability()->setUiTreeChildrenHidden( true );
-    m_unionSourceStepping.xmlCapability()->disableIO();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -258,70 +243,6 @@ std::vector<RimSummaryCurve*> RimSummaryCurveCollection::curves() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryCurve*> RimSummaryCurveCollection::curvesForSourceStepping( RimSummaryDataSourceStepping::Axis steppingType ) const
-{
-    std::vector<RimSummaryCurve*> stepCurves;
-
-    if ( m_curveForSourceStepping )
-    {
-        stepCurves.push_back( m_curveForSourceStepping );
-
-        {
-            // Add corresponding history/summary curve with or without H
-
-            const std::string historyIdentifier = "H";
-
-            std::string vectorName;
-
-            if ( steppingType == RimSummaryDataSourceStepping::Axis::X_AXIS )
-            {
-                vectorName = m_curveForSourceStepping->summaryAddressX().vectorName();
-            }
-            else if ( steppingType == RimSummaryDataSourceStepping::Axis::Y_AXIS )
-            {
-                vectorName = m_curveForSourceStepping->summaryAddressY().vectorName();
-            }
-
-            std::string candidateName;
-            if ( RiaStdStringTools::endsWith( vectorName, historyIdentifier ) )
-            {
-                candidateName = vectorName.substr( 0, vectorName.size() - 1 );
-            }
-            else
-            {
-                candidateName = vectorName + historyIdentifier;
-            }
-
-            for ( const auto& c : curves() )
-            {
-                if ( steppingType == RimSummaryDataSourceStepping::Axis::X_AXIS )
-                {
-                    if ( c->summaryCaseX() == m_curveForSourceStepping->summaryCaseX() && c->summaryAddressX().vectorName() == candidateName )
-                    {
-                        stepCurves.push_back( c );
-                    }
-                }
-                else if ( steppingType == RimSummaryDataSourceStepping::Axis::Y_AXIS )
-                {
-                    if ( c->summaryCaseY() == m_curveForSourceStepping->summaryCaseY() && c->summaryAddressY().vectorName() == candidateName )
-                    {
-                        stepCurves.push_back( c );
-                    }
-                }
-            }
-        }
-    }
-    else
-    {
-        stepCurves = curves();
-    }
-
-    return stepCurves;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void RimSummaryCurveCollection::deleteCurvesAssosiatedWithCase( RimSummaryCase* summaryCase )
 {
     std::vector<RimSummaryCurve*> summaryCurvesToDelete;
@@ -425,22 +346,9 @@ RimSummaryCurve* RimSummaryCurveCollection::curveForSourceStepping() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimSummaryPlotSourceStepping* RimSummaryCurveCollection::sourceSteppingObject( RimSummaryDataSourceStepping::Axis sourceSteppingType ) const
+RimSummaryPlotSourceStepping* RimSummaryCurveCollection::sourceSteppingObject() const
 {
-    if ( sourceSteppingType == RimSummaryDataSourceStepping::Axis::X_AXIS )
-    {
-        return m_xSourceStepping();
-    }
-    else if ( sourceSteppingType == RimSummaryDataSourceStepping::Axis::Y_AXIS )
-    {
-        return m_ySourceStepping();
-    }
-    if ( sourceSteppingType == RimSummaryDataSourceStepping::Axis::UNION_X_Y_AXIS )
-    {
-        return m_unionSourceStepping();
-    }
-
-    return nullptr;
+    return m_ySourceStepping();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.h
@@ -52,11 +52,10 @@ public:
     void             setCurveForSourceStepping( RimSummaryCurve* curve );
     RimSummaryCurve* curveForSourceStepping() const;
 
-    RimSummaryPlotSourceStepping* sourceSteppingObject( RimSummaryDataSourceStepping::Axis sourceSteppingType ) const;
+    RimSummaryPlotSourceStepping* sourceSteppingObject() const;
 
     std::set<RiaDefines::HorizontalAxisType> horizontalAxisTypes() const;
     std::vector<RimSummaryCurve*>            curves() const;
-    std::vector<RimSummaryCurve*>            curvesForSourceStepping( RimSummaryDataSourceStepping::Axis steppingType ) const;
 
     void setCurveAsTopZWithinCategory( RimSummaryCurve* curve );
 
@@ -108,8 +107,6 @@ private:
     caf::PdmField<bool>                       m_editPlot;
 
     caf::PdmChildField<RimSummaryPlotSourceStepping*> m_ySourceStepping;
-    caf::PdmChildField<RimSummaryPlotSourceStepping*> m_xSourceStepping;
-    caf::PdmChildField<RimSummaryPlotSourceStepping*> m_unionSourceStepping;
 
     caf::PdmPointer<RimSummaryCurve> m_currentSummaryCurve;
     caf::PdmPointer<RimSummaryCurve> m_curveForSourceStepping;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDataSourceStepping.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDataSourceStepping.h
@@ -26,13 +26,6 @@ class RimEnsembleCurveSet;
 class RimSummaryDataSourceStepping
 {
 public:
-    enum class Axis
-    {
-        Y_AXIS,
-        X_AXIS,
-        UNION_X_Y_AXIS
-    };
-
     enum class SourceSteppingDimension
     {
         SUMMARY_CASE,
@@ -48,8 +41,7 @@ public:
     };
 
 public:
-    virtual std::vector<RimSummaryDataSourceStepping::Axis> availableAxes() const                                              = 0;
-    virtual std::vector<RimSummaryCurve*>                   curvesForStepping( RimSummaryDataSourceStepping::Axis axis ) const = 0;
-    virtual std::vector<RimSummaryCurve*>                   allCurves( RimSummaryDataSourceStepping::Axis axis ) const         = 0;
-    virtual std::vector<RimEnsembleCurveSet*>               curveSets() const                                                  = 0;
+    virtual std::vector<RimSummaryCurve*>     curvesForStepping() const = 0;
+    virtual std::vector<RimSummaryCurve*>     allCurves() const         = 0;
+    virtual std::vector<RimEnsembleCurveSet*> curveSets() const         = 0;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.cpp
@@ -163,7 +163,6 @@ RimSummaryMultiPlot::RimSummaryMultiPlot()
     CAF_PDM_InitFieldNoDefault( &m_sourceStepping, "SourceStepping", "" );
 
     m_sourceStepping = new RimSummaryPlotSourceStepping;
-    m_sourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::Y_AXIS );
     m_sourceStepping->setSourceSteppingObject( this );
     m_sourceStepping.uiCapability()->setUiTreeHidden( true );
     m_sourceStepping.uiCapability()->setUiTreeChildrenHidden( true );
@@ -308,21 +307,13 @@ void RimSummaryMultiPlot::updateAfterPlotRemove()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryDataSourceStepping::Axis> RimSummaryMultiPlot::availableAxes() const
-{
-    return { RimSummaryDataSourceStepping::Axis::X_AXIS };
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryCurve*> RimSummaryMultiPlot::curvesForStepping( RimSummaryDataSourceStepping::Axis axis ) const
+std::vector<RimSummaryCurve*> RimSummaryMultiPlot::curvesForStepping() const
 {
     std::vector<RimSummaryCurve*> curves;
 
     for ( auto summaryPlot : summaryPlots() )
     {
-        for ( auto curve : summaryPlot->curvesForStepping( axis ) )
+        for ( auto curve : summaryPlot->curvesForStepping() )
         {
             curves.push_back( curve );
         }
@@ -352,13 +343,13 @@ std::vector<RimEnsembleCurveSet*> RimSummaryMultiPlot::curveSets() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryCurve*> RimSummaryMultiPlot::allCurves( RimSummaryDataSourceStepping::Axis axis ) const
+std::vector<RimSummaryCurve*> RimSummaryMultiPlot::allCurves() const
 {
     std::vector<RimSummaryCurve*> curves;
 
     for ( auto summaryPlot : summaryPlots() )
     {
-        for ( auto curve : summaryPlot->allCurves( axis ) )
+        for ( auto curve : summaryPlot->allCurves() )
         {
             curves.push_back( curve );
         }
@@ -378,7 +369,7 @@ void RimSummaryMultiPlot::populateNameHelper( RimSummaryPlotNameHelper* nameHelp
     std::vector<RimSummaryCase*>           sumCases;
     std::vector<RimSummaryCaseCollection*> ensembleCases;
 
-    for ( RimSummaryCurve* curve : allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS ) )
+    for ( RimSummaryCurve* curve : allCurves() )
     {
         addresses.push_back( curve->curveAddress() );
         sumCases.push_back( curve->summaryCaseY() );
@@ -1538,7 +1529,7 @@ void RimSummaryMultiPlot::appendSubPlotByStepping( int direction )
         if ( m_sourceStepping()->stepDimension() == RimSummaryDataSourceStepping::SourceSteppingDimension::SUMMARY_CASE )
         {
             RimSummaryCase* newCase = m_sourceStepping()->stepCase( direction );
-            for ( auto curve : newPlot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS ) )
+            for ( auto curve : newPlot->allCurves() )
             {
                 curve->setSummaryCaseY( newCase );
 
@@ -1585,7 +1576,7 @@ void RimSummaryMultiPlot::appendCurveByStepping( int direction )
     {
         std::vector<caf::PdmObjectHandle*> addresses;
 
-        for ( auto curve : plot->allCurves( RimSummaryDataSourceStepping::Axis::Y_AXIS ) )
+        for ( auto curve : plot->allCurves() )
         {
             auto address   = curve->summaryAddressY();
             auto sumCase   = curve->summaryCaseY();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.h
@@ -68,10 +68,9 @@ public:
     void setAutoPlotTitle( bool enable );
     void setAutoSubPlotTitle( bool enable );
 
-    std::vector<RimSummaryDataSourceStepping::Axis> availableAxes() const override;
-    std::vector<RimSummaryCurve*>                   curvesForStepping( RimSummaryDataSourceStepping::Axis axis ) const override;
-    std::vector<RimEnsembleCurveSet*>               curveSets() const override;
-    std::vector<RimSummaryCurve*>                   allCurves( RimSummaryDataSourceStepping::Axis axis ) const override;
+    std::vector<RimSummaryCurve*>     curvesForStepping() const override;
+    std::vector<RimEnsembleCurveSet*> curveSets() const override;
+    std::vector<RimSummaryCurve*>     allCurves() const override;
 
     void addPlot( RimPlot* plot ) override;
     void insertPlot( RimPlot* plot, size_t index ) override;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -461,7 +461,7 @@ void RimSummaryPlot::moveCurvesToPlot( RimSummaryPlot* plot, const std::vector<R
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryCurve*> RimSummaryPlot::curvesForStepping( RimSummaryDataSourceStepping::Axis axis ) const
+std::vector<RimSummaryCurve*> RimSummaryPlot::curvesForStepping() const
 {
     auto curveForStepping = summaryCurveCollection()->curveForSourceStepping();
     if ( curveForStepping )
@@ -483,24 +483,9 @@ std::vector<RimEnsembleCurveSet*> RimSummaryPlot::curveSets() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryCurve*> RimSummaryPlot::allCurves( RimSummaryDataSourceStepping::Axis axis ) const
+std::vector<RimSummaryCurve*> RimSummaryPlot::allCurves() const
 {
     return summaryCurves();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryDataSourceStepping::Axis> RimSummaryPlot::availableAxes() const
-{
-    auto axisTypes = m_summaryCurveCollection->horizontalAxisTypes();
-
-    if ( axisTypes.contains( RiaDefines::HorizontalAxisType::SUMMARY_VECTOR ) )
-    {
-        return { RimSummaryDataSourceStepping::Axis::X_AXIS, RimSummaryDataSourceStepping::Axis::Y_AXIS };
-    }
-
-    return { RimSummaryDataSourceStepping::Axis::X_AXIS };
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1241,16 +1226,6 @@ void RimSummaryPlot::ensureRequiredAxisObjectsForCurves()
         axisProperties->requestLoadDataAndUpdate.connect( this, &RimSummaryPlot::timeAxisSettingsChangedReloadRequired );
 
         m_axisPropertiesArray.push_back( axisProperties );
-    }
-
-    auto axisTypes = m_summaryCurveCollection->horizontalAxisTypes();
-    if ( axisTypes.contains( RiaDefines::HorizontalAxisType::SUMMARY_VECTOR ) )
-    {
-        m_sourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::UNION_X_Y_AXIS );
-    }
-    else
-    {
-        m_sourceStepping->setSourceSteppingType( RimSummaryDataSourceStepping::Axis::Y_AXIS );
     }
 }
 
@@ -3078,7 +3053,7 @@ RimSummaryPlotSourceStepping* RimSummaryPlot::sourceSteppingObjectForKeyEventHan
 
     if ( axisTypes.contains( RiaDefines::HorizontalAxisType::SUMMARY_VECTOR ) )
     {
-        return summaryCurveCollection()->sourceSteppingObject( RimSummaryDataSourceStepping::Axis::UNION_X_Y_AXIS );
+        return summaryCurveCollection()->sourceSteppingObject();
     }
 
     return m_sourceStepping;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
@@ -198,10 +198,9 @@ public:
 
     static void moveCurvesToPlot( RimSummaryPlot* plot, const std::vector<RimSummaryCurve*> curves, int insertAtPosition );
 
-    std::vector<RimSummaryDataSourceStepping::Axis> availableAxes() const override;
-    std::vector<RimSummaryCurve*>                   curvesForStepping( RimSummaryDataSourceStepping::Axis axis ) const override;
-    std::vector<RimEnsembleCurveSet*>               curveSets() const override;
-    std::vector<RimSummaryCurve*>                   allCurves( RimSummaryDataSourceStepping::Axis axis ) const override;
+    std::vector<RimSummaryCurve*>     curvesForStepping() const override;
+    std::vector<RimEnsembleCurveSet*> curveSets() const override;
+    std::vector<RimSummaryCurve*>     allCurves() const override;
 
     std::vector<RimPlotAxisProperties*> plotAxes( RimPlotAxisProperties::Orientation orientation ) const;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
@@ -59,7 +59,6 @@ CAF_PDM_SOURCE_INIT( RimSummaryPlotSourceStepping, "RimSummaryCurveCollectionMod
 ///
 //--------------------------------------------------------------------------------------------------
 RimSummaryPlotSourceStepping::RimSummaryPlotSourceStepping()
-    : m_sourceSteppingType( RimSummaryDataSourceStepping::Axis::Y_AXIS )
 {
     CAF_PDM_InitObject( "Summary Curves Modifier" );
 
@@ -94,14 +93,6 @@ RimSummaryPlotSourceStepping::RimSummaryPlotSourceStepping()
     m_indexLabel.xmlCapability()->disableIO();
 
     CAF_PDM_InitField( &m_autoUpdateAppearance, "AutoUpdateAppearance", false, "Update Appearance" );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimSummaryPlotSourceStepping::setSourceSteppingType( RimSummaryDataSourceStepping::Axis sourceSteppingType )
-{
-    m_sourceSteppingType = sourceSteppingType;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -325,7 +316,7 @@ QList<caf::PdmOptionItemInfo> RimSummaryPlotSourceStepping::calculateValueOption
 void RimSummaryPlotSourceStepping::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
     std::vector<RimSummaryCurve*> curves;
-    if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->allCurves( m_sourceSteppingType );
+    if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->allCurves();
 
     bool isAutoZoomAllowed = false;
     bool doZoomAll         = false;
@@ -398,25 +389,19 @@ void RimSummaryPlotSourceStepping::fieldChangedByUi( const caf::PdmFieldHandle* 
 
             for ( auto curve : curves )
             {
-                if ( isYAxisStepping() )
+                if ( previousCase == curve->summaryCaseY() )
                 {
-                    if ( previousCase == curve->summaryCaseY() )
-                    {
-                        curve->setSummaryCaseY( m_summaryCase );
+                    curve->setSummaryCaseY( m_summaryCase );
 
-                        if ( m_autoUpdateAppearance )
-                        {
-                            curve->setCurveAppearanceFromCaseType();
-                        }
+                    if ( m_autoUpdateAppearance )
+                    {
+                        curve->setCurveAppearanceFromCaseType();
                     }
                 }
 
-                if ( isXAxisStepping() )
+                if ( previousCase == curve->summaryCaseX() )
                 {
-                    if ( previousCase == curve->summaryCaseX() )
-                    {
-                        curve->setSummaryCaseX( m_summaryCase );
-                    }
+                    curve->setSummaryCaseX( m_summaryCase );
                 }
             }
 
@@ -507,19 +492,13 @@ void RimSummaryPlotSourceStepping::fieldChangedByUi( const caf::PdmFieldHandle* 
         {
             for ( auto curve : curves )
             {
-                if ( isYAxisStepping() )
-                {
-                    RifEclipseSummaryAddress adr = curve->summaryAddressY();
-                    RimDataSourceSteppingTools::updateAddressIfMatching( oldValue, newValue, summaryCategoryToModify, adr );
-                    curve->setSummaryAddressY( adr );
-                }
+                RifEclipseSummaryAddress adrY = curve->summaryAddressY();
+                RimDataSourceSteppingTools::updateAddressIfMatching( oldValue, newValue, summaryCategoryToModify, adrY );
+                curve->setSummaryAddressY( adrY );
 
-                if ( isXAxisStepping() )
-                {
-                    RifEclipseSummaryAddress adr = curve->summaryAddressX();
-                    RimDataSourceSteppingTools::updateAddressIfMatching( oldValue, newValue, summaryCategoryToModify, adr );
-                    curve->setSummaryAddressX( adr );
-                }
+                RifEclipseSummaryAddress adrX = curve->summaryAddressX();
+                RimDataSourceSteppingTools::updateAddressIfMatching( oldValue, newValue, summaryCategoryToModify, adrX );
+                curve->setSummaryAddressX( adrX );
             }
 
             if ( dataSourceSteppingObject() )
@@ -634,7 +613,7 @@ std::set<RifEclipseSummaryAddress> RimSummaryPlotSourceStepping::adressesForSour
         }
 
         std::vector<RimSummaryCurve*> curves;
-        if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->curvesForStepping( m_sourceSteppingType );
+        if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->curvesForStepping();
 
         size_t maxAddrCount = 0;
         int    maxAddrIndex = -1;
@@ -644,7 +623,7 @@ std::set<RifEclipseSummaryAddress> RimSummaryPlotSourceStepping::adressesForSour
             auto curve = curves[i];
             if ( !curve ) continue;
 
-            if ( isYAxisStepping() && curve->summaryCaseY() && curve->summaryCaseY()->summaryReader() )
+            if ( curve->summaryCaseY() && curve->summaryCaseY()->summaryReader() )
             {
                 auto addresses = curve->summaryCaseY()->summaryReader()->allResultAddresses();
 
@@ -656,7 +635,7 @@ std::set<RifEclipseSummaryAddress> RimSummaryPlotSourceStepping::adressesForSour
                 }
             }
 
-            if ( isXAxisStepping() && curve->summaryCaseX() && curve->summaryCaseX()->summaryReader() )
+            if ( curve->summaryCaseX() && curve->summaryCaseX()->summaryReader() )
             {
                 auto   addresses = curve->summaryCaseX()->summaryReader()->allResultAddresses();
                 size_t addrCount = addresses.size();
@@ -672,13 +651,13 @@ std::set<RifEclipseSummaryAddress> RimSummaryPlotSourceStepping::adressesForSour
         {
             auto curve = curves[maxAddrIndex];
 
-            if ( isXAxisStepping() && curve->summaryCaseX() && curve->summaryCaseX()->summaryReader() )
+            if ( curve->summaryCaseX() && curve->summaryCaseX()->summaryReader() )
             {
                 auto addresses = curve->summaryCaseX()->summaryReader()->allResultAddresses();
                 addressSet.insert( addresses.begin(), addresses.end() );
             }
 
-            if ( isYAxisStepping() && curve->summaryCaseY() && curve->summaryCaseY()->summaryReader() )
+            if ( curve->summaryCaseY() && curve->summaryCaseY()->summaryReader() )
             {
                 auto addresses = curve->summaryCaseY()->summaryReader()->allResultAddresses();
                 addressSet.insert( addresses.begin(), addresses.end() );
@@ -704,16 +683,13 @@ std::set<RifEclipseSummaryAddress> RimSummaryPlotSourceStepping::addressesForCur
         }
 
         std::vector<RimSummaryCurve*> curves;
-        if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->curvesForStepping( m_sourceSteppingType );
+        if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->curvesForStepping();
 
         for ( auto curve : curves )
         {
-            if ( isYAxisStepping() )
-            {
-                addresses.insert( curve->summaryAddressY() );
-            }
+            addresses.insert( curve->summaryAddressY() );
 
-            if ( isXAxisStepping() )
+            if ( curve->axisTypeX() == RiaDefines::HorizontalAxisType::SUMMARY_VECTOR )
             {
                 addresses.insert( curve->summaryAddressX() );
             }
@@ -731,15 +707,12 @@ std::set<RimSummaryCase*> RimSummaryPlotSourceStepping::summaryCasesCurveCollect
     std::set<RimSummaryCase*> sumCases;
 
     std::vector<RimSummaryCurve*> curves;
-    if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->curvesForStepping( m_sourceSteppingType );
+    if ( dataSourceSteppingObject() ) curves = dataSourceSteppingObject()->curvesForStepping();
     for ( auto c : curves )
     {
-        if ( isYAxisStepping() )
-        {
-            sumCases.insert( c->summaryCaseY() );
-        }
+        sumCases.insert( c->summaryCaseY() );
 
-        if ( isXAxisStepping() )
+        if ( c->axisTypeX() == RiaDefines::HorizontalAxisType::SUMMARY_VECTOR )
         {
             sumCases.insert( c->summaryCaseX() );
         }
@@ -916,30 +889,6 @@ std::set<RimSummaryCaseCollection*> RimSummaryPlotSourceStepping::ensembleCollec
     }
 
     return summaryCaseCollections;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-bool RimSummaryPlotSourceStepping::isXAxisStepping() const
-{
-    if ( m_sourceSteppingType == RimSummaryDataSourceStepping::Axis::UNION_X_Y_AXIS ) return true;
-
-    if ( m_sourceSteppingType == RimSummaryDataSourceStepping::Axis::X_AXIS ) return true;
-
-    return false;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-bool RimSummaryPlotSourceStepping::isYAxisStepping() const
-{
-    if ( m_sourceSteppingType == RimSummaryDataSourceStepping::Axis::UNION_X_Y_AXIS ) return true;
-
-    if ( m_sourceSteppingType == RimSummaryDataSourceStepping::Axis::Y_AXIS ) return true;
-
-    return false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1302,13 +1251,11 @@ void RimSummaryPlotSourceStepping::updateVectorNameInCurves( std::vector<RimSumm
     std::map<RimSummaryPlot*, std::vector<RimSummaryCurve*>> curvesInPlot;
     for ( auto curve : curves )
     {
-        if ( isYAxisStepping() )
         {
             auto adr = curve->summaryAddressY();
             if ( RimDataSourceSteppingTools::updateQuantityIfMatching( oldValue, newValue, adr ) ) curve->setSummaryAddressY( adr );
         }
 
-        if ( isXAxisStepping() )
         {
             auto adr = curve->summaryAddressX();
             if ( RimDataSourceSteppingTools::updateQuantityIfMatching( oldValue, newValue, adr ) ) curve->setSummaryAddressX( adr );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.h
@@ -49,7 +49,6 @@ class RimSummaryPlotSourceStepping : public caf::PdmObject
 public:
     RimSummaryPlotSourceStepping();
 
-    void setSourceSteppingType( RimSummaryDataSourceStepping::Axis sourceSteppingType );
     void setSourceSteppingObject( caf::PdmObject* sourceObject );
 
     void applyNextStep();
@@ -92,9 +91,6 @@ private:
     std::vector<caf::PdmFieldHandle*> activeFieldsForDataSourceStepping();
     std::vector<caf::PdmFieldHandle*> toolbarFieldsForDataSourceStepping();
 
-    bool isXAxisStepping() const;
-    bool isYAxisStepping() const;
-
     void modifyCurrentIndex( caf::PdmValueField* valueField, int indexOffset, bool notifyChange = true );
 
     std::vector<RimSummaryCase*> summaryCasesForSourceStepping();
@@ -132,6 +128,5 @@ private:
     caf::PdmField<bool> m_includeEnsembleCasesForCaseStepping;
     caf::PdmField<bool> m_autoUpdateAppearance;
 
-    RimSummaryDataSourceStepping::Axis m_sourceSteppingType;
-    std::vector<QString>               m_cachedIdentifiers;
+    std::vector<QString> m_cachedIdentifiers;
 };


### PR DESCRIPTION
After merging the cross plot with the summary plot, the sources stepping can be simplified. Remove obsolete sources stepping code, as preparation before fixing other source stepping issues.