### PR TITLE
Disable unity build for OdbReader

### DIFF
--- a/ApplicationLibCode/GeoMech/OdbReader/CMakeLists.txt
+++ b/ApplicationLibCode/GeoMech/OdbReader/CMakeLists.txt
@@ -1,11 +1,5 @@
 project(RifOdbReader)
 
-# Unity Build
-if(RESINSIGHT_ENABLE_UNITY_BUILD)
-  message("Cmake Unity build is enabled on : ${PROJECT_NAME}")
-  set(CMAKE_UNITY_BUILD true)
-endif()
-
 if(MSVC)
   add_definitions(-DHKS_NT)
   add_definitions(-DABQ_WIN86_64)


### PR DESCRIPTION
Unity build was recently broken, hard to find source to the broken build. Few files in this library, no unity build is required.
