### PR TITLE
Fix computation of bounding box main grid

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
@@ -625,11 +625,9 @@ void RimEclipseCase::computeCachedData()
         caf::ProgressInfo pInf( 30, "" );
 
         {
-            auto task = pInf.task( "", 1 );
-            computeActiveCellsBoundingBox();
-        }
+            // NB! Call computeCachedData() first, as this function also computes the bounding box used in other functions, specifically
+            // computeActiveCellsBoundingBox()
 
-        {
             auto task = pInf.task( "Calculating Cell Search Tree", 10 );
 
             std::string aabbTreeInfo;
@@ -637,6 +635,11 @@ void RimEclipseCase::computeCachedData()
 
             // Debug output of the content of the AABB tree
             // RiaLogging::debug( QString::fromStdString( aabbTreeInfo ) );
+        }
+
+        {
+            auto task = pInf.task( "", 1 );
+            computeActiveCellsBoundingBox();
         }
 
         {


### PR DESCRIPTION
Calculation of the bounding box for main grid used to be on demand. This was changed in a previous commit. The computation of bounding box is now done first.

The regression was introduced in 51517177435fd0d7cf2d9fd60bb7b1c3e7517cee
