### PR TITLE
GHA: Skip check on event_name

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -325,7 +325,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing  
     
     # If this is a tagged release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.base_ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags') && github.base_ref == 'refs/heads/main'
     steps:
     - name: Download python distribution folder
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Make the trigger for publish to PyPi more general

Closes #12354
