### PR TITLE
Fixes focus out event on combo box

### DIFF
--- a/Fwk/AppFwk/cafTests/cafTestApplication/TamComboBox.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/TamComboBox.cpp
@@ -68,6 +68,9 @@ void TamComboBox::defineEditorAttribute( const caf::PdmFieldHandle* field,
     auto attr = dynamic_cast<caf::PdmUiComboBoxEditorAttribute*>( attribute );
     if ( attr )
     {
-        attr->enableEditableContent = true;
+        attr->enableEditableContent  = true;
+        attr->enableAutoComplete     = false;
+        attr->adjustWidthToContents  = true;
+        attr->notifyWhenTextIsEdited = false;
     }
 }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.h
@@ -108,6 +108,7 @@ protected slots:
     void slotIndexActivated( int index );
     void slotEditTextChanged( const QString& );
 
+    void slotSetCurrentTextToField();
     void slotNextButtonPressed();
     void slotPreviousButtonPressed();
     void slotApplyAutoValue();
@@ -125,6 +126,29 @@ private:
 
     QString m_interactiveEditText;
     int     m_interactiveEditCursorPosition;
+};
+
+//--------------------------------------------------------------------------------------------------
+// Special class used to prevent a combo box to steal focus when scrolling
+// the QScrollArea using the mouse wheel
+//
+// Based on
+// http://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
+//--------------------------------------------------------------------------------------------------
+class CustomQComboBox : public QComboBox
+{
+    Q_OBJECT
+public:
+    explicit CustomQComboBox( QWidget* parent = nullptr );
+
+    void wheelEvent( QWheelEvent* e ) override;
+
+protected:
+    void focusInEvent( QFocusEvent* e ) override;
+    void focusOutEvent( QFocusEvent* e ) override;
+
+signals:
+    void signalFocusOutEvent();
 };
 
 } // end namespace caf


### PR DESCRIPTION
Connects the focus out event of the combo box to a slot that sets the current text to the field.
This ensures that the entered text is saved when the combo box loses focus.
