### PR TITLE
Fix resampling issue for statistics curves

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaCurveMerger.h
+++ b/ApplicationLibCode/Application/Tools/RiaCurveMerger.h
@@ -22,6 +22,16 @@
 
 #include <ctime>
 
+namespace RiaCurveDefines
+{
+enum class InterpolationMethod
+{
+    STEP_LEFT,
+    STEP_RIGHT,
+    LINEAR
+};
+}
+
 template <typename XValueType>
 class XValueComparator
 {
@@ -39,7 +49,8 @@ class RiaCurveMerger
 {
 public:
     using XComparator = XValueComparator<XValueType>;
-    RiaCurveMerger();
+
+    RiaCurveMerger( RiaCurveDefines::InterpolationMethod method );
 
     void   addCurveData( const std::vector<XValueType>& xValues, const std::vector<double>& yValues );
     size_t curveCount() const;
@@ -63,8 +74,10 @@ public:
 public:
     // Helper methods, available as public to be able to access from unit tests
 
-    static double
-        interpolatedYValue( const XValueType& xValue, const std::vector<XValueType>& curveXValues, const std::vector<double>& curveYValues );
+    static double interpolatedYValue( const XValueType&                    xValue,
+                                      const std::vector<XValueType>&       curveXValues,
+                                      const std::vector<double>&           curveYValues,
+                                      RiaCurveDefines::InterpolationMethod interpolationMethod );
 
 private:
     void        computeUnionOfXValues( bool includeValuesFromPartialCurves );
@@ -78,8 +91,9 @@ private:
     std::vector<XValueType>          m_allXValues;
     std::vector<std::vector<double>> m_interpolatedValuesForAllCurves;
 
-    bool m_isXValuesSharedBetweenCurves;
-    bool m_isXValuesMonotonicallyIncreasing;
+    bool                                 m_isXValuesSharedBetweenCurves;
+    bool                                 m_isXValuesMonotonicallyIncreasing;
+    RiaCurveDefines::InterpolationMethod m_interpolationMethod;
 };
 
 using RiaTimeHistoryCurveMerger = RiaCurveMerger<time_t>;

--- a/ApplicationLibCode/FileInterface/RifReaderEnsembleStatisticsRft.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEnsembleStatisticsRft.cpp
@@ -220,7 +220,7 @@ void RifReaderEnsembleStatisticsRft::calculateStatistics( const QString& wellNam
         // The TVD values is extracted from the first summary case
 
         RifEclipseRftAddress              mdAddress = RifEclipseRftAddress::createAddress( wellName, timeStep, ChannelType::MD );
-        RiaCurveMerger<double>            curveMerger;
+        RiaCurveMerger<double>            curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
         RiaWeightedMeanCalculator<size_t> dataSetSizeCalc;
 
         for ( RimSummaryCase* summaryCase : m_summaryCaseCollection->allSummaryCases() )
@@ -247,7 +247,7 @@ void RifReaderEnsembleStatisticsRft::calculateStatistics( const QString& wellNam
         // Compute statistics based on TVD depths. No measured depth can be estimated.
         // This concept works well for vertical wells, but does not work for horizontal wells.
 
-        RiaCurveMerger<double>            curveMerger;
+        RiaCurveMerger<double>            curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
         RiaWeightedMeanCalculator<size_t> dataSetSizeCalc;
         RifEclipseRftAddress              tvdAddress = RifEclipseRftAddress::createAddress( wellName, timeStep, ChannelType::TVD );
 

--- a/ApplicationLibCode/ProjectDataModel/RimSummaryCalculation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSummaryCalculation.cpp
@@ -326,7 +326,7 @@ std::optional<std::pair<std::vector<double>, std::vector<time_t>>>
 {
     QString leftHandSideVariableName = RimSummaryCalculation::findLeftHandSide( expression );
 
-    RiaTimeHistoryCurveMerger timeHistoryCurveMerger;
+    RiaTimeHistoryCurveMerger timeHistoryCurveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
 
     for ( size_t i = 0; i < variables.size(); i++ )
     {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryCase.cpp
@@ -316,7 +316,9 @@ std::pair<std::vector<time_t>, std::vector<double>> RimDeltaSummaryCase::calcula
         return ResultPair();
     }
 
-    RiaTimeHistoryCurveMerger merger;
+    auto                      interpolationMethod = address.hasAccumulatedData() ? RiaCurveDefines::InterpolationMethod::LINEAR
+                                                                                 : RiaCurveDefines::InterpolationMethod::STEP_RIGHT;
+    RiaTimeHistoryCurveMerger merger( interpolationMethod );
     merger.addCurveData( reader1->timeSteps( address ), values1 );
     merger.addCurveData( reader2->timeSteps( address ), values2 );
     merger.computeInterpolatedValues( includeIncompleteCurves );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp
@@ -157,7 +157,9 @@ void RimEnsembleStatisticsCase::calculate( const std::vector<RimSummaryCase*>& s
     // The last time step for the individual realizations in an ensemble is usually identical. Add a small threshold to improve robustness.
     const auto timeThreshold = RiaSummaryTools::calculateTimeThreshold( minTime, maxTime );
 
-    RiaTimeHistoryCurveMerger curveMerger;
+    auto                      interpolationMethod = inputAddress.hasAccumulatedData() ? RiaCurveDefines::InterpolationMethod::LINEAR
+                                                                                      : RiaCurveDefines::InterpolationMethod::STEP_RIGHT;
+    RiaTimeHistoryCurveMerger curveMerger( interpolationMethod );
     for ( const auto& sumCase : summaryCases )
     {
         const auto& reader = sumCase->summaryReader();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurve.cpp
@@ -631,7 +631,7 @@ void RimSummaryCurve::onLoadDataAndUpdate( bool updateParentPlot )
                 }
                 else
                 {
-                    RiaTimeHistoryCurveMerger curveMerger;
+                    RiaTimeHistoryCurveMerger curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
                     curveMerger.addCurveData( curveTimeStepsX, curveValuesX );
                     curveMerger.addCurveData( curveTimeStepsY, curveValuesY );
 
@@ -1258,7 +1258,7 @@ void RimSummaryCurve::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
 
         if ( !curveValuesX.empty() && !curveValuesY.empty() )
         {
-            RiaTimeHistoryCurveMerger curveMerger;
+            RiaTimeHistoryCurveMerger curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
             curveMerger.addCurveData( curveTimeStepsX, curveValuesX );
             curveMerger.addCurveData( curveTimeStepsY, curveValuesY );
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.cpp
@@ -156,8 +156,8 @@ QString RimSummaryCurvesData::createTextForExport( const std::vector<RimSummaryC
 
     std::vector<RimSummaryCurvesData> exportData( 2 );
 
-    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, ResampleAlgorithm::DATA_DECIDES, summaryCurvesData, &exportData[0] );
-    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, ResampleAlgorithm::PERIOD_END, gridCurvesData, &exportData[1] );
+    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, summaryCurvesData, &exportData[0] );
+    RimSummaryCurvesData::prepareCaseCurvesForExport( resamplingPeriod, gridCurvesData, &exportData[1] );
 
     RimSummaryCurvesData::appendToExportData( out, exportData, showTimeAsLongString );
 
@@ -279,7 +279,6 @@ void RimSummaryCurvesData::populateSummaryCurvesData( std::vector<RimSummaryCurv
 ///
 //--------------------------------------------------------------------------------------------------
 void RimSummaryCurvesData::prepareCaseCurvesForExport( RiaDefines::DateTimePeriod  period,
-                                                       ResampleAlgorithm           algorithm,
                                                        const RimSummaryCurvesData& inputCurvesData,
                                                        RimSummaryCurvesData*       resultCurvesData )
 {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurvesData.h
@@ -40,13 +40,6 @@ enum class SummaryCurveType
     CURVE_TYPE_OBSERVED = 0x2
 };
 
-enum class ResampleAlgorithm
-{
-    NONE,
-    DATA_DECIDES,
-    PERIOD_END
-};
-
 class RimSummaryCurvesData
 {
 public:
@@ -74,7 +67,6 @@ private:
     static void populateAsciiDataCurvesData( std::vector<RimAsciiDataCurve*> curves, RimSummaryCurvesData* curvesData );
 
     static void prepareCaseCurvesForExport( RiaDefines::DateTimePeriod  period,
-                                            ResampleAlgorithm           algorithm,
                                             const RimSummaryCurvesData& inputCurvesData,
                                             RimSummaryCurvesData*       resultCurvesData );
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -1730,7 +1730,7 @@ bool RimSummaryPlot::updateStackedCurveDataForAxis( RiuPlotAxis plotAxis )
 
     if ( stackingItems.empty() ) return true;
 
-    RiaCurveMerger<double>                  curveMerger;
+    RiaCurveMerger<double>                  curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
     std::map<RiaDefines::PhaseType, size_t> curvePhaseCount;
 
     for ( auto stackingItem : stackingItems )

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogStatistics.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogStatistics.cpp
@@ -85,8 +85,8 @@ void RimEnsembleWellLogStatistics::calculate( const std::vector<RimWellLogLasFil
 //--------------------------------------------------------------------------------------------------
 void RimEnsembleWellLogStatistics::calculate( const std::vector<RimWellLogLasFile*>& wellLogFiles, const QString& wellLogChannelName )
 {
-    RiaCurveMerger<double> curveMerger;
-    RiaCurveMerger<double> tvdCurveMerger;
+    RiaCurveMerger<double> curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
+    RiaCurveMerger<double> tvdCurveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
 
     RiaWeightedMeanCalculator<size_t> dataSetSizeCalc;
 

--- a/ApplicationLibCode/UnitTests/RigTimeCurveHistoryMerger-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigTimeCurveHistoryMerger-Test.cpp
@@ -12,26 +12,28 @@ TEST( RiaTimeHistoryCurveMergerTest, TestDateInterpolation )
     std::vector<double> values{ 2.0, 3.5, 5.0, 6.0 };
     std::vector<time_t> timeSteps{ 1, 5, 10, 15 };
 
+    auto interpolationMethod = RiaCurveDefines::InterpolationMethod::LINEAR;
+
     {
-        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 1, timeSteps, values );
+        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 1, timeSteps, values, interpolationMethod );
 
         EXPECT_EQ( 2.0, val );
     }
 
     {
-        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 0, timeSteps, values );
+        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 0, timeSteps, values, interpolationMethod );
 
         EXPECT_EQ( HUGE_VAL, val );
     }
 
     {
-        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 20, timeSteps, values );
+        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 20, timeSteps, values, interpolationMethod );
 
         EXPECT_EQ( HUGE_VAL, val );
     }
 
     {
-        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 3, timeSteps, values );
+        double val = RiaTimeHistoryCurveMerger::interpolatedYValue( 3, timeSteps, values, interpolationMethod );
 
         EXPECT_EQ( 2.75, val );
     }
@@ -53,7 +55,7 @@ TEST( RiaTimeHistoryCurveMergerTest, ExtractIntervalsWithSameTimeSteps )
         timeSteps.push_back( i );
     }
 
-    RiaTimeHistoryCurveMerger interpolate;
+    RiaTimeHistoryCurveMerger interpolate( RiaCurveDefines::InterpolationMethod::LINEAR );
     interpolate.addCurveData( timeSteps, valuesA );
     interpolate.addCurveData( timeSteps, valuesB );
     interpolate.computeInterpolatedValues( true );
@@ -81,7 +83,7 @@ TEST( RiaTimeHistoryCurveMergerTest, ExtractIntervalsWithSameTimeStepsOneComplet
         timeSteps.push_back( i );
     }
 
-    RiaTimeHistoryCurveMerger interpolate;
+    RiaTimeHistoryCurveMerger interpolate( RiaCurveDefines::InterpolationMethod::LINEAR );
     interpolate.addCurveData( timeSteps, valuesA );
     interpolate.addCurveData( timeSteps, valuesB );
     interpolate.computeInterpolatedValues( true );
@@ -109,7 +111,7 @@ TEST( RiaTimeHistoryCurveMergerTest, ExtractIntervalsWithSameTimeStepsBothComple
         timeSteps.push_back( i );
     }
 
-    RiaTimeHistoryCurveMerger interpolate;
+    RiaTimeHistoryCurveMerger interpolate( RiaCurveDefines::InterpolationMethod::LINEAR );
     interpolate.addCurveData( timeSteps, valuesA );
     interpolate.addCurveData( timeSteps, valuesB );
     interpolate.computeInterpolatedValues( true );
@@ -134,7 +136,7 @@ TEST( RiaTimeHistoryCurveMergerTest, OverlappintTimes )
     std::vector<time_t> timeStepsA{ 0, 10, 11, 15, 20 };
     std::vector<time_t> timeStepsB{ 1, 2, 3, 5, 7 };
 
-    RiaTimeHistoryCurveMerger interpolate;
+    RiaTimeHistoryCurveMerger interpolate( RiaCurveDefines::InterpolationMethod::LINEAR );
     interpolate.addCurveData( timeStepsA, valuesA );
     interpolate.addCurveData( timeStepsB, valuesB );
     interpolate.computeInterpolatedValues( true );
@@ -153,7 +155,7 @@ TEST( RiaTimeHistoryCurveMergerTest, OverlappintTimes )
 TEST( RiaTimeHistoryCurveMergerTest, RobustUse )
 {
     {
-        RiaTimeHistoryCurveMerger curveMerger;
+        RiaTimeHistoryCurveMerger curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
         curveMerger.computeInterpolatedValues( true );
         EXPECT_EQ( 0, static_cast<int>( curveMerger.allXValues().size() ) );
     }
@@ -165,7 +167,7 @@ TEST( RiaTimeHistoryCurveMergerTest, RobustUse )
     std::vector<time_t> timeStepsB{ 1, 2, 3 };
 
     {
-        RiaTimeHistoryCurveMerger curveMerger;
+        RiaTimeHistoryCurveMerger curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
         curveMerger.addCurveData( timeStepsA, valuesA );
         curveMerger.computeInterpolatedValues( true );
         EXPECT_EQ( timeStepsA.size(), curveMerger.allXValues().size() );
@@ -173,7 +175,7 @@ TEST( RiaTimeHistoryCurveMergerTest, RobustUse )
     }
 
     {
-        RiaTimeHistoryCurveMerger curveMerger;
+        RiaTimeHistoryCurveMerger curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
         curveMerger.addCurveData( timeStepsA, valuesA );
         curveMerger.addCurveData( timeStepsB, valuesB );
 
@@ -198,7 +200,7 @@ TEST( RiaTimeHistoryCurveMergerTest, NoTimeStepOverlap )
     std::vector<time_t> timeStepsB{ 100, 200, 300 };
 
     {
-        RiaTimeHistoryCurveMerger curveMerger;
+        RiaTimeHistoryCurveMerger curveMerger( RiaCurveDefines::InterpolationMethod::LINEAR );
         curveMerger.addCurveData( timeStepsA, valuesA );
         curveMerger.addCurveData( timeStepsB, valuesB );
 
@@ -218,7 +220,7 @@ TEST( RiaTimeHistoryCurveMergerTest, SharedXValues )
     std::vector<double> valuesB{ 10, 20, 30, 40, 50, 60, 70 };
     std::vector<time_t> timeSteps{ 1, 2, 3, 4, 5, 6, 7 };
 
-    RiaTimeHistoryCurveMerger interpolate;
+    RiaTimeHistoryCurveMerger interpolate( RiaCurveDefines::InterpolationMethod::LINEAR );
     interpolate.addCurveData( timeSteps, valuesA );
     interpolate.addCurveData( timeSteps, valuesB );
     interpolate.computeInterpolatedValues( true );


### PR DESCRIPTION
A performance fix for resampling was introduced in 118ecf941adc4214fe764afc55875fc04103bbeb. This fix revealed a weakness in the code used to create the values for P90/P10/mean curves in `Show Plot Data`. To mitigate this issue, the `RiaCurveMerger` has learned how to interpolate using linear, step right or step left.

When the fix for this issue is used, comparing with Excel now gives identical results for mean. P10 and P90 has still some (small) difference compared to Excel, and this is probably due to individual resampling of each curve. These differences were also present before the performance fix.

The resampling in `Show Plot Data` is based on values in each individual curve. The resampling operation happens in the text producing code, and is independent to the other curves. The statistical curves values are computed once based on raw data from reader (no resampling). When resampling is required, the values for P10/P90 curves  are resampled using `RiaSummaryTools::resampledValuesForPeriod`. A more robust method is probably to compute the P10/P90 based on the resampled values from each realization. This will make the QC process more robust. 

Resampling of curve data happens in `RimSummaryCurvesData::prepareCaseCurvesForExport`