### PR TITLE
Update clang to 18, fix clang-tidy

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -57,7 +57,7 @@ jobs:
             }
           - {
               name: "Ubuntu 22.04 clang-18",
-              os: ubuntu-24.04,
+              os: ubuntu-22.04,
               cc: "clang-18",
               cxx: "clang++-18",
               build-python-module: true,
@@ -214,10 +214,10 @@ jobs:
           sudo apt-get update --option="APT::Acquire::Retries=3"
           sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev libhdf5-dev
 
-      - name: Install clang-18 - probaly not needed
-        if: contains( matrix.config.cc, 'does-not-exist')
+      - name: Install clang-18
+        if: contains( matrix.config.cc, 'clang')
         run: |
-          # sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
           sudo apt-get upgrade
           wget https://apt.llvm.org/llvm.sh
           sudo chmod +x llvm.sh

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -56,10 +56,10 @@ jobs:
               ri-unit-test-path: "ResInsight-tests",
             }
           - {
-              name: "Ubuntu 22.04 clang-16",
-              os: ubuntu-22.04,
-              cc: "clang-16",
-              cxx: "clang++-16",
+              name: "Ubuntu 22.04 clang-18",
+              os: ubuntu-24.04,
+              cc: "clang-18",
+              cxx: "clang++-18",
               build-python-module: true,
               execute-unit-tests: true,
               execute-pytests: false,

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -214,14 +214,14 @@ jobs:
           sudo apt-get update --option="APT::Acquire::Retries=3"
           sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev libhdf5-dev
 
-      - name: Install clang-16
-        if: contains( matrix.config.cc, 'clang')
+      - name: Install clang-18 - probaly not needed
+        if: contains( matrix.config.cc, 'does-not-exist')
         run: |
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
+          # sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
           sudo apt-get upgrade
           wget https://apt.llvm.org/llvm.sh
           sudo chmod +x llvm.sh
-          sudo ./llvm.sh 16 all
+          sudo ./llvm.sh 18 all
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   clang-format-job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set apt mirror
         # GitHub Actions apt proxy is super unstable
@@ -15,26 +15,26 @@ jobs:
           curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
           sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
 
-      - name: Install clang-format 15.0
+      - name: Install clang-format 18
         run: |
           sudo apt-get update
-          sudo apt-get install --option="APT::Acquire::Retries=3" clang-format-15
-          clang-format-15 --version
+          sudo apt-get install --option="APT::Acquire::Retries=3" clang-format-18
+          clang-format-18 --version
       - uses: actions/checkout@v4
       - name: Check format - ApplicationLibCode
         run: |
           cd ApplicationLibCode
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i
           git diff
       - name: Check format - ApplicationExeCode
         run: |
           cd ApplicationExeCode
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i
           git diff
       - name: Check format - AppFwk
         run: |
           cd Fwk/AppFwk
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | grep -v gtest | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | grep -v gtest | xargs clang-format-18 -i
           git diff
       - uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update --option="APT::Acquire::Retries=3"
           sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev libhdf5-dev
-          sudo apt-get install clang-tidy-15 clang-format-15
+          sudo apt-get install clang-tidy-18 clang-format-18
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -54,20 +54,20 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux-release -DRESINSIGHT_USE_OPENMP=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+          cmake -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DRESINSIGHT_USE_OPENMP=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
           mv compile_commands.json compile_commands_original.json
           python ../scripts/fix_json_database.py compile_commands_original.json >> compile_commands.json
       - name: Run clang-tidy and apply fixes, clang-format after fixes
         run: |
           cd build
-          run-clang-tidy-15 -config-file ../ApplicationLibCode/.clang-tidy -fix files ApplicationLibCode
-          run-clang-tidy-15 -config-file ../GrpcInterface/.clang-tidy -fix files GrpcInterface
+          run-clang-tidy-18 -config-file ../ApplicationLibCode/.clang-tidy -fix files ApplicationLibCode
+          run-clang-tidy-18 -config-file ../GrpcInterface/.clang-tidy -fix files GrpcInterface
       - name: Run clang-format after clang-tidy
         run: |
           cd ApplicationLibCode
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i
           cd ../GrpcInterface
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -18,7 +18,6 @@ env:
 jobs:
   ResInsight-clang-tidy:
     runs-on: ubuntu-24.04
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -56,12 +56,14 @@ jobs:
           cmake -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DRESINSIGHT_USE_OPENMP=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
           mv compile_commands.json compile_commands_original.json
           python ../scripts/fix_json_database.py compile_commands_original.json >> compile_commands.json
-      - name: Run clang-tidy and apply fixes, clang-format after fixes
+      - name: Run clang-tidy and apply fixes
+        continue-on-error: true
         run: |
           cd build
           run-clang-tidy-18 -config-file ../ApplicationLibCode/.clang-tidy -fix files ApplicationLibCode
           run-clang-tidy-18 -config-file ../GrpcInterface/.clang-tidy -fix files GrpcInterface
       - name: Run clang-format after clang-tidy
+        continue-on-error: true
         run: |
           cd ApplicationLibCode
           find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   ResInsight-clang-tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Checkout

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 5.12.12
+          version: 6.7.0
           dir: "${{ github.workspace }}/Qt/"
           cache: true
-          modules: "qtnetworkauth"
+          modules: "qtnetworkauth qtcharts"
 
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7

--- a/ApplicationLibCode/.clang-tidy
+++ b/ApplicationLibCode/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:            '-*,modernize-use-override,modernize-deprecated-headers,modernize-use-using,modernize-make-unique,modernize-make-shared,bugprone-bool-pointer-implicit-conversion,bugprone-parent-virtual-call,bugprone-redundant-branch-condition,bugprone-suspicious-semicolon,bugprone-suspicious-string-compare,modernize-redundant-void-arg,readability-static-accessed-through-instance,readability-simplify-boolean-expr,readability-container-size-empty'
+Checks:            '-*,modernize-use-override,modernize-deprecated-headers,modernize-use-using,modernize-make-unique,modernize-make-shared,modernize-use-nullptr,modernize-concat-nested-namespaces,bugprone-bool-pointer-implicit-conversion,bugprone-parent-virtual-call,bugprone-redundant-branch-condition,bugprone-suspicious-semicolon,bugprone-suspicious-string-compare,modernize-redundant-void-arg,readability-static-accessed-through-instance,readability-simplify-boolean-expr,readability-container-size-empty'
 WarningsAsErrors:  ''
 HeaderFilterRegex: 'ApplicationLibCode/*.*$'
 FormatStyle:       'file'

--- a/ApplicationLibCode/Application/Tools/RiaQuantityInfoTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaQuantityInfoTools.cpp
@@ -30,9 +30,8 @@
 
 #include <unordered_map>
 
-namespace RiaQuantityInfoTools
-{
-namespace internal
+
+namespace RiaQuantityInfoTools::internal
 {
     //--------------------------------------------------------------------------------------------------
     ///
@@ -116,8 +115,8 @@ namespace internal
         RiuSummaryQuantityNameInfoProvider::instance()->setQuantityInfos( quantityInfos );
     }
 
-} // namespace internal
-} // namespace RiaQuantityInfoTools
+} // namespace RiaQuantityInfoTools::internal
+
 
 //--------------------------------------------------------------------------------------------------
 ///

--- a/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
@@ -44,9 +44,7 @@ bool RicApplyUserDefinedCameraFeature::isCommandEnabled() const
     cvf::Vec3d up  = cvf::Vec3d::UNDEFINED;
 
     readCameraFromSettings( eye, vrp, up );
-    if ( eye.isUndefined() || vrp.isUndefined() || up.isUndefined() ) return false;
-
-    return true;
+    return !(eye.isUndefined() || vrp.isUndefined() || up.isUndefined());
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
@@ -44,7 +44,7 @@ bool RicApplyUserDefinedCameraFeature::isCommandEnabled() const
     cvf::Vec3d up  = cvf::Vec3d::UNDEFINED;
 
     readCameraFromSettings( eye, vrp, up );
-    return !(eye.isUndefined() || vrp.isUndefined() || up.isUndefined());
+    return !( eye.isUndefined() || vrp.isUndefined() || up.isUndefined() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/ApplicationCommands/RicExitApplicationFeature.cpp
+++ b/ApplicationLibCode/Commands/ApplicationCommands/RicExitApplicationFeature.cpp
@@ -67,7 +67,7 @@ void RicExitApplicationFeature::onActionTriggered( bool isChecked )
     // shutdown. The slot onLastWindowClosed() configured in RiaGuiApplication::RiaGuiApplication is never called. Testing with
     // processEvents() had no effect.
     app->closeProject();
-    app->quit();
+    RiaGuiApplication::quit();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/PolygonCommands/RicBasicPolygonFeature.cpp
+++ b/ApplicationLibCode/Commands/PolygonCommands/RicBasicPolygonFeature.cpp
@@ -41,7 +41,7 @@ bool RicBasicPolygonFeature::isCommandEnabled() const
 {
     auto polygons = selectedPolygons();
 
-    return m_multiSelectSupported ? polygons.size() > 0 : polygons.size() == 1;
+    return m_multiSelectSupported ? !polygons.empty() : polygons.size() == 1;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifCaseRealizationParametersReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifCaseRealizationParametersReader.cpp
@@ -63,11 +63,11 @@ std::shared_ptr<RifCaseRealizationReader> RifCaseRealizationReader::createReader
 
     if ( fileName.endsWith( parametersFileName() ) )
     {
-        reader.reset( new RifCaseRealizationParametersReader( fileName ) );
+        reader = std::make_shared<RifCaseRealizationParametersReader>( fileName );
     }
     else if ( fileName.endsWith( runSpecificationFileName() ) )
     {
-        reader.reset( new RifCaseRealizationRunspecificationReader( fileName ) );
+        reader = std::make_shared<RifCaseRealizationRunspecificationReader>( fileName );
     }
     return reader;
 }

--- a/ApplicationLibCode/FileInterface/RifEclipseReportKeywords.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseReportKeywords.h
@@ -64,9 +64,10 @@ public:
                 return RiaDefines::ResultDataType::DOUBLE;
             case RifEclipseKeywordValueCount::KeywordDataType::INTEGER:
                 return RiaDefines::ResultDataType::INTEGER;
+            default:
+                return RiaDefines::ResultDataType::UNKNOWN;
         }
 
-        return RiaDefines::ResultDataType::UNKNOWN;
     }
 
 private:

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryAddress.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryAddress.cpp
@@ -490,7 +490,7 @@ std::string RifEclipseSummaryAddress::generateStringFromAddresses( const std::ve
     std::string addrString;
     for ( const RifEclipseSummaryAddress& address : addressVector )
     {
-        if ( addrString.length() > 0 )
+        if ( !addrString.empty() )
         {
             addrString += jointString;
         }

--- a/ApplicationLibCode/FileInterface/RifOpmCommonSummary.h
+++ b/ApplicationLibCode/FileInterface/RifOpmCommonSummary.h
@@ -33,14 +33,13 @@
 #include <tuple>
 #include <vector>
 
-namespace Opm
-{
-namespace EclIO
+
+namespace Opm::EclIO
 {
     class ESmry;
     class ExtESmry;
-} // namespace EclIO
-} // namespace Opm
+} // namespace Opm::EclIO
+
 
 class RiaThreadSafeLogger;
 

--- a/ApplicationLibCode/FileInterface/RifOpmRadialGridTools.h
+++ b/ApplicationLibCode/FileInterface/RifOpmRadialGridTools.h
@@ -24,13 +24,12 @@
 #include <string>
 #include <vector>
 
-namespace Opm
-{
-namespace EclIO
+
+namespace Opm::EclIO
 {
     class EGrid;
 }
-} // namespace Opm
+
 
 class RigMainGrid;
 class RigGridBase;

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -772,7 +772,7 @@ std::vector<RigEclipseTimeStepInfo> RifReaderOpmCommon::createFilteredTimeStepIn
 
     auto timeStepsOnFile = readTimeSteps();
 
-    if ( timeStepsOnFile.size() == 0 ) return timeStepInfos;
+    if ( timeStepsOnFile.empty() ) return timeStepInfos;
 
     auto  startDayOffset = timeStepsOnFile[0].simulationTimeFromStart;
     QDate startDate( timeStepsOnFile[0].year, timeStepsOnFile[0].month, timeStepsOnFile[0].day );
@@ -1026,7 +1026,7 @@ std::vector<QDateTime> RifReaderOpmCommon::timeStepsOnFile( QString gridFileName
     if ( m_restartFile == nullptr ) return {};
 
     auto timeStepsOnFile = readTimeSteps();
-    if ( timeStepsOnFile.size() == 0 ) return {};
+    if ( timeStepsOnFile.empty() ) return {};
 
     auto  startDayOffset = timeStepsOnFile[0].simulationTimeFromStart;
     QDate startDate( timeStepsOnFile[0].year, timeStepsOnFile[0].month, timeStepsOnFile[0].day );

--- a/ApplicationLibCode/FileInterface/RifReaderOpmRft.h
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmRft.h
@@ -25,13 +25,12 @@
 
 #include <memory>
 
-namespace Opm
-{
-namespace EclIO
+
+namespace Opm::EclIO
 {
     class ERft;
-} // namespace EclIO
-} // namespace Opm
+} // namespace Opm::EclIO
+
 
 class RifReaderOpmRft : public RifReaderRftInterface, public cvf::Object
 {

--- a/ApplicationLibCode/ProjectDataModel/Annotations/RimReachCircleAnnotation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Annotations/RimReachCircleAnnotation.cpp
@@ -18,6 +18,8 @@
 
 #include "RimReachCircleAnnotation.h"
 
+#include <memory>
+
 #include "RimAnnotationCollection.h"
 #include "RimAnnotationInViewCollection.h"
 #include "RimAnnotationLineAppearance.h"
@@ -54,7 +56,7 @@ RimReachCircleAnnotation::RimReachCircleAnnotation()
     m_appearance = new RimReachCircleLineAppearance();
     m_appearance.uiCapability()->setUiTreeChildrenHidden( true );
 
-    m_centerPointEventHandler.reset( new RicVec3dPickEventHandler( &m_centerPointXyd ) );
+    m_centerPointEventHandler = std::make_shared<RicVec3dPickEventHandler>( &m_centerPointXyd );
 
     setDeletable( true );
 }

--- a/ApplicationLibCode/ProjectDataModel/Annotations/RimTextAnnotation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Annotations/RimTextAnnotation.cpp
@@ -37,6 +37,7 @@
 
 #include <QAction>
 #include <QPointer>
+#include <memory>
 
 CAF_PDM_SOURCE_INIT( RimTextAnnotation, "RimTextAnnotation" );
 
@@ -73,8 +74,8 @@ RimTextAnnotation::RimTextAnnotation()
     m_nameProxy.uiCapability()->setUiReadOnly( true );
     m_nameProxy.xmlCapability()->disableIO();
 
-    m_anchorPointPickEventHandler.reset( new RicVec3dPickEventHandler( &m_anchorPointXyd ) );
-    m_labelPointPickEventHandler.reset( new RicVec3dPickEventHandler( &m_labelPointXyd, 0.1 ) );
+    m_anchorPointPickEventHandler = std::make_shared<RicVec3dPickEventHandler>( &m_anchorPointXyd );
+    m_labelPointPickEventHandler = std::make_shared<RicVec3dPickEventHandler>( &m_labelPointXyd, 0.1 );
 
     setDeletable( true );
 }

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
@@ -150,7 +150,7 @@ RimStatisticsContourMap::RimStatisticsContourMap()
 //--------------------------------------------------------------------------------------------------
 void RimStatisticsContourMap::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-    if ( ( eclipseCase() == nullptr ) && ( ensemble()->cases().size() > 0 ) )
+    if ( ( eclipseCase() == nullptr ) && ( !ensemble()->cases().empty() ) )
     {
         auto selCase = ensemble()->cases().front();
         setEclipseCase( selCase );
@@ -551,7 +551,7 @@ void RimStatisticsContourMap::computeStatistics()
             auto          formationNames = selectedFormations();
 
             bool formationNamesOk = true;
-            if ( formationNames.size() > 0 )
+            if ( !formationNames.empty() )
             {
                 if ( auto names = eCase->activeFormationNames() )
                 {

--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
@@ -1661,7 +1661,7 @@ void Rim3dView::appendAnnotationsToModel()
     if ( frameScene )
     {
         cvf::String name = "Annotations";
-        this->removeModelByName( frameScene, name );
+        Rim3dView::removeModelByName( frameScene, name );
 
         cvf::ref<cvf::ModelBasicList> model = new cvf::ModelBasicList;
         model->setName( name );

--- a/ApplicationLibCode/ProjectDataModel/RimGridStatisticsPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridStatisticsPlot.cpp
@@ -43,6 +43,7 @@
 #include "cvfAssert.h"
 
 #include <cmath>
+#include <memory>
 
 CAF_PDM_SOURCE_INIT( RimGridStatisticsPlot, "GridStatisticsPlot" );
 
@@ -243,7 +244,7 @@ bool RimGridStatisticsPlot::hasStatisticsData() const
 RigHistogramData RimGridStatisticsPlot::createStatisticsData() const
 {
     std::unique_ptr<RimHistogramCalculator> histogramCalculator;
-    histogramCalculator.reset( new RimHistogramCalculator );
+    histogramCalculator = std::make_unique<RimHistogramCalculator>( );
     histogramCalculator->setNumBins( static_cast<size_t>( m_numHistogramBins() ) );
 
     RigHistogramData histogramData;

--- a/ApplicationLibCode/ProjectDataModel/RimGridTimeHistoryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridTimeHistoryCurve.cpp
@@ -641,7 +641,7 @@ void RimGridTimeHistoryCurve::fieldChangedByUi( const caf::PdmFieldHandle* chang
     }
     else
     {
-        RimPlotCurve::fieldChangedByUi( changedField, oldValue, newValue );
+        RimStackablePlotCurve::fieldChangedByUi( changedField, oldValue, newValue );
     }
 }
 

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
@@ -260,7 +260,7 @@ std::vector<std::vector<std::pair<size_t, double>>>
     std::vector<std::vector<std::pair<size_t, double>>> projected3dGridIndices( nCells );
 
     const bool isSummationResult = RigContourMapCalculator::isStraightSummationResult( resultAggregation );
-    const bool usePolygonLimits  = limitToPolygons.size() > 0;
+    const bool usePolygonLimits  = !limitToPolygons.empty();
 
 #pragma omp parallel for
     for ( int index = 0; index < nCells; ++index )

--- a/ApplicationLibCode/ReservoirDataModel/cvfGeometryTools.inl
+++ b/ApplicationLibCode/ReservoirDataModel/cvfGeometryTools.inl
@@ -626,7 +626,7 @@ void GeometryTools::calculatePartiallyFreeCubeFacePolygon( ArrayWrapperConst<Ver
     typedef std::map<IndexType, typename std::vector<IndexType>::const_iterator> VxIdxToPolygonPositionMap;
 
     CVF_ASSERT( m_partiallyFreeCubeFaceHasHoles );
-    CVF_ASSERT( partialFacePolygon != NULL );
+    CVF_ASSERT( partialFacePolygon != nullptr );
 
     // Copy the start polygon
     std::list<IndexType> resultPolygon;

--- a/ApplicationLibCode/UnitTests/SolveSpaceSolver-Test.cpp
+++ b/ApplicationLibCode/UnitTests/SolveSpaceSolver-Test.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 #include "RiaSCurveCalculator.h"

--- a/ApplicationLibCode/UserInterface/RiuQtChartView.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQtChartView.cpp
@@ -79,6 +79,7 @@ void RiuQtChartView::mouseReleaseEvent( QMouseEvent* event )
         if ( event->button() == Qt::RightButton )
         {
             // Skip QtCharts::QChartView::mouseReleaseEvent() to avoid zoom on right mouse button
+            // NOLINTNEXTLINE: Suppress clang-tidy for the next line
             return QGraphicsView::mouseReleaseEvent( event );
         }
 

--- a/ApplicationLibCode/UserInterface/RiuQtChartsPlotCurve.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQtChartsPlotCurve.cpp
@@ -380,9 +380,7 @@ void RiuQtChartsPlotCurve::updateScatterSeries()
 //--------------------------------------------------------------------------------------------------
 bool RiuQtChartsPlotCurve::isQtChartObjectsPresent() const
 {
-    if ( !lineSeries() ) return false;
-
-    return true;
+    return lineSeries() != nullptr;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuQtChartsPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQtChartsPlotWidget.cpp
@@ -1188,9 +1188,7 @@ void RiuQtChartsPlotWidget::wheelEvent( QWheelEvent* wheelEvent )
 //--------------------------------------------------------------------------------------------------
 bool RiuQtChartsPlotWidget::eventFilter( QObject* watched, QEvent* event )
 {
-    if ( RiuPlotWidget::handleDragDropEvent( event ) ) return true;
-
-    return false;
+    return RiuPlotWidget::handleDragDropEvent( event );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
@@ -1014,7 +1014,7 @@ void RiuQwtPlotWidget::selectClosestPlotItem( const QPoint& pos, bool toggleItem
         {
             for ( auto highlightedCurve : m_hightlightedCurves )
             {
-                if ( toggleItemInSelection && ( highlightedCurve == clickedCurve ) )
+                if ( ( highlightedCurve == clickedCurve ) )
                 {
                     wasToggledOff = true;
                     continue;

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
@@ -1014,7 +1014,7 @@ void RiuQwtPlotWidget::selectClosestPlotItem( const QPoint& pos, bool toggleItem
         {
             for ( auto highlightedCurve : m_hightlightedCurves )
             {
-                if ( ( highlightedCurve == clickedCurve ) )
+                if ( highlightedCurve == clickedCurve )
                 {
                     wasToggledOff = true;
                     continue;

--- a/ThirdParty/Ert/lib/util/util.c
+++ b/ThirdParty/Ert/lib/util/util.c
@@ -4639,7 +4639,6 @@ bool util_mkdir_p(const char *_path) {
   int current_pos = 0;
 
   if (!util_is_directory(path)) {
-    int i = 0;
     active_path = (char*)util_calloc(strlen(path) + 1 , sizeof * active_path );
 
     do {
@@ -4647,7 +4646,6 @@ bool util_mkdir_p(const char *_path) {
       if (n < strlen(path))
         n += 1;
       path += n;
-      i++;
       strncpy(active_path , _path , n + current_pos);
       active_path[n+current_pos] = '\0';
       current_pos += n;


### PR DESCRIPTION
- Use clang 18 to compile ResInsight
- Fix failing build of clang-tidy

Continut to sse the script to install clang: `./llvm.sh 18 all` This scripts installs all required libraries, including `openmp` library that is not installed by default. This could probably be fixed by a manual install using `apt-get install`, but I expect the script to be more stable across different distributions than a manual install.
