### PR TITLE
Improve user control on resampling operations

### DIFF
--- a/ApplicationLibCode/Application/RiaSummaryDefines.cpp
+++ b/ApplicationLibCode/Application/RiaSummaryDefines.cpp
@@ -28,6 +28,15 @@ void caf::AppEnum<RiaDefines::HorizontalAxisType>::setUp()
     addItem( RiaDefines::HorizontalAxisType::SUMMARY_VECTOR, "SUMMARY_VECTOR", "Summary Vector" );
     setDefault( RiaDefines::HorizontalAxisType::SUMMARY_VECTOR );
 }
+
+template <>
+void caf::AppEnum<RiaDefines::SummaryCurveType>::setUp()
+{
+    addItem( RiaDefines::SummaryCurveType::AUTO, "AUTO", "Auto" );
+    addItem( RiaDefines::SummaryCurveType::ACCUMULATED, "ACCUMULATED", "Accumulated" );
+    addItem( RiaDefines::SummaryCurveType::RATE, "RATE", "Rate" );
+    setDefault( RiaDefines::SummaryCurveType::AUTO );
+}
 } // namespace caf
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaSummaryDefines.cpp
+++ b/ApplicationLibCode/Application/RiaSummaryDefines.cpp
@@ -30,13 +30,13 @@ void caf::AppEnum<RiaDefines::HorizontalAxisType>::setUp()
 }
 
 template <>
-void caf::AppEnum<RiaDefines::SummaryCurveType>::setUp()
+void caf::AppEnum<RiaDefines::SummaryCurveTypeMode>::setUp()
 {
-    addItem( RiaDefines::SummaryCurveType::AUTO, "AUTO", "Auto" );
-    addItem( RiaDefines::SummaryCurveType::ACCUMULATED, "ACCUMULATED", "Accumulated" );
-    addItem( RiaDefines::SummaryCurveType::RATE, "RATE", "Rate" );
-    setDefault( RiaDefines::SummaryCurveType::AUTO );
+    addItem( RiaDefines::SummaryCurveTypeMode::AUTO, "AUTO", "Auto" );
+    addItem( RiaDefines::SummaryCurveTypeMode::CUSTOM, "CUSTOM", "Custom" );
+    setDefault( RiaDefines::SummaryCurveTypeMode::AUTO );
 }
+
 } // namespace caf
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaSummaryDefines.h
+++ b/ApplicationLibCode/Application/RiaSummaryDefines.h
@@ -35,6 +35,13 @@ enum class HorizontalAxisType
     SUMMARY_VECTOR
 };
 
+enum class SummaryCurveType
+{
+    AUTO,
+    ACCUMULATED,
+    RATE
+};
+
 QString summaryField();
 QString summaryAquifer();
 QString summaryNetwork();

--- a/ApplicationLibCode/Application/RiaSummaryDefines.h
+++ b/ApplicationLibCode/Application/RiaSummaryDefines.h
@@ -35,11 +35,10 @@ enum class HorizontalAxisType
     SUMMARY_VECTOR
 };
 
-enum class SummaryCurveType
+enum class SummaryCurveTypeMode
 {
     AUTO,
-    ACCUMULATED,
-    RATE
+    CUSTOM
 };
 
 QString summaryField();

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
@@ -233,6 +233,10 @@ std::pair<std::vector<time_t>, std::vector<double>> RiaSummaryTools::resampledVa
                                                                                                const std::vector<double>&      values,
                                                                                                RiaDefines::DateTimePeriod      period )
 {
+    // NB! The curve type can be overridden by the user, so there might be a discrepancy between the curve type and the curve type derived
+    // from the address
+    // See RimSummaryCurve::curveType()
+
     return resampledValuesForPeriod( RiaSummaryTools::identifyCurveType( address ), timeSteps, values, period );
 }
 

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
@@ -175,7 +175,7 @@ RimSummaryTableCollection* RiaSummaryTools::parentSummaryTableCollection( caf::P
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RiaSummaryTools::hasAccumulatedData( const RifEclipseSummaryAddress& address )
+RifEclipseSummaryAddressDefines::CurveType RiaSummaryTools::identifyCurveType( const RifEclipseSummaryAddress& address )
 {
     if ( address.isCalculated() )
     {
@@ -187,15 +187,16 @@ bool RiaSummaryTools::hasAccumulatedData( const RifEclipseSummaryAddress& addres
         {
             if ( !variableAddress.hasAccumulatedData() )
             {
-                return false;
+                return RifEclipseSummaryAddressDefines::CurveType::RATE;
             }
         }
 
         // All the variables are accumulated
-        return true;
+        return RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED;
     }
 
-    return address.hasAccumulatedData();
+    return address.hasAccumulatedData() ? RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED
+                                        : RifEclipseSummaryAddressDefines::CurveType::RATE;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -232,10 +233,22 @@ std::pair<std::vector<time_t>, std::vector<double>> RiaSummaryTools::resampledVa
                                                                                                const std::vector<double>&      values,
                                                                                                RiaDefines::DateTimePeriod      period )
 {
+    return resampledValuesForPeriod( RiaSummaryTools::identifyCurveType( address ), timeSteps, values, period );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::pair<std::vector<time_t>, std::vector<double>>
+    RiaSummaryTools::resampledValuesForPeriod( RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate,
+                                               const std::vector<time_t>&                             timeSteps,
+                                               const std::vector<double>&                             values,
+                                               RiaDefines::DateTimePeriod                             period )
+{
     RiaTimeHistoryCurveResampler resampler;
     resampler.setCurveData( values, timeSteps );
 
-    if ( RiaSummaryTools::hasAccumulatedData( address ) )
+    if ( accumulatedOrRate == CurveType::ACCUMULATED )
     {
         resampler.resampleAndComputePeriodEndValues( period );
     }

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.cpp
@@ -241,9 +241,9 @@ std::pair<std::vector<time_t>, std::vector<double>> RiaSummaryTools::resampledVa
 //--------------------------------------------------------------------------------------------------
 std::pair<std::vector<time_t>, std::vector<double>>
     RiaSummaryTools::resampledValuesForPeriod( RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate,
-                                               const std::vector<time_t>&                             timeSteps,
-                                               const std::vector<double>&                             values,
-                                               RiaDefines::DateTimePeriod                             period )
+                                               const std::vector<time_t>&                 timeSteps,
+                                               const std::vector<double>&                 values,
+                                               RiaDefines::DateTimePeriod                 period )
 {
     RiaTimeHistoryCurveResampler resampler;
     resampler.setCurveData( values, timeSteps );

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "RiaDateTimeDefines.h"
+#include "RifEclipseSummaryAddressDefines.h"
 #include "RimObservedDataCollection.h"
 
 #include <QString>
@@ -66,15 +67,21 @@ public:
     static RimSummaryTable*           parentSummaryTable( caf::PdmObject* object );
     static RimSummaryTableCollection* parentSummaryTableCollection( caf::PdmObject* object );
 
-    static bool hasAccumulatedData( const RifEclipseSummaryAddress& address );
-    static void getSummaryCasesAndAddressesForCalculation( int                                    id,
-                                                           std::vector<RimSummaryCase*>&          cases,
-                                                           std::vector<RifEclipseSummaryAddress>& addresses );
+    static RifEclipseSummaryAddressDefines::CurveType             identifyCurveType( const RifEclipseSummaryAddress& address );
+    static void                                                   getSummaryCasesAndAddressesForCalculation( int                                    id,
+                                                                                                             std::vector<RimSummaryCase*>&          cases,
+                                                                                                             std::vector<RifEclipseSummaryAddress>& addresses );
 
     static std::pair<std::vector<time_t>, std::vector<double>> resampledValuesForPeriod( const RifEclipseSummaryAddress& address,
                                                                                          const std::vector<time_t>&      timeSteps,
                                                                                          const std::vector<double>&      values,
                                                                                          RiaDefines::DateTimePeriod      period );
+
+    static std::pair<std::vector<time_t>, std::vector<double>>
+        resampledValuesForPeriod( RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate,
+                                  const std::vector<time_t>&                             timeSteps,
+                                  const std::vector<double>&                             values,
+                                  RiaDefines::DateTimePeriod                             period );
 
     static RimSummaryCase*     summaryCaseById( int caseId );
     static RimSummaryEnsemble* ensembleById( int ensembleId );

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
@@ -67,10 +67,10 @@ public:
     static RimSummaryTable*           parentSummaryTable( caf::PdmObject* object );
     static RimSummaryTableCollection* parentSummaryTableCollection( caf::PdmObject* object );
 
-    static RifEclipseSummaryAddressDefines::CurveType             identifyCurveType( const RifEclipseSummaryAddress& address );
-    static void                                                   getSummaryCasesAndAddressesForCalculation( int                                    id,
-                                                                                                             std::vector<RimSummaryCase*>&          cases,
-                                                                                                             std::vector<RifEclipseSummaryAddress>& addresses );
+    static RifEclipseSummaryAddressDefines::CurveType identifyCurveType( const RifEclipseSummaryAddress& address );
+    static void                                       getSummaryCasesAndAddressesForCalculation( int                                    id,
+                                                                                                 std::vector<RimSummaryCase*>&          cases,
+                                                                                                 std::vector<RifEclipseSummaryAddress>& addresses );
 
     static std::pair<std::vector<time_t>, std::vector<double>> resampledValuesForPeriod( const RifEclipseSummaryAddress& address,
                                                                                          const std::vector<time_t>&      timeSteps,
@@ -79,9 +79,9 @@ public:
 
     static std::pair<std::vector<time_t>, std::vector<double>>
         resampledValuesForPeriod( RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate,
-                                  const std::vector<time_t>&                             timeSteps,
-                                  const std::vector<double>&                             values,
-                                  RiaDefines::DateTimePeriod                             period );
+                                  const std::vector<time_t>&                 timeSteps,
+                                  const std::vector<double>&                 values,
+                                  RiaDefines::DateTimePeriod                 period );
 
     static RimSummaryCase*     summaryCaseById( int caseId );
     static RimSummaryEnsemble* ensembleById( int ensembleId );

--- a/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaSummaryTools.h
@@ -19,7 +19,9 @@
 #pragma once
 
 #include "RiaDateTimeDefines.h"
+
 #include "RifEclipseSummaryAddressDefines.h"
+
 #include "RimObservedDataCollection.h"
 
 #include <QString>

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryAddressDefines.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryAddressDefines.cpp
@@ -33,6 +33,14 @@ void caf::AppEnum<RifEclipseSummaryAddressDefines::StatisticsType>::setUp()
     setDefault( RifEclipseSummaryAddressDefines::StatisticsType::NONE );
 }
 
+template <>
+void caf::AppEnum<RifEclipseSummaryAddressDefines::CurveType>::setUp()
+{
+    addItem( RifEclipseSummaryAddressDefines::CurveType::RATE, "RATE", "Rate" );
+    addItem( RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED, "ACCUMULATED", "Accumulated" );
+    setDefault( RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED );
+}
+
 } // namespace caf
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryAddressDefines.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryAddressDefines.cpp
@@ -32,6 +32,7 @@ void caf::AppEnum<RifEclipseSummaryAddressDefines::StatisticsType>::setUp()
     addItem( RifEclipseSummaryAddressDefines::StatisticsType::MEAN, "MEAN", "Mean" );
     setDefault( RifEclipseSummaryAddressDefines::StatisticsType::NONE );
 }
+
 } // namespace caf
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryAddressDefines.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryAddressDefines.h
@@ -73,6 +73,12 @@ enum class StatisticsType
     MEAN
 };
 
+enum class CurveType
+{
+    ACCUMULATED,
+    RATE
+};
+
 std::string statisticsNameP10();
 std::string statisticsNameP50();
 std::string statisticsNameP90();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -925,7 +925,7 @@ void RimSummaryCurve::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
         curveDataGroup->add( &m_yPushButtonSelectSummaryAddress, { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
         curveDataGroup->add( &m_yPlotAxisProperties, { .newRow = true, .totalColumnSpan = 3, .leftLabelColumnSpan = 1 } );
 
-        caf::PdmUiGroup* detailGroup = curveDataGroup->addNewGroup( "Advanced" );
+        caf::PdmUiGroup* detailGroup = curveDataGroup->addNewGroup( "Advanced Curve Properties" );
         detailGroup->setCollapsedByDefault();
         detailGroup->add( &m_yValuesResampling, { .newRow = true, .totalColumnSpan = 3, .leftLabelColumnSpan = 1 } );
         detailGroup->add( &m_showErrorBars );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -1422,8 +1422,9 @@ void RimSummaryCurve::calculateCurveInterpolationFromAddress()
 {
     if ( !m_yValuesSummaryAddress() ) return;
 
-    auto address = m_yValuesSummaryAddress()->address();
-    if ( RiaSummaryTools::identifyCurveType( address ) == RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED )
+    calculateCurveTypeFromAddress();
+
+    if ( curveType() == RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED )
     {
         m_curveAppearance->setInterpolation( RiuQwtPlotCurveDefines::CurveInterpolationEnum::INTERPOLATION_POINT_TO_POINT );
     }
@@ -1431,8 +1432,6 @@ void RimSummaryCurve::calculateCurveInterpolationFromAddress()
     {
         m_curveAppearance->setInterpolation( RiuQwtPlotCurveDefines::CurveInterpolationEnum::INTERPOLATION_STEP_LEFT );
     }
-
-    calculateCurveTypeFromAddress();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -1374,36 +1374,6 @@ RifSummaryReaderInterface* RimSummaryCurve::valuesSummaryReaderY() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RimSummaryCurve::accumulatedOrRateText() const
-{
-    QString text;
-
-    /*
-        if ( m_yAccumulatedOrRate() == RiaDefines::SummaryCurveType::AUTO )
-        {
-            text = "Auto : ";
-        }
-        else
-        {
-            text = "User Defined : ";
-        }
-
-        if ( accumulatedOrRate() == RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED )
-        {
-            text += "Accumulated";
-        }
-        else
-        {
-            text += "Rate";
-        }
-    */
-
-    return text;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 std::vector<time_t> RimSummaryCurve::timeStepsX() const
 {
     RifSummaryReaderInterface* reader = valuesSummaryReaderX();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.h
@@ -35,7 +35,6 @@
 #include "RimStackablePlotCurve.h"
 
 #include "cafAppEnum.h"
-#include "cafPdmProxyValueField.h"
 #include "cafTristate.h"
 
 class RifSummaryReaderInterface;
@@ -79,7 +78,7 @@ public:
     double                      yValueAtTimeT( time_t time ) const;
     void                        setOverrideCurveDataY( const std::vector<time_t>& xValues, const std::vector<double>& yValues );
 
-    RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate() const;
+    RifEclipseSummaryAddressDefines::CurveType curveType() const;
 
     // X Axis functions
     void                           setAxisTypeX( RiaDefines::HorizontalAxisType axisType );
@@ -147,6 +146,7 @@ private:
     QString accumulatedOrRateText() const;
 
     void calculateCurveInterpolationFromAddress();
+    void calculateCurveTypeFromAddress();
 
     static void appendOptionItemsForSummaryAddresses( QList<caf::PdmOptionItemInfo>* options, RimSummaryCase* summaryCase );
 
@@ -159,8 +159,8 @@ private:
     caf::PdmPtrField<RimPlotAxisPropertiesInterface*> m_yPlotAxisProperties;
     caf::PdmField<RiaDefines::DateTimePeriodEnum>     m_yValuesResampling;
 
-    caf::PdmField<caf::AppEnum<RiaDefines::SummaryCurveType>> m_yAccumulatedOrRate;
-    caf::PdmProxyValueField<QString>                          m_yAccumulatedOrRateText;
+    caf::PdmField<caf::AppEnum<RiaDefines::SummaryCurveTypeMode>>           m_yCurveTypeMode;
+    caf::PdmField<caf::AppEnum<RifEclipseSummaryAddressDefines::CurveType>> m_yCurveType;
 
     // X values
     caf::PdmField<caf::AppEnum<RiaDefines::HorizontalAxisType>> m_xAxisType;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.h
@@ -29,10 +29,13 @@
 #include "RiaSummaryCurveAddress.h"
 #include "RiaSummaryDefines.h"
 
+#include "RifEclipseSummaryAddressDefines.h"
 #include "RifEclipseSummaryAddressQMetaType.h"
+
 #include "RimStackablePlotCurve.h"
 
 #include "cafAppEnum.h"
+#include "cafPdmProxyValueField.h"
 #include "cafTristate.h"
 
 class RifSummaryReaderInterface;
@@ -75,6 +78,8 @@ public:
     virtual std::vector<time_t> timeStepsY() const;
     double                      yValueAtTimeT( time_t time ) const;
     void                        setOverrideCurveDataY( const std::vector<time_t>& xValues, const std::vector<double>& yValues );
+
+    RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate() const;
 
     // X Axis functions
     void                           setAxisTypeX( RiaDefines::HorizontalAxisType axisType );
@@ -139,6 +144,8 @@ private:
     RifSummaryReaderInterface* valuesSummaryReaderX() const;
     RifSummaryReaderInterface* valuesSummaryReaderY() const;
 
+    QString accumulatedOrRateText() const;
+
     void calculateCurveInterpolationFromAddress();
 
     static void appendOptionItemsForSummaryAddresses( QList<caf::PdmOptionItemInfo>* options, RimSummaryCase* summaryCase );
@@ -151,6 +158,9 @@ private:
     caf::PdmField<bool>                               m_yPushButtonSelectSummaryAddress;
     caf::PdmPtrField<RimPlotAxisPropertiesInterface*> m_yPlotAxisProperties;
     caf::PdmField<RiaDefines::DateTimePeriodEnum>     m_yValuesResampling;
+
+    caf::PdmField<caf::AppEnum<RiaDefines::SummaryCurveType>> m_yAccumulatedOrRate;
+    caf::PdmProxyValueField<QString>                          m_yAccumulatedOrRateText;
 
     // X values
     caf::PdmField<caf::AppEnum<RiaDefines::HorizontalAxisType>> m_xAxisType;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.h
@@ -143,8 +143,6 @@ private:
     RifSummaryReaderInterface* valuesSummaryReaderX() const;
     RifSummaryReaderInterface* valuesSummaryReaderY() const;
 
-    QString accumulatedOrRateText() const;
-
     void calculateCurveInterpolationFromAddress();
     void calculateCurveTypeFromAddress();
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
@@ -49,7 +49,9 @@ void RimSummaryCurvesData::populateTimeHistoryCurvesData( std::vector<RimGridTim
         if ( !curve->isChecked() ) continue;
         QString curveCaseName = curve->caseName();
 
-        CurveData curveData = { curve->curveExportDescription( {} ), RifEclipseSummaryAddress(), curve->yValues() };
+        CurveData curveData = { curve->curveExportDescription( {} ),
+                                RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED,
+                                curve->yValues() };
 
         curvesData->addCurveData( curveCaseName, "", curve->timeStepValues(), curveData );
     }
@@ -68,7 +70,9 @@ void RimSummaryCurvesData::populateAsciiDataCurvesData( std::vector<RimAsciiData
     {
         if ( !curve->isChecked() ) continue;
 
-        CurveData curveData = { curve->curveExportDescription( {} ), RifEclipseSummaryAddress(), curve->yValues() };
+        CurveData curveData = { curve->curveExportDescription( {} ),
+                                RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED,
+                                curve->yValues() };
 
         curvesData->addCurveDataNoSearch( "", "", curve->timeSteps(), { curveData } );
     }
@@ -145,30 +149,25 @@ QString RimSummaryCurvesData::createTextForExport( const std::vector<RimSummaryC
 
     QString out;
 
-    RimSummaryCurvesData summaryCurvesGridData;
+    RimSummaryCurvesData summaryCurvesData;
     RimSummaryCurvesData summaryCurvesObsData;
-    RimSummaryCurvesData::populateSummaryCurvesData( curves, SummaryCurveType::CURVE_TYPE_GRID, &summaryCurvesGridData );
+    RimSummaryCurvesData gridCurvesData;
+    RimSummaryCurvesData::populateSummaryCurvesData( curves, SummaryCurveType::CURVE_TYPE_SUMMARY, &summaryCurvesData );
     RimSummaryCurvesData::populateSummaryCurvesData( curves, SummaryCurveType::CURVE_TYPE_OBSERVED, &summaryCurvesObsData );
+    RimSummaryCurvesData::populateTimeHistoryCurvesData( gridCurves, &gridCurvesData );
 
-    RimSummaryCurvesData timeHistoryCurvesData;
-    RimSummaryCurvesData::populateTimeHistoryCurvesData( gridCurves, &timeHistoryCurvesData );
-
-    // Export observed data
     RimSummaryCurvesData::appendToExportData( out, { summaryCurvesObsData }, showTimeAsLongString );
 
     std::vector<RimSummaryCurvesData> exportData( 2 );
 
-    // Summary grid data for export
-    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, ResampleAlgorithm::DATA_DECIDES, summaryCurvesGridData, &exportData[0] );
+    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, ResampleAlgorithm::DATA_DECIDES, summaryCurvesData, &exportData[0] );
+    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, ResampleAlgorithm::PERIOD_END, gridCurvesData, &exportData[1] );
 
-    // Time history data for export
-    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, ResampleAlgorithm::PERIOD_END, timeHistoryCurvesData, &exportData[1] );
-
-    // Export resampled summary and time history data
     RimSummaryCurvesData::appendToExportData( out, exportData, showTimeAsLongString );
 
-    // Pasted observed data
     {
+        // Handle observed data pasted into plot from clipboard
+
         RimSummaryCurvesData asciiCurvesData;
         RimSummaryCurvesData::populateAsciiDataCurvesData( asciiCurves, &asciiCurvesData );
 
@@ -239,7 +238,7 @@ void RimSummaryCurvesData::populateSummaryCurvesData( std::vector<RimSummaryCurv
 
         if ( !curve->isChecked() ) continue;
         if ( isObservedCurve && ( curveType != SummaryCurveType::CURVE_TYPE_OBSERVED ) ) continue;
-        if ( !isObservedCurve && ( curveType != SummaryCurveType::CURVE_TYPE_GRID ) ) continue;
+        if ( !isObservedCurve && ( curveType != SummaryCurveType::CURVE_TYPE_SUMMARY ) ) continue;
         if ( !curve->summaryCaseY() ) continue;
 
         QString curveCaseName = curve->summaryCaseY()->displayCaseName();
@@ -249,7 +248,7 @@ void RimSummaryCurvesData::populateSummaryCurvesData( std::vector<RimSummaryCurv
             ensembleName = curve->curveDefinition().ensemble()->name();
         }
 
-        CurveData curveData = { curve->curveExportDescription( {} ), curve->summaryAddressY(), curve->valuesY() };
+        CurveData curveData = { curve->curveExportDescription( {} ), curve->accumulatedOrRate(), curve->valuesY() };
         CurveData errorCurveData;
 
         // Error data
@@ -258,9 +257,9 @@ void RimSummaryCurvesData::populateSummaryCurvesData( std::vector<RimSummaryCurv
 
         if ( hasErrorData )
         {
-            errorCurveData.name    = curve->curveExportDescription( curve->errorSummaryAddressY() );
-            errorCurveData.address = curve->errorSummaryAddressY();
-            errorCurveData.values  = errorValues;
+            errorCurveData.name              = curve->curveExportDescription( curve->errorSummaryAddressY() );
+            errorCurveData.accumulatedOrRate = curve->accumulatedOrRate();
+            errorCurveData.values            = errorValues;
         }
 
         auto curveDataList = std::vector<CurveData>( { curveData } );
@@ -307,7 +306,7 @@ void RimSummaryCurvesData::prepareCaseCurvesForExport( RiaDefines::DateTimePerio
             for ( auto& curveDataItem : caseCurveData )
             {
                 const auto [resampledTime, resampledValues] =
-                    RiaSummaryTools::resampledValuesForPeriod( curveDataItem.address, caseTimeSteps, curveDataItem.values, period );
+                    RiaSummaryTools::resampledValuesForPeriod( curveDataItem.accumulatedOrRate, caseTimeSteps, curveDataItem.values, period );
 
                 auto cd   = curveDataItem;
                 cd.values = resampledValues;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
@@ -244,7 +244,7 @@ void RimSummaryCurvesData::populateSummaryCurvesData( std::vector<RimSummaryCurv
             ensembleName = curve->curveDefinition().ensemble()->name();
         }
 
-        CurveData curveData = { curve->curveExportDescription( {} ), curve->accumulatedOrRate(), curve->valuesY() };
+        CurveData curveData = { curve->curveExportDescription( {} ), curve->curveType(), curve->valuesY() };
         CurveData errorCurveData;
 
         // Error data
@@ -253,9 +253,9 @@ void RimSummaryCurvesData::populateSummaryCurvesData( std::vector<RimSummaryCurv
 
         if ( hasErrorData )
         {
-            errorCurveData.name              = curve->curveExportDescription( curve->errorSummaryAddressY() );
-            errorCurveData.accumulatedOrRate = curve->accumulatedOrRate();
-            errorCurveData.values            = errorValues;
+            errorCurveData.name      = curve->curveExportDescription( curve->errorSummaryAddressY() );
+            errorCurveData.curveType = curve->curveType();
+            errorCurveData.values    = errorValues;
         }
 
         auto curveDataList = std::vector<CurveData>( { curveData } );
@@ -302,7 +302,7 @@ void RimSummaryCurvesData::prepareCaseCurvesForExport( RiaDefines::DateTimePerio
             for ( auto& curveDataItem : caseCurveData )
             {
                 const auto [resampledTime, resampledValues] =
-                    RiaSummaryTools::resampledValuesForPeriod( curveDataItem.accumulatedOrRate, caseTimeSteps, curveDataItem.values, period );
+                    RiaSummaryTools::resampledValuesForPeriod( curveDataItem.curveType, caseTimeSteps, curveDataItem.values, period );
 
                 auto cd   = curveDataItem;
                 cd.values = resampledValues;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
@@ -49,9 +49,7 @@ void RimSummaryCurvesData::populateTimeHistoryCurvesData( std::vector<RimGridTim
         if ( !curve->isChecked() ) continue;
         QString curveCaseName = curve->caseName();
 
-        CurveData curveData = { curve->curveExportDescription( {} ),
-                                RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED,
-                                curve->yValues() };
+        CurveData curveData = { curve->curveExportDescription( {} ), RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED, curve->yValues() };
 
         curvesData->addCurveData( curveCaseName, "", curve->timeStepValues(), curveData );
     }
@@ -70,9 +68,7 @@ void RimSummaryCurvesData::populateAsciiDataCurvesData( std::vector<RimAsciiData
     {
         if ( !curve->isChecked() ) continue;
 
-        CurveData curveData = { curve->curveExportDescription( {} ),
-                                RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED,
-                                curve->yValues() };
+        CurveData curveData = { curve->curveExportDescription( {} ), RifEclipseSummaryAddressDefines::CurveType::ACCUMULATED, curve->yValues() };
 
         curvesData->addCurveDataNoSearch( "", "", curve->timeSteps(), { curveData } );
     }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.h
@@ -29,14 +29,14 @@ class RimAsciiDataCurve;
 
 struct CurveData
 {
-    QString                  name;
-    RifEclipseSummaryAddress address;
-    std::vector<double>      values;
+    QString                                    name;
+    RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate;
+    std::vector<double>                        values;
 };
 
 enum class SummaryCurveType
 {
-    CURVE_TYPE_GRID     = 0x1,
+    CURVE_TYPE_SUMMARY  = 0x1,
     CURVE_TYPE_OBSERVED = 0x2
 };
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.h
@@ -30,7 +30,7 @@ class RimAsciiDataCurve;
 struct CurveData
 {
     QString                                    name;
-    RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate;
+    RifEclipseSummaryAddressDefines::CurveType curveType;
     std::vector<double>                        values;
 };
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.cpp
@@ -86,11 +86,7 @@ std::vector<double> RimSummaryDeclineCurve::valuesY() const
 {
     auto [minTimeStep, maxTimeStep] = selectedTimeStepRange();
 
-    return createDeclineCurveValues( RimSummaryCurve::valuesY(),
-                                     RimSummaryCurve::timeStepsY(),
-                                     minTimeStep,
-                                     maxTimeStep,
-                                     RiaSummaryTools::identifyCurveType( summaryAddressY() ) );
+    return createDeclineCurveValues( RimSummaryCurve::valuesY(), RimSummaryCurve::timeStepsY(), minTimeStep, maxTimeStep, curveType() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -100,11 +96,7 @@ std::vector<double> RimSummaryDeclineCurve::valuesX() const
 {
     auto [minTimeStep, maxTimeStep] = selectedTimeStepRange();
 
-    return createDeclineCurveValues( RimSummaryCurve::valuesX(),
-                                     RimSummaryCurve::timeStepsX(),
-                                     minTimeStep,
-                                     maxTimeStep,
-                                     RiaSummaryTools::identifyCurveType( summaryAddressX() ) );
+    return createDeclineCurveValues( RimSummaryCurve::valuesX(), RimSummaryCurve::timeStepsX(), minTimeStep, maxTimeStep, curveType() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
@@ -72,11 +72,11 @@ private:
 
     void appendFutureTimeSteps( std::vector<time_t>& timeSteps ) const;
 
-    std::vector<double> createDeclineCurveValues( const std::vector<double>& values,
-                                                  const std::vector<time_t>& timeSteps,
-                                                  time_t                     minTimeStep,
-                                                  time_t                     maxTimeStep,
-                                                  bool                       isAccumulatedResult ) const;
+    std::vector<double> createDeclineCurveValues( const std::vector<double>&                 values,
+                                                  const std::vector<time_t>&                 timeSteps,
+                                                  time_t                                     minTimeStep,
+                                                  time_t                                     maxTimeStep,
+                                                  RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate ) const;
 
     static std::pair<std::vector<time_t>, std::vector<double>>
         getInRangeValues( const std::vector<time_t>& timeSteps, const std::vector<double>& values, time_t minTimeStep, time_t maxTimeStep );
@@ -85,11 +85,14 @@ private:
     std::set<QDateTime> createFutureTimeSteps( const std::vector<time_t>& timeSteps ) const;
     static void         appendTimeSteps( std::vector<time_t>& timeSteps, const std::set<QDateTime>& moreTimeSteps );
 
-    static std::pair<double, double> computeInitialProductionAndDeclineRate( const std::vector<double>& values,
-                                                                             const std::vector<time_t>& timeSteps,
-                                                                             bool                       isAccumulatedResult );
+    static std::pair<double, double> computeInitialProductionAndDeclineRate( const std::vector<double>&                 values,
+                                                                             const std::vector<time_t>&                 timeSteps,
+                                                                             RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate );
 
-    double computePredictedValue( double initialProductionRate, double initialDeclineRate, double timeSinceStart, bool isAccumulatedResult ) const;
+    double computePredictedValue( double                                     initialProductionRate,
+                                  double                                     initialDeclineRate,
+                                  double                                     timeSinceStart,
+                                  RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate ) const;
 
     std::pair<time_t, time_t> fullTimeStepRange() const;
     std::pair<time_t, time_t> selectedTimeStepRange() const;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryDeclineCurve.h
@@ -76,7 +76,7 @@ private:
                                                   const std::vector<time_t>&                 timeSteps,
                                                   time_t                                     minTimeStep,
                                                   time_t                                     maxTimeStep,
-                                                  RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate ) const;
+                                                  RifEclipseSummaryAddressDefines::CurveType curveType ) const;
 
     static std::pair<std::vector<time_t>, std::vector<double>>
         getInRangeValues( const std::vector<time_t>& timeSteps, const std::vector<double>& values, time_t minTimeStep, time_t maxTimeStep );
@@ -87,12 +87,12 @@ private:
 
     static std::pair<double, double> computeInitialProductionAndDeclineRate( const std::vector<double>&                 values,
                                                                              const std::vector<time_t>&                 timeSteps,
-                                                                             RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate );
+                                                                             RifEclipseSummaryAddressDefines::CurveType curveType );
 
     double computePredictedValue( double                                     initialProductionRate,
                                   double                                     initialDeclineRate,
                                   double                                     timeSinceStart,
-                                  RifEclipseSummaryAddressDefines::CurveType accumulatedOrRate ) const;
+                                  RifEclipseSummaryAddressDefines::CurveType curveType ) const;
 
     std::pair<time_t, time_t> fullTimeStepRange() const;
     std::pair<time_t, time_t> selectedTimeStepRange() const;


### PR DESCRIPTION
When resampling a rate curve, the last time period with no data is not affecting the computed range.

Allow user to set Accumulated or Rate for a summary curve. Default value is Auto, and Accumulated/Rate is derived from the summary address.