### PR TITLE
Python: Add pinning to be compatible with ortools

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r GrpcInterface/Python/dev-requirements.txt
+          pip install -r GrpcInterface/Python/build-requirements.txt
 
       - name: Use CMake
         uses: lukka/get-cmake@latest

--- a/GrpcInterface/Python/build-requirements.txt
+++ b/GrpcInterface/Python/build-requirements.txt
@@ -1,0 +1,8 @@
+grpcio
+grpcio-tools<1.64 # to make sure we use libprotoc 26.1, to display version info use 'python -m grpc_tools.protoc --version'
+protobuf>=5.26.1,<5.27 # use same requirements as ortools https://github.com/google/or-tools/blob/stable/ortools/python/setup.py.in
+wheel
+typing-extensions
+pytest
+setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+packaging>=22.0 # https://github.com/pypa/setuptools/issues/4483

--- a/GrpcInterface/Python/setup.py.cmake
+++ b/GrpcInterface/Python/setup.py.cmake
@@ -6,7 +6,7 @@ with open('README.md') as f:
 with open('LICENSE') as f:
     license = f.read()
 
-RIPS_DIST_VERSION = '2'
+RIPS_DIST_VERSION = '3'
 	
 setup(
     name='rips',
@@ -19,6 +19,6 @@ setup(
     license=license,
     packages=['rips'],
     package_data={'rips': ['py.typed', '*.py', 'generated/*.py', 'PythonExamples/*.py', 'tests/*.py']},
-    install_requires=['grpcio', 'protobuf', 'wheel'],
+    install_requires=['grpcio', 'protobuf', 'wheel', 'typing_extensions'],
     python_requires='>=3.8',
 )


### PR DESCRIPTION
Closes #11772

`ortools` will be installed in the same environment as `rips.` Use same pinning to make sure compability between `rips` and `ortool.`

The main point is to make sure we do not use `libprotoc` 27 or newer, as this causes issues when importing the `rips` module.

https://developers.google.com/optimization
