### PR TITLE
Set correct version of opm-common and fix use of grid case group

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
@@ -248,7 +248,8 @@ std::vector<RimEclipseCase*> RimGridCalculation::outputEclipseCases() const
 
     if ( m_additionalCasesType() == RimGridCalculation::AdditionalCasesType::GRID_CASE_GROUP )
     {
-        if ( m_additionalCaseGroup() ) return m_additionalCaseGroup->reservoirs.childrenByType();
+        if ( m_additionalCaseGroup() && m_additionalCaseGroup()->caseCollection() )
+            return m_additionalCaseGroup()->caseCollection()->reservoirs.childrenByType();
     }
 
     return { m_destinationCase };

--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.h
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.h
@@ -33,7 +33,7 @@ class RimEclipseCase;
 class RimGridView;
 class RigEclipseResultAddress;
 class RimEclipseResultAddress;
-class RimCaseCollection;
+class RimIdenticalGridCaseGroup;
 
 //==================================================================================================
 ///
@@ -146,7 +146,7 @@ private:
     caf::PdmPtrField<RimEclipseCase*>             m_destinationCase;
 
     caf::PdmField<caf::AppEnum<AdditionalCasesType>> m_additionalCasesType;
-    caf::PdmPtrField<RimCaseCollection*>             m_additionalCaseGroup;
+    caf::PdmPtrField<RimIdenticalGridCaseGroup*>     m_additionalCaseGroup;
 
     caf::PdmField<std::vector<int>> m_selectedTimeSteps;
 

--- a/ResInsightVersion.cmake
+++ b/ResInsightVersion.cmake
@@ -11,7 +11,7 @@ set(RESINSIGHT_VERSION_TEXT "-dev")
 # Must be unique and increasing within one combination of major/minor/patch version 
 # The uniqueness of this text is independent of RESINSIGHT_VERSION_TEXT 
 # Format of text must be ".xx"
-set(RESINSIGHT_DEV_VERSION ".11")
+set(RESINSIGHT_DEV_VERSION ".12")
 
 # https://github.com/CRAVA/crava/tree/master/libs/nrlib
 set(NRLIB_GITHUB_SHA "ba35d4359882f1c6f5e9dc30eb95fe52af50fd6f") 


### PR DESCRIPTION
Wrong version of `opm-common` was used in a previous commit. Set to correct version.

Use correct type when selecting a grid case group.