### PR TITLE
#10785 Work-around for legend item disappearing when highlighted

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuQwtPlotLegend.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotLegend.cpp
@@ -91,7 +91,10 @@ QSize RiuQwtPlotLegend::sizeHint() const
 
         if ( legendLayout->itemCount() % numColumns ) numRows++;
 
-        int width = numColumns * legendLayout->maxItemWidth();
+        // Extra width to workaround layout issue on linux
+        // https://github.com/OPM/ResInsight/issues/10785
+        const int extraWidth = 20;
+        const int width      = numColumns * legendLayout->maxItemWidth() + extraWidth;
 
         int maxHeight = 0;
         for ( unsigned int i = 0; i < legendLayout->itemCount(); ++i )


### PR DESCRIPTION
Seen on Linux only. The legend item would be wider than anticipated by the layout (for unknown reasons), and would be place on the next line. Added extra with to the size hint to work around the problem.

Fixes #10785,