### PR TITLE
Add missing Qt component to silence CMake warnings

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CEE_USE_QT6)
   find_package(
     Qt6
     COMPONENTS
-    REQUIRED Core
+    REQUIRED Core Widgets
   )
   qt_standard_project_setup()
 else()


### PR DESCRIPTION
The project cafProjectDataModel_UnitTests was triggering multiple CMake warnings saying that the Widget component was missing when trying to collect dependencies.

The warnings can be seen here for example: 
https://github.com/OPM/ResInsight/actions/runs/7753949547/job/21146279132#step:8:94