### PR TITLE
Improve auto naming to avoid ensembles with identical names

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -776,7 +776,7 @@ bool RiaApplication::loadProject( const QString& projectFileName, ProjectLoadAct
         if ( !sumMainCollection ) continue;
 
         sumMainCollection->updateAutoShortName();
-        for ( auto sumCaseGroup : sumMainCollection->summaryCaseCollections() )
+        for ( auto sumCaseGroup : sumMainCollection->summaryEnsembles() )
         {
             sumCaseGroup->updateName();
             sumCaseGroup->loadDataAndUpdate();

--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -776,9 +776,9 @@ bool RiaApplication::loadProject( const QString& projectFileName, ProjectLoadAct
         if ( !sumMainCollection ) continue;
 
         sumMainCollection->updateAutoShortName();
-        for ( auto sumCaseGroup : sumMainCollection->summaryEnsembles() )
+        for ( auto ensemble : sumMainCollection->summaryEnsembles() )
         {
-            sumCaseGroup->loadDataAndUpdate();
+            ensemble->loadDataAndUpdate();
         }
         sumMainCollection->updateEnsembleNames();
 

--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -778,9 +778,9 @@ bool RiaApplication::loadProject( const QString& projectFileName, ProjectLoadAct
         sumMainCollection->updateAutoShortName();
         for ( auto sumCaseGroup : sumMainCollection->summaryEnsembles() )
         {
-            sumCaseGroup->updateName();
             sumCaseGroup->loadDataAndUpdate();
         }
+        sumMainCollection->updateEnsembleNames();
 
         for ( auto well : oilField->wellPathCollection()->allWellPaths() )
         {

--- a/ApplicationLibCode/Application/Tools/RiaEnsembleNameTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaEnsembleNameTools.cpp
@@ -403,37 +403,6 @@ std::map<QString, std::pair<QString, QString>>
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RiaEnsembleNameTools::updateAutoNameEnsembles( std::vector<RimSummaryEnsemble*> ensembles )
-{
-    std::set<std::string> key1;
-    std::set<std::string> key2;
-
-    for ( const auto& ensemble : ensembles )
-    {
-        const auto keys = ensemble->nameKeys();
-        key1.insert( keys.first );
-        key2.insert( keys.second );
-    }
-
-    bool useKey1 = key1.size() > 1;
-    bool useKey2 = key2.size() > 1;
-
-    if ( !useKey1 && !useKey2 )
-    {
-        useKey2 = true;
-    }
-
-    for ( auto ensemble : ensembles )
-    {
-        ensemble->setUsePathKey1( useKey1 );
-        ensemble->setUsePathKey2( useKey2 );
-        ensemble->updateName();
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 QString RiaEnsembleNameTools::uniqueShortNameForEnsembleCase( RimSummaryCase* summaryCase )
 {
     CAF_ASSERT( summaryCase && summaryCase->ensemble() );

--- a/ApplicationLibCode/Application/Tools/RiaEnsembleNameTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaEnsembleNameTools.h
@@ -59,8 +59,6 @@ public:
                                                                                          const QStringList&   fileNames,
                                                                                          const std::vector<QStringList>& fileNameComponents );
 
-    static void updateAutoNameEnsembles( std::vector<RimSummaryEnsemble*> ensembles );
-
     static QString uniqueShortNameForEnsembleCase( RimSummaryCase* summaryCase );
     static QString uniqueShortNameForSummaryCase( RimSummaryCase* summaryCase );
 

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryStringTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryStringTools.cpp
@@ -149,7 +149,7 @@ std::pair<std::vector<RimSummaryCase*>, std::vector<RimSummaryEnsemble*>> RiaSum
     if ( !sumCaseMainColl ) return { {}, {} };
 
     auto summaryCases = sumCaseMainColl->topLevelSummaryCases();
-    auto ensembles    = sumCaseMainColl->summaryCaseCollections();
+    auto ensembles    = sumCaseMainColl->summaryEnsembles();
 
     return { summaryCases, ensembles };
 }

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
@@ -442,3 +442,14 @@ time_t RiaSummaryTools::calculateTimeThreshold( const time_t& minimum, const tim
 
     return timeThreshold;
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiaSummaryTools::updateSummaryEnsembleNames()
+{
+    if ( auto sumCaseMainColl = RiaSummaryTools::summaryCaseMainCollection() )
+    {
+        sumCaseMainColl->updateEnsembleNames();
+    }
+}

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.h
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.h
@@ -99,6 +99,8 @@ public:
 
     static time_t calculateTimeThreshold( const time_t& minimum, const time_t& maximum );
 
+    static void updateSummaryEnsembleNames();
+
 private:
     static void updateRequiredCalculatedCurves( RimSummaryCase* sourceSummaryCase );
     static bool isCalculationRequired( const RimUserDefinedCalculation* summaryCalculation, const RimSummaryCase* summaryCase );

--- a/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp
+++ b/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp
@@ -119,7 +119,7 @@ void RicDeleteSummaryCaseCollectionFeature::onActionTriggered( bool isChecked )
 
     for ( RimSummaryEnsemble* caseCollection : selection )
     {
-        summaryCaseMainCollection->removeCaseCollection( caseCollection );
+        summaryCaseMainCollection->removeEnsemble( caseCollection );
         delete caseCollection;
     }
 

--- a/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp
@@ -102,7 +102,7 @@ void RicImportEnsembleFeature::onActionTriggered( bool isChecked )
                 importSingleEnsemble( fileNames, useEnsembleNameDialog, ensembleGroupingMode, fileType, groupName );
             }
 
-            RiaEnsembleNameTools::updateAutoNameEnsembles( RiaApplication::instance()->project()->summaryGroups() );
+            RiaSummaryTools::updateSummaryEnsembleNames();
         }
     }
 }
@@ -136,6 +136,8 @@ RimSummaryEnsemble* RicImportEnsembleFeature::importSingleEnsemble( const QStrin
         {
             summaryCase->updateAutoShortName();
         }
+
+        RiaSummaryTools::updateSummaryEnsembleNames();
 
         RiaSummaryPlotTools::createAndAppendDefaultSummaryMultiPlot( {}, { ensemble } );
     }

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicNewDerivedEnsembleFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicNewDerivedEnsembleFeature.cpp
@@ -94,7 +94,7 @@ void RicNewDerivedEnsembleFeature::onActionTriggered( bool isChecked )
                 {
                     if ( !showWarningDialogWithQuestion() )
                     {
-                        mainColl->removeCaseCollection( newEnsemble );
+                        mainColl->removeEnsemble( newEnsemble );
                     }
                 }
             }

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicReplaceSummaryEnsembleFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicReplaceSummaryEnsembleFeature.cpp
@@ -75,10 +75,9 @@ void RicReplaceSummaryEnsembleFeature::onActionTriggered( bool isChecked )
         summaryCase->updateAutoShortName();
     }
 
-    summaryEnsemble->updateName();
-
     if ( auto sumCaseMainColl = RiaSummaryTools::summaryCaseMainCollection() )
     {
+        sumCaseMainColl->updateEnsembleNames();
         sumCaseMainColl->updateAllRequiredEditors();
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/Cloud/RimCloudDataSourceCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Cloud/RimCloudDataSourceCollection.cpp
@@ -88,13 +88,13 @@ void RimCloudDataSourceCollection::createEnsemblesFromSelectedDataSources( const
         RimSummaryEnsembleSumo* ensemble = new RimSummaryEnsembleSumo();
         ensemble->setUsePathKey1( true );
         ensemble->setSumoDataSource( dataSource );
-        ensemble->updateName();
         RiaSummaryTools::summaryCaseMainCollection()->addEnsemble( ensemble );
         ensemble->loadDataAndUpdate();
 
         RiaSummaryPlotTools::createAndAppendDefaultSummaryMultiPlot( {}, { ensemble } );
     }
 
+    RiaSummaryTools::updateSummaryEnsembleNames();
     RiaSummaryTools::summaryCaseMainCollection()->updateAllRequiredEditors();
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -760,7 +760,7 @@ std::vector<RimSummaryEnsemble*> RimProject::summaryGroups() const
         RimSummaryCaseMainCollection* sumCaseMainColl = oilField->summaryCaseMainCollection();
         if ( sumCaseMainColl )
         {
-            std::vector<RimSummaryEnsemble*> g = sumCaseMainColl->summaryCaseCollections();
+            std::vector<RimSummaryEnsemble*> g = sumCaseMainColl->summaryEnsembles();
             groups.insert( groups.end(), g.begin(), g.end() );
         }
     }

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -752,7 +752,7 @@ std::vector<RimSummaryCase*> RimProject::allSummaryCases() const
 //--------------------------------------------------------------------------------------------------
 std::vector<RimSummaryEnsemble*> RimProject::summaryGroups() const
 {
-    std::vector<RimSummaryEnsemble*> groups;
+    std::vector<RimSummaryEnsemble*> ensembles;
 
     for ( RimOilField* oilField : oilFields )
     {
@@ -760,12 +760,12 @@ std::vector<RimSummaryEnsemble*> RimProject::summaryGroups() const
         RimSummaryCaseMainCollection* sumCaseMainColl = oilField->summaryCaseMainCollection();
         if ( sumCaseMainColl )
         {
-            std::vector<RimSummaryEnsemble*> g = sumCaseMainColl->summaryEnsembles();
-            groups.insert( groups.end(), g.begin(), g.end() );
+            std::vector<RimSummaryEnsemble*> ensemble = sumCaseMainColl->summaryEnsembles();
+            ensembles.insert( ensembles.end(), ensemble.begin(), ensemble.end() );
         }
     }
 
-    return groups;
+    return ensembles;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimSummaryCalculationCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSummaryCalculationCollection.cpp
@@ -82,10 +82,9 @@ void RimSummaryCalculationCollection::updateDataDependingOnCalculations()
         }
     }
 
-    auto summaryCaseCollections = summaryCaseCollection->summaryEnsembles();
-    for ( RimSummaryEnsemble* summaryCaseCollection : summaryCaseCollections )
+    for ( auto ensemble : summaryCaseCollection->summaryEnsembles() )
     {
-        summaryCaseCollection->onCalculationUpdated();
+        ensemble->onCalculationUpdated();
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimSummaryCalculationCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSummaryCalculationCollection.cpp
@@ -82,7 +82,7 @@ void RimSummaryCalculationCollection::updateDataDependingOnCalculations()
         }
     }
 
-    auto summaryCaseCollections = summaryCaseCollection->summaryCaseCollections();
+    auto summaryCaseCollections = summaryCaseCollection->summaryEnsembles();
     for ( RimSummaryEnsemble* summaryCaseCollection : summaryCaseCollections )
     {
         summaryCaseCollection->onCalculationUpdated();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
@@ -568,7 +568,7 @@ std::vector<RimDeltaSummaryEnsemble*> RimDeltaSummaryEnsemble::findReferringEnse
     auto mainColl = firstAncestorOrThisOfType<RimSummaryCaseMainCollection>();
     if ( mainColl )
     {
-        for ( auto group : mainColl->summaryCaseCollections() )
+        for ( auto group : mainColl->summaryEnsembles() )
         {
             auto derivedEnsemble = dynamic_cast<RimDeltaSummaryEnsemble*>( group );
             if ( derivedEnsemble )

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
@@ -18,15 +18,17 @@
 
 #include "RiaQDateTimeTools.h"
 
+#include "Summary/RiaSummaryTools.h"
+
 #include "SummaryPlotCommands/RicNewDerivedEnsembleFeature.h"
+
+#include "RifSummaryReaderInterface.h"
 
 #include "RimDeltaSummaryCase.h"
 #include "RimDeltaSummaryEnsemble.h"
 #include "RimProject.h"
 #include "RimSummaryCaseMainCollection.h"
 #include "RimSummaryEnsemble.h"
-
-#include "RifSummaryReaderInterface.h"
 
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
@@ -107,7 +109,8 @@ RimDeltaSummaryEnsemble::~RimDeltaSummaryEnsemble()
 void RimDeltaSummaryEnsemble::setEnsemble1( RimSummaryEnsemble* ensemble )
 {
     m_ensemble1 = ensemble;
-    updateName();
+
+    RiaSummaryTools::updateSummaryEnsembleNames();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -116,7 +119,8 @@ void RimDeltaSummaryEnsemble::setEnsemble1( RimSummaryEnsemble* ensemble )
 void RimDeltaSummaryEnsemble::setEnsemble2( RimSummaryEnsemble* ensemble )
 {
     m_ensemble2 = ensemble;
-    updateName();
+
+    RiaSummaryTools::updateSummaryEnsembleNames();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -271,7 +275,6 @@ void RimDeltaSummaryEnsemble::onLoadDataAndUpdate()
 {
     updateDerivedEnsembleCases();
     updateReferringCurveSets();
-    updateName();
     updateConnectedEditors();
 }
 
@@ -349,7 +352,6 @@ void RimDeltaSummaryEnsemble::defineUiOrdering( QString uiConfigName, caf::PdmUi
 
     uiOrdering.skipRemainingFields( true );
 
-    updateName();
     if ( !isValid() ) m_caseCount = "";
 }
 
@@ -389,7 +391,7 @@ void RimDeltaSummaryEnsemble::fieldChangedByUi( const caf::PdmFieldHandle* chang
 
     if ( doUpdate )
     {
-        updateName();
+        RiaSummaryTools::updateSummaryEnsembleNames();
 
         if ( doUpdateCases )
         {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
@@ -570,9 +570,9 @@ std::vector<RimDeltaSummaryEnsemble*> RimDeltaSummaryEnsemble::findReferringEnse
     auto mainColl = firstAncestorOrThisOfType<RimSummaryCaseMainCollection>();
     if ( mainColl )
     {
-        for ( auto group : mainColl->summaryEnsembles() )
+        for ( auto ensemble : mainColl->summaryEnsembles() )
         {
-            auto derivedEnsemble = dynamic_cast<RimDeltaSummaryEnsemble*>( group );
+            auto derivedEnsemble = dynamic_cast<RimDeltaSummaryEnsemble*>( ensemble );
             if ( derivedEnsemble )
             {
                 if ( derivedEnsemble->m_ensemble1() == this || derivedEnsemble->m_ensemble2() == this )

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -105,7 +105,7 @@ RimSummaryCaseMainCollection::RimSummaryCaseMainCollection()
     CAF_PDM_InitFieldNoDefault( &m_cases, "SummaryCases", "" );
     caf::PdmFieldReorderCapability::addToField( &m_cases );
 
-    CAF_PDM_InitFieldNoDefault( &m_caseCollections, "SummaryCaseCollections", "" );
+    CAF_PDM_InitFieldNoDefault( &m_ensembles, "SummaryCaseCollections", "" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -114,7 +114,7 @@ RimSummaryCaseMainCollection::RimSummaryCaseMainCollection()
 RimSummaryCaseMainCollection::~RimSummaryCaseMainCollection()
 {
     m_cases.deleteChildrenAsync();
-    m_caseCollections.deleteChildrenAsync();
+    m_ensembles.deleteChildrenAsync();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -165,7 +165,7 @@ void RimSummaryCaseMainCollection::removeCase( RimSummaryCase* summaryCase, bool
     std::vector<RimDeltaSummaryEnsemble*> derivedEnsembles;
 
     // Build a list of derived ensembles that must be updated after delete
-    for ( auto group : summaryCaseCollections() )
+    for ( auto group : summaryEnsembles() )
     {
         auto derEnsemble = dynamic_cast<RimDeltaSummaryEnsemble*>( group );
         if ( derEnsemble )
@@ -179,9 +179,9 @@ void RimSummaryCaseMainCollection::removeCase( RimSummaryCase* summaryCase, bool
 
     m_cases.removeChild( summaryCase );
 
-    for ( RimSummaryEnsemble* summaryCaseCollection : m_caseCollections )
+    for ( RimSummaryEnsemble* ensemble : m_ensembles )
     {
-        summaryCaseCollection->removeCase( summaryCase, notifyChange );
+        ensemble->removeCase( summaryCase, notifyChange );
     }
 
     // Update derived ensemble cases (if any)
@@ -203,9 +203,9 @@ void RimSummaryCaseMainCollection::removeCases( std::vector<RimSummaryCase*>& ca
         removeCase( sumCase, false );
     }
 
-    for ( RimSummaryEnsemble* summaryCaseCollection : m_caseCollections )
+    for ( RimSummaryEnsemble* ensemble : m_ensembles )
     {
-        summaryCaseCollection->updateReferringCurveSetsZoomAll();
+        ensemble->updateReferringCurveSetsZoomAll();
     }
 
     dataSourceHasChanged.send();
@@ -232,13 +232,13 @@ RimSummaryEnsemble* RimSummaryCaseMainCollection::addEnsemble( const std::vector
                                                                bool                                 isEnsemble,
                                                                std::function<RimSummaryEnsemble*()> allocator )
 {
-    RimSummaryEnsemble* summaryCaseCollection = allocator();
-    if ( !collectionName.isEmpty() ) summaryCaseCollection->setNameTemplate( collectionName );
+    RimSummaryEnsemble* ensemble = allocator();
+    if ( !collectionName.isEmpty() ) ensemble->setNameTemplate( collectionName );
 
-    if ( summaryCaseCollection->ensembleId() == -1 )
+    if ( ensemble->ensembleId() == -1 )
     {
         RimProject* project = RimProject::current();
-        project->assignIdToEnsemble( summaryCaseCollection );
+        project->assignIdToEnsemble( ensemble );
     }
 
     for ( RimSummaryCase* summaryCase : summaryCases )
@@ -253,21 +253,21 @@ RimSummaryEnsemble* RimSummaryCaseMainCollection::addEnsemble( const std::vector
             m_cases.removeChild( summaryCase );
         }
 
-        summaryCaseCollection->addCase( summaryCase );
+        ensemble->addCase( summaryCase );
         if ( isEnsemble )
         {
             summaryCase->setDisplayNameOption( RimCaseDisplayNameTools::DisplayName::SHORT_CASE_NAME );
         }
     }
 
-    summaryCaseCollection->setAsEnsemble( isEnsemble );
+    ensemble->setAsEnsemble( isEnsemble );
 
-    summaryCaseCollection->caseNameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
-    m_caseCollections.push_back( summaryCaseCollection );
+    ensemble->caseNameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
+    m_ensembles.push_back( ensemble );
 
     dataSourceHasChanged.send();
 
-    return summaryCaseCollection;
+    return ensemble;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -275,9 +275,9 @@ RimSummaryEnsemble* RimSummaryCaseMainCollection::addEnsemble( const std::vector
 //--------------------------------------------------------------------------------------------------
 void RimSummaryCaseMainCollection::removeEnsemble( RimSummaryEnsemble* ensemble )
 {
-    m_caseCollections.removeChild( ensemble );
+    m_ensembles.removeChild( ensemble );
 
-    RiaEnsembleNameTools::updateAutoNameEnsembles( summaryCaseCollections() );
+    RiaEnsembleNameTools::updateAutoNameEnsembles( summaryEnsembles() );
 
     dataSourceHasChanged.send();
 }
@@ -289,7 +289,7 @@ void RimSummaryCaseMainCollection::addEnsemble( RimSummaryEnsemble* ensemble )
 {
     CVF_ASSERT( ensemble );
 
-    m_caseCollections.push_back( ensemble );
+    m_ensembles.push_back( ensemble );
 
     if ( ensemble->ensembleId() == -1 )
     {
@@ -325,9 +325,9 @@ std::vector<RimSummaryCase*> RimSummaryCaseMainCollection::allSummaryCases() con
 
     if ( !m_cases.empty() ) cases.insert( cases.end(), m_cases.begin(), m_cases.end() );
 
-    for ( auto& coll : m_caseCollections )
+    for ( auto& ensemble : m_ensembles )
     {
-        auto collCases = coll->allSummaryCases();
+        auto collCases = ensemble->allSummaryCases();
         if ( collCases.empty() ) continue;
         cases.insert( cases.end(), collCases.begin(), collCases.end() );
     }
@@ -351,14 +351,14 @@ std::vector<RimSummaryCase*> RimSummaryCaseMainCollection::topLevelSummaryCases(
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSummaryEnsemble*> RimSummaryCaseMainCollection::summaryCaseCollections() const
+std::vector<RimSummaryEnsemble*> RimSummaryCaseMainCollection::summaryEnsembles() const
 {
-    std::vector<RimSummaryEnsemble*> summaryCaseCollections;
-    for ( const auto& caseColl : m_caseCollections )
+    std::vector<RimSummaryEnsemble*> ensembles;
+    for ( const auto& ensemble : m_ensembles )
     {
-        summaryCaseCollections.push_back( caseColl );
+        ensembles.push_back( ensemble );
     }
-    return summaryCaseCollections;
+    return ensembles;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -381,7 +381,7 @@ void RimSummaryCaseMainCollection::initAfterRead()
         sumCase->nameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
     }
 
-    for ( auto caseCollection : summaryCaseCollections() )
+    for ( auto caseCollection : summaryEnsembles() )
     {
         caseCollection->caseNameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
     }
@@ -545,7 +545,7 @@ RimSummaryEnsemble* RimSummaryCaseMainCollection::defaultAllocator()
 //--------------------------------------------------------------------------------------------------
 void RimSummaryCaseMainCollection::onCaseNameChanged( const SignalEmitter* emitter )
 {
-    RiaEnsembleNameTools::updateAutoNameEnsembles( summaryCaseCollections() );
+    RiaEnsembleNameTools::updateAutoNameEnsembles( summaryEnsembles() );
 
     RimSummaryMultiPlotCollection* summaryPlotColl = RiaSummaryTools::summaryMultiPlotCollection();
     summaryPlotColl->updateSummaryNameHasChanged();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -277,7 +277,7 @@ void RimSummaryCaseMainCollection::removeEnsemble( RimSummaryEnsemble* ensemble 
 {
     m_ensembles.removeChild( ensemble );
 
-    RiaEnsembleNameTools::updateAutoNameEnsembles( summaryEnsembles() );
+    RiaSummaryTools::updateSummaryEnsembleNames();
 
     dataSourceHasChanged.send();
 }
@@ -545,7 +545,7 @@ RimSummaryEnsemble* RimSummaryCaseMainCollection::defaultAllocator()
 //--------------------------------------------------------------------------------------------------
 void RimSummaryCaseMainCollection::onCaseNameChanged( const SignalEmitter* emitter )
 {
-    RiaEnsembleNameTools::updateAutoNameEnsembles( summaryEnsembles() );
+    RiaSummaryTools::updateSummaryEnsembleNames();
 
     RimSummaryMultiPlotCollection* summaryPlotColl = RiaSummaryTools::summaryMultiPlotCollection();
     summaryPlotColl->updateSummaryNameHasChanged();
@@ -719,5 +719,40 @@ void RimSummaryCaseMainCollection::onProjectBeingSaved()
         {
             fileSumCase->onProjectBeingSaved();
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryCaseMainCollection::updateEnsembleNames()
+{
+    std::set<std::string> key1;
+    std::set<std::string> key2;
+
+    auto ensembles = summaryEnsembles();
+
+    for ( const auto& ensemble : ensembles )
+    {
+        const auto keys = ensemble->nameKeys();
+        key1.insert( keys.first );
+        key2.insert( keys.second );
+    }
+
+    bool useKey1 = key1.size() > 1;
+    bool useKey2 = key2.size() > 1;
+
+    if ( !useKey1 && !useKey2 )
+    {
+        useKey2 = true;
+    }
+
+    std::set<QString> existingNames;
+    for ( auto ensemble : ensembles )
+    {
+        ensemble->setUsePathKey1( useKey1 );
+        ensemble->setUsePathKey2( useKey2 );
+        ensemble->updateName( existingNames );
+        existingNames.insert( ensemble->name() );
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -165,9 +165,9 @@ void RimSummaryCaseMainCollection::removeCase( RimSummaryCase* summaryCase, bool
     std::vector<RimDeltaSummaryEnsemble*> derivedEnsembles;
 
     // Build a list of derived ensembles that must be updated after delete
-    for ( auto group : summaryEnsembles() )
+    for ( auto ensemble : summaryEnsembles() )
     {
-        auto derEnsemble = dynamic_cast<RimDeltaSummaryEnsemble*>( group );
+        auto derEnsemble = dynamic_cast<RimDeltaSummaryEnsemble*>( ensemble );
         if ( derEnsemble )
         {
             if ( derEnsemble->hasCaseReference( summaryCase ) )
@@ -381,9 +381,9 @@ void RimSummaryCaseMainCollection::initAfterRead()
         sumCase->nameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
     }
 
-    for ( auto caseCollection : summaryEnsembles() )
+    for ( auto ensemble : summaryEnsembles() )
     {
-        caseCollection->caseNameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
+        ensemble->caseNameChanged.connect( this, &RimSummaryCaseMainCollection::onCaseNameChanged );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -273,9 +273,9 @@ RimSummaryEnsemble* RimSummaryCaseMainCollection::addEnsemble( const std::vector
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryCaseMainCollection::removeCaseCollection( RimSummaryEnsemble* caseCollection )
+void RimSummaryCaseMainCollection::removeEnsemble( RimSummaryEnsemble* ensemble )
 {
-    m_caseCollections.removeChild( caseCollection );
+    m_caseCollections.removeChild( ensemble );
 
     RiaEnsembleNameTools::updateAutoNameEnsembles( summaryCaseCollections() );
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
@@ -49,7 +49,7 @@ public:
 
     std::vector<RimSummaryCase*>     allSummaryCases() const;
     std::vector<RimSummaryCase*>     topLevelSummaryCases() const;
-    std::vector<RimSummaryEnsemble*> summaryCaseCollections() const;
+    std::vector<RimSummaryEnsemble*> summaryEnsembles() const;
 
     std::vector<RimSummaryCase*> createSummaryCasesFromFileInfos( const std::vector<RifSummaryCaseFileResultInfo>& summaryHeaderFileInfos,
                                                                   bool                                             showProgress = false );
@@ -87,5 +87,5 @@ private:
 
 private:
     caf::PdmChildArrayField<RimSummaryCase*>     m_cases;
-    caf::PdmChildArrayField<RimSummaryEnsemble*> m_caseCollections;
+    caf::PdmChildArrayField<RimSummaryEnsemble*> m_ensembles;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
@@ -76,6 +76,8 @@ public:
     void updateAutoShortName();
     void onProjectBeingSaved();
 
+    void updateEnsembleNames();
+
 private:
     void initAfterRead() override;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
@@ -66,7 +66,7 @@ public:
                                      const QString&                       coolectionName,
                                      bool                                 isEnsemble,
                                      std::function<RimSummaryEnsemble*()> allocator = defaultAllocator );
-    void                removeCaseCollection( RimSummaryEnsemble* caseCollection );
+    void                removeEnsemble( RimSummaryEnsemble* ensemble );
     void                addEnsemble( RimSummaryEnsemble* ensemble );
 
     void loadAllSummaryCaseData();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
@@ -26,6 +26,7 @@
 #include "RiaStdStringTools.h"
 #include "RiaTextStringTools.h"
 #include "Summary/RiaSummaryAddressAnalyzer.h"
+#include "Summary/RiaSummaryTools.h"
 
 #include "RifSummaryReaderInterface.h"
 
@@ -236,7 +237,7 @@ QString RimSummaryEnsemble::name() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryEnsemble::updateName()
+void RimSummaryEnsemble::updateName( const std::set<QString>& existingEnsembleNames )
 {
     const auto [key1, key2] = nameKeys();
 
@@ -269,6 +270,19 @@ void RimSummaryEnsemble::updateName()
         if ( candidateName.endsWith( "," ) )
         {
             candidateName = candidateName.left( candidateName.length() - 1 );
+        }
+
+        // Avoid identical ensemble names by appending a number
+        if ( existingEnsembleNames.contains( candidateName ) )
+        {
+            int     counter = 1;
+            QString uniqueName;
+            do
+            {
+                uniqueName = QString( "%1 (subset-%2)" ).arg( candidateName ).arg( counter++ );
+            } while ( existingEnsembleNames.contains( uniqueName ) );
+
+            candidateName = uniqueName;
         }
     }
 
@@ -889,7 +903,7 @@ void RimSummaryEnsemble::fieldChangedByUi( const caf::PdmFieldHandle* changedFie
     }
     if ( changedField == &m_autoName || changedField == &m_nameTemplateString )
     {
-        updateName();
+        RiaSummaryTools::updateSummaryEnsembleNames();
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.h
@@ -66,7 +66,7 @@ public:
     QString name() const;
 
     void                                        setNameTemplate( const QString& name );
-    void                                        updateName();
+    void                                        updateName( const std::set<QString>& existingEnsembleNames );
     void                                        setUsePathKey1( bool useKey1 );
     void                                        setUsePathKey2( bool useKey2 );
     virtual std::pair<std::string, std::string> nameKeys() const;

--- a/ApplicationLibCode/ProjectDataModel/Summary/Sumo/RimSummaryEnsembleSumo.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/Sumo/RimSummaryEnsembleSumo.cpp
@@ -488,7 +488,7 @@ void RimSummaryEnsembleSumo::fieldChangedByUi( const caf::PdmFieldHandle* change
     {
         clearCachedData();
         updateResultAddresses();
-        updateName();
+        RiaSummaryTools::updateSummaryEnsembleNames();
         buildMetaData();
 
         updateConnectedEditors();
@@ -555,7 +555,7 @@ void RimSummaryEnsembleSumo::onLoadDataAndUpdate()
         }
     }
 
-    updateName();
+    RiaSummaryTools::updateSummaryEnsembleNames();
     updateResultAddresses();
 
     buildMetaData();

--- a/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
@@ -590,9 +590,9 @@ QList<caf::PdmOptionItemInfo>
             if ( !hideEnsembles )
             {
                 bool ensembleHeaderCreated = false;
-                for ( const auto& sumCaseColl : sumCaseMainColl->summaryEnsembles() )
+                for ( const auto& ensemble : sumCaseMainColl->summaryEnsembles() )
                 {
-                    if ( !sumCaseColl->isEnsemble() ) continue;
+                    if ( !ensemble->isEnsemble() ) continue;
 
                     if ( !ensembleHeaderCreated )
                     {
@@ -601,7 +601,7 @@ QList<caf::PdmOptionItemInfo>
                     }
                     // Ensemble level
                     {
-                        auto optionItem = caf::PdmOptionItemInfo( sumCaseColl->name(), sumCaseColl );
+                        auto optionItem = caf::PdmOptionItemInfo( ensemble->name(), ensemble );
                         optionItem.setLevel( 1 );
                         options.push_back( optionItem );
                     }
@@ -611,13 +611,13 @@ QList<caf::PdmOptionItemInfo>
             if ( !hideSummaryCases )
             {
                 // Grouped cases
-                for ( const auto& sumCaseColl : sumCaseMainColl->summaryEnsembles() )
+                for ( const auto& ensemble : sumCaseMainColl->summaryEnsembles() )
                 {
-                    if ( sumCaseColl->isEnsemble() && !showIndividualEnsembleCases ) continue;
+                    if ( ensemble->isEnsemble() && !showIndividualEnsembleCases ) continue;
 
-                    options.push_back( caf::PdmOptionItemInfo::createHeader( sumCaseColl->name(), true ) );
+                    options.push_back( caf::PdmOptionItemInfo::createHeader( ensemble->name(), true ) );
 
-                    for ( const auto& sumCase : sumCaseColl->allSummaryCases() )
+                    for ( const auto& sumCase : ensemble->allSummaryCases() )
                     {
                         auto optionItem = caf::PdmOptionItemInfo( sumCase->displayCaseName(), sumCase );
                         optionItem.setLevel( 1 );

--- a/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
@@ -590,7 +590,7 @@ QList<caf::PdmOptionItemInfo>
             if ( !hideEnsembles )
             {
                 bool ensembleHeaderCreated = false;
-                for ( const auto& sumCaseColl : sumCaseMainColl->summaryCaseCollections() )
+                for ( const auto& sumCaseColl : sumCaseMainColl->summaryEnsembles() )
                 {
                     if ( !sumCaseColl->isEnsemble() ) continue;
 
@@ -611,7 +611,7 @@ QList<caf::PdmOptionItemInfo>
             if ( !hideSummaryCases )
             {
                 // Grouped cases
-                for ( const auto& sumCaseColl : sumCaseMainColl->summaryCaseCollections() )
+                for ( const auto& sumCaseColl : sumCaseMainColl->summaryEnsembles() )
                 {
                     if ( sumCaseColl->isEnsemble() && !showIndividualEnsembleCases ) continue;
 


### PR DESCRIPTION
Closes #12282

Renaming to use the term `ensemble` instead of `summaryCaseCollection`