### PR TITLE
RFT segment topology

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimRftTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimRftTools.cpp
@@ -178,27 +178,48 @@ QList<caf::PdmOptionItemInfo> RimRftTools::segmentBranchIndexOptions( RifReaderR
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RimRftTools::seglenstValues( RifReaderRftInterface*    readerRft,
-                                                 const QString&            wellName,
-                                                 const QDateTime&          dateTime,
-                                                 int                       segmentBranchIndex,
-                                                 RiaDefines::RftBranchType segmentBranchType )
+std::vector<double> RimRftTools::segmentStartMdValues( RifReaderRftInterface*    readerRft,
+                                                       const QString&            wellName,
+                                                       const QDateTime&          dateTime,
+                                                       int                       segmentBranchIndex,
+                                                       RiaDefines::RftBranchType segmentBranchType )
 {
-    std::vector<double> seglenstValues;
+    std::vector<double> values;
 
     auto resultNameSeglenst = RifEclipseRftAddress::createBranchSegmentAddress( wellName,
                                                                                 dateTime,
                                                                                 RiaDefines::segmentStartDepthResultName(),
                                                                                 segmentBranchIndex,
                                                                                 segmentBranchType );
-    readerRft->values( resultNameSeglenst, &seglenstValues );
+    readerRft->values( resultNameSeglenst, &values );
 
-    if ( seglenstValues.size() > 2 )
+    if ( values.size() > 2 )
     {
         // Segment 1 has zero length, assign seglenst to the start value of segment 2
         // Ref mail dated June 10, 2022, topic "SELENST fix"
-        seglenstValues[0] = seglenstValues[1];
+        values[0] = values[1];
     }
 
-    return seglenstValues;
+    return values;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<double> RimRftTools::segmentEndMdValues( RifReaderRftInterface*    readerRft,
+                                                     const QString&            wellName,
+                                                     const QDateTime&          dateTime,
+                                                     int                       segmentBranchIndex,
+                                                     RiaDefines::RftBranchType segmentBranchType )
+{
+    std::vector<double> values;
+
+    auto resultNameSeglenst = RifEclipseRftAddress::createBranchSegmentAddress( wellName,
+                                                                                dateTime,
+                                                                                RiaDefines::segmentEndDepthResultName(),
+                                                                                segmentBranchIndex,
+                                                                                segmentBranchType );
+    readerRft->values( resultNameSeglenst, &values );
+
+    return values;
 }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimRftTools.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimRftTools.h
@@ -46,9 +46,15 @@ public:
                                                                     const QDateTime&          timeStep,
                                                                     RiaDefines::RftBranchType branchType );
 
-    static std::vector<double> seglenstValues( RifReaderRftInterface*    readerRft,
-                                               const QString&            wellName,
-                                               const QDateTime&          dateTime,
-                                               int                       segmentBranchIndex,
-                                               RiaDefines::RftBranchType segmentBranchType );
+    static std::vector<double> segmentStartMdValues( RifReaderRftInterface*    readerRft,
+                                                     const QString&            wellName,
+                                                     const QDateTime&          dateTime,
+                                                     int                       segmentBranchIndex,
+                                                     RiaDefines::RftBranchType segmentBranchType );
+
+    static std::vector<double> segmentEndMdValues( RifReaderRftInterface*    readerRft,
+                                                   const QString&            wellName,
+                                                   const QDateTime&          dateTime,
+                                                   int                       segmentBranchIndex,
+                                                   RiaDefines::RftBranchType segmentBranchType );
 };

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimRftTopologyCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimRftTopologyCurve.h
@@ -44,6 +44,13 @@ public:
         ANNULUS
     };
 
+    enum class SymbolLocationType
+    {
+        START,
+        MID,
+        END
+    };
+
 public:
     RimRftTopologyCurve();
 
@@ -77,12 +84,13 @@ protected:
     void onLoadDataAndUpdate( bool updateParentPlot ) override;
 
 private:
-    caf::PdmPtrField<RimSummaryCase*>                           m_summaryCase;
-    caf::PdmField<QDateTime>                                    m_timeStep;
-    caf::PdmField<QString>                                      m_wellName;
-    caf::PdmField<int>                                          m_segmentBranchIndex;
-    caf::PdmField<caf::AppEnum<RiaDefines::RftBranchType>>      m_segmentBranchType;
-    caf::PdmField<caf::AppEnum<RimRftTopologyCurve::CurveType>> m_curveType;
+    caf::PdmPtrField<RimSummaryCase*>                                    m_summaryCase;
+    caf::PdmField<QDateTime>                                             m_timeStep;
+    caf::PdmField<QString>                                               m_wellName;
+    caf::PdmField<int>                                                   m_segmentBranchIndex;
+    caf::PdmField<caf::AppEnum<RiaDefines::RftBranchType>>               m_segmentBranchType;
+    caf::PdmField<caf::AppEnum<RimRftTopologyCurve::CurveType>>          m_curveType;
+    caf::PdmField<caf::AppEnum<RimRftTopologyCurve::SymbolLocationType>> m_symbolLocation;
 
 public:
     void setAdditionalDataSources( const std::vector<RimPlotCurve*>& additionalDataSources );

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -1152,7 +1152,8 @@ std::vector<double> RimWellLogRftCurve::measuredDepthValues( QString& prefixText
         {
             prefixText = "SEGMENT/";
 
-            return RimRftTools::seglenstValues( reader, m_wellName(), m_timeStep, segmentBranchIndex(), m_segmentBranchType() );
+            // Always use segment end MD values for segment data, as the curve is plotted as step left
+            return RimRftTools::segmentEndMdValues( reader, m_wellName(), m_timeStep, segmentBranchIndex(), m_segmentBranchType() );
         }
         return {};
     }


### PR DESCRIPTION
The segment symbol is displayed once per segment. Previous code used segment start as symbol location. Add support for selecting the location for the segment indicator, either start, mid or end.

When reading segment property values, always use segment end as the curve is plotted using step left.

Closes #11069 