### PR TITLE
Qt6: update to changed name of QButtonGroup signal.

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
@@ -150,7 +150,7 @@ RiuRelativePermeabilityPlotPanel::RiuRelativePermeabilityPlotPanel( QWidget* par
 
     setLayout( mainLayout );
 
-    connect( m_selectedCurvesButtonGroup, SIGNAL( buttonClicked( int ) ), SLOT( slotButtonInButtonGroupClicked( int ) ) );
+    connect( m_selectedCurvesButtonGroup, SIGNAL( idClicked( int ) ), SLOT( slotButtonInButtonGroupClicked( int ) ) );
     connect( m_logarithmicScaleKrAxisCheckBox, SIGNAL( stateChanged( int ) ), SLOT( slotSomeCheckBoxStateChanged( int ) ) );
     connect( m_showUnscaledCheckBox, SIGNAL( stateChanged( int ) ), SLOT( slotSomeCheckBoxStateChanged( int ) ) );
     connect( m_fixedXAxisCheckBox, SIGNAL( stateChanged( int ) ), SLOT( slotSomeCheckBoxStateChanged( int ) ) );


### PR DESCRIPTION
Changed names from buttonClicked to idClicked.