### PR TITLE
#11310 Fix assert on single cell model.

### DIFF
--- a/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp
+++ b/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp
@@ -380,7 +380,7 @@ void StructGridInterface::computeCharacteristicCellSize( const std::vector<size_
 
         size_t i, j, k = 0;
         size_t index = 0;
-        while ( index < globalCellIndices.size() - 1 )
+        while ( index < globalCellIndices.size() )
         {
             size_t cellIndex = globalCellIndices[index];
             ijkFromCellIndex( cellIndex, &i, &j, &k );


### PR DESCRIPTION
Well pipe radius would become HUGE_VAL due to off-by-one error. The assert could only happen on model with a single cell.

Fixes #11310.