### PR TITLE
Fix curve highlight for non-ensemble curves

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsembleTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsembleTools.cpp
@@ -338,6 +338,17 @@ size_t RimSummaryEnsembleTools::calculateEnsembleParametersIntersectionHash( con
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RimSummaryEnsembleTools::isEnsembleCurve( RimPlotCurve* sourceCurve )
+{
+    auto summaryCurve = dynamic_cast<RimSummaryCurve*>( sourceCurve );
+    if ( !summaryCurve ) return false;
+
+    return summaryCurve->isEnsembleCurve();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimSummaryEnsembleTools::highlightCurvesForSameRealization( RimPlotCurve* sourceCurve )
 {
     auto sourceSummaryCurve = dynamic_cast<RimSummaryCurve*>( sourceCurve );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsembleTools.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsembleTools.h
@@ -38,6 +38,7 @@ std::vector<RigEnsembleParameter> createVariationSortedEnsembleParameters( const
 
 size_t calculateEnsembleParametersIntersectionHash( const std::vector<RimSummaryCase*>& summaryCases );
 
+bool isEnsembleCurve( RimPlotCurve* sourceCurve );
 void highlightCurvesForSameRealization( RimPlotCurve* sourceCurve );
 void resetHighlightAllPlots();
 

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
@@ -935,9 +935,19 @@ void RiuQwtPlotWidget::selectClosestPlotItem( const QPoint& pos, bool toggleItem
     {
         bool updateCurveOrder = false;
         resetPlotItemHighlighting( updateCurveOrder );
-        if ( auto curve = dynamic_cast<RiuPlotCurve*>( closestItem ) )
+
+        auto curve = dynamic_cast<RiuPlotCurve*>( closestItem );
+        if ( curve && curve->ownerRimCurve() )
         {
-            RimSummaryEnsembleTools::highlightCurvesForSameRealization( curve->ownerRimCurve() );
+            const auto rimCurve = curve->ownerRimCurve();
+            if ( RimSummaryEnsembleTools::isEnsembleCurve( rimCurve ) )
+            {
+                RimSummaryEnsembleTools::highlightCurvesForSameRealization( rimCurve );
+            }
+            else
+            {
+                highlightCurvesUpdateOrder( { rimCurve } );
+            }
         }
         else
         {

--- a/ResInsightVersion.cmake
+++ b/ResInsightVersion.cmake
@@ -5,7 +5,7 @@ set(RESINSIGHT_PATCH_VERSION 0)
 
 # Opional text with no restrictions
 #set(RESINSIGHT_VERSION_TEXT "-dev")
-set(RESINSIGHT_VERSION_TEXT "-RC_1")
+set(RESINSIGHT_VERSION_TEXT "-RC_2")
 
 # Optional text
 # Must be unique and increasing within one combination of major/minor/patch version 


### PR DESCRIPTION
#11771 introduced support for highlighting of curves belonging to the same realization. This change introduced a bug making it impossible to highlight curves for a single summary file.