### PR TITLE
Improve robustness when importing incomplete project file

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.cpp
+++ b/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlotDataEntry.cpp
@@ -80,11 +80,12 @@ RiaSummaryCurveDefinition RimAnalysisPlotDataEntry::curveDefinition() const
     {
         return RiaSummaryCurveDefinition( m_summaryCase(), m_summaryAddress->address(), m_isEnsembleCurve );
     }
-    else
+    else if ( m_ensemble() )
     {
-        CAF_ASSERT( m_ensemble() );
         return RiaSummaryCurveDefinition( m_ensemble(), m_summaryAddress->address() );
     }
+
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Avoid assert, and return empty curve definition if both summary case and ensemble is undefined.
