### PR TITLE
Remove summary ensemble import setting

### DIFF
--- a/ApplicationLibCode/Application/RiaPreferencesSummary.cpp
+++ b/ApplicationLibCode/Application/RiaPreferencesSummary.cpp
@@ -82,22 +82,18 @@ CAF_PDM_SOURCE_INIT( RiaPreferencesSummary, "RiaPreferencesSummary" );
 //--------------------------------------------------------------------------------------------------
 RiaPreferencesSummary::RiaPreferencesSummary()
 {
-    CAF_PDM_InitFieldNoDefault( &m_summaryRestartFilesShowImportDialog, "summaryRestartFilesShowImportDialog", "Show Import Dialog" );
+    CAF_PDM_InitFieldNoDefault( &m_summaryRestartFilesShowImportDialog, "summaryRestartFilesShowImportDialog", "Show Summary Import Dialog" );
 
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_summaryRestartFilesShowImportDialog );
 
     CAF_PDM_InitField( &m_summaryImportMode,
                        "summaryImportMode",
                        SummaryRestartFilesImportModeType( RiaPreferencesSummary::SummaryRestartFilesImportMode::IMPORT ),
-                       "Default Summary Import Option" );
+                       "Summary Origin Import Option" );
     CAF_PDM_InitField( &m_gridImportMode,
                        "gridImportMode",
                        SummaryRestartFilesImportModeType( RiaPreferencesSummary::SummaryRestartFilesImportMode::NOT_IMPORT ),
-                       "Default Grid Import Option" );
-    CAF_PDM_InitField( &m_summaryEnsembleImportMode,
-                       "summaryEnsembleImportMode",
-                       SummaryRestartFilesImportModeType( RiaPreferencesSummary::SummaryRestartFilesImportMode::IMPORT ),
-                       "Default Ensemble Summary Import Option" );
+                       "Grid Origin Import Option" );
 
     CAF_PDM_InitField( &m_defaultSummaryHistoryCurveStyle,
                        "defaultSummaryHistoryCurveStyle",
@@ -272,21 +268,8 @@ void RiaPreferencesSummary::appendRestartFileGroup( caf::PdmUiOrdering& uiOrderi
 {
     caf::PdmUiGroup* restartBehaviourGroup = uiOrdering.addNewGroup( "Origin Files" );
     restartBehaviourGroup->add( &m_summaryRestartFilesShowImportDialog );
-
-    {
-        caf::PdmUiGroup* group = restartBehaviourGroup->addNewGroup( "Origin Summary Files" );
-        group->add( &m_summaryImportMode );
-    }
-
-    {
-        caf::PdmUiGroup* group = restartBehaviourGroup->addNewGroup( "Origin Grid Files" );
-        group->add( &m_gridImportMode );
-    }
-
-    {
-        caf::PdmUiGroup* group = restartBehaviourGroup->addNewGroup( "Origin Ensemble Summary Files" );
-        group->add( &m_summaryEnsembleImportMode );
-    }
+    restartBehaviourGroup->add( &m_summaryImportMode );
+    restartBehaviourGroup->add( &m_gridImportMode );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -388,14 +371,6 @@ RiaPreferencesSummary::SummaryRestartFilesImportMode RiaPreferencesSummary::summ
 RiaPreferencesSummary::SummaryRestartFilesImportMode RiaPreferencesSummary::gridImportMode() const
 {
     return m_gridImportMode();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RiaPreferencesSummary::SummaryRestartFilesImportMode RiaPreferencesSummary::summaryEnsembleImportMode() const
-{
-    return m_summaryEnsembleImportMode();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -535,15 +510,6 @@ QList<caf::PdmOptionItemInfo> RiaPreferencesSummary::calculateValueOptions( cons
 
         options.push_back( caf::PdmOptionItemInfo( skip.uiText(), RiaPreferencesSummary::SummaryRestartFilesImportMode::NOT_IMPORT ) );
         options.push_back( caf::PdmOptionItemInfo( separate.uiText(), RiaPreferencesSummary::SummaryRestartFilesImportMode::SEPARATE_CASES ) );
-    }
-    else if ( fieldNeedingOptions == &m_summaryEnsembleImportMode )
-    {
-        // Manual option handling in order to one only a subset of the enum values
-        SummaryRestartFilesImportModeType skip( RiaPreferencesSummary::SummaryRestartFilesImportMode::NOT_IMPORT );
-        SummaryRestartFilesImportModeType allowImport( RiaPreferencesSummary::SummaryRestartFilesImportMode::IMPORT );
-
-        options.push_back( caf::PdmOptionItemInfo( skip.uiText(), RiaPreferencesSummary::SummaryRestartFilesImportMode::NOT_IMPORT ) );
-        options.push_back( caf::PdmOptionItemInfo( allowImport.uiText(), RiaPreferencesSummary::SummaryRestartFilesImportMode::IMPORT ) );
     }
     else if ( fieldNeedingOptions == &m_defaultColumnCount )
     {

--- a/ApplicationLibCode/Application/RiaPreferencesSummary.h
+++ b/ApplicationLibCode/Application/RiaPreferencesSummary.h
@@ -107,7 +107,6 @@ public:
 
     SummaryRestartFilesImportMode summaryImportMode() const;
     SummaryRestartFilesImportMode gridImportMode() const;
-    SummaryRestartFilesImportMode summaryEnsembleImportMode() const;
     QString                       defaultSummaryCurvesTextFilter() const;
     bool                          colorCurvesByPhase() const;
     bool                          appendHistoryVectors() const;
@@ -138,7 +137,6 @@ private:
     caf::PdmField<bool>                              m_summaryRestartFilesShowImportDialog;
     caf::PdmField<SummaryRestartFilesImportModeType> m_summaryImportMode;
     caf::PdmField<SummaryRestartFilesImportModeType> m_gridImportMode;
-    caf::PdmField<SummaryRestartFilesImportModeType> m_summaryEnsembleImportMode;
 
     caf::PdmField<QString>                          m_defaultSummaryCurvesTextFilter;
     caf::PdmField<QString>                          m_crossPlotAddressCombinations;

--- a/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp
+++ b/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp
@@ -171,19 +171,9 @@ void RifSummaryCaseRestartSelector::determineFilesToImportByAskingUser( const st
     m_gridFiles.clear();
     m_summaryFileErrors.clear();
 
-    RiaPreferencesSummary* prefs = RiaPreferencesSummary::current();
-
-    RicSummaryCaseRestartDialog::ImportOptions defaultSummaryImportMode;
-    if ( m_ensembleOrGroupMode )
-    {
-        defaultSummaryImportMode = mapReadOption( prefs->summaryEnsembleImportMode() );
-    }
-    else
-    {
-        defaultSummaryImportMode = mapReadOption( prefs->summaryImportMode() );
-    }
-
-    RicSummaryCaseRestartDialog::ImportOptions defaultGridImportMode = mapReadOption( prefs->gridImportMode() );
+    RiaPreferencesSummary*                     prefs                    = RiaPreferencesSummary::current();
+    RicSummaryCaseRestartDialog::ImportOptions defaultSummaryImportMode = mapReadOption( prefs->summaryImportMode() );
+    RicSummaryCaseRestartDialog::ImportOptions defaultGridImportMode    = mapReadOption( prefs->gridImportMode() );
 
     for ( const RifSummaryCaseFileImportInfo& initialFile : initialFiles )
     {
@@ -252,15 +242,7 @@ void RifSummaryCaseRestartSelector::determineFilesToImportUsingPrefs( const std:
 
     RiaPreferencesSummary* prefs = RiaPreferencesSummary::current();
 
-    RicSummaryCaseRestartDialog::ImportOptions defaultSummaryImportMode;
-    if ( m_ensembleOrGroupMode )
-    {
-        defaultSummaryImportMode = mapReadOption( prefs->summaryEnsembleImportMode() );
-    }
-    else
-    {
-        defaultSummaryImportMode = mapReadOption( prefs->summaryImportMode() );
-    }
+    RicSummaryCaseRestartDialog::ImportOptions defaultSummaryImportMode = mapReadOption( prefs->summaryImportMode() );
 
     caf::ProgressInfo progress( initialFiles.size(), QString( "Importing files" ) );
     for ( const RifSummaryCaseFileImportInfo& initialFile : initialFiles )


### PR DESCRIPTION
Remove special setting for ensemble summary import. Simplify the settings in preferences to only have one setting.

Closes #13147