### PR TITLE
Add support for Apple Clang 17

### DIFF
--- a/ApplicationExeCode/RiaMainTools.cpp
+++ b/ApplicationExeCode/RiaMainTools.cpp
@@ -30,11 +30,16 @@
 
 #include <QDir>
 
+#include <version>
+
+#if __cpp_lib_stacktrace >= 202011L
 #include <stacktrace>
+#endif
 
 namespace internal
 {
 // Custom formatter for stacktrace
+#if __cpp_lib_stacktrace >= 202011L
 std::string formatStacktrace( const std::stacktrace& st )
 {
     std::stringstream ss;
@@ -46,6 +51,7 @@ std::string formatStacktrace( const std::stacktrace& st )
     }
     return ss.str();
 }
+#endif
 } // namespace internal
 
 //--------------------------------------------------------------------------------------------------
@@ -67,10 +73,11 @@ void manageSegFailure( int signalCode )
         {
             fileLogger->error( str.toStdString().data() );
 
+#if __cpp_lib_stacktrace >= 202011L
             auto        st      = std::stacktrace::current();
             std::string message = "Stack trace:\n" + internal::formatStacktrace( st );
             logger->error( message.data() );
-
+#endif
             fileLogger->flush();
         }
     }

--- a/ApplicationLibCode/FileInterface/RifOpenVDSReader.h
+++ b/ApplicationLibCode/FileInterface/RifOpenVDSReader.h
@@ -71,9 +71,14 @@ protected:
 
 private:
     QString                                            m_filename;
-    OpenVDS::VDS*                                      m_handle;
-    OpenVDS::VolumeDataLayout const*                   m_layout;
     int                                                m_dataChannelToUse;
-    std::unique_ptr<OpenVDS::IJKCoordinateTransformer> m_coordinateTransform;
     std::unique_ptr<ZGYAccess::HistogramData>          m_histogram;
+
+#if HAVE_OPENVDS
+    OpenVDS::VDS*                                      m_handle = nullptr;
+    OpenVDS::VolumeDataLayout const*                   m_layout = nullptr;
+    std::unique_ptr<OpenVDS::IJKCoordinateTransformer> m_coordinateTransform;
+#else
+    void* m_handle = nullptr;
+#endif // HAVE_OPENVDS
 };

--- a/ApplicationLibCode/FileInterface/RifVtkImportUtil.cpp
+++ b/ApplicationLibCode/FileInterface/RifVtkImportUtil.cpp
@@ -21,10 +21,15 @@
 #include "RiaStdStringTools.h"
 
 #include <filesystem>
-#include <spanstream>
-#include <sstream>
+#include <version>
 #include <string>
 #include <vector>
+#if __cpp_lib_spanstream >= 202106L
+#include <spanstream>
+#else
+#include <sstream>
+#endif
+
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -180,7 +185,11 @@ std::vector<RifVtkImportUtil::PvdDataset> RifVtkImportUtil::parsePvdDatasets( co
 //--------------------------------------------------------------------------------------------------
 std::vector<cvf::Vec3d> RifVtkImportUtil::parseVec3ds( std::string_view text )
 {
+#if __cpp_lib_spanstream >= 202106L
     std::ispanstream iss( text );
+#else
+    std::istringstream iss( (std::string( text )) );
+#endif
 
     std::vector<cvf::Vec3d> vecs;
 
@@ -204,7 +213,11 @@ std::vector<cvf::Vec3d> RifVtkImportUtil::parseVec3ds( std::string_view text )
 //--------------------------------------------------------------------------------------------------
 std::vector<cvf::Vec3f> RifVtkImportUtil::parseVec3fs( std::string_view text )
 {
+#if __cpp_lib_spanstream >= 202106L
     std::ispanstream iss( text );
+#else
+    std::istringstream iss( (std::string( text )) );
+#endif
 
     std::vector<cvf::Vec3f> vecs;
 

--- a/ApplicationLibCode/ProjectDataModel/Jobs/RimOpmFlowJob.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Jobs/RimOpmFlowJob.cpp
@@ -60,6 +60,8 @@
 #include <QMessageBox>
 #include <QTextStream>
 
+#include <filesystem>
+
 CAF_PDM_SOURCE_INIT( RimOpmFlowJob, "OpmFlowJob" );
 
 namespace caf

--- a/ApplicationLibCode/SocketInterface/RiaSocketServerDefines.h
+++ b/ApplicationLibCode/SocketInterface/RiaSocketServerDefines.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <iterator> // for std::distance within Qt
+
 #include <QDataStream>
 
 #include <string>

--- a/ApplicationLibCode/UserInterface/RiuDragDrop.cpp
+++ b/ApplicationLibCode/UserInterface/RiuDragDrop.cpp
@@ -155,7 +155,7 @@ private:
         std::vector<T*> typedAncestorsVec;
         for ( size_t i = 0; i < m_objects.size(); i++ )
         {
-            auto typedAncestor = m_objects[i]->firstAncestorOfType<T>();
+            auto typedAncestor = m_objects[i]->template firstAncestorOfType<T>();
             if ( typedAncestor )
             {
                 typedAncestorsVec.push_back( typedAncestor );

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0)
     message(
       FATAL_ERROR
-        "Minimum supported version is Clang 19, detected version: ${CMAKE_CXX_COMPILER_VERSION}"
+        "Minimum supported version is Clang 17, detected version: ${CMAKE_CXX_COMPILER_VERSION}"
     )
   endif()
 endif()
@@ -426,34 +426,43 @@ endif()
 # OpenVDS seismic file access
 # ##############################################################################
 
-message(STATUS "Starting download of external library OpenVDS ...")
-
 if(MSVC)
+  message(STATUS "Starting download of external library OpenVDS ...")
   FetchContent_Declare(
     openvds
     URL https://downloads.bluware.com/artifactory/Releases-OpenVDSPlus/3.4/openvds+-3.4.6-win.zip
   )
-else()
+elseif(LINUX)
+  message(STATUS "Starting download of external library OpenVDS ...")
   FetchContent_Declare(
     openvds
     URL https://downloads.bluware.com/artifactory/Releases-OpenVDSPlus/3.4/openvds+-3.4.6-manylinux_2014.tar.gz
   )
+else()
+  message(
+    WARNING
+      "OpenVDS is not supported on this platform. Compiling without OpenVDS support."
+  )
 endif()
 
-FetchContent_MakeAvailable(openvds)
-message(STATUS "... completed download of external library OpenVDS")
+if(MSVC OR LINUX)
+  FetchContent_MakeAvailable(openvds)
+  message(STATUS "... completed download of external library OpenVDS")
 
-set(RESINSIGHT_OPENVDS_API_DIR ${openvds_SOURCE_DIR})
-message(STATUS "Using OpenVDS api from : ${RESINSIGHT_OPENVDS_API_DIR}")
+  set(RESINSIGHT_OPENVDS_API_DIR ${openvds_SOURCE_DIR})
+  message(STATUS "Using OpenVDS api from : ${RESINSIGHT_OPENVDS_API_DIR}")
+endif()
 
 if(MSVC)
   list(APPEND EXTERNAL_LINK_LIBRARIES
        ${RESINSIGHT_OPENVDS_API_DIR}/lib/msvc_141/openvds.lib
   )
-else()
+  add_compile_definitions(HAVE_OPENVDS)
+elseif(LINUX)
   list(APPEND EXTERNAL_LINK_LIBRARIES
        ${RESINSIGHT_OPENVDS_API_DIR}/lib64/libopenvds.so
   )
+  add_compile_definitions(HAVE_OPENVDS)
 endif()
 
 # ##############################################################################
@@ -785,8 +794,7 @@ if(MSVC)
     endforeach(HDF5_DLL_NAME)
   endif()
 
-else()
-  # Linux
+elseif(LINUX)
 
   # OpenVDS lib files
   list(APPEND RI_FILENAMES ${RESINSIGHT_OPENVDS_API_DIR}/bin/SEGYImport)
@@ -805,7 +813,7 @@ else()
          ${RESINSIGHT_OPENVDS_API_DIR}/lib64/${OPENVDS_LIB_NAME}
     )
   endforeach(OPENVDS_LIB_NAME)
-endif(MSVC)
+endif()
 
 # ##############################################################################
 # Unity Build
@@ -1039,7 +1047,7 @@ if(RESINSIGHT_BUNDLE_TESTMODELS)
   )
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(Linux)
   set(OPENVDS_SHARED_LIB_FILES
       ${RESINSIGHT_OPENVDS_API_DIR}/lib64/libopenvds.so
       ${RESINSIGHT_OPENVDS_API_DIR}/lib64/libopenvds.so.3


### PR DESCRIPTION
These are the minimal changes that I needed to make ResInsight compile in macOS:

* Minor clang issues.
* Conditionally skip OpenDVS. There are no binaries for Apple, and it is quite big library to make the user compile it by himself.
* Use string streams only when span streams are not available. They of course consume more memory tho.
* Avoid using `<stacktrace>` if not available. As far as I am concerned, there is very limited support for this. Clang does not have it even for linux, and I've tried to use the GCC version at the beginning of this year but it was almost impossible to get a version with it working. And, if my memory does not fail, it was only available for x86.

I still get some segfaults here and there, but I would investigate this in another PR.