### PR TITLE
Adjust workflow to create release on tag for usage in webviz

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         config:
           - {
-              name: "Windows Latest MSVC",
+              name: "Windows_Latest_MSVC",
               os: windows-2022,
               cc: "cl",
               cxx: "cl",
@@ -38,7 +38,7 @@ jobs:
               publish-to-pypi: false,
             }
           - {
-              name: "Ubuntu 20.04 gcc",
+              name: "Ubuntu_20.04_gcc",
               os: ubuntu-20.04,
               cc: "gcc",
               cxx: "g++",
@@ -51,7 +51,7 @@ jobs:
               publish-to-pypi: false,
             }
           - {
-              name: "Ubuntu 22.04 clang-16",
+              name: "Ubuntu_22.04_clang-16",
               os: ubuntu-22.04,
               cc: "clang-16",
               cxx: "clang++-16",

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -48,7 +48,7 @@ jobs:
               execute-unit-tests: true,
               execute-pytests: true,
               unity-build: false,
-              publish-to-pypi: true,
+              publish-to-pypi: false,
             }
           - {
               name: "Ubuntu 22.04 clang-16",
@@ -281,7 +281,22 @@ jobs:
           name: ResInsight-${{ matrix.config.name }}
           path: ${{ runner.workspace }}/ResInsight/cmakebuild/install
 
+      - name: Compress gcc build for GitHub release
+        if: matrix.config.cc == 'gcc'
+        run: |
+          cd ${{ runner.workspace }}/ResInsight/cmakebuild/
+          tar -czvf ResInsight-${{ matrix.config.name }}.tar.gz install
+
+      - name: Publish gcc GitHub release
+        if: matrix.config.cc == 'gcc' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2        
+        with:
+          files: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight-${{ matrix.config.name }}.tar.gz
+
   pypi-publish:
+    # If this is a tagged release (DISABLED)
+    if: false && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
     name: Upload release to PyPI
     needs: build
     runs-on: ubuntu-latest
@@ -291,9 +306,6 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing  
     
-    # If this is a tagged release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-
     steps:
     - name: Download python distribution folder
       uses: actions/download-artifact@v4

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -288,7 +288,7 @@ jobs:
           tar -czvf ResInsight-${{ matrix.config.name }}.tar.gz install
 
       - name: Publish gcc GitHub release
-        if: matrix.config.cc == 'gcc' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.config.cc == 'gcc' && startsWith(github.ref, 'refs/tags/webviz')
         uses: softprops/action-gh-release@v2        
         with:
           files: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight-${{ matrix.config.name }}.tar.gz


### PR DESCRIPTION
Adjust workflow for build for generating release on tag

- Create automatic release for tag having prefix `webviz`. Provide gcc build for Ubuntu 20.04 as of now
- Prevent publish to pypi