### PR TITLE
Fix nodiscard warnings in ObservedDataParser-Test.cpp

### DIFF
--- a/ApplicationLibCode/UnitTests/ObservedDataParser-Test.cpp
+++ b/ApplicationLibCode/UnitTests/ObservedDataParser-Test.cpp
@@ -269,7 +269,8 @@ DAYS;BARS;BARS;BARS
     QTextStream out( &data );
 
     RifCsvUserDataPastedTextParser parser = RifCsvUserDataPastedTextParser( data );
-    parser.parse( parseOptions );
+    auto parseResult = parser.parse( parseOptions );
+    ASSERT_TRUE( parseResult.has_value() );
 
     auto timeColumn = parser.columnInfo( 0 );
     ASSERT_TRUE( timeColumn != nullptr );
@@ -299,7 +300,8 @@ DATE       ;VECTOR    ;VALUE ;ERROR
     QTextStream out( &data );
 
     RifCsvUserDataPastedTextParser parser = RifCsvUserDataPastedTextParser( data );
-    parser.parse( {} );
+    auto parseResult = parser.parse( {} );
+    ASSERT_TRUE( parseResult.has_value() );
 
     auto tableData   = parser.tableData();
     auto columnInfos = tableData.columnInfos();
@@ -338,7 +340,8 @@ DATE       ;VECTOR    ;VALUE
     QTextStream out( &data );
 
     RifCsvUserDataPastedTextParser parser = RifCsvUserDataPastedTextParser( data );
-    parser.parse( {} );
+    auto parseResult = parser.parse( {} );
+    ASSERT_TRUE( parseResult.has_value() );
 
     auto tableData   = parser.tableData();
     auto columnInfos = tableData.columnInfos();

--- a/ApplicationLibCode/UnitTests/ObservedDataParser-Test.cpp
+++ b/ApplicationLibCode/UnitTests/ObservedDataParser-Test.cpp
@@ -268,8 +268,8 @@ DAYS;BARS;BARS;BARS
 
     QTextStream out( &data );
 
-    RifCsvUserDataPastedTextParser parser = RifCsvUserDataPastedTextParser( data );
-    auto parseResult = parser.parse( parseOptions );
+    RifCsvUserDataPastedTextParser parser      = RifCsvUserDataPastedTextParser( data );
+    auto                           parseResult = parser.parse( parseOptions );
     ASSERT_TRUE( parseResult.has_value() );
 
     auto timeColumn = parser.columnInfo( 0 );
@@ -299,8 +299,8 @@ DATE       ;VECTOR    ;VALUE ;ERROR
 
     QTextStream out( &data );
 
-    RifCsvUserDataPastedTextParser parser = RifCsvUserDataPastedTextParser( data );
-    auto parseResult = parser.parse( {} );
+    RifCsvUserDataPastedTextParser parser      = RifCsvUserDataPastedTextParser( data );
+    auto                           parseResult = parser.parse( {} );
     ASSERT_TRUE( parseResult.has_value() );
 
     auto tableData   = parser.tableData();
@@ -339,8 +339,8 @@ DATE       ;VECTOR    ;VALUE
 
     QTextStream out( &data );
 
-    RifCsvUserDataPastedTextParser parser = RifCsvUserDataPastedTextParser( data );
-    auto parseResult = parser.parse( {} );
+    RifCsvUserDataPastedTextParser parser      = RifCsvUserDataPastedTextParser( data );
+    auto                           parseResult = parser.parse( {} );
     ASSERT_TRUE( parseResult.has_value() );
 
     auto tableData   = parser.tableData();


### PR DESCRIPTION
The parse() method returns std::expected<void, QString> with [[nodiscard]]
attribute, but the return value was being ignored in unit tests. Fixed by:

- Capture parse result in auto variable
- Add ASSERT_TRUE assertions to verify parsing succeeded
- Improve test quality by explicitly checking for parse errors

Resolves compiler warnings:
warning C4834: discarding return value of function with [[nodiscard]] attribute
