### PR TITLE
Add support for Arrow v21

### DIFF
--- a/ApplicationLibCode/FileInterface/RifArrowTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifArrowTools.cpp
@@ -34,7 +34,11 @@ QString RifArrowTools::readFirstRowsOfTable( const QByteArray& contents )
 
     // Open Parquet file reader
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+#if ARROW_VERSION_MAJOR > 19
+    if ( auto openResult = parquet::arrow::OpenFile( input, pool ).Value(&arrow_reader); !openResult.ok() )
+#else
     if ( !parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() )
+#endif
     {
         return {};
     }

--- a/ApplicationLibCode/FileInterface/RifOsduWellLogReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellLogReader.cpp
@@ -46,7 +46,11 @@ std::pair<cvf::ref<RigOsduWellLogData>, QString> RifOsduWellLogReader::readWellL
 
     // Open Parquet file reader
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+#if ARROW_VERSION_MAJOR > 19
+    if ( auto openResult = parquet::arrow::OpenFile( input, pool ).Value(&arrow_reader); !openResult.ok() )
+#else
     if ( !parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() )
+#endif
     {
         return { nullptr, "Unable to read parquet data." };
     }

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -116,7 +116,11 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
 
     // Open Parquet file reader
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+#if ARROW_VERSION_MAJOR > 19
+    if ( auto openResult = parquet::arrow::OpenFile( input, pool ).Value(&arrow_reader); !openResult.ok() )
+#else
     if ( !parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() )
+#endif
     {
         return { nullptr, "Unable to read parquet data." };
     }

--- a/ApplicationLibCode/ProjectDataModel/Summary/Sumo/RimSummaryEnsembleSumo.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/Sumo/RimSummaryEnsembleSumo.cpp
@@ -161,7 +161,11 @@ std::shared_ptr<arrow::Table> RimSummaryEnsembleSumo::readParquetTable( const QB
 
     std::shared_ptr<arrow::Table>               table;
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+#if ARROW_VERSION_MAJOR > 19
+    if ( auto openResult = parquet::arrow::OpenFile( input, pool ).Value(&arrow_reader); openResult.ok() )
+#else
     if ( auto openResult = parquet::arrow::OpenFile( input, pool, &arrow_reader ); openResult.ok() )
+#endif
     {
         if ( auto readResult = arrow_reader->ReadTable( &table ); readResult.ok() )
         {


### PR DESCRIPTION
The signature of `OpenFile` with the file pointer as a reference was deprecated in version 19 and removed in version 21 of Apache Arrow. Similarly, the version that returns a Result object was introduced in version 19. So this ifdef is necessary to support both versions.