### PR TITLE
Find Intersecting Cells: Crash fix, do not assert, return empty list

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -832,9 +832,11 @@ const RigFault* RigMainGrid::findFaultFromCellIndexAndCellFace( size_t reservoir
 //--------------------------------------------------------------------------------------------------
 std::vector<size_t> RigMainGrid::findIntersectingCells( const cvf::BoundingBox& inputBB ) const
 {
-    CVF_ASSERT( m_cellSearchTree.notNull() );
     std::vector<size_t> cellIndices;
-    m_cellSearchTree->findIntersections( inputBB, &cellIndices );
+    if ( m_cellSearchTree.notNull() )
+    {
+        m_cellSearchTree->findIntersections( inputBB, &cellIndices );
+    }
     return cellIndices;
 }
 


### PR DESCRIPTION
Fixes things like this:

 [0] manageSegFailure(int) at :0
  [1]  at :0
  [2] gsignal at :0
  [3] abort at :0
  [4] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at :0
  [5] RigMainGrid::findIntersectingCells(cvf::BoundingBox const&) const at :0
  [6] RigStimPlanModelTools::calculateTSTDirection(RigEclipseCaseData*, cvf::Vector3<double> const&, double, double) at :0
  [7] RimStimPlanModel::updateThicknessDirection() at :0
  [8] RimStimPlanModel::resetAnchorPositionAndThicknessDirection() at :0
  [9] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at :0
  [10] RicOpenProjectFeature::onActionTriggered(bool) at :0
  [11] caf::CmdFeature::actionTriggered(bool) at :0
  [12]  at :0
  [13] QAction::triggered(bool) at :0
  [14] QAction::activate(QAction::ActionEvent) at :0
  [15]  at :0
  [16]  at :0
  [17] QWidget::event(QEvent*) at :0
  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
  [19] QApplication::notify(QObject*, QEvent*) at :0
  [20] RiaGuiApplication::notify(QObject*, QEvent*) at :0
  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
  [22] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
  [23]  at :0
  [24]  at :0
  [25] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
  [26] RiaGuiApplication::notify(QObject*, QEvent*) at :0
  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
  [28] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
  [29] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
  [30]  at :0
  [31] g_main_context_dispatch at :0
  [32] g_main_context_iterate.isra.20 at :0
  [33] g_main_context_iteration at :0
  [34] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
  [35] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
  [36] QCoreApplication::exec() at :0
  [37] main at :0
  [38] __libc_start_main at :0
  [39] _start at :0
  [40]  at :0