### PR TITLE
AppFwk: Move include of windows.h to top of file

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
@@ -48,6 +48,14 @@
 #include <algorithm>
 #include <iostream>
 
+#ifdef _MSC_VER
+// Define this one to tell windows.h to not define min() and max() as macros
+#if defined WIN32 && !defined NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 namespace caf
 {
 //--------------------------------------------------------------------------------------------------
@@ -358,17 +366,6 @@ bool ProgressState::isActive()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable : 4668 )
-// Define this one to tell windows.h to not define min() and max() as macros
-#if defined WIN32 && !defined NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#pragma warning( pop )
-#endif
-
 void openDebugWindow()
 {
 #ifdef _MSC_VER


### PR DESCRIPTION
The include was located in the middle of a file inside a namespace caf block and lead to ambiguous symbols when compiling with unity build and Qt6. It is also considered good practice to have includes at the top.

The pragma warning disable is also removed as the warning seems to be gone (and none of the other windows.h includes have it).

Closes #11327