### PR TITLE
Fix insufficient forward declaration

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldCapability.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldCapability.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-class QString;
+#include <QString>
 
 namespace caf
 {


### PR DESCRIPTION
It is not sufficient with a forward declaration of QString here. Since the vector is created in PdmFieldCapability::attributes() the size of QString must be known at that point.

closes #10950