### PR TITLE
Replaces transparency with opacity settings

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Appearance/RimCurveSetAppearance.h
+++ b/ApplicationLibCode/ProjectDataModel/Appearance/RimCurveSetAppearance.h
@@ -68,6 +68,7 @@ private:
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
+    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
     void updateRealizationColor();
     void updateEnsembleParameterLegend( RimRegularLegendConfig* legendConfig ) const;
@@ -76,7 +77,7 @@ private:
     caf::PdmField<ColorModeEnum>                                             m_colorMode;
     caf::PdmField<cvf::Color3f>                                              m_mainEnsembleColor;
     caf::PdmField<cvf::Color3f>                                              m_colorForRealizations;
-    caf::PdmField<double>                                                    m_colorTransparency;
+    caf::PdmField<double>                                                    m_colorOpacity;
     caf::PdmField<QString>                                                   m_ensembleParameter;
     caf::PdmField<caf::AppEnum<RimCurveAppearanceDefines::ParameterSorting>> m_ensembleParameterSorting;
 

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramCurve.cpp
@@ -477,6 +477,6 @@ void RimHistogramCurve::setAppearanceFromGraphType( RimHistogramPlot::GraphType 
 {
     auto fillType = graphType == RimHistogramPlot::GraphType::BAR_GRAPH ? Qt::SolidPattern : Qt::NoBrush;
     setFillStyle( fillType );
-    float transparency = graphType == RimHistogramPlot::GraphType::BAR_GRAPH ? 0.2 : 1.0;
-    setFillColorTransparency( transparency );
+    float opacity = graphType == RimHistogramPlot::GraphType::BAR_GRAPH ? 0.2 : 1.0;
+    setFillColorOpacity( opacity );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp
@@ -727,9 +727,17 @@ void RimPlotCurve::setFillColor( const cvf::Color3f& fillColor )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimPlotCurve::setFillColorTransparency( float fillColorTransparency )
+void RimPlotCurve::setFillColorOpacity( float opacity )
 {
-    m_curveAppearance->setFillColorTransparency( fillColorTransparency );
+    m_curveAppearance->setFillColorOpacity( opacity );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimPlotCurve::setCurveColorOpacity( float opacity )
+{
+    m_curveAppearance->setCurveColorOpacity( opacity );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -969,7 +977,7 @@ void RimPlotCurve::setZOrder( double z )
 //--------------------------------------------------------------------------------------------------
 void RimPlotCurve::updateCurveAppearance()
 {
-    QColor curveColor = RiaColorTools::toQColor( m_curveAppearance->color() );
+    QColor curveColor = RiaColorTools::toQColor( m_curveAppearance->color(), m_curveAppearance->curveColorOpacity() );
 
     if ( !m_plotCurve ) return;
 
@@ -1015,7 +1023,7 @@ void RimPlotCurve::updateCurveAppearance()
     QColor fillColor = RiaColorTools::toQColor( m_curveAppearance->fillColor() );
 
     fillColor = RiaColorTools::blendQColors( fillColor, QColor( Qt::white ), 3, 1 );
-    fillColor.setAlphaF( m_curveAppearance->fillColorTransparency() );
+    fillColor.setAlphaF( m_curveAppearance->fillColorOpacity() );
 
     QBrush fillBrush( fillColor, fillStyle() );
     m_plotCurve->setAppearance( m_curveAppearance->lineStyle(),

--- a/ApplicationLibCode/ProjectDataModel/RimPlotCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/RimPlotCurve.h
@@ -77,7 +77,8 @@ public:
     virtual Qt::BrushStyle              fillStyle() const;
     void                                setFillStyle( Qt::BrushStyle brushStyle );
     void                                setFillColor( const cvf::Color3f& fillColor );
-    void                                setFillColorTransparency( float fillColorTransparency );
+    void                                setFillColorOpacity( float opacity );
+    void                                setCurveColorOpacity( float opacity );
 
     bool isChecked() const;
     void setCheckState( bool isChecked );

--- a/ApplicationLibCode/ProjectDataModel/RimPlotCurveAppearance.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimPlotCurveAppearance.cpp
@@ -88,9 +88,16 @@ RimPlotCurveAppearance::RimPlotCurveAppearance()
     CAF_PDM_InitObject( "Curve Apperance" );
 
     CAF_PDM_InitField( &m_curveColor, "Color", RiaColorTools::textColor3f(), "Color" );
+
+    CAF_PDM_InitField( &m_curveColorOpacity, "CurveColorOpacity", 1.0f, "Opacity" );
+    m_curveColorOpacity.registerKeywordAlias( "CurveColorTransparency" );
+    m_curveColorOpacity.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
+
     CAF_PDM_InitField( &m_fillColor, "FillColor", cvf::Color3f( -1.0, -1.0, -1.0 ), "Fill Color" );
-    CAF_PDM_InitField( &m_fillColorTransparency, "FillColorTransparency", 1.0f, "Fill Color Transparency" );
-    m_fillColorTransparency.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
+
+    CAF_PDM_InitField( &m_fillColorOpacity, "FillColorOpacity", 1.0f, "Fill Color Opacity" );
+    m_fillColorOpacity.registerKeywordAlias( "FillColorTransparency" );
+    m_fillColorOpacity.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_curveThickness, "Thickness", 1, "Line Thickness" );
     m_curveThickness.uiCapability()->setUiEditorTypeName( caf::PdmUiComboBoxEditor::uiEditorTypeName() );
@@ -151,13 +158,13 @@ void RimPlotCurveAppearance::fieldChangedByUi( const caf::PdmFieldHandle* change
 //--------------------------------------------------------------------------------------------------
 void RimPlotCurveAppearance ::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_fillColorTransparency )
+    if ( field == &m_curveColorOpacity || field == &m_fillColorOpacity )
     {
-        caf::PdmUiDoubleSliderEditorAttribute* myAttr = dynamic_cast<caf::PdmUiDoubleSliderEditorAttribute*>( attribute );
-        if ( myAttr )
+        if ( auto myAttr = dynamic_cast<caf::PdmUiDoubleSliderEditorAttribute*>( attribute ) )
         {
-            myAttr->m_minimum = 0.0;
-            myAttr->m_maximum = 1.0;
+            myAttr->m_minimum  = 0.0;
+            myAttr->m_maximum  = 1.0;
+            myAttr->m_decimals = 2;
         }
     }
 }
@@ -205,7 +212,9 @@ void RimPlotCurveAppearance::setColorWithFieldChanged( const QColor& color )
 void RimPlotCurveAppearance::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
     uiOrdering.add( &m_curveColor );
+    uiOrdering.add( &m_curveColorOpacity );
     m_curveColor.uiCapability()->setUiHidden( !m_colorVisible );
+    m_curveColorOpacity.uiCapability()->setUiHidden( !m_colorVisible );
 
     uiOrdering.add( &m_pointSymbol );
     if ( RiuPlotCurveSymbol::isFilledSymbol( m_pointSymbol() ) )
@@ -229,10 +238,10 @@ void RimPlotCurveAppearance::defineUiOrdering( QString uiConfigName, caf::PdmUiO
     if ( m_fillStyle != Qt::BrushStyle::NoBrush )
     {
         uiOrdering.add( &m_fillColor );
-        uiOrdering.add( &m_fillColorTransparency );
+        uiOrdering.add( &m_fillColorOpacity );
     }
     m_fillColor.uiCapability()->setUiHidden( !m_fillOptionsVisible );
-    m_fillColorTransparency.uiCapability()->setUiHidden( !m_fillOptionsVisible );
+    m_fillColorOpacity.uiCapability()->setUiHidden( !m_fillOptionsVisible );
 
     uiOrdering.add( &m_curveInterpolation );
     m_curveInterpolation.uiCapability()->setUiHidden( !m_interpolationVisible );
@@ -443,17 +452,17 @@ void RimPlotCurveAppearance::setFillColor( const cvf::Color3f& fillColor )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimPlotCurveAppearance::setFillColorTransparency( float fillColorTransparency )
+void RimPlotCurveAppearance::setFillColorOpacity( float opacity )
 {
-    m_fillColorTransparency = fillColorTransparency;
+    m_fillColorOpacity = opacity;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-float RimPlotCurveAppearance::fillColorTransparency() const
+float RimPlotCurveAppearance::fillColorOpacity() const
 {
-    return m_fillColorTransparency;
+    return m_fillColorOpacity;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -502,4 +511,20 @@ void RimPlotCurveAppearance::setFillOptionsVisible( bool isVisible )
 void RimPlotCurveAppearance::setCurveFittingToleranceVisible( bool isVisible )
 {
     m_curveFittingToleranceVisible = isVisible;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimPlotCurveAppearance::setCurveColorOpacity( float opacity )
+{
+    m_curveColorOpacity = opacity;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+float RimPlotCurveAppearance::curveColorOpacity() const
+{
+    return m_curveColorOpacity;
 }

--- a/ApplicationLibCode/ProjectDataModel/RimPlotCurveAppearance.h
+++ b/ApplicationLibCode/ProjectDataModel/RimPlotCurveAppearance.h
@@ -86,8 +86,11 @@ public:
     void         setFillColor( const cvf::Color3f& fillColor );
     cvf::Color3f fillColor() const;
 
-    void  setFillColorTransparency( float fillColorTransparency );
-    float fillColorTransparency() const;
+    void  setCurveColorOpacity( float opacity );
+    float curveColorOpacity() const;
+
+    void  setFillColorOpacity( float opacity );
+    float fillColorOpacity() const;
 
     float curveFittingTolerance() const;
 
@@ -114,6 +117,7 @@ protected:
     caf::PdmField<int>     m_symbolSize;
 
     caf::PdmField<cvf::Color3f> m_curveColor;
+    caf::PdmField<float>        m_curveColorOpacity;
     caf::PdmField<int>          m_curveThickness;
     caf::PdmField<float>        m_symbolSkipPixelDistance;
 
@@ -123,7 +127,7 @@ protected:
     caf::PdmField<LineStyle>          m_lineStyle;
     caf::PdmField<FillStyle>          m_fillStyle;
     caf::PdmField<cvf::Color3f>       m_fillColor;
-    caf::PdmField<float>              m_fillColorTransparency;
+    caf::PdmField<float>              m_fillColorOpacity;
     caf::PdmField<CurveInterpolation> m_curveInterpolation;
     caf::PdmField<LabelPosition>      m_symbolLabelPosition;
     caf::PdmField<cvf::Color3f>       m_symbolEdgeColor;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
@@ -231,7 +231,7 @@ private:
     void onObjectiveFunctionChanged( const caf::SignalEmitter* emitter );
     void onCustomObjectiveFunctionChanged( const caf::SignalEmitter* emitter );
 
-    void setTransparentCurveColor();
+    void computeRealizationColor();
     void onColorTagClicked( const SignalEmitter* emitter, size_t index );
 
     void setSummaryAddressX( RifEclipseSummaryAddress address );
@@ -262,8 +262,8 @@ private:
 
     caf::PdmField<ColorModeEnum>                                             m_colorMode;
     caf::PdmField<cvf::Color3f>                                              m_mainEnsembleColor;
-    caf::PdmField<cvf::Color3f>                                              m_colorForRealizations;
-    caf::PdmField<double>                                                    m_colorTransparency;
+    cvf::Color3f                                                             m_colorForRealizations;
+    caf::PdmField<double>                                                    m_colorOpacity;
     caf::PdmField<QString>                                                   m_ensembleParameter;
     caf::PdmField<caf::AppEnum<RimCurveAppearanceDefines::ParameterSorting>> m_ensembleParameterSorting;
 


### PR DESCRIPTION
Rename from transparency to opacity. Add transparency support to plot curves, and use transparency for ensemble curves. This makes it possible to blend curve colors from ensemble curves on top of each other.

Closes #12790