### PR TITLE
Exclude inactive cells from contour map calculations

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
@@ -240,7 +240,12 @@ double RigContourMapCalculator::calculateSum( const RigContourMapProjection&    
     double sum = 0.0;
     for ( auto [cellIdx, weight] : matchingCells )
     {
-        double cellValue = gridCellValues[contourMapProjection.gridResultIndex( cellIdx )];
+        const auto valueIndex = contourMapProjection.gridResultIndex( cellIdx );
+
+        // Safety check, should not happen
+        if ( valueIndex >= gridCellValues.size() ) continue;
+
+        const double cellValue = gridCellValues[valueIndex];
         if ( std::abs( cellValue ) != std::numeric_limits<double>::infinity() )
         {
             sum += cellValue * weight;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
@@ -427,6 +427,8 @@ std::vector<RigContourMapCalculator::CellIndexAndResult>
     auto cellGridIdxVisibility = contourMapProjection.getCellVisibility();
     for ( size_t globalCellIdx : allCellIndices )
     {
+        if ( !contourMapProjection.isCellActive( globalCellIdx ) ) continue;
+
         if ( cellGridIdxVisibility.isNull() || ( *cellGridIdxVisibility )[globalCellIdx] )
         {
             auto k = contourMapProjection.kLayer( globalCellIdx );

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.cpp
@@ -420,6 +420,29 @@ double RigContourMapProjection::calculateValueAtVertex( unsigned int vi, unsigne
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RigContourMapProjection::contourMapCellContainsOnlyInactiveCells( unsigned int i, unsigned int j ) const
+{
+    const std::vector<CellIndexAndResult>& matchingCells = cellsAtIJ( i, j );
+
+    if ( matchingCells.empty() )
+    {
+        return true;
+    }
+
+    for ( const auto& cellResult : matchingCells )
+    {
+        if ( isCellActive( cellResult.first ) )
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<std::pair<size_t, double>> RigContourMapProjection::cellsAtIJ( unsigned int i, unsigned int j ) const
 {
     size_t cellIndex = m_contourMapGrid.cellIndexFromIJ( i, j );

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.h
@@ -84,6 +84,7 @@ public:
     virtual double calculateRayLengthInCell( size_t globalCellIdx, const cvf::Vec3d& highestPoint, const cvf::Vec3d& lowestPoint ) const = 0;
     virtual double getParameterWeightForCell( size_t globalCellIdx, const std::vector<double>& parameterWeights ) const = 0;
     virtual std::vector<bool> getMapCellVisibility( int viewStepIndex, RigContourMapCalculator::ResultAggregationType resultAggregation ) = 0;
+    virtual bool isCellActive( size_t globalCellIdx ) const = 0;
 
     void                      setCellVisibility( cvf::ref<cvf::UByteArray> cellVisibility );
     cvf::ref<cvf::UByteArray> getCellVisibility() const;
@@ -116,6 +117,7 @@ protected:
     double valueInCell( unsigned int i, unsigned int j ) const;
     bool   hasResultInCell( unsigned int i, unsigned int j ) const;
     double calculateValueAtVertex( unsigned int i, unsigned int j ) const;
+    bool   contourMapCellContainsOnlyInactiveCells( unsigned int i, unsigned int j ) const;
 
 protected:
     cvf::ref<cvf::UByteArray>                           m_cellGridIdxVisibility;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
@@ -328,6 +328,19 @@ size_t RigEclipseContourMapProjection::gridResultIndex( size_t globalCellIdx ) c
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RigEclipseContourMapProjection::isCellActive( size_t globalCellIdx ) const
+{
+    if ( m_useActiveCellInfo && m_activeCellInfo.notNull() )
+    {
+        return m_activeCellInfo->isActive( globalCellIdx );
+    }
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<bool> RigEclipseContourMapProjection::getMapCellVisibility( int                                            viewStepIndex,
                                                                         RigContourMapCalculator::ResultAggregationType resultAggregation )
 

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.h
@@ -65,6 +65,7 @@ public:
                                                                  RigFloodingSettings&                           floodingSettings );
 
     std::vector<bool> getMapCellVisibility( int viewStepIndex, RigContourMapCalculator::ResultAggregationType resultAggregation ) override;
+    bool              isCellActive( size_t globalCellIdx ) const override;
 
 protected:
     using CellIndexAndResult = RigContourMapProjection::CellIndexAndResult;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.cpp
@@ -381,3 +381,12 @@ std::vector<double> RigGeoMechContourMapProjection::gridCellValues( RigFemResult
     }
     return gridCellValues;
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RigGeoMechContourMapProjection::isCellActive( size_t globalCellIdx ) const
+{
+    // For GeoMech grids, all cells are considered active
+    return true;
+}

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.h
@@ -60,6 +60,8 @@ public:
                                             int                                            viewStepIndex,
                                             RigContourMapCalculator::ResultAggregationType resultAggregation );
 
+    bool isCellActive( size_t globalCellIdx ) const override;
+
 protected:
     // GeoMech implementation specific data generation methods
     std::vector<size_t> findIntersectingCells( const cvf::BoundingBox& bbox ) const override;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.cpp
@@ -139,3 +139,12 @@ std::vector<std::pair<size_t, double>> RigStatisticsContourMapProjection::cellsA
 
     return std::vector<std::pair<size_t, double>>();
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RigStatisticsContourMapProjection::isCellActive( size_t globalCellIdx ) const
+{
+    // For statistics projections, all cells are considered active
+    return true;
+}

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.h
@@ -46,6 +46,7 @@ public:
                              const std::vector<std::vector<cvf::Vec3d>>&    limitToPolygons ) override;
 
     std::vector<bool> getMapCellVisibility( int viewStepIndex, RigContourMapCalculator::ResultAggregationType resultAggregation ) override;
+    bool              isCellActive( size_t globalCellIdx ) const override;
 
 protected:
     using CellIndexAndResult = RigContourMapProjection::CellIndexAndResult;


### PR DESCRIPTION
The contour map calculations are mostly tested with `opm-common` without inactive cells for performance reasons. If inactive cells are imported, the calculations ends up with a contour map with only NaN values due to missing filtering. This PR excludes inactive cells from the calculations.

For best performance, always use `opm-common` without inactive cells.

Closes #12847