### PR TITLE
OpenSSL: remove OpenSSL bundling.

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -185,18 +185,6 @@ jobs:
             "${{ github.workspace }}/ThirdParty/vcpkg"
           appendedCacheKey: ${{ matrix.config.os }}-${{ matrix.config.cxx }}-cache-key-v2
 
-      - name: Cache dynamic version of OpenSSL (Linux)
-        if: contains( matrix.config.os, 'ubuntu_disabled')
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/ThirdParty/vcpkg/installed/x64-linux-dynamic
-          key: ${{ matrix.config.os }}-vcpkg-x64-linux-dynamic_v05
-
-      - name: Install dynamic version of OpenSSL (Linux)
-        if: contains( matrix.config.os, 'ubuntu')
-        run: |
-          $VCPKG_ROOT/vcpkg install --overlay-triplets=${{ github.workspace }}/ThirdParty/vcpkg-custom-triplets --triplet x64-linux-dynamic openssl
-
       - name: Configure
         shell: cmake -P {0}
         run: |
@@ -209,7 +197,6 @@ jobs:
               -B cmakebuild
               -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
               -D CMAKE_INSTALL_PREFIX=cmakebuild/install
-              -D RESINSIGHT_BUNDLE_OPENSSL=true
               -D RESINSIGHT_QT5_BUNDLE_LIBRARIES=true
               -D RESINSIGHT_INCLUDE_APPLICATION_UNIT_TESTS=true
               -D RESINSIGHT_TREAT_WARNINGS_AS_ERRORS=true

--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -662,50 +662,6 @@ else(RESINSIGHT_PRIVATE_INSTALL)
   )
 endif(RESINSIGHT_PRIVATE_INSTALL)
 
-# OpenSSL
-option(RESINSIGHT_BUNDLE_OPENSSL "Bundle the OpenSSL binary library files" OFF)
-mark_as_advanced(FORCE RESINSIGHT_BUNDLE_OPENSSL)
-
-if(RESINSIGHT_BUNDLE_OPENSSL)
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    find_package(OpenSSL)
-
-    if(OPENSSL_FOUND)
-      message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
-      set(OPENSSL_BIN_DIR ${OPENSSL_INCLUDE_DIR})
-      string(REPLACE "include" "bin" OPENSSL_BIN_DIR ${OPENSSL_BIN_DIR})
-      message("OpenSSL binary dir: ${OPENSSL_BIN_DIR}")
-
-      install(FILES ${OPENSSL_BIN_DIR}/libcrypto-3-x64.dll
-              DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
-      )
-      install(FILES ${OPENSSL_BIN_DIR}/libssl-3-x64.dll
-              DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
-      )
-    endif(OPENSSL_FOUND)
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    # Assumes that OpenSSL is installed by ./vcpkg install
-    # --overlay-triplets=custom-triplets --triplet x64-linux-dynamic openssl
-    set(OPENSSL_BIN_DIR
-        ${CMAKE_SOURCE_DIR}/ThirdParty/vcpkg/installed/x64-linux-dynamic/lib
-    )
-    message("OpenSSL binary dir: ${OPENSSL_BIN_DIR}")
-
-    install(FILES ${OPENSSL_BIN_DIR}/libcrypto.so
-            DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
-    )
-    install(FILES ${OPENSSL_BIN_DIR}/libcrypto.so.3
-            DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
-    )
-    install(FILES ${OPENSSL_BIN_DIR}/libssl.so
-            DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
-    )
-    install(FILES ${OPENSSL_BIN_DIR}/libssl.so.3
-            DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
-    )
-  endif()
-endif(RESINSIGHT_BUNDLE_OPENSSL)
-
 # ##############################################################################
 # Installation packaging
 # ##############################################################################
@@ -740,10 +696,6 @@ if(NOT ${OCTAVE_VERSION_STRING} EQUAL "")
   set(RESINSIGHT_PACKAGE_NAME
       "${RESINSIGHT_PACKAGE_NAME}_oct-${OCTAVE_VERSION_STRING}"
   )
-endif()
-
-if(RESINSIGHT_BUNDLE_OPENSSL AND OPENSSL_FOUND)
-  set(RESINSIGHT_PACKAGE_NAME "${RESINSIGHT_PACKAGE_NAME}_openssl")
 endif()
 
 # Append el5 when compiled on RHEL5 and el6 if compiled on RHEL6


### PR DESCRIPTION
The OpenSSL library from vcpkg is unlikely to be the one needed by Qt.