### PR TITLE
Reduces the minimum preferred Y size

### DIFF
--- a/Fwk/AppFwk/cafVizExtensions/cafOverlayScalarMapperLegend.cpp
+++ b/Fwk/AppFwk/cafVizExtensions/cafOverlayScalarMapperLegend.cpp
@@ -710,7 +710,7 @@ cvf::Vec2ui OverlayScalarMapperLegend::preferredSize()
     }
 
     preferredXSize = std::min( preferredXSize, 400.0f );
-    preferredYSize = std::max( preferredYSize, 400.0f );
+    preferredYSize = std::max( preferredYSize, 150.0f );
 
     return { (unsigned int)( std::ceil( preferredXSize ) ), (unsigned int)( std::ceil( preferredYSize ) ) };
 }


### PR DESCRIPTION
The preferred height was recently adjusted to 400 pixels based on to https://github.com/OPM/ResInsight/issues/12711

This was a bit to high preferred height. Reduce the minimum preferred Y size of the overlay scalar mapper legend to 150 pixels. When many legends are present, the preferred height of 400 was a bit to much. Using 150 will make sure the legend is not shrinking too much. This will affect the height for level count usually less than 5.

One regression test with preferred height 400
<img width="1686" height="684" alt="image" src="https://github.com/user-attachments/assets/2f022ee0-6f8a-481f-b256-977d928f35f5" />

Suggested minimum height 150
<img width="858" height="347" alt="image" src="https://github.com/user-attachments/assets/ae962a56-7c19-45c6-a3ef-b08e230b134d" />
<img width="684" height="326" alt="image" src="https://github.com/user-attachments/assets/2a4fad08-170e-4aed-9592-6263a1fb53cb" />

<img width="700" height="353" alt="image" src="https://github.com/user-attachments/assets/98886781-3bc1-48c3-a9d7-057c14bcc7fe" />



