### PR TITLE
Change action version to avoid warnings on GitHub actions

### DIFF
--- a/.github/workflows/AppFwkUnitTest.yml
+++ b/.github/workflows/AppFwkUnitTest.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@master
         with:
           version: ${{ matrix.qtver }}
           dir: "${{ github.workspace }}/Qt/"

--- a/.github/workflows/AppFwkUnitTest.yml
+++ b/.github/workflows/AppFwkUnitTest.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@master
+        uses: jurplel/install-qt-action@main
         with:
           version: ${{ matrix.qtver }}
           dir: "${{ github.workspace }}/Qt/"

--- a/.github/workflows/AppFwkUnitTest.yml
+++ b/.github/workflows/AppFwkUnitTest.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@main
+        uses: jurplel/install-qt-action@a7683763fa44598d9faf6157a27632def618ad42
         with:
           version: ${{ matrix.qtver }}
           dir: "${{ github.workspace }}/Qt/"

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -170,7 +170,7 @@ jobs:
           sudo ./llvm.sh 16 all
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@master
         with:
           version: 5.12.12
           dir: "${{ github.workspace }}/Qt/"

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -170,7 +170,7 @@ jobs:
           sudo ./llvm.sh 16 all
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@master
+        uses: jurplel/install-qt-action@main
         with:
           version: 5.12.12
           dir: "${{ github.workspace }}/Qt/"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install clang-tidy-15 clang-format-15
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@master
+        uses: jurplel/install-qt-action@main
         with:
           version: 5.12.12
           modules: qtscript

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install clang-tidy-15 clang-format-15
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@master
         with:
           version: 5.12.12
           modules: qtscript


### PR DESCRIPTION
Use master branch temporarily to avoid warnings on GitHub. Pin to a specific version when a new release is available.
https://github.com/jurplel/install-qt-action
