### PR TITLE
Improve error handling when trying to access OSDU data

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -1711,6 +1711,18 @@ RiaOsduConnector* RiaApplication::makeOsduConnector()
 {
     if ( m_osduConnector ) return m_osduConnector;
 
+    if ( !QSslSocket::supportsSsl() )
+    {
+        QString errMsg = "SSL support is not available. ";
+#ifdef Q_OS_WIN
+        errMsg +=
+            "Make sure that the SSL libraries are available (on Windows platform, they are called 'libcrypto*.dll' and 'libssl*.dll').";
+#endif
+        RiaLogging::errorInMessageBox( nullptr, "OSDU Service Connection", errMsg );
+
+        return nullptr;
+    }
+
     RiaPreferencesOsdu* osduPreferences = preferences()->osduPreferences();
     const QString       server          = osduPreferences->server();
     const QString       dataPartitionId = osduPreferences->dataPartitionId();

--- a/ApplicationLibCode/Commands/OsduImportCommands/RicWellPathsImportOsduFeature.cpp
+++ b/ApplicationLibCode/Commands/OsduImportCommands/RicWellPathsImportOsduFeature.cpp
@@ -67,6 +67,11 @@ void RicWellPathsImportOsduFeature::onActionTriggered( bool isChecked )
     if ( !oilField ) return;
 
     RiaOsduConnector* osduConnector = app->makeOsduConnector();
+    if ( !osduConnector )
+    {
+        RiaLogging::error( "Failed to create OSDU connector" );
+        return;
+    }
 
     RiuWellImportWizard wellImportwizard( osduConnector, RiuMainWindow::instance() );
 

--- a/ApplicationLibCode/Commands/RicImportWellLogOsduFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportWellLogOsduFeature.cpp
@@ -62,6 +62,11 @@ void RicImportWellLogOsduFeature::onActionTriggered( bool isChecked )
         if ( !oilField->wellPathCollection ) oilField->wellPathCollection = std::make_unique<RimWellPathCollection>();
 
         auto osduConnector = app->makeOsduConnector();
+        if ( !osduConnector )
+        {
+            RiaLogging::error( "Failed to create OSDU connector" );
+            return;
+        }
 
         RiuWellLogImportWizard wellLogImportWizard( osduConnector, wellPath->wellboreId(), RiuMainWindow::instance() );
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
@@ -182,8 +182,10 @@ bool RimWellPathCollection::loadDataAndUpdate()
 
     if ( hasOsduData( allWellPaths() ) )
     {
-        auto osduConnector = RiaApplication::instance()->makeOsduConnector();
-        osduConnector->requestTokenBlocking();
+        if ( auto osduConnector = RiaApplication::instance()->makeOsduConnector() )
+        {
+            osduConnector->requestTokenBlocking();
+        }
     }
 
     caf::DataLoadController* dataLoadController = caf::DataLoadController::instance();


### PR DESCRIPTION
Show more details when support for SSL is missing.

Move connection of signal/slot away from constructor. This makes it possible to use ResInsight even if SSL is not available.

