### PR TITLE
Flip Y to get local coordinate element nodes in correct order 

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigFaultReactivationModelGenerator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigFaultReactivationModelGenerator.cpp
@@ -154,8 +154,6 @@ void RigFaultReactivationModelGenerator::setupLocalCoordinateTransform()
 {
     auto [xNormal, yNormal] = modelLocalNormalsXY();
 
-    // yNormal = yNormal * -1.0;
-
     m_localCoordTransform = cvf::Mat4d::fromCoordSystemAxes( &xNormal, &yNormal, &cvf::Vec3d::Z_AXIS );
     cvf::Vec3d center     = m_startPosition * -1.0;
     center.z()            = 0.0;

--- a/ApplicationLibCode/ReservoirDataModel/RigFaultReactivationModelGenerator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigFaultReactivationModelGenerator.cpp
@@ -154,7 +154,7 @@ void RigFaultReactivationModelGenerator::setupLocalCoordinateTransform()
 {
     auto [xNormal, yNormal] = modelLocalNormalsXY();
 
-    yNormal = -1.0 * yNormal;
+    // yNormal = yNormal * -1.0;
 
     m_localCoordTransform = cvf::Mat4d::fromCoordSystemAxes( &xNormal, &yNormal, &cvf::Vec3d::Z_AXIS );
     cvf::Vec3d center     = m_startPosition * -1.0;

--- a/ApplicationLibCode/ReservoirDataModel/RigGriddedPart3d.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigGriddedPart3d.cpp
@@ -644,8 +644,15 @@ void RigGriddedPart3d::generateLocalNodes( const cvf::Mat4d transform )
 {
     m_localNodes.clear();
 
+    // need to flip the Y axis for the element corners to be in an acceptable order for abaqus and the IJK numbering algorithm in resinsight
+    cvf::Vec3d xAxis = { 1.0, 0.0, 0.0 };
+    cvf::Vec3d yAxis = { 0.0, -1.0, 0.0 };
+    cvf::Vec3d zAxis = { 0.0, 0.0, 1.0 };
+    cvf::Mat4d flipY = cvf::Mat4d::fromCoordSystemAxes( &xAxis, &yAxis, &zAxis );
+
     for ( auto& node : m_nodes )
     {
-        m_localNodes.push_back( node.getTransformedPoint( transform ) );
+        auto tn = node.getTransformedPoint( transform );
+        m_localNodes.push_back( tn.getTransformedPoint( flipY ) );
     }
 }

--- a/ResInsightVersion.cmake
+++ b/ResInsightVersion.cmake
@@ -11,7 +11,7 @@ set(RESINSIGHT_VERSION_TEXT "-dev")
 # Must be unique and increasing within one combination of major/minor/patch version 
 # The uniqueness of this text is independent of RESINSIGHT_VERSION_TEXT 
 # Format of text must be ".xx"
-set(RESINSIGHT_DEV_VERSION ".02")
+set(RESINSIGHT_DEV_VERSION ".03")
 
 # https://github.com/CRAVA/crava/tree/master/libs/nrlib
 set(NRLIB_GITHUB_SHA "ba35d4359882f1c6f5e9dc30eb95fe52af50fd6f") 


### PR DESCRIPTION
Abaqus likes it better that way.

Bump version to dev.03