### PR TITLE
Use correct qt version check for SkipEmptyParts

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmReferenceHelper.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmReferenceHelper.cpp
@@ -328,7 +328,7 @@ PdmObjectHandle* PdmReferenceHelper::objectFromFieldReference( PdmFieldHandle* f
     if ( reference.isEmpty() ) return nullptr;
     if ( reference.trimmed().isEmpty() ) return nullptr;
 
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
+#if ( QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 ) )
     auto SkipEmptyParts = QString::SkipEmptyParts;
 #else
     auto SkipEmptyParts = Qt::SkipEmptyParts;

--- a/Fwk/AppFwk/cafUserInterface/cafMemoryInspector.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafMemoryInspector.cpp
@@ -25,7 +25,7 @@
 
 #ifdef __linux__
 
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
+#if ( QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 ) )
     auto SkipEmptyParts = QString::SkipEmptyParts;
 #else
     auto SkipEmptyParts = Qt::SkipEmptyParts;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
@@ -598,7 +598,7 @@ void PdmUiTreeSelectionEditor::slotInvertCheckedStateOfAll()
 //--------------------------------------------------------------------------------------------------
 void PdmUiTreeSelectionEditor::setCheckedStateForIntegerItemsMatchingFilter()
 {
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
+#if ( QT_VERSION < QT_VERSION_CHECK( 5, 14, 0 ) )
     auto SkipEmptyParts = QString::SkipEmptyParts;
 #else
     auto SkipEmptyParts = Qt::SkipEmptyParts;


### PR DESCRIPTION
Qt::SkipEmptyParts was introduced in Qt 5.14 and QString::SkipEmptyParts was deprecated in Qt 5.15. This will avoid warnings when compiling with Qt 5.15.

Just a very tiny change that will benefit those few building with Qt 5.15 only. 