### PR TITLE
Reduce memory use during grid calculation

### DIFF
--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -127,6 +127,10 @@ bool RifReaderOpmCommon::staticResult( const QString& result, RiaDefines::Porosi
                     }
                 }
             }
+
+            // Always clear data after reading to avoid memory use
+            m_initFile->clearData();
+
             return true;
         }
         catch ( std::exception& e )
@@ -178,6 +182,9 @@ bool RifReaderOpmCommon::dynamicResult( const QString&                result,
                     }
                 }
             }
+
+            // Always clear data after reading to avoid memory use
+            m_restartFile->clearData();
 
             return true;
         }

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -441,22 +441,29 @@ std::vector<RifReaderOpmCommon::TimeDataFile> RifReaderOpmCommon::readTimeSteps(
     {
         namespace VI = Opm::RestartIO::Helpers::VectorItems;
 
-        for ( auto seqNumber : restartFile->listOfReportStepNumbers() )
+        for ( auto seqNum : restartFile->listOfReportStepNumbers() )
         {
-            auto fileView = std::make_shared<EclIO::RestartFileView>( restartFile, seqNumber );
+            const std::string inteheadString = "INTEHEAD";
+            const std::string doubheadString = "DOUBHEAD";
 
-            auto intehead = fileView->intehead();
+            if ( restartFile->hasArray( inteheadString, seqNum ) )
+            {
+                auto intehead = restartFile->getRestartData<int>( inteheadString, seqNum );
+                auto year     = intehead[VI::intehead::YEAR];
+                auto month    = intehead[VI::intehead::MONTH];
+                auto day      = intehead[VI::intehead::DAY];
 
-            auto year  = intehead[VI::intehead::YEAR];
-            auto month = intehead[VI::intehead::MONTH];
-            auto day   = intehead[VI::intehead::DAY];
+                double daySinceSimStart = 0.0;
 
-            auto doubhead = fileView->doubhead();
+                if ( restartFile->hasArray( doubheadString, seqNum ) )
+                {
+                    auto doubhead    = restartFile->getRestartData<double>( doubheadString, seqNum );
+                    daySinceSimStart = doubhead[VI::doubhead::TsInit];
+                }
 
-            auto daySinceSimStart = doubhead[VI::doubhead::TsInit];
-
-            reportTimeData.emplace_back(
-                TimeDataFile{ .sequenceNumber = seqNumber, .year = year, .month = month, .day = day, .simulationTimeFromStart = daySinceSimStart } );
+                reportTimeData.emplace_back(
+                    TimeDataFile{ .sequenceNumber = seqNum, .year = year, .month = month, .day = day, .simulationTimeFromStart = daySinceSimStart } );
+            }
         }
     }
     catch ( std::exception& e )

--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
@@ -33,7 +33,9 @@
 #include "RigResultAccessorFactory.h"
 #include "RigStatisticsMath.h"
 
+#include "RimCaseCollection.h"
 #include "RimEclipseCase.h"
+#include "RimEclipseCaseCollection.h"
 #include "RimEclipseCaseTools.h"
 #include "RimEclipseCellColors.h"
 #include "RimEclipseResultAddress.h"
@@ -41,6 +43,8 @@
 #include "RimEclipseView.h"
 #include "RimGridCalculationCollection.h"
 #include "RimGridCalculationVariable.h"
+#include "RimIdenticalGridCaseGroup.h"
+#include "RimOilField.h"
 #include "RimProject.h"
 #include "RimReloadCaseTools.h"
 #include "RimResultSelectionUi.h"
@@ -67,6 +71,14 @@ void caf::AppEnum<RimGridCalculation::DefaultValueType>::setUp()
     addItem( RimGridCalculation::DefaultValueType::USER_DEFINED, "USER_DEFINED", "User Defined Custom Value" );
     setDefault( RimGridCalculation::DefaultValueType::POSITIVE_INFINITY );
 }
+template <>
+void caf::AppEnum<RimGridCalculation::AdditionalCasesType>::setUp()
+{
+    addItem( RimGridCalculation::AdditionalCasesType::NONE, "NONE", "None" );
+    addItem( RimGridCalculation::AdditionalCasesType::GRID_CASE_GROUP, "GRID_CASE_GROUP", "Case Group" );
+    addItem( RimGridCalculation::AdditionalCasesType::ALL_CASES, "NONE", "All Cases" );
+    setDefault( RimGridCalculation::AdditionalCasesType::NONE );
+}
 }; // namespace caf
 
 //--------------------------------------------------------------------------------------------------
@@ -79,7 +91,12 @@ RimGridCalculation::RimGridCalculation()
     CAF_PDM_InitFieldNoDefault( &m_defaultValueType, "DefaultValueType", "Non-visible Cell Value" );
     CAF_PDM_InitField( &m_defaultValue, "DefaultValue", 0.0, "Custom Value" );
     CAF_PDM_InitFieldNoDefault( &m_destinationCase, "DestinationCase", "Destination Case" );
-    CAF_PDM_InitField( &m_applyToAllCases, "AllDestinationCase", false, "Apply to All Cases" );
+
+    CAF_PDM_InitField( &m_applyToAllCases_OBSOLETE, "AllDestinationCase", false, "Apply to All Cases" );
+    m_applyToAllCases_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitFieldNoDefault( &m_additionalCasesType, "AdditionalCasesType", "Apply To Additional Cases" );
+    CAF_PDM_InitFieldNoDefault( &m_additionalCaseGroup, "AdditionalCaseGroup", "Case Group" );
 
     CAF_PDM_InitFieldNoDefault( &m_nonVisibleResultAddress, "NonVisibleResultAddress", "" );
     m_nonVisibleResultAddress = new RimEclipseResultAddress;
@@ -102,7 +119,7 @@ RimGridCalculation::RimGridCalculation()
 //--------------------------------------------------------------------------------------------------
 bool RimGridCalculation::preCalculate() const
 {
-    if ( RiaGuiApplication::isRunning() && m_applyToAllCases() )
+    if ( RiaGuiApplication::isRunning() && m_additionalCasesType() != RimGridCalculation::AdditionalCasesType::NONE )
     {
         const QString cacheKey = "GridCalculatorMessage";
 
@@ -222,15 +239,16 @@ bool RimGridCalculation::calculate()
 //--------------------------------------------------------------------------------------------------
 std::vector<RimEclipseCase*> RimGridCalculation::outputEclipseCases() const
 {
-    if ( m_applyToAllCases )
+    if ( m_additionalCasesType() == RimGridCalculation::AdditionalCasesType::ALL_CASES )
     {
         // Find all Eclipse cases suitable for grid calculations. This includes all single grid cases and source cases in a grid case group.
         // Exclude the statistics cases, as it is not possible to use them in a grid calculations.
-        //
-        // Note that data read from file can be released from memory when statistics for a time step is calculated. See
-        // RimEclipseStatisticsCaseEvaluator::evaluateForResults()
-
         return RimEclipseCaseTools::allEclipseGridCases();
+    }
+
+    if ( m_additionalCasesType() == RimGridCalculation::AdditionalCasesType::GRID_CASE_GROUP )
+    {
+        if ( m_additionalCaseGroup() ) return m_additionalCaseGroup->reservoirs.childrenByType();
     }
 
     return { m_destinationCase };
@@ -287,12 +305,9 @@ void RimGridCalculation::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
 
     uiOrdering.add( &m_destinationCase );
 
-    uiOrdering.add( &m_applyToAllCases );
-    if ( !allSourceCasesAreEqualToDestinationCase() )
-    {
-        m_applyToAllCases = false;
-    }
-    m_applyToAllCases.uiCapability()->setUiReadOnly( !allSourceCasesAreEqualToDestinationCase() );
+    uiOrdering.add( &m_additionalCasesType );
+    uiOrdering.add( &m_additionalCaseGroup );
+    m_additionalCaseGroup.uiCapability()->setUiHidden( m_additionalCasesType() != RimGridCalculation::AdditionalCasesType::GRID_CASE_GROUP );
 
     caf::PdmUiGroup* filterGroup = uiOrdering.addNewGroup( "Cell Filter" );
     filterGroup->setCollapsedByDefault();
@@ -339,8 +354,8 @@ QList<caf::PdmOptionItemInfo> RimGridCalculation::calculateValueOptions( const c
         }
         else
         {
-            // If no input cases are defined, use the destination case to determine the grid size. This will enable use of expressions with
-            // no input cases like "calculation := 1.0"
+            // If no input cases are defined, use the destination case to determine the grid size. This will enable use of expressions
+            // with no input cases like "calculation := 1.0"
             firstEclipseCase = m_destinationCase();
         }
 
@@ -391,6 +406,20 @@ QList<caf::PdmOptionItemInfo> RimGridCalculation::calculateValueOptions( const c
             }
         }
     }
+    else if ( &m_additionalCaseGroup == fieldNeedingOptions )
+    {
+        options.push_back( caf::PdmOptionItemInfo( "None", nullptr ) );
+
+        RimProject* proj = RimProject::current();
+        if ( proj->activeOilField() && proj->activeOilField()->analysisModels() )
+        {
+            auto analysisModels = proj->activeOilField()->analysisModels();
+            for ( RimIdenticalGridCaseGroup* cg : analysisModels->caseGroups() )
+            {
+                options.push_back( caf::PdmOptionItemInfo( cg->name(), cg, false, cg->uiIconProvider() ) );
+            }
+        }
+    }
 
     return options;
 }
@@ -410,6 +439,8 @@ void RimGridCalculation::initAfterRead()
             if ( m_destinationCase == nullptr ) m_destinationCase = gridVar->eclipseCase();
         }
     }
+
+    if ( m_applyToAllCases_OBSOLETE ) m_additionalCasesType = RimGridCalculation::AdditionalCasesType::ALL_CASES;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -561,8 +592,8 @@ std::vector<double> RimGridCalculation::getDataForResult( const QString&        
     auto rigCaseCellResultsData = eclipseCaseData->results( porosityModel );
     if ( !rigCaseCellResultsData->findOrLoadKnownScalarResultForTimeStep( resAddr, timeStepToUse ) ) return {};
 
-    // Active cell info must always be retrieved from the destination case, as the returned vector must be of the same size as number of
-    // active cells in the destination case. Active cells can be different between source and destination case.
+    // Active cell info must always be retrieved from the destination case, as the returned vector must be of the same size as
+    // number of active cells in the destination case. Active cells can be different between source and destination case.
     auto activeCellInfoDestination = destinationCase->eclipseCaseData()->activeCellInfo( porosityModel );
     auto activeReservoirCells      = activeCellInfoDestination->activeReservoirCellIndices();
 
@@ -972,9 +1003,9 @@ void RimGridCalculation::findAndEvaluateDependentCalculations( const std::vector
     {
         if ( dependentCalc == this ) continue;
 
-        // Propagate the settings for this calculation to the dependent calculation. This will allow changes on top level calculation to be
-        // propagated to dependent calculations automatically. Do not trigger findAndEvaluateDependentCalculations() recursively, as all
-        // dependent calculations are traversed in this function.
+        // Propagate the settings for this calculation to the dependent calculation. This will allow changes on top level
+        // calculation to be propagated to dependent calculations automatically. Do not trigger
+        // findAndEvaluateDependentCalculations() recursively, as all dependent calculations are traversed in this function.
 
         bool evaluateDependentCalculations = false;
         dependentCalc->calculateForCases( calculationCases, inputValueVisibilityFilter, timeSteps, evaluateDependentCalculations );

--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.h
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.h
@@ -33,6 +33,7 @@ class RimEclipseCase;
 class RimGridView;
 class RigEclipseResultAddress;
 class RimEclipseResultAddress;
+class RimCaseCollection;
 
 //==================================================================================================
 ///
@@ -48,6 +49,13 @@ public:
         POSITIVE_INFINITY,
         FROM_PROPERTY,
         USER_DEFINED
+    };
+
+    enum class AdditionalCasesType
+    {
+        NONE,
+        GRID_CASE_GROUP,
+        ALL_CASES
     };
 
     RimGridCalculation();
@@ -136,11 +144,15 @@ private:
     caf::PdmField<caf::AppEnum<DefaultValueType>> m_defaultValueType;
     caf::PdmField<double>                         m_defaultValue;
     caf::PdmPtrField<RimEclipseCase*>             m_destinationCase;
-    caf::PdmField<bool>                           m_applyToAllCases;
+
+    caf::PdmField<caf::AppEnum<AdditionalCasesType>> m_additionalCasesType;
+    caf::PdmPtrField<RimCaseCollection*>             m_additionalCaseGroup;
 
     caf::PdmField<std::vector<int>> m_selectedTimeSteps;
 
     caf::PdmProxyValueField<QString>             m_nonVisibleResultText;
     caf::PdmChildField<RimEclipseResultAddress*> m_nonVisibleResultAddress;
     caf::PdmField<bool>                          m_editNonVisibleResultAddress;
+
+    caf::PdmField<bool> m_applyToAllCases_OBSOLETE;
 };

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -742,10 +742,14 @@ void RigCaseCellResultsData::freeAllocatedResultsData( std::vector<RiaDefines::R
             }
 
             auto& dataForTimeStep = m_cellScalarResults[resultIdx][index];
-            // Using swap with an empty vector as that is the safest way to really get rid of the allocated data in a
-            // vector
-            std::vector<double> empty;
-            dataForTimeStep.swap( empty );
+
+            if ( !dataForTimeStep.empty() )
+            {
+                // Using swap with an empty vector as that is the safest way to really get rid of the allocated data in a
+                // vector
+                std::vector<double> empty;
+                dataForTimeStep.swap( empty );
+            }
         }
     }
 }

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
@@ -131,8 +131,11 @@ public:
     QString makeResultNameUnique( const QString& resultNameProposal ) const;
 
     bool ensureKnownResultLoaded( const RigEclipseResultAddress& resultAddress );
-
     bool findAndLoadResultByName( const QString& resultName, const std::vector<RiaDefines::ResultCatType>& resultCategorySearchOrder );
+
+    // Load result for a single time step. This can be used to process data for a single time step
+    // Other data access functions assume all time steps are loaded at the same time
+    size_t findOrLoadKnownScalarResultForTimeStep( const RigEclipseResultAddress& resVarAddr, size_t timeStepIndex );
 
     bool hasResultEntry( const RigEclipseResultAddress& resultAddress ) const;
     bool isResultLoaded( const RigEclipseResultAddress& resultAddress ) const;
@@ -167,7 +170,6 @@ private:
     friend class RigOilVolumeResultCalculator;
     friend class RigCellVolumeResultCalculator;
     friend class RigCellsWithNncsCalculator;
-    size_t findOrLoadKnownScalarResultForTimeStep( const RigEclipseResultAddress& resVarAddr, size_t timeStepIndex );
 
     size_t findOrCreateScalarResultIndex( const RigEclipseResultAddress& resVarAddr, bool needsToBeStored );
 


### PR DESCRIPTION
- read data for a single time step
- calculate expression
- if input data source is not a `Generated` result, release memory

Avoid caching data in opm-common file reader.
Allow selection of a grid case group to perform a calculation on all cases in a grid group.

Closes #11089