### PR TITLE
fixed: build against QT 6.8

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp
@@ -209,7 +209,9 @@ bool RiaTextStringTools::isNumber( const QString& text, const QString& decimalPo
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+#if QT_VERSION < QT_VERSION_CHECK( 6, 8, 0 )
 std::strong_ordering operator<=>( const QString& lhs, const QString& rhs )
 {
     return lhs.compare( rhs ) <=> 0;
 }
+#endif

--- a/ApplicationLibCode/Application/Tools/RiaTextStringTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaTextStringTools.h
@@ -21,6 +21,7 @@
 #include <QRegularExpression>
 #include <QString>
 #include <QStringList>
+#include <QtGlobal>
 
 #include <map>
 
@@ -47,6 +48,7 @@ bool    isNumber( const QString& text, const QString& decimalPoint );
 
 } // namespace RiaTextStringTools
 
+#if QT_VERSION < QT_VERSION_CHECK( 6, 8, 0 )
 //--------------------------------------------------------------------------------------------------
 //
 // Add operator<=> for QString to global scope
@@ -60,3 +62,4 @@ bool    isNumber( const QString& text, const QString& decimalPoint );
 //
 //--------------------------------------------------------------------------------------------------
 std::strong_ordering operator<=>( const QString& lhs, const QString& rhs );
+#endif


### PR DESCRIPTION
```
/home/akva/kode/opm/ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:212:22: error: redefinition of ‘std::strong_ordering operator<=>(const QString&, const QString&)’
  212 | std::strong_ordering operator<=>( const QString& lhs, const QString& rhs )
      |                      ^~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/qglobal.h:63,
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/qregularexpression.h:9,
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/QRegularExpression:1,
                 from /home/akva/kode/opm/ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.h:21,
                 from /home/akva/kode/opm/ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:19:
/usr/include/x86_64-linux-gnu/qt6/QtCore/qstring.h:777:5: note: ‘std::strong_ordering operator<=>(const QString&, const QString&)’ previously defined here
  777 |     Q_DECLARE_STRONGLY_ORDERED(QString)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
[1192/2818] Building CXX object ApplicationLibCode/CMakeFiles/ApplicationLibCode.dir/Application/RiaPreferences.cpp.o
ninja: build stopped: subcommand failed.
```

I'm not entirely sure this was introduced in 6.8 but something like this is needed.