### PR TITLE
#11562 RFT plots with nonproducing segments

### DIFF
--- a/ApplicationLibCode/FileInterface/RifRftSegment.h
+++ b/ApplicationLibCode/FileInterface/RifRftSegment.h
@@ -74,12 +74,12 @@ public:
     std::vector<size_t> segmentIndicesForBranchNumber( int branchNumber ) const;
     std::vector<size_t> segmentIndicesForBranchIndex( int branchIndex, RiaDefines::RftBranchType branchType ) const;
     std::vector<size_t> packerSegmentIndicesOnAnnulus( int branchIndex ) const;
+    std::vector<size_t> nonContinuousDeviceSegmentIndices( int branchIndex ) const;
 
     std::vector<int> segmentNumbersForBranchIndex( int oneBasedBranchIndex, RiaDefines::RftBranchType branchType ) const;
 
     std::set<int> uniqueOneBasedBranchIndices( RiaDefines::RftBranchType branchType ) const;
 
-private:
     int segmentIndexFromSegmentNumber( int segmentNumber ) const;
 
 private:


### PR DESCRIPTION
Identify when we have a tubing segments that do not have a device segment connected. Mark the downstream device segment as non-continuous. When MD for device curve is created, add an extra MD for noncontinuous segments. Use inf as data value for this MD. This will ensure that no curve is displayed in this section of the device curve.
