### PR TITLE
CMake: Update/Remove old minimum version check

### DIFF
--- a/Fwk/AppFwk/CMakeLists.txt
+++ b/Fwk/AppFwk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 
 project(CeeApp)
 

--- a/Fwk/AppFwk/cafHexInterpolator/cafHexInterpolator_UnitTest/CMakeLists.txt
+++ b/Fwk/AppFwk/cafHexInterpolator/cafHexInterpolator_UnitTest/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 project(cafHexInterpolator_UnitTests)
 
 if(MSVC AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.11))

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 find_package(Qt5 CONFIG COMPONENTS Core)
 if(Qt5Core_FOUND)
   find_package(Qt5 CONFIG REQUIRED Core)

--- a/Fwk/AppFwk/cafVizExtensions/cafHexGridIntersectionTools/cafHexGridIntersectionTools_UnitTest/CMakeLists.txt
+++ b/Fwk/AppFwk/cafVizExtensions/cafHexGridIntersectionTools/cafHexGridIntersectionTools_UnitTest/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 project(cafHexGridIntersectionTools_UnitTests)
 
 if(MSVC AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.11))

--- a/Fwk/VizFwk/CMakeLists.txt
+++ b/Fwk/VizFwk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 
 project(VizFramework)
 

--- a/Fwk/VizFwk/LibFreeType/CMakeLists.txt
+++ b/Fwk/VizFwk/LibFreeType/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibFreeType)
 
 

--- a/Fwk/VizFwk/LibIo/CMakeLists.txt
+++ b/Fwk/VizFwk/LibIo/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibIo)
 
 

--- a/Fwk/VizFwk/LibRegGrid2D/CMakeLists.txt
+++ b/Fwk/VizFwk/LibRegGrid2D/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibRegGrid2D)
 
 

--- a/Fwk/VizFwk/LibStructGrid/CMakeLists.txt
+++ b/Fwk/VizFwk/LibStructGrid/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibStructGrid)
 
 

--- a/Fwk/VizFwk/LibUtilities/CMakeLists.txt
+++ b/Fwk/VizFwk/LibUtilities/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibUtilities)
 
 

--- a/Fwk/VizFwk/TestApps/Qt/QtMinimal/CMakeLists.txt
+++ b/Fwk/VizFwk/TestApps/Qt/QtMinimal/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 project(QtMinimal)
 
 

--- a/Fwk/VizFwk/TestApps/Qt/QtMultiView/CMakeLists.txt
+++ b/Fwk/VizFwk/TestApps/Qt/QtMultiView/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 project(QtMultiView)
 
 

--- a/Fwk/VizFwk/TestApps/Qt/QtSnippetRunner/CMakeLists.txt
+++ b/Fwk/VizFwk/TestApps/Qt/QtSnippetRunner/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 project(QtSnippetRunner)
 
 

--- a/Fwk/VizFwk/Tests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.15)
 
 # Builds all the unit tests
 

--- a/Fwk/VizFwk/Tests/LibCore_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibCore_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibCore_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibGeometry_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibGeometry_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibGeometry_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibGuiQt_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibGuiQt_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 project(LibGuiQt_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibIo_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibIo_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibIo_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibRegGrid2D_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibRegGrid2D_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibRegGrid2D_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibRender_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibRender_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibRender_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibStructGrid_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibStructGrid_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibStructGrid_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibUtilities_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibUtilities_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibUtilities_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/LibViewing_UnitTests/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/LibViewing_UnitTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(LibViewing_UnitTests)
 
 # Compile flags should already be setup by caller

--- a/Fwk/VizFwk/Tests/SnippetsBasis/CMakeLists.txt
+++ b/Fwk/VizFwk/Tests/SnippetsBasis/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(SnippetsBasis)
 
 

--- a/Fwk/VizFwk/ThirdParty/FreeType/CMakeLists.txt
+++ b/Fwk/VizFwk/ThirdParty/FreeType/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(freetype)
 
 


### PR DESCRIPTION
- Update the minimum required CMake version to 3.15 for Fwk folders that might be used as top level projects.
- Remove the minimum required CMake version from projects that is just included from other top level projects.

Since version 3.19 CMake has been warning that CMake versions below 3.5 is deprecated and support will be removed in the future. This will silence those warning.

By removing the minimum required version check from projects that is not intended as top level projects we avoid redundant checks and simplifies future maintenance.

Closes #10957