### PR TITLE
Use type definition from ClipperLib to avoid overflow

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigCellGeometryTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCellGeometryTools.cpp
@@ -407,9 +407,10 @@ double clipperConversionFactor = 10000; // For transform to clipper int
 
 ClipperLib::IntPoint toClipperPoint( const cvf::Vec3d& cvfPoint )
 {
-    int xInt = cvfPoint.x() * clipperConversionFactor;
-    int yInt = cvfPoint.y() * clipperConversionFactor;
-    int zInt = cvfPoint.z() * clipperConversionFactor;
+    ClipperLib::cInt xInt = cvfPoint.x() * clipperConversionFactor;
+    ClipperLib::cInt yInt = cvfPoint.y() * clipperConversionFactor;
+    ClipperLib::cInt zInt = cvfPoint.z() * clipperConversionFactor;
+
     return ClipperLib::IntPoint( xInt, yInt, zInt );
 }
 

--- a/ApplicationLibCode/UnitTests/RigCellGeometryTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigCellGeometryTools-Test.cpp
@@ -566,9 +566,9 @@ double clipperConversionFactor2 = 10000; // For transform to clipper int
 
 ClipperLib::IntPoint toClipperEdgePoint( const cvf::Vec3d& cvfPoint )
 {
-    int xInt = cvfPoint.x() * clipperConversionFactor2;
-    int yInt = cvfPoint.y() * clipperConversionFactor2;
-    int zInt = cvfPoint.z();
+    ClipperLib::cInt xInt = cvfPoint.x() * clipperConversionFactor2;
+    ClipperLib::cInt yInt = cvfPoint.y() * clipperConversionFactor2;
+    ClipperLib::cInt zInt = cvfPoint.z();
     return ClipperLib::IntPoint( xInt, yInt, zInt );
 }
 


### PR DESCRIPTION
When converting a cvf::Vec3d to an integer vector, the platform int type was used as an intermediate variable. This caused overflow for large double values.

Closes #11798
Closes #11243