### PR TITLE
Performance: Use a small set of header file names to compute name

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaEnsembleNameTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaEnsembleNameTools.cpp
@@ -445,12 +445,19 @@ QString RiaEnsembleNameTools::uniqueShortNameForEnsembleCase( RimSummaryCase* su
     QStringList summaryFilePaths;
     summaryFilePaths.push_back( summaryCase->summaryHeaderFilename() );
 
-    for ( auto otherSummaryCase : summaryCases )
+    // Use a small number of names to find a short name for the ensemble, as RiaEnsembleNameTools::uniqueShortName is slow
+    if ( !summaryCases.empty() )
     {
-        if ( otherSummaryCase != summaryCase )
+        for ( int i = 0; i < std::min( 4, static_cast<int>( summaryCases.size() ) ); ++i )
         {
-            summaryFilePaths.push_back( otherSummaryCase->summaryHeaderFilename() );
+            auto otherSummaryCase = summaryCases[i];
+            if ( otherSummaryCase != summaryCase )
+            {
+                summaryFilePaths.push_back( otherSummaryCase->summaryHeaderFilename() );
+            }
         }
+
+        summaryFilePaths.push_back( summaryCases.back()->summaryHeaderFilename() );
     }
 
     return RiaEnsembleNameTools::uniqueShortName( summaryCase->summaryHeaderFilename(), summaryFilePaths, ensembleCaseName );


### PR DESCRIPTION
Avoid using the complete set of header files when computing short name for summary case
