### PR TITLE
#11285 GRPC: fix high CPU usage in console application

### DIFF
--- a/ApplicationExeCode/RiaGrpcConsoleApplication.cpp
+++ b/ApplicationExeCode/RiaGrpcConsoleApplication.cpp
@@ -46,7 +46,7 @@ RiaGrpcConsoleApplication::RiaGrpcConsoleApplication( int& argc, char** argv )
 {
     m_idleTimer = new QTimer( this );
     connect( m_idleTimer, SIGNAL( timeout() ), this, SLOT( doIdleProcessing() ) );
-    m_idleTimer->start( 0 );
+    m_idleTimer->start( 5 );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Increase polling interval to avoid using one core constantly.

Fixes #11285.