### PR TITLE
Bump vcpkg

### DIFF
--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -75,38 +75,6 @@ if(RESINSIGHT_ENABLE_GRPC)
        RiaGrpcGuiApplication.h
   )
 
-  # Find Protobuf installation Looks for protobuf-config.cmake file installed by
-  # Protobuf's cmake installation.
-  set(protobuf_MODULE_COMPATIBLE ON)
-  find_package(Protobuf CONFIG 3.0 QUIET)
-
-  if(Protobuf_FOUND)
-    # Find gRPC installation Looks for gRPCConfig.cmake file installed by gRPC's
-    # cmake installation.
-    find_package(gRPC CONFIG REQUIRED)
-    set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
-    set(_GRPC_GRPCPP_UNSECURE gRPC::grpc++_unsecure gRPC::grpc_unsecure
-                              gRPC::gpr
-    )
-    set(GRPC_LINK_LIBRARIES ${_GRPC_GRPCPP_UNSECURE} ${_PROTOBUF_LIBPROTOBUF})
-  else()
-    set(RESINSIGHT_GRPC_INSTALL_PREFIX
-        ""
-        CACHE PATH "gRPC : Install prefix for gRPC"
-    )
-    set(ENV{PKG_CONFIG_PATH} "${RESINSIGHT_GRPC_INSTALL_PREFIX}/lib/pkgconfig")
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(
-      GRPC
-      REQUIRED
-      grpc
-      grpc++_unsecure>=1.20
-      grpc_unsecure
-      gpr
-      protobuf
-      libcares
-    )
-  endif()
 endif()
 
 list(APPEND CPP_SOURCES ${CODE_SOURCE_FILES})

--- a/GrpcInterface/CMakeLists.txt
+++ b/GrpcInterface/CMakeLists.txt
@@ -56,7 +56,7 @@ set(SOURCE_GROUP_SOURCE_FILES
 # Find Protobuf installation Looks for protobuf-config.cmake file installed by
 # Protobuf's cmake installation.
 set(protobuf_MODULE_COMPATIBLE ON)
-find_package(Protobuf CONFIG 3.0 QUIET)
+find_package(Protobuf CONFIG QUIET)
 
 if(Protobuf_FOUND)
   message(STATUS "Using protobuf ${protobuf_VERSION}")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
     "default-registry": {
         "kind": "git",
-        "baseline": "fba75d09065fcc76a25dcf386b1d00d33f5175af",
+        "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
         "repository": "https://github.com/microsoft/vcpkg"
     },
   "registries": [

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,9 +1,9 @@
 {
-  "default-registry": {
-    "kind": "git",
-    "baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
-    "repository": "https://github.com/microsoft/vcpkg"
-  },
+    "default-registry": {
+        "kind": "git",
+        "baseline": "fba75d09065fcc76a25dcf386b1d00d33f5175af",
+        "repository": "https://github.com/microsoft/vcpkg"
+    },
   "registries": [
     {
       "kind": "artifact",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,18 @@
 {
-  "dependencies": [
-    "arrow",
-    "boost-filesystem",
-    "boost-spirit",
-    "eigen3",
-    "grpc",
-    "type-lite",
-    "fast-float",
-    "spdlog"
-  ]
+    "dependencies": [
+        "arrow",
+        "boost-filesystem",
+        "boost-spirit",
+        "eigen3",
+        "grpc",
+        "type-lite",
+        "fast-float",
+        "spdlog"
+    ],
+    "overrides": [
+        {
+            "name": "fmt",
+            "version": "10.1.1"
+        }
+    ]
 }


### PR DESCRIPTION
A `msys` package was removed from the upstream distribution server, causing a new build on a blank system to fail. The issue is not seen if the binary is cached locally by `vcpkg`. To fix this, a newer `vcpkg.exe` was required. When this was done, several other issues appeared.

Baseline for `vcpkg` is now set to `2025.01.11`

- Use `fmt 10.1.1` to avoid compile bug on `MSVC`
- Avoid pinning of `Protobuf`
- Remove obsolete `Protobuf` at top level

## References
https://github.com/apache/arrow/issues/42027
https://github.com/microsoft/vcpkg/issues/42965
https://github.com/microsoft/vcpkg-tool/releases/tag/2025-01-11
