### PR TITLE
Make sure std::equal is executed on valid range of vectors

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaCurveMerger.inl
+++ b/ApplicationLibCode/Application/Tools/RiaCurveMerger.inl
@@ -79,8 +79,15 @@ void RiaCurveMerger<XValueType>::addCurveData( const std::vector<XValueType>& xV
         {
             if ( m_isXValuesSharedBetweenCurves )
             {
-                const auto& firstXValues       = m_originalValues.front().first;
-                m_isXValuesSharedBetweenCurves = std::equal( firstXValues.begin(), firstXValues.end(), xValues.begin() );
+                const auto& firstXValues = m_originalValues.front().first;
+                if ( firstXValues.size() == xValues.size() )
+                {
+                    m_isXValuesSharedBetweenCurves = std::equal( firstXValues.begin(), firstXValues.end(), xValues.begin(), xValues.end() );
+                }
+                else
+                {
+                    m_isXValuesSharedBetweenCurves = false;
+                }
             }
 
             if ( m_isXValuesMonotonicallyIncreasing )


### PR DESCRIPTION
Previous solution did not check for equal length of these vectors, causing out of bounds compare. Detected by debug build using MSVC
