### PR TITLE
Use single * as default "all files" filter 

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiFilePathEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiFilePathEditor.h
@@ -58,7 +58,7 @@ public:
     PdmUiFilePathEditorAttribute()
     {
         m_selectSaveFileName           = false;
-        m_fileSelectionFilter          = "All files (*.*)";
+        m_fileSelectionFilter          = "All files (*)";
         m_defaultPath                  = QString();
         m_selectDirectory              = false;
         m_appendUiSelectedFolderToText = false;


### PR DESCRIPTION
This ensures all files are shown, also those without extension on Linux