### PR TITLE
Add dependency on QtSvg for project cafUserInterface

### DIFF
--- a/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
@@ -18,9 +18,9 @@ set(QRC_FILES ${QRC_FILES} textedit.qrc)
 find_package(
   Qt5
   COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL Svg
+  REQUIRED Core Gui Widgets OpenGL
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
 qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
 qt5_add_resources(QRC_FILES_CPP ${QRC_FILES})
 

--- a/Fwk/AppFwk/cafTests/cafTestCvfApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestCvfApplication/CMakeLists.txt
@@ -11,9 +11,9 @@ set(QRC_FILES textedit.qrc)
 find_package(
   Qt5
   COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL Svg
+  REQUIRED Core Gui Widgets OpenGL
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
 qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
 qt5_add_resources(QRC_FILES_CPP ${QRC_FILES})
 

--- a/Fwk/AppFwk/cafUserInterface/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/CMakeLists.txt
@@ -58,9 +58,9 @@ set(MOC_HEADER_FILES
 find_package(
   Qt5
   COMPONENTS
-  REQUIRED Core Gui Widgets
+  REQUIRED Core Gui Widgets Svg
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg)
 qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
 
 set(PROJECT_FILES

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
@@ -5,9 +5,9 @@ project(cafUserInterface_UnitTests)
 find_package(
   Qt5
   COMPONENTS
-  REQUIRED Core Gui Widgets Svg
+  REQUIRED Core Gui Widgets
 )
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Svg)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 )


### PR DESCRIPTION
The project cafUserInterface requires the library QtSvg because of the use of QSvgRenderer in cafUiIconFactory.cpp. The library has to be linked into the final executable. The target introdicing the dependency should also be the one specifying it.

This allows us to remove the dependency from targets that doesn't directly use QtSvg at all.

Closes #10955