### PR TITLE
Enables labels to display hyperlinks

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldEditorHandle.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldEditorHandle.cpp
@@ -226,16 +226,9 @@ void PdmUiFieldEditorHandle::updateLabelFromField( QLabel* label, const QString&
         }
         else
         {
-            QString uiName = fieldHandle->uiName( uiConfigName );
-            if ( auto shortLabel = dynamic_cast<QShortenedLabel*>( label ) )
-            {
-                // It is required to do a dynamic cast here, as the setText() function is not virtual
-                shortLabel->setText( uiName );
-            }
-            else
-            {
-                label->setText( uiName );
-            }
+            QString text = fieldHandle->uiName( uiConfigName );
+
+            caf::setLabelText( label, text );
         }
 
         label->setEnabled( !fieldHandle->isUiReadOnly( uiConfigName ) );

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafQShortenedLabel.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafQShortenedLabel.cpp
@@ -40,7 +40,26 @@
 #include <QMenu>
 #include <QResizeEvent>
 
-using namespace caf;
+namespace caf
+{
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void setLabelText( QLabel* label, const QString& text )
+{
+    if ( !label ) return;
+
+    if ( auto shortLabel = dynamic_cast<QShortenedLabel*>( label ) )
+    {
+        // It is required to do a dynamic cast here, as the setText() function is not virtual
+        shortLabel->setText( text );
+    }
+    else
+    {
+        label->setText( text );
+    }
+}
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -213,3 +232,4 @@ void QShortenedLabel::setDisplayText( const QString& displayText )
 {
     QLabel::setText( displayText );
 }
+} //namespace caf

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafQShortenedLabel.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafQShortenedLabel.h
@@ -39,6 +39,8 @@
 
 namespace caf
 {
+void setLabelText( QLabel* label, const QString& text );
+
 class QShortenedLabel : public QLabel
 {
     Q_OBJECT

--- a/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
@@ -42,6 +42,8 @@ set(PROJECT_FILES
     TamComboBox.cpp
     LineEditAndPushButtons.h
     LineEditAndPushButtons.cpp
+    LabelsAndHyperlinks.h
+    LabelsAndHyperlinks.cpp
     ApplicationEnum.h
     ApplicationEnum.cpp
     OptionalFields.h

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.cpp
@@ -1,0 +1,52 @@
+#include "LabelsAndHyperlinks.h"
+
+#include "MainWindow.h"
+#include "OptionalFields.h"
+
+#include "cafPdmUiLabelEditor.h"
+
+CAF_PDM_SOURCE_INIT( LabelsAndHyperlinks, "LabelsAndHyperlinks" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+LabelsAndHyperlinks::LabelsAndHyperlinks()
+{
+    CAF_PDM_InitObject( "Labels And Hyperlinks", "", "", "" );
+
+    CAF_PDM_InitFieldNoDefault( &m_labelTextField, "LabelTextField", "Label Text this text can be very long", "", "", "" );
+    m_labelTextField.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
+
+    CAF_PDM_InitFieldNoDefault( &m_hyperlinkTextField, "HyperlinkTextField", "" );
+    m_hyperlinkTextField.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void LabelsAndHyperlinks::defineEditorAttribute( const caf::PdmFieldHandle* field,
+                                                 QString                    uiConfigName,
+                                                 caf::PdmUiEditorAttribute* attribute )
+{
+    if ( field == &m_hyperlinkTextField )
+    {
+        if ( auto labelEditorAttribute = dynamic_cast<caf::PdmUiLabelEditorAttribute*>( attribute ) )
+        {
+            labelEditorAttribute->m_linkText =
+                "Click <a href=\"dummy\">link</a> to select the <b>Optional Field</b> object.";
+
+            labelEditorAttribute->m_linkActivatedCallback = [this]( const QString& link )
+            {
+                auto mainWin = MainWindow::instance();
+                if ( auto root = mainWin->root() )
+                {
+                    auto obj = root->descendantsIncludingThisOfType<OptionalFields>();
+                    if ( !obj.empty() )
+                    {
+                        mainWin->setTreeViewSelection( obj.front() );
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+class LabelsAndHyperlinks : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    LabelsAndHyperlinks();
+
+protected:
+    void defineEditorAttribute( const caf::PdmFieldHandle* field,
+                                QString                    uiConfigName,
+                                caf::PdmUiEditorAttribute* attribute ) override;
+
+private:
+    caf::PdmField<QString> m_labelTextField;
+    caf::PdmField<QString> m_hyperlinkTextField;
+};

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -5,6 +5,7 @@
 
 #include "ApplicationEnum.h"
 #include "CustomObjectEditor.h"
+#include "LabelsAndHyperlinks.h"
 #include "LineEditAndPushButtons.h"
 #include "ManyGroups.h"
 #include "MenuItemProducer.h"
@@ -1319,6 +1320,7 @@ void MainWindow::buildTestModel()
     m_testRoot->objects.push_back( singleEditorObj );
 
     m_testRoot->objects.push_back( new LineEditAndPushButtons );
+    m_testRoot->objects.push_back( new LabelsAndHyperlinks );
     m_testRoot->objects.push_back( new OptionalFields );
 
     auto tamComboBox = new TamComboBox;
@@ -1408,6 +1410,25 @@ void MainWindow::setPdmRoot( caf::PdmObjectHandle* pdmRoot )
     }
 
     m_customObjectEditor->updateUi();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void MainWindow::setTreeViewSelection( caf::PdmObjectHandle* obj )
+{
+    if ( auto uiObj = caf::uiObj( obj ) )
+    {
+        m_pdmUiTreeView->selectAsCurrentItem( uiObj );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::PdmObjectHandle* MainWindow::root() const
+{
+    return m_testRoot;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.h
@@ -32,6 +32,10 @@ public:
     static MainWindow* instance();
     void               setPdmRoot( caf::PdmObjectHandle* pdmRoot );
 
+    void setTreeViewSelection( caf::PdmObjectHandle* obj );
+
+    caf::PdmObjectHandle* root() const;
+
 private:
     void createActions();
     void createDockPanels();

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.cpp
@@ -66,7 +66,31 @@ void PdmUiLabelEditor::configureAndUpdateUi( const QString& uiConfigName )
 {
     CAF_ASSERT( !m_label.isNull() );
 
-    PdmUiFieldEditorHandle::updateLabelFromField( m_label, uiConfigName );
+    PdmUiLabelEditorAttribute attributes;
+    if ( auto uiObject = uiObj( uiField()->fieldHandle()->ownerObject() ) )
+    {
+        uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );
+    }
+
+    if ( !attributes.m_linkText.isEmpty() )
+    {
+        // Configure rich text and hyper link support
+        m_label->setTextFormat( Qt::RichText );
+        m_label->setTextInteractionFlags( Qt::TextBrowserInteraction );
+
+        caf::setLabelText( m_label, attributes.m_linkText );
+    }
+    else
+    {
+        PdmUiFieldEditorHandle::updateLabelFromField( m_label, uiConfigName );
+    }
+
+    if ( attributes.m_linkActivatedCallback )
+    {
+        connect( m_label,
+                 &QLabel::linkActivated,
+                 [attributes]( const QString& link ) { attributes.m_linkActivatedCallback( link ); } );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -74,8 +98,7 @@ void PdmUiLabelEditor::configureAndUpdateUi( const QString& uiConfigName )
 //--------------------------------------------------------------------------------------------------
 QWidget* PdmUiLabelEditor::createCombinedWidget( QWidget* parent )
 {
-    caf::PdmUiObjectHandle* uiObject = uiObj( uiField()->fieldHandle()->ownerObject() );
-    if ( uiObject )
+    if ( auto uiObject = uiObj( uiField()->fieldHandle()->ownerObject() ) )
     {
         const QString             uiConfigName;
         PdmUiLabelEditorAttribute attributes;
@@ -106,8 +129,7 @@ QWidget* PdmUiLabelEditor::createLabelWidget( QWidget* parent )
     if ( m_label.isNull() )
     {
         PdmUiLabelEditorAttribute attributes;
-        caf::PdmUiObjectHandle*   uiObject = uiObj( uiField()->fieldHandle()->ownerObject() );
-        if ( uiObject )
+        if ( auto uiObject = uiObj( uiField()->fieldHandle()->ownerObject() ) )
         {
             const QString uiConfigName;
             uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.h
@@ -43,6 +43,8 @@
 #include <QString>
 #include <QWidget>
 
+#include <functional>
+
 class QGridLayout;
 
 namespace caf
@@ -60,8 +62,10 @@ public:
     }
 
 public:
-    bool m_useWordWrap;
-    bool m_useSingleWidgetInsteadOfLabelAndEditorWidget;
+    bool                                  m_useWordWrap;
+    bool                                  m_useSingleWidgetInsteadOfLabelAndEditorWidget;
+    QString                               m_linkText;
+    std::function<void( const QString& )> m_linkActivatedCallback;
 };
 
 //==================================================================================================


### PR DESCRIPTION
Introduces the ability for labels to display hyperlinks.

This is achieved by adding a `setLabelText` function to handle both regular and shortened labels and allowing a callback function to be executed when the link is activated.

Adds a test object with labels and hyperlinks to the test application.
