### PR TITLE
Do not crash if no valid points are found when importing a surface .dat file

### DIFF
--- a/ApplicationLibCode/FileInterface/RifSurfaceImporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifSurfaceImporter.cpp
@@ -465,6 +465,8 @@ std::pair<std::vector<cvf::Vec3d>, std::vector<unsigned>> RifSurfaceImporter::re
         }
     }
 
+    if ( surfacePoints.size() == 0 ) return { {}, {} };
+
     // Determine axes vectors
     std::vector<std::pair<cvf::Vec2d, unsigned>> pairs;
     for ( auto itr = axesVectorCandidatesNum.begin(); itr != axesVectorCandidatesNum.end(); ++itr )


### PR DESCRIPTION
Ref. #11257 