### PR TITLE
GHA: Disable install and use of grpc on GitHub Actions

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -188,7 +188,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Replace and use vcpkg.json without grpc
-        if: matrix.config.build-python-module == 'false' 
+        if: contains( matrix.config.os, 'windows')
         run: |
           cp vcpkg_no_grpc.json vcpkg.json
 

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -45,9 +45,9 @@ jobs:
               os: ubuntu-24.04,
               cc: "gcc",
               cxx: "g++",
-              build-python-module: false,
+              build-python-module: true,
               execute-unit-tests: true,
-              execute-pytests: false,
+              execute-pytests: true,
               unity-build: false,
               publish-to-pypi: true,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
@@ -60,9 +60,9 @@ jobs:
               os: ubuntu-22.04,
               cc: "clang-16",
               cxx: "clang++-16",
-              build-python-module: false,
+              build-python-module: true,
               execute-unit-tests: true,
-              execute-pytests: false,
+              execute-pytests: true,
               unity-build: false,
               publish-to-pypi: false,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
@@ -188,6 +188,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Replace and use vcpkg.json without grpc
+        if: ${{ matrix.config.build-python-module == 'false' }} 
         run: |
           cp vcpkg_no_grpc.json vcpkg.json
 

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -30,9 +30,9 @@ jobs:
               os: windows-2022,
               cc: "cl",
               cxx: "cl",
-              build-python-module: true,
+              build-python-module: false,
               execute-unit-tests: true,
-              execute-pytests: true,
+              execute-pytests: false,
               unity-build: true,
               publish-to-pypi: false,
               vcpkg-bootstrap: bootstrap-vcpkg.bat,
@@ -45,9 +45,9 @@ jobs:
               os: ubuntu-24.04,
               cc: "gcc",
               cxx: "g++",
-              build-python-module: true,
+              build-python-module: false,
               execute-unit-tests: true,
-              execute-pytests: true,
+              execute-pytests: false,
               unity-build: false,
               publish-to-pypi: true,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
@@ -60,7 +60,7 @@ jobs:
               os: ubuntu-22.04,
               cc: "clang-16",
               cxx: "clang++-16",
-              build-python-module: true,
+              build-python-module: false,
               execute-unit-tests: true,
               execute-pytests: false,
               unity-build: false,
@@ -186,6 +186,10 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Replace and use vcpkg.json without grpc
+        run: |
+          cp vcpkg_no_grpc.json vcpkg.json
 
       - name: vcpkg bootstrap
         run: |

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -62,7 +62,7 @@ jobs:
               cxx: "clang++-16",
               build-python-module: true,
               execute-unit-tests: true,
-              execute-pytests: true,
+              execute-pytests: false,
               unity-build: false,
               publish-to-pypi: false,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -188,7 +188,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Replace and use vcpkg.json without grpc
-        if: ${{ matrix.config.build-python-module == 'false' }} 
+        if: matrix.config.build-python-module == 'false' 
         run: |
           cp vcpkg_no_grpc.json vcpkg.json
 

--- a/vcpkg_no_grpc.json
+++ b/vcpkg_no_grpc.json
@@ -7,5 +7,11 @@
         "type-lite",
         "fast-float",
         "spdlog"
+    ],
+    "overrides": [
+        {
+            "name": "fmt",
+            "version": "10.1.1"
+        }
     ]
 }

--- a/vcpkg_no_grpc.json
+++ b/vcpkg_no_grpc.json
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "arrow",
+        "boost-filesystem",
+        "boost-spirit",
+        "eigen3",
+        "type-lite",
+        "fast-float",
+        "spdlog"
+    ]
+}


### PR DESCRIPTION
The grpc package installed as part of vcpkg is huge, and is rejected from the build cache on GitHub Action. This causes a very long build time.

Temporarily disable build of grpc on GitHub Actions
