### PR TITLE
#12894 Stimplan model export: make sure MD is always increasing.

### DIFF
--- a/ApplicationLibCode/FileInterface/RifStimPlanModelDeviationFrkExporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifStimPlanModelDeviationFrkExporter.cpp
@@ -88,7 +88,8 @@ void RifStimPlanModelDeviationFrkExporter::appendHeaderToStream( QTextStream& st
 //--------------------------------------------------------------------------------------------------
 void RifStimPlanModelDeviationFrkExporter::appendToStream( QTextStream& stream, const QString& label, const std::vector<double>& values )
 {
-    stream.setRealNumberPrecision( 8 );
+    stream.setRealNumberNotation( QTextStream::FixedNotation );
+    stream.setRealNumberPrecision( 4 );
     stream << "<cNamedSet>" << '\n'
            << "<name>" << '\n'
            << label << '\n'
@@ -170,6 +171,13 @@ void RifStimPlanModelDeviationFrkExporter::fixupDepthValuesForExport( const std:
             // Add small amount in addition to delta TVD to work around floating point imprecision.
             double wiggle = 0.001;
             exportMdValues.push_back( exportMdValues[i - 1] + changeTvd + wiggle );
+        }
+        else if ( std::fabs( changeMd ) < 0.001 )
+        {
+            // Stimplan wants the MD to always be increasing.
+            // Add small amount when that is not the case.
+            double wiggle = 0.002;
+            exportMdValues.push_back( exportMdValues[i - 1] + wiggle );
         }
         else
         {


### PR DESCRIPTION
The numerical precision in the output was lowered in #11556 since Stimplan was not correctly handling the high precision (requested by Nan). That change leads to the MD not always increasing (which is expected by Stimplan). Added another tweak to the MD values to make sure it increases in the precision range that will be written to file.

The original issue asked for improved precision in the output, but that is not a viable option this Stimplan does not use all of the decimal precision.

Fixes #12894.