### PR TITLE
Make sure data for a variable is using correct case

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.h
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.h
@@ -71,10 +71,11 @@ protected:
 
     std::pair<bool, QString> validateVariables();
 
-    std::vector<double> getInputVectorForVariable( RimGridCalculationVariable*   v,
-                                                   size_t                        tsId,
-                                                   RiaDefines::PorosityModelType porosityModel,
-                                                   RimEclipseCase*               outputEclipseCase ) const;
+    std::vector<double> getDataForVariable( RimGridCalculationVariable*   variable,
+                                            size_t                        tsId,
+                                            RiaDefines::PorosityModelType porosityModel,
+                                            RimEclipseCase*               destinationCase,
+                                            bool                          useDataFromDestinationCase ) const;
 
     void filterResults( RimGridView*                            cellFilterView,
                         const std::vector<std::vector<double>>& values,

--- a/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.cpp
@@ -84,6 +84,14 @@ void RigActiveCellInfo::setCellResultIndex( size_t reservoirCellIndex, size_t re
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<size_t> RigActiveCellInfo::activeReservoirCellIndices() const
+{
+    return m_activeCellIndices;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RigActiveCellInfo::setGridCount( size_t gridCount )
 {
     m_perGridActiveCellInfo.resize( gridCount );
@@ -109,6 +117,14 @@ void RigActiveCellInfo::computeDerivedData()
     for ( size_t i = 0; i < m_perGridActiveCellInfo.size(); i++ )
     {
         m_reservoirActiveCellCount += m_perGridActiveCellInfo[i].activeCellCount();
+    }
+
+    for ( size_t i = 0; i < m_cellIndexToResultIndex.size(); i++ )
+    {
+        if ( m_cellIndexToResultIndex[i] != cvf::UNDEFINED_SIZE_T )
+        {
+            m_activeCellIndices.push_back( i );
+        }
     }
 }
 

--- a/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.h
@@ -35,9 +35,10 @@ public:
     size_t reservoirCellCount() const;
     size_t reservoirActiveCellCount() const;
 
-    bool   isActive( size_t reservoirCellIndex ) const;
-    size_t cellResultIndex( size_t reservoirCellIndex ) const;
-    void   setCellResultIndex( size_t reservoirCellIndex, size_t globalResultCellIndex );
+    bool                isActive( size_t reservoirCellIndex ) const;
+    size_t              cellResultIndex( size_t reservoirCellIndex ) const;
+    void                setCellResultIndex( size_t reservoirCellIndex, size_t globalResultCellIndex );
+    std::vector<size_t> activeReservoirCellIndices() const;
 
     void   setGridCount( size_t gridCount );
     void   setGridActiveCellCounts( size_t gridIndex, size_t activeCellCount );
@@ -71,6 +72,7 @@ private:
     std::vector<GridActiveCellCounts> m_perGridActiveCellInfo;
 
     std::vector<size_t> m_cellIndexToResultIndex;
+    std::vector<size_t> m_activeCellIndices;
 
     size_t m_reservoirActiveCellCount;
 


### PR DESCRIPTION
Make sure the correct Eclipse case is used when extracting values for a variable. Simplify the data extraction using activeReservoirCellIndices

See also #10884