### PR TITLE
Revert "Pin cmake to 3.28.x due to build issues with 3.29"

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -91,8 +91,6 @@ jobs:
 
       - name: Use CMake
         uses: lukka/get-cmake@latest
-        with:
-          cmakeVersion: "~3.28.0"
 
       - name: Use MSVC (Windows)
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
This reverts commit df0a86f076b81a8bb2d01a6f71e5e98851922d8e.

Issue was fixed in 3.29.2
https://gitlab.kitware.com/cmake/cmake/-/issues/25873