### PR TITLE
Add optional time threshold before creating ESMRY

### DIFF
--- a/ApplicationLibCode/Application/RiaPreferencesSummary.cpp
+++ b/ApplicationLibCode/Application/RiaPreferencesSummary.cpp
@@ -26,6 +26,7 @@
 
 #include "PlotTemplates/RimPlotTemplateFileItem.h"
 
+#include "cafPdmUiCheckBoxAndTextEditor.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiListEditor.h"
@@ -145,6 +146,15 @@ RiaPreferencesSummary::RiaPreferencesSummary()
                        "If present, import summary files with extension '*.ESMRY'",
                        "" );
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_useEnhancedSummaryDataFile );
+
+    CAF_PDM_InitField( &m_esmryTimeThreshold,
+                       "esmryTimeThreshold",
+                       std::make_pair( false, 30 ),
+                       "ESMRY Time Difference Threshold [s]",
+                       "",
+                       " Create ESMRY file if time difference between SMSPEC and ESMRY is larger than the threshold.",
+                       "" );
+    m_esmryTimeThreshold.uiCapability()->setUiEditorTypeName( caf::PdmUiCheckBoxAndTextEditor::uiEditorTypeName() );
 
     CAF_PDM_InitField( &m_createH5SummaryDataFile,
                        "createH5SummaryDataFile_v01",
@@ -351,6 +361,19 @@ bool RiaPreferencesSummary::useImprovedSummaryImport() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+int RiaPreferencesSummary::esmryTimeThreshold() const
+{
+    if ( m_esmryTimeThreshold().first )
+    {
+        return m_esmryTimeThreshold().second;
+    }
+
+    return 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 RiaPreferencesSummary::SummaryRestartFilesImportMode RiaPreferencesSummary::summaryImportMode() const
 {
     return m_summaryImportMode();
@@ -430,6 +453,10 @@ void RiaPreferencesSummary::defineUiOrdering( QString uiConfigName, caf::PdmUiOr
             uiOrdering.add( &m_useEnhancedSummaryDataFile );
         }
         uiOrdering.add( &m_createEnhancedSummaryDataFile );
+        if ( m_createEnhancedSummaryDataFile() )
+        {
+            uiOrdering.add( &m_esmryTimeThreshold );
+        }
     }
     else if ( m_summaryReader == SummaryReaderMode::HDF5_OPM_COMMON )
     {

--- a/ApplicationLibCode/Application/RiaPreferencesSummary.h
+++ b/ApplicationLibCode/Application/RiaPreferencesSummary.h
@@ -101,6 +101,8 @@ public:
     bool summaryRestartFilesShowImportDialog() const;
     bool useImprovedSummaryImport() const;
 
+    int esmryTimeThreshold() const;
+
     SummaryRestartFilesImportMode summaryImportMode() const;
     SummaryRestartFilesImportMode gridImportMode() const;
     SummaryRestartFilesImportMode summaryEnsembleImportMode() const;
@@ -143,8 +145,9 @@ private:
     caf::PdmField<bool> m_showSummaryTimeAsLongString;
     caf::PdmField<bool> m_useMultipleThreadsWhenLoadingSummaryCases;
 
-    caf::PdmField<bool> m_createEnhancedSummaryDataFile;
-    caf::PdmField<bool> m_useEnhancedSummaryDataFile;
+    caf::PdmField<bool>                 m_createEnhancedSummaryDataFile;
+    caf::PdmField<bool>                 m_useEnhancedSummaryDataFile;
+    caf::PdmField<std::pair<bool, int>> m_esmryTimeThreshold;
 
     caf::PdmField<bool> m_createH5SummaryDataFile;
     caf::PdmField<int>  m_createH5SummaryFileThreadCount;

--- a/ApplicationLibCode/Application/Tools/RiaFilePathTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaFilePathTools.cpp
@@ -372,13 +372,18 @@ std::map<QString, QStringList> keyPathComponentsForEachFilePath( const QStringLi
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool isFirstOlderThanSecond( const std::string& firstFileName, const std::string& secondFileName )
+bool isFirstOlderThanSecond( const std::string& firstFileName, const std::string& secondFileName, int timeThresholdInSeconds )
 {
     if ( !std::filesystem::exists( firstFileName ) || !std::filesystem::exists( secondFileName ) ) return false;
 
     auto timeFirstFile  = std::filesystem::last_write_time( firstFileName );
     auto timeSecondFile = std::filesystem::last_write_time( secondFileName );
 
+    if ( timeThresholdInSeconds > 0 )
+    {
+        auto timeDiff = std::chrono::seconds( timeThresholdInSeconds );
+        timeFirstFile += timeDiff;
+    }
     return ( timeFirstFile < timeSecondFile );
 }
 

--- a/ApplicationLibCode/Application/Tools/RiaFilePathTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaFilePathTools.h
@@ -48,5 +48,5 @@ QStringList splitPathIntoComponents( const QString& path, bool splitExtensionInt
 
 std::map<QString, QStringList> keyPathComponentsForEachFilePath( const QStringList& filePaths );
 
-bool isFirstOlderThanSecond( const std::string& firstFileName, const std::string& secondFileName );
+bool isFirstOlderThanSecond( const std::string& firstFileName, const std::string& secondFileName, int timeThresholdInSeconds );
 }; // namespace RiaFilePathTools

--- a/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp
@@ -91,9 +91,9 @@ bool RifHdf5SummaryExporter::ensureHdf5FileIsCreated( const std::string& smspecF
 
     if ( !std::filesystem::exists( smspecFileName ) ) return false;
 
-    bool exportIsRequired = false;
-
-    bool h5FileExists = std::filesystem::exists( h5FileName );
+    bool      exportIsRequired       = false;
+    const int timeThresholdInSeconds = 0;
+    bool      h5FileExists           = std::filesystem::exists( h5FileName );
     if ( !h5FileExists )
     {
         if ( createHdfIfNotPresent )
@@ -101,7 +101,7 @@ bool RifHdf5SummaryExporter::ensureHdf5FileIsCreated( const std::string& smspecF
             exportIsRequired = true;
         }
     }
-    else if ( RiaFilePathTools::isFirstOlderThanSecond( h5FileName, smspecFileName ) )
+    else if ( RiaFilePathTools::isFirstOlderThanSecond( h5FileName, smspecFileName, timeThresholdInSeconds ) )
     {
         // If both files are present, check if the SMSPEC file is newer than the H5 file. If the SMSPEC file is newer, we abort if it is not
         // possible to write to the H5 file

--- a/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
@@ -20,6 +20,7 @@
 
 #include "RiaFilePathTools.h"
 #include "RiaLogging.h"
+#include "RiaPreferencesSummary.h"
 
 #ifdef _MSC_VER
 // Disable warning from external library to make sure treat warnings as error works
@@ -28,9 +29,9 @@
 #include "opm/io/eclipse/ESmry.hpp"
 #include "opm/io/eclipse/ExtESmry.hpp"
 
-#include "QRegularExpression"
 #include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -181,7 +182,8 @@ bool RifOpmSummaryTools::isEsmryConversionRequired( const QString& fileName )
         return true;
     }
 
-    if ( RiaFilePathTools::isFirstOlderThanSecond( candidateEsmryFileName.toStdString(), smspecFileName.toStdString() ) )
+    const int timeThresholdInSeconds = RiaPreferencesSummary::current()->esmryTimeThreshold();
+    if ( RiaFilePathTools::isFirstOlderThanSecond( candidateEsmryFileName.toStdString(), smspecFileName.toStdString(), timeThresholdInSeconds ) )
     {
         QString root = QFileInfo( smspecFileName ).canonicalPath();
 


### PR DESCRIPTION
When checking timestamp for ESMRY vs SMSPEC, allow ESMRY to be written before SMSPEC within a given limit in time difference.

Closes #12927 