### PR TITLE
#9925 Use stripped vector name for stepping and title

### DIFF
--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryAddressAnalyzer.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryAddressAnalyzer.cpp
@@ -134,6 +134,18 @@ std::string RiaSummaryAddressAnalyzer::quantityNameForTitle() const
         return title;
     }
 
+    // Strip off the extension(H or _DIFF) and return the unique quantity name if there is only one
+    std::set<std::string> quantitiesNoExtension;
+    for ( const auto& quantity : quantities() )
+    {
+        const auto [name, extension] = RifEclipseSummaryTools::vectorNameAndExtension( quantity );
+        quantitiesNoExtension.insert( name );
+    }
+    if ( quantitiesNoExtension.size() == 1 )
+    {
+        return *quantitiesNoExtension.begin();
+    }
+
     return {};
 }
 
@@ -424,7 +436,7 @@ void RiaSummaryAddressAnalyzer::analyzeSingleAddress( const RifEclipseSummaryAdd
         m_wellNames.insert( { wellName, address } );
     }
 
-    const auto [vectorNameToUse, extension] = RifEclipseSummaryTools::vectorNameAndExtension( address.vectorName() );
+    const auto vectorNameToUse = address.vectorName();
     if ( !vectorNameToUse.empty() )
     {
         // The ordering of the quantities is used when creating titles of plots

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
@@ -25,6 +25,8 @@
 #include "Summary/RiaSummaryAddressModifier.h"
 #include "Summary/RiaSummaryCurveDefinition.h"
 
+#include "RifEclipseSummaryTools.h"
+
 #include "RimDataSourceSteppingTools.h"
 #include "RimEnsembleCurveSet.h"
 #include "RimEnsembleCurveSetCollection.h"
@@ -1274,7 +1276,14 @@ std::map<QString, QString> RimSummaryPlotSourceStepping::optionsForQuantity( Ria
     {
         auto vectorNames = analyzser->vectorNamesForCategory( category );
 
+        std::set<std::string> vectorNamesNoExtension;
         for ( const auto& s : vectorNames )
+        {
+            const auto [vectorNameToUse, extension] = RifEclipseSummaryTools::vectorNameAndExtension( s );
+            vectorNamesNoExtension.insert( vectorNameToUse );
+        }
+
+        for ( const auto& s : vectorNamesNoExtension )
         {
             QString valueString = QString::fromStdString( s );
 


### PR DESCRIPTION
Avoid stripping extension H/_DIFF during summary address analysis. Strip extension only for plot title and source stepping in toolbar.
