### PR TITLE
Prepare building with Qt6

### DIFF
--- a/Fwk/AppFwk/CommonCode/CMakeLists.txt
+++ b/Fwk/AppFwk/CommonCode/CMakeLists.txt
@@ -14,13 +14,23 @@ find_package(OpenGL)
 # These headers need to go through Qt's MOC compiler
 set(MOC_HEADER_FILES cafMessagePanel.h)
 
-find_package(
-  Qt5
-  COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL
-)
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
-qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
+if(CEE_USE_QT6)
+  find_package(
+    Qt6
+    COMPONENTS
+    REQUIRED Core Gui Widgets OpenGL
+  )
+  set(QT_LIBRARIES Qt6::Core Qt6::Gui Qt6::Widgets Qt6::OpenGL)
+  qt_standard_project_setup()
+else()
+  find_package(
+    Qt5
+    COMPONENTS
+    REQUIRED Core Gui Widgets OpenGL
+  )
+  set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
+  qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
+endif()
 
 add_library(
   ${PROJECT_NAME}

--- a/Fwk/AppFwk/CommonCode/cafEffectGenerator.cpp
+++ b/Fwk/AppFwk/CommonCode/cafEffectGenerator.cpp
@@ -58,8 +58,6 @@
 #include "cvfTextureImage.h"
 #include "cvfUniform.h"
 
-#include <QtOpenGL/QGLFormat>
-
 namespace caf
 {
 //#############################################################################################################################

--- a/Fwk/AppFwk/CommonCode/cafUtils.cpp
+++ b/Fwk/AppFwk/CommonCode/cafUtils.cpp
@@ -42,8 +42,6 @@
 #include <QLineEdit>
 #include <QRegularExpression>
 
-#include <QtOpenGL/QGLContext>
-
 #include <QFileDialog>
 #include <QMessageBox>
 

--- a/Fwk/AppFwk/CommonCode/cafUtils.h
+++ b/Fwk/AppFwk/CommonCode/cafUtils.h
@@ -38,9 +38,10 @@
 
 #include <vector>
 
+#include <QStringList>
+
 class QLineEdit;
 class QString;
-class QStringList;
 
 namespace caf
 {

--- a/Fwk/AppFwk/cafViewer/CMakeLists.txt
+++ b/Fwk/AppFwk/cafViewer/CMakeLists.txt
@@ -11,13 +11,23 @@ endif()
 # These headers need to go through Qt's MOC compiler
 set(MOC_HEADER_FILES cafViewer.h)
 
-find_package(
-  Qt5
-  COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL
-)
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
-qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
+if(CEE_USE_QT6)
+  find_package(
+    Qt6
+    COMPONENTS
+    REQUIRED Core Gui Widgets OpenGL
+  )
+  set(QT_LIBRARIES Qt6::Core Qt6::Gui Qt6::Widgets Qt6::OpenGL)
+  qt_standard_project_setup()
+else()
+  find_package(
+    Qt5
+    COMPONENTS
+    REQUIRED Core Gui Widgets OpenGL
+  )
+  set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
+  qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
+endif()
 
 add_library(
   ${PROJECT_NAME}

--- a/Fwk/AppFwk/cafViewer/cafCadNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCadNavigation.cpp
@@ -144,7 +144,11 @@ bool caf::CadNavigation::handleInputEvent( QInputEvent* inputEvent )
             {
                 QWheelEvent* we = static_cast<QWheelEvent*>( inputEvent );
 
+#if ( QT_VERSION < QT_VERSION_CHECK( 5, 15, 0 ) )
                 QPoint cursorPosition = we->pos();
+#else
+                QPoint cursorPosition = we->position().toPoint();
+#endif
 
                 updatePointOfInterestDuringZoomIfNecessary( cursorPosition.x(), cursorPosition.y() );
 

--- a/Fwk/AppFwk/cafViewer/cafCadNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCadNavigation.cpp
@@ -144,12 +144,14 @@ bool caf::CadNavigation::handleInputEvent( QInputEvent* inputEvent )
             {
                 QWheelEvent* we = static_cast<QWheelEvent*>( inputEvent );
 
-                updatePointOfInterestDuringZoomIfNecessary( we->x(), we->y() );
+                QPoint cursorPosition = we->pos();
+
+                updatePointOfInterestDuringZoomIfNecessary( cursorPosition.x(), cursorPosition.y() );
 
                 if ( m_isRotCenterInitialized )
                 {
                     int translatedMousePosX, translatedMousePosY;
-                    cvfEventPos( we->x(), we->y(), &translatedMousePosX, &translatedMousePosY );
+                    cvfEventPos( cursorPosition.x(), cursorPosition.y(), &translatedMousePosX, &translatedMousePosY );
 
                     cvf::ref<cvf::Ray> ray = createZoomRay( translatedMousePosX, translatedMousePosY );
 

--- a/Fwk/AppFwk/cafViewer/cafCadNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCadNavigation.cpp
@@ -153,7 +153,7 @@ bool caf::CadNavigation::handleInputEvent( QInputEvent* inputEvent )
 
                     cvf::ref<cvf::Ray> ray = createZoomRay( translatedMousePosX, translatedMousePosY );
 
-                    zoomAlongRay( ray.p(), -we->delta() );
+                    zoomAlongRay( ray.p(), -we->angleDelta().y() );
                 }
                 isEventHandled = true;
             }

--- a/Fwk/AppFwk/cafViewer/cafCeetronNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCeetronNavigation.cpp
@@ -202,11 +202,12 @@ void caf::CeetronNavigation::wheelEvent( QWheelEvent* event )
     int navDelta = vpHeight / 5;
     if ( event->angleDelta().y() < 0 ) navDelta *= -1;
 
-    int posY = m_viewer->height() - event->y();
+    QPoint cursorPosition = event->pos();
+    int posY = m_viewer->height() - cursorPosition.y();
 
-    m_trackball->startNavigation( ManipulatorTrackball::WALK, event->x(), posY );
+    m_trackball->startNavigation( ManipulatorTrackball::WALK, cursorPosition.x(), posY );
 
-    m_trackball->updateNavigation( event->x(), posY + navDelta );
+    m_trackball->updateNavigation( cursorPosition.x(), posY + navDelta );
     m_trackball->endNavigation();
 
     m_viewer->updateParallelProjectionHeightFromMoveZoom( m_pointOfInterest );

--- a/Fwk/AppFwk/cafViewer/cafCeetronNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCeetronNavigation.cpp
@@ -200,7 +200,7 @@ void caf::CeetronNavigation::wheelEvent( QWheelEvent* event )
     if ( vpHeight <= 0 ) return;
 
     int navDelta = vpHeight / 5;
-    if ( event->delta() < 0 ) navDelta *= -1;
+    if ( event->angleDelta().y() < 0 ) navDelta *= -1;
 
     int posY = m_viewer->height() - event->y();
 

--- a/Fwk/AppFwk/cafViewer/cafCeetronNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCeetronNavigation.cpp
@@ -202,7 +202,11 @@ void caf::CeetronNavigation::wheelEvent( QWheelEvent* event )
     int navDelta = vpHeight / 5;
     if ( event->angleDelta().y() < 0 ) navDelta *= -1;
 
+#if ( QT_VERSION < QT_VERSION_CHECK( 5, 15, 0 ) )
     QPoint cursorPosition = event->pos();
+#else
+    QPoint cursorPosition = event->position().toPoint();
+#endif
     int posY = m_viewer->height() - cursorPosition.y();
 
     m_trackball->startNavigation( ManipulatorTrackball::WALK, cursorPosition.x(), posY );

--- a/Fwk/AppFwk/cafViewer/cafCeetronPlusNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCeetronPlusNavigation.cpp
@@ -194,7 +194,7 @@ bool caf::CeetronPlusNavigation::handleInputEvent( QInputEvent* inputEvent )
 
                     cvf::ref<cvf::Ray> ray = createZoomRay( translatedMousePosX, translatedMousePosY );
 
-                    zoomAlongRay( ray.p(), we->delta() );
+                    zoomAlongRay( ray.p(), we->angleDelta().y() );
                 }
                 isEventHandled = true;
             }

--- a/Fwk/AppFwk/cafViewer/cafCeetronPlusNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCeetronPlusNavigation.cpp
@@ -185,12 +185,14 @@ bool caf::CeetronPlusNavigation::handleInputEvent( QInputEvent* inputEvent )
             {
                 QWheelEvent* we = static_cast<QWheelEvent*>( inputEvent );
 
-                updatePointOfInterestDuringZoomIfNecessary( we->x(), we->y() );
+                QPoint cursorPosition = we->pos();
+
+                updatePointOfInterestDuringZoomIfNecessary( cursorPosition.x(), cursorPosition.y() );
 
                 if ( m_isRotCenterInitialized )
                 {
                     int translatedMousePosX, translatedMousePosY;
-                    cvfEventPos( we->x(), we->y(), &translatedMousePosX, &translatedMousePosY );
+                    cvfEventPos( cursorPosition.x(), cursorPosition.y(), &translatedMousePosX, &translatedMousePosY );
 
                     cvf::ref<cvf::Ray> ray = createZoomRay( translatedMousePosX, translatedMousePosY );
 

--- a/Fwk/AppFwk/cafViewer/cafCeetronPlusNavigation.cpp
+++ b/Fwk/AppFwk/cafViewer/cafCeetronPlusNavigation.cpp
@@ -185,7 +185,11 @@ bool caf::CeetronPlusNavigation::handleInputEvent( QInputEvent* inputEvent )
             {
                 QWheelEvent* we = static_cast<QWheelEvent*>( inputEvent );
 
+#if ( QT_VERSION < QT_VERSION_CHECK( 5, 15, 0 ) )
                 QPoint cursorPosition = we->pos();
+#else
+                QPoint cursorPosition = we->position().toPoint();
+#endif
 
                 updatePointOfInterestDuringZoomIfNecessary( cursorPosition.x(), cursorPosition.y() );
 

--- a/Fwk/AppFwk/cafVizExtensions/CMakeLists.txt
+++ b/Fwk/AppFwk/cafVizExtensions/CMakeLists.txt
@@ -10,13 +10,26 @@ endif()
 find_package(OpenGL)
 
 # Qt
-find_package(
-  Qt5
-  COMPONENTS
-  REQUIRED Core Gui Widgets OpenGL
-)
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
-qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
+if(CEE_USE_QT6)
+  find_package(
+    Qt6
+    COMPONENTS
+    REQUIRED Core Gui Widgets OpenGL
+  )
+  set(QT_LIBRARIES Qt6::Core Qt6::Gui Qt6::Widgets Qt6::OpenGL)
+  qt_standard_project_setup()
+  set_property(
+    SOURCE cafTransparentWBRenderConfiguration.cpp PROPERTY SKIP_AUTOMOC ON
+  )
+else()
+  find_package(
+    Qt5
+    COMPONENTS
+    REQUIRED Core Gui Widgets OpenGL
+  )
+  set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
+  qt5_wrap_cpp(MOC_SOURCE_FILES ${MOC_HEADER_FILES})
+endif()
 
 add_library(
   ${PROJECT_NAME}

--- a/Fwk/CMakeLists.txt
+++ b/Fwk/CMakeLists.txt
@@ -32,9 +32,22 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNO_DEBUG")
 endif()
 
-
-find_package(Qt5 COMPONENTS REQUIRED Core Gui OpenGL Widgets)
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Widgets)
+if(CEE_USE_QT6)
+  find_package(
+    Qt6
+    COMPONENTS
+    REQUIRED Core Gui OpenGL Widgets
+  )
+  set(QT_LIBRARIES Qt6::Core Qt6::Gui Qt6::OpenGL Qt6::Widgets)
+  qt_standard_project_setup()
+else()
+  find_package(
+    Qt5
+    COMPONENTS
+    REQUIRED Core Gui OpenGL Widgets
+  )
+  set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Widgets)
+endif()
 
 # Libraries
 add_subdirectory(AppFwk/cafProjectDataModel/cafPdmCore)


### PR DESCRIPTION
I just wanted to make a tiny contribution to issue #10567.

- Add possibility to use Qt6 to more Fwk libraries.
- Update includes to work with Qt6 as well
- Use updated qt-functions for cursor position and scrolling. 

The following still remains for Fwk to be ready for Qt6:
- There are a few libraries that I have not migrated (including some unit test libraries)
- caf::OpenGLWidget in cafViewer does not work with Qt6. It is not used anymore after commit 8e13d6c5283b4a7a5363da2215f7a475aa3d4f1b so it might as well be removed completely?