### PR TITLE
Guards dataChanged signal emission

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp
@@ -544,7 +544,10 @@ bool caf::PdmUiTreeSelectionQModel::setData( const QModelIndex& index, const QVa
             }
 
             PdmUiCommandSystemProxy::instance()->setUiValueToField( m_uiFieldHandle->uiField(), fieldValueSelection );
-            emit dataChanged( index, index );
+            if ( index.isValid() )
+            {
+                emit dataChanged( index, index );
+            }
             return true;
         }
     }


### PR DESCRIPTION
Ensures that the `dataChanged` signal is only emitted if the index is valid. This prevents potential issues when the index is invalid, such as during object destruction.

Closes #13166 