### PR TITLE
Handles error result addresses for statistics curves

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp
@@ -73,6 +73,8 @@ bool RimEnsembleStatisticsCase::hasMeanData() const
 //--------------------------------------------------------------------------------------------------
 std::pair<bool, std::vector<double>> RimEnsembleStatisticsCase::values( const RifEclipseSummaryAddress& resultAddress ) const
 {
+    if ( resultAddress.isErrorResult() ) return {};
+
     switch ( resultAddress.statisticsType() )
     {
         case RifEclipseSummaryAddressDefines::StatisticsType::P10:

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp
@@ -73,7 +73,7 @@ bool RimEnsembleStatisticsCase::hasMeanData() const
 //--------------------------------------------------------------------------------------------------
 std::pair<bool, std::vector<double>> RimEnsembleStatisticsCase::values( const RifEclipseSummaryAddress& resultAddress ) const
 {
-    if ( resultAddress.isErrorResult() ) return {};
+    if ( resultAddress.isErrorResult() ) return std::make_pair(false, std::vector<double>{});
 
     switch ( resultAddress.statisticsType() )
     {


### PR DESCRIPTION
Changes in the summary system has introduced a bug causing two identical results to be displayed, the correct statistical vector and the error. If error is asked for, return no values.
