### PR TITLE
#1479 RigWellPath: improve api to force pairs of points and measured …

### DIFF
--- a/ApplicationLibCode/FileInterface/RifWellPathImporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifWellPathImporter.cpp
@@ -169,9 +169,7 @@ RifWellPathImporter::WellData RifWellPathImporter::readJsonWellData( const QStri
                           -( coordinateMap["tvd"].toDouble() - datumElevation ) );
 
         double measuredDepth = coordinateMap["md"].toDouble();
-
-        wellData.m_wellPathGeometry->addWellPathPoint( vec3d );
-        wellData.m_wellPathGeometry->addMeasuredDepth( measuredDepth );
+        wellData.m_wellPathGeometry->addWellPathPoint( vec3d, measuredDepth );
     }
     return wellData;
 }
@@ -215,8 +213,7 @@ void RifWellPathImporter::readAllAsciiWellData( const QString& filePath )
                 }
 
                 cvf::Vec3d wellPoint( x, y, -tvd );
-                fileWellDataArray.back().m_wellPathGeometry->addWellPathPoint( wellPoint );
-                fileWellDataArray.back().m_wellPathGeometry->addMeasuredDepth( md );
+                fileWellDataArray.back().m_wellPathGeometry->addWellPathPoint( wellPoint, md );
 
                 hasReadWellPointInCurrentWell = true;
             }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
@@ -300,7 +300,6 @@ void RimFileWellPath::ensureWellPathStartAtSeaLevel( RigWellPath* wellPath )
         // first point in the read well path.
         std::vector<cvf::Vec3d> newPoints = { cvf::Vec3d( firstPoint.x(), firstPoint.y(), 0.0 ) };
         newPoints.insert( newPoints.end(), wellPathPoints.begin(), wellPathPoints.end() );
-        wellPath->setWellPathPoints( newPoints );
 
         // Use rkbDiff as MD for the point at sea level
         double mdAtSeaLevel = 0.0;
@@ -316,7 +315,7 @@ void RimFileWellPath::ensureWellPathStartAtSeaLevel( RigWellPath* wellPath )
         std::vector<double> newMeasuredDepths = { mdAtSeaLevel };
         newMeasuredDepths.insert( newMeasuredDepths.end(), measuredDepths.begin(), measuredDepths.end() );
 
-        wellPath->setMeasuredDepths( newMeasuredDepths );
+        wellPath->setWellPathPoints( newPoints, newMeasuredDepths );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
@@ -294,8 +294,7 @@ cvf::ref<RigWellPath>
             measuredDepths.push_back( md + startMD );
         }
     }
-    wellPathGeometry->setWellPathPoints( wellPathPoints );
-    wellPathGeometry->setMeasuredDepths( measuredDepths );
+    wellPathGeometry->setWellPathPoints( wellPathPoints, measuredDepths );
 
     if ( m_airGap != 0.0 )
     {

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPath.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPath.cpp
@@ -124,32 +124,19 @@ std::vector<double> RigWellPath::trueVerticalDepths() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellPath::setWellPathPoints( const std::vector<cvf::Vec3d>& wellPathPoints )
+void RigWellPath::setWellPathPoints( const std::vector<cvf::Vec3d>& wellPathPoints, const std::vector<double>& measuredDepths )
 {
+    CVF_ASSERT( wellPathPoints.size() == measuredDepths.size() );
     m_wellPathPoints = wellPathPoints;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RigWellPath::setMeasuredDepths( const std::vector<double>& measuredDepths )
-{
     m_measuredDepths = measuredDepths;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellPath::addWellPathPoint( const cvf::Vec3d& wellPathPoint )
+void RigWellPath::addWellPathPoint( const cvf::Vec3d& wellPathPoint, double measuredDepth )
 {
     m_wellPathPoints.push_back( wellPathPoint );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RigWellPath::addMeasuredDepth( double measuredDepth )
-{
     m_measuredDepths.push_back( measuredDepth );
 }
 

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPath.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPath.h
@@ -49,11 +49,8 @@ public:
     const std::vector<double>&     measuredDepths() const;
     std::vector<double>            trueVerticalDepths() const;
 
-    void setWellPathPoints( const std::vector<cvf::Vec3d>& wellPathPoints );
-    void setMeasuredDepths( const std::vector<double>& measuredDepths );
-
-    void addWellPathPoint( const cvf::Vec3d& wellPathPoint );
-    void addMeasuredDepth( double measuredDepth );
+    void setWellPathPoints( const std::vector<cvf::Vec3d>& wellPathPoints, const std::vector<double>& measuredDepths );
+    void addWellPathPoint( const cvf::Vec3d& wellPathPoint, double measuredDepth );
 
     void       setDatumElevation( double value );
     bool       hasDatumElevation() const;

--- a/ApplicationLibCode/UnitTests/RigWellLogExtractor-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogExtractor-Test.cpp
@@ -67,8 +67,7 @@ TEST( RigEclipseWellLogExtractor, ShortWellPathInsideOneCell )
             mdValues.push_back( offset );
         }
 
-        wellPathGeometry->setWellPathPoints( wellPathPoints );
-        wellPathGeometry->setMeasuredDepths( mdValues );
+        wellPathGeometry->setWellPathPoints( wellPathPoints, mdValues );
     }
 
     cvf::ref<RigEclipseWellLogExtractor> e = new RigEclipseWellLogExtractor( reservoir.p(), wellPathGeometry.p(), "" );

--- a/ApplicationLibCode/UnitTests/RigWellPathGeometryExporter-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellPathGeometryExporter-Test.cpp
@@ -38,8 +38,7 @@ TEST( RigWellPathGeometryExporter, VerticalPath )
 
     for ( double md : inputMds )
     {
-        rigWellPath.addMeasuredDepth( md );
-        rigWellPath.addWellPathPoint( cvf::Vec3d( x, y, -md ) );
+        rigWellPath.addWellPathPoint( cvf::Vec3d( x, y, -md ), md );
     }
 
     double              mdStepSize = 5.0;

--- a/ApplicationLibCode/UnitTests/RigWellPathIntersectionTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellPathIntersectionTools-Test.cpp
@@ -46,8 +46,7 @@ TEST( RigWellPathTest, FindWellPathCoordsIncludingIntersectionPoint )
         mdValues.push_back( 3.0 );
         mdValues.push_back( 4.0 );
 
-        wellPathGeometry.setWellPathPoints( wellPathPoints );
-        wellPathGeometry.setMeasuredDepths( mdValues );
+        wellPathGeometry.setWellPathPoints( wellPathPoints, mdValues );
     }
 
     // Before first MD


### PR DESCRIPTION
…depths.

Refactored RigWellPath to ensure that a well path points and measured depths always come pairs, as their usage often relies on both being present.

Fixes #1479.