### PR TITLE
#12654 Las import: fix crash for files with CR/LF on linux

### DIFF
--- a/ThirdParty/NRLib/nrlib/well/laswell.cpp
+++ b/ThirdParty/NRLib/nrlib/well/laswell.cpp
@@ -439,7 +439,7 @@ LasWell::GetRecord(std:: ifstream           & fin,
       record.insert(record.end(), items.begin(), items.end());
     }
   }
-  return(true);
+  return(!record.empty());
 }
 
 void LasWell::AddLog(const std::string         & name,


### PR DESCRIPTION
The file in question had a "empty" line with CR/LF line ending at the end of the file.

When reading this on linux (using getline) you get a non-empty string containing the CR token. For these cases GetRecord returns true with a empty record vector, and this expected in the calling code.

Crash happens when accessing the first (non-existing) element of the empty vector when trying to provide error message.

Fixed by having GetRecord return false when vector is empty.

Fixes #12654.