### PR TITLE
clang-format: Reduce ColumnLimit to avoid single long lines

### DIFF
--- a/GrpcInterface/.clang-format
+++ b/GrpcInterface/.clang-format
@@ -77,5 +77,6 @@ Standard:        Cpp11
 TabWidth:        4
 UseTab:          Never
 ---
-Language:        Proto
+Language: Proto
+ColumnLimit: 80
 ...

--- a/GrpcInterface/GrpcProtos/SimulationWell.proto
+++ b/GrpcInterface/GrpcProtos/SimulationWell.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+// clang-format off
+
 import "Definitions.proto";
 
 package rips;


### PR DESCRIPTION
clang-format wants to change from 

```
service SimulationWell {
  rpc ShortMethod(SimulationWellRequest)
     returns (SimulationWellStatus) {}
  rpc GetSimulationWellCells(SimulationWellRequest)
      returns (SimulationWellCellInfoArray) {}
}

```
to

```
service SimulationWell {
  rpc ShortMethod(SimulationWellRequest) returns (SimulationWellStatus) {}
  rpc GetSimulationWellCells(SimulationWellRequest)
      returns (SimulationWellCellInfoArray) {}
}

```
`clang-format` is useful for large files like Commands.proto. For smaller files, consider to disable `clang-format`.

Reducing ColumnLimit reduce the number functions put on a single line, but will not work for very short function names. Use `// clang-format off` in the proto file if required.