### PR TITLE
Fix compiler issue when importing arrow

### DIFF
--- a/ApplicationLibCode/FileInterface/RifArrowTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifArrowTools.cpp
@@ -22,12 +22,6 @@
 
 #include <vector>
 
-// #include <arrow/array/array_primitive.h>
-// #include <arrow/csv/api.h>
-// #include <arrow/io/api.h>
-// #include <arrow/scalar.h>
-// #include <parquet/arrow/reader.h>
-
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifArrowTools.h
+++ b/ApplicationLibCode/FileInterface/RifArrowTools.h
@@ -18,7 +18,9 @@
 
 #pragma once
 
+#undef signals
 #include <arrow/array/array_primitive.h>
+#define signals Q_SIGNALS
 
 #include <memory>
 #include <vector>

--- a/ApplicationLibCode/FileInterface/RifByteArrayArrowRandomAccessFile.h
+++ b/ApplicationLibCode/FileInterface/RifByteArrayArrowRandomAccessFile.h
@@ -18,10 +18,12 @@
 
 #pragma once
 
+#undef signals
 #include <arrow/csv/api.h>
 #include <arrow/io/api.h>
 #include <arrow/scalar.h>
 #include <parquet/arrow/reader.h>
+#define signals Q_SIGNALS
 
 #include <QByteArray>
 

--- a/ApplicationLibCode/FileInterface/RifOsduWellLogReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellLogReader.cpp
@@ -27,11 +27,13 @@
 
 #include "RifArrowTools.h"
 
+#undef signals
 #include <arrow/array/array_primitive.h>
 #include <arrow/csv/api.h>
 #include <arrow/io/api.h>
 #include <arrow/scalar.h>
 #include <parquet/arrow/reader.h>
+#define signals Q_SIGNALS
 
 //--------------------------------------------------------------------------------------------------
 ///

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -18,12 +18,14 @@
 
 #include "RifOsduWellPathReader.h"
 
+#undef signals
 #include <arrow/array/array_primitive.h>
 #include <arrow/csv/api.h>
 #include <arrow/io/api.h>
 #include <arrow/scalar.h>
 #include <arrow/util/cancel.h>
 #include <parquet/arrow/reader.h>
+#define signals Q_SIGNALS
 
 #include "RiaLogging.h"
 #include "RiaTextStringTools.h"

--- a/ApplicationLibCode/UnitTests/RifParquetReader-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifParquetReader-Test.cpp
@@ -2,10 +2,12 @@
 
 #include "RiaTestDataDirectory.h"
 
+#undef signals
 #include <arrow/csv/api.h>
 #include <arrow/io/api.h>
 #include <arrow/scalar.h>
 #include <parquet/arrow/reader.h>
+#define signals Q_SIGNALS
 
 #include <QDir>
 #include <QString>

--- a/ApplicationLibCode/pch.h
+++ b/ApplicationLibCode/pch.h
@@ -16,11 +16,6 @@
 //
 /////////////////////////////////////////////////////////////////////////////////
 
-// NOTE: This file must be included before any other Qt header files, as the keyword 'signals' is used as a parameter name in
-// RegisterCancellingSignalHandler(const std::vector<int>& signals);
-// Qt has special treatment of 'signals', and causes compiler issues using PCH
-#include <arrow/util/cancel.h>
-
 #include "cvfObject.h"
 #include "cvfVector3.h"
 


### PR DESCRIPTION
The arrow library has a function parameter called `signals` that causes trouble when compiled using Qt. Add undef signals to avoid this issue.
