### PR TITLE
Bump minimum required CMake to 3.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.15)
+# The way boost is configured and used in Boost 1.86 requires CMake 3.26
+cmake_minimum_required(VERSION 3.26)
 
 include(CheckCSourceCompiles)
 include(FetchContent)


### PR DESCRIPTION
Recently, dependencies using vcpkg was updated, including boost 1.86. When boost 1.86 is linked by ResInsight, the minimum required CMake version is 3.26.

It is possible to manage dependencies manually without using vcpkg. In this case, the ResInsight build might work with a lower CMake requirement. This scenario is not tested by the ResInsight team.
