### PR TITLE
Add feature to set parent well

### DIFF
--- a/ApplicationLibCode/Commands/WellPathCommands/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/WellPathCommands/CMakeLists_files.cmake
@@ -31,6 +31,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/PointTangentManipulator/RicPolyline3dEditor.h
     ${CMAKE_CURRENT_LIST_DIR}/PointTangentManipulator/RicPolylineTarget3dEditor.h
     ${CMAKE_CURRENT_LIST_DIR}/RicDuplicateWellPathFeature.h
+    ${CMAKE_CURRENT_LIST_DIR}/RicSetParentWellPathFeature.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -66,6 +67,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/PointTangentManipulator/RicPolyline3dEditor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/PointTangentManipulator/RicPolylineTarget3dEditor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicDuplicateWellPathFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicSetParentWellPathFeature.cpp
 )
 
 list(APPEND COMMAND_CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
@@ -1,0 +1,76 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2021-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicSetParentWellPathFeature.h"
+
+#include "RimTools.h"
+#include "RimWellPath.h"
+#include "RimWellPathCollection.h"
+
+#include "cafSelectionManager.h"
+
+#include <QAction>
+
+CAF_CMD_SOURCE_INIT( RicSetParentWellPathFeature, "RicSetParentWellPathFeature" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RicSetParentWellPathFeature::isCommandEnabled() const
+{
+    std::vector<RimWellPath*> objects;
+    caf::SelectionManager::instance()->objectsByType( &objects );
+
+    return !objects.empty();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicSetParentWellPathFeature::onActionTriggered( bool isChecked )
+{
+    std::vector<RimWellPath*> wellPaths;
+    caf::SelectionManager::instance()->objectsByType( &wellPaths );
+
+    if ( !wellPaths.empty() )
+    {
+        auto wpc = RimTools::wellPathCollection();
+
+        for ( auto w : wellPaths )
+        {
+            for ( auto wl : w->allWellPathLaterals() )
+            {
+                wpc->deleteWell( wl );
+            }
+        }
+
+        wpc->rebuildWellPathNodes();
+        wpc->scheduleRedrawAffectedViews();
+        wpc->updateAllRequiredEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicSetParentWellPathFeature::setupActionLook( QAction* actionToSetup )
+{
+    actionToSetup->setText( "Delete Well Path" );
+    actionToSetup->setIcon( QIcon( ":/Erase.svg" ) );
+    actionToSetup->setShortcut( Qt::Key_Delete );
+}

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
@@ -18,50 +18,122 @@
 
 #include "RicSetParentWellPathFeature.h"
 
+#include "RigWellPath.h"
+
 #include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
+#include "RimWellPathTieIn.h"
 
+#include "cafPdmUiPropertyViewDialog.h"
 #include "cafSelectionManager.h"
 
 #include <QAction>
+
+CAF_PDM_SOURCE_INIT( RicSelectWellPathUi, "RicSelectWellPathUi" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RicSelectWellPathUi::RicSelectWellPathUi()
+{
+    CAF_PDM_InitObject( "RicSelectWellPathUi" );
+
+    CAF_PDM_InitFieldNoDefault( &m_selectedWellPath, "SelectedWellPath", "Well Path" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicSelectWellPathUi::setWellPaths( const std::vector<RimWellPath*>& wellPaths )
+{
+    m_wellPaths = wellPaths;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicSelectWellPathUi::setSelectedWell( RimWellPath* selectedWell )
+{
+    m_selectedWellPath = selectedWell;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPath* RicSelectWellPathUi::wellPath() const
+{
+    return m_selectedWellPath();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RicSelectWellPathUi::calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions )
+{
+    QList<caf::PdmOptionItemInfo> options;
+
+    options.push_back( caf::PdmOptionItemInfo( "None", nullptr ) );
+
+    RimTools::optionItemsForSpecifiedWellPaths( m_wellPaths, &options );
+    return options;
+}
 
 CAF_CMD_SOURCE_INIT( RicSetParentWellPathFeature, "RicSetParentWellPathFeature" );
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RicSetParentWellPathFeature::isCommandEnabled() const
-{
-    std::vector<RimWellPath*> objects;
-    caf::SelectionManager::instance()->objectsByType( &objects );
-
-    return !objects.empty();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void RicSetParentWellPathFeature::onActionTriggered( bool isChecked )
 {
-    std::vector<RimWellPath*> wellPaths;
-    caf::SelectionManager::instance()->objectsByType( &wellPaths );
+    auto selectedWellPath = caf::SelectionManager::instance()->selectedItemOfType<RimWellPath>();
+    if ( !selectedWellPath ) return;
 
-    if ( !wellPaths.empty() )
+    auto wpc = RimTools::wellPathCollection();
+    if ( !wpc ) return;
+
+    std::vector<RimWellPath*> wellPathCandidates;
+    for ( auto w : wpc->allWellPaths() )
     {
-        auto wpc = RimTools::wellPathCollection();
+        if ( w != selectedWellPath ) wellPathCandidates.push_back( w );
+    }
 
-        for ( auto w : wellPaths )
+    RicSelectWellPathUi ui;
+    ui.setWellPaths( wellPathCandidates );
+
+    RimWellPath* parentWell = nullptr;
+    if ( selectedWellPath->wellPathTieIn() ) parentWell = selectedWellPath->wellPathTieIn()->parentWell();
+    ui.setSelectedWell( parentWell );
+
+    caf::PdmUiPropertyViewDialog propertyDialog( nullptr, &ui, "Select Parent Well", "" );
+    propertyDialog.resize( QSize( 400, 200 ) );
+
+    if ( propertyDialog.exec() == QDialog::Accepted )
+    {
+        auto parentWellPath = ui.wellPath();
+
+        double tieInMeasuredDepth = 0.0;
+        if ( parentWellPath )
         {
-            for ( auto wl : w->allWellPathLaterals() )
-            {
-                wpc->deleteWell( wl );
-            }
+            if ( !parentWellPath->wellPathGeometry() || parentWellPath->wellPathGeometry()->measuredDepths().size() < 2 ) return;
+            if ( selectedWellPath->wellPathGeometry()->wellPathPoints().empty() ) return;
+
+            auto headOfLateral = selectedWellPath->wellPathGeometry()->wellPathPoints().front();
+
+            cvf::Vec3d p1, p2;
+            parentWellPath->wellPathGeometry()->twoClosestPoints( headOfLateral, &p1, &p2 );
+
+            tieInMeasuredDepth = parentWellPath->wellPathGeometry()->closestMeasuredDepth( p1 );
         }
+
+        selectedWellPath->connectWellPaths( parentWellPath, tieInMeasuredDepth );
 
         wpc->rebuildWellPathNodes();
         wpc->scheduleRedrawAffectedViews();
         wpc->updateAllRequiredEditors();
+
+        RiuMainWindow::instance()->setExpanded( selectedWellPath );
+        RiuMainWindow::instance()->selectAsCurrentItem( selectedWellPath );
     }
 }
 
@@ -70,7 +142,6 @@ void RicSetParentWellPathFeature::onActionTriggered( bool isChecked )
 //--------------------------------------------------------------------------------------------------
 void RicSetParentWellPathFeature::setupActionLook( QAction* actionToSetup )
 {
-    actionToSetup->setText( "Delete Well Path" );
-    actionToSetup->setIcon( QIcon( ":/Erase.svg" ) );
-    actionToSetup->setShortcut( Qt::Key_Delete );
+    actionToSetup->setText( "Set Parent Well Path" );
+    actionToSetup->setIcon( QIcon( ":/Well.svg" ) );
 }

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
@@ -25,6 +25,8 @@
 #include "RimWellPathCollection.h"
 #include "RimWellPathTieIn.h"
 
+#include "RiuMainWindow.h"
+
 #include "cafPdmUiPropertyViewDialog.h"
 #include "cafSelectionManager.h"
 

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2021-     Equinor ASA
+//  Copyright (C) 2024     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
@@ -19,6 +19,38 @@
 #pragma once
 
 #include "cafCmdFeature.h"
+#include "cafPdmPtrField.h"
+
+#include <QList>
+
+#include <vector>
+
+namespace caf
+{
+class PdmOptionItemInfo;
+}
+
+class RimWellPath;
+
+class RicSelectWellPathUi : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RicSelectWellPathUi();
+
+    void setWellPaths( const std::vector<RimWellPath*>& wellPaths );
+    void setSelectedWell( RimWellPath* selectedWell );
+
+    RimWellPath* wellPath() const;
+
+protected:
+    QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
+
+private:
+    caf::PdmPtrField<RimWellPath*> m_selectedWellPath;
+    std::vector<RimWellPath*>      m_wellPaths;
+};
 
 //==================================================================================================
 ///
@@ -28,7 +60,6 @@ class RicSetParentWellPathFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
 };

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "cafCmdFeature.h"
+#include "cafPdmObject.h"
 #include "cafPdmPtrField.h"
 
 #include <QList>

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
@@ -1,0 +1,34 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2021-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cafCmdFeature.h"
+
+//==================================================================================================
+///
+//==================================================================================================
+class RicSetParentWellPathFeature : public caf::CmdFeature
+{
+    CAF_CMD_HEADER_INIT;
+
+protected:
+    bool isCommandEnabled() const override;
+    void onActionTriggered( bool isChecked ) override;
+    void setupActionLook( QAction* actionToSetup ) override;
+};

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2021-     Equinor ASA
+//  Copyright (C) 2024     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -389,8 +389,10 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         {
             menuBuilder << "RicNewEditableWellPathFeature";
             menuBuilder << "RicNewWellPathLateralFeature";
-            menuBuilder << "RicLinkWellPathFeature";
             menuBuilder << "RicDuplicateWellPathFeature";
+
+            menuBuilder.addSeparator();
+            menuBuilder << "RicSetParentWellPathFeature";
 
             menuBuilder.addSeparator();
             menuBuilder << "RicNewWellPathIntersectionFeature";
@@ -421,6 +423,7 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
             menuBuilder.subMenuEnd();
             menuBuilder.addSeparator();
 
+            menuBuilder << "RicLinkWellPathFeature";
             menuBuilder << "RicDeleteWellPathFeature";
 
             menuBuilder.addSeparator();

--- a/ApplicationLibCode/ProjectDataModel/RimTools.h
+++ b/ApplicationLibCode/ProjectDataModel/RimTools.h
@@ -82,6 +82,5 @@ public:
 
     static void timeStepsForCase( RimCase* gridCase, QList<caf::PdmOptionItemInfo>* options );
 
-private:
     static void optionItemsForSpecifiedWellPaths( const std::vector<RimWellPath*>& wellPaths, QList<caf::PdmOptionItemInfo>* options );
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.h
@@ -170,7 +170,7 @@ public:
     std::vector<RimWellPath*> wellPathLaterals() const;
 
     RimWellPathTieIn* wellPathTieIn() const;
-    void              connectWellPaths( RimWellPath* childWell, double tieInMeasuredDepth );
+    void              connectWellPaths( RimWellPath* parentWell, double tieInMeasuredDepth );
 
 protected:
     // Override PdmObject

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.cpp
@@ -30,7 +30,6 @@
 
 #include "RiuMainWindow.h"
 
-#include "RigWellPathGeometryTools.h"
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiLabelEditor.h"
 
@@ -198,6 +197,8 @@ void RimWellPathTieIn::fieldChangedByUi( const caf::PdmFieldHandle* changedField
 {
     // TODO: It is not possible to change the parent well from the UI as the field is set to read only. Refactor and possibly delete this
     // method.
+    // https://github.com/OPM/ResInsight/issues/11312
+    // https://github.com/OPM/ResInsight/issues/11313
 
     if ( changedField == &m_parentWell )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.cpp
@@ -32,6 +32,7 @@
 
 #include "RigWellPathGeometryTools.h"
 #include "cafPdmUiDoubleSliderEditor.h"
+#include "cafPdmUiLabelEditor.h"
 
 CAF_PDM_SOURCE_INIT( RimWellPathTieIn, "RimWellPathTieIn" );
 
@@ -42,7 +43,14 @@ RimWellPathTieIn::RimWellPathTieIn()
 {
     CAF_PDM_InitObject( "Well Path Tie In", ":/NotDefined.png", "", "Well Path Tie In description" );
 
+    CAF_PDM_InitFieldNoDefault( &m_infoLabel, "InfoLabel", "Use right-click menu of well to set parent well." );
+    m_infoLabel.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
+    m_infoLabel.xmlCapability()->disableIO();
+    m_infoLabel.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::TOP );
+
     CAF_PDM_InitFieldNoDefault( &m_parentWell, "ParentWellPath", "Parent Well Path" );
+    m_parentWell.uiCapability()->setUiReadOnly( true );
+
     CAF_PDM_InitFieldNoDefault( &m_childWell, "ChildWellPath", "ChildWellPath" );
     CAF_PDM_InitFieldNoDefault( &m_tieInMeasuredDepth, "TieInMeasuredDepth", "Tie In Measured Depth" );
     m_tieInMeasuredDepth.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
@@ -161,6 +169,7 @@ const RimWellPathValve* RimWellPathTieIn::outletValve() const
 void RimWellPathTieIn::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
     auto tieInGroup = uiOrdering.addNewGroup( "Tie In Settings" );
+    tieInGroup->add( &m_infoLabel );
     tieInGroup->add( &m_parentWell );
     if ( m_parentWell() != nullptr )
     {
@@ -187,6 +196,9 @@ void RimWellPathTieIn::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderin
 //--------------------------------------------------------------------------------------------------
 void RimWellPathTieIn::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
+    // TODO: It is not possible to change the parent well from the UI as the field is set to read only. Refactor and possibly delete this
+    // method.
+
     if ( changedField == &m_parentWell )
     {
         updateFirstTargetFromParentWell();

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.h
@@ -55,6 +55,8 @@ private:
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
 private:
+    caf::PdmField<QString> m_infoLabel;
+
     caf::PdmPtrField<RimWellPath*> m_parentWell;
     caf::PdmPtrField<RimWellPath*> m_childWell;
     caf::PdmField<double>          m_tieInMeasuredDepth;


### PR DESCRIPTION
Setting parent well directly from Property Editor caused crash. Use a feature to connect a well to a parent well.

Closes #11313
Closes #11312

