### PR TITLE
#13220 Replace Case: read and recompute faults correctly.

### DIFF
--- a/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp
@@ -74,6 +74,7 @@ void RicReplaceCaseFeature::onActionTriggered( bool isChecked )
     const auto& fileName = fileNames.front();
 
     eclipseResultCase->setGridFileName( fileName );
+    eclipseResultCase->setFilesContainingFaults( {} );
     eclipseResultCase->reloadEclipseGridFile();
 
     std::vector<RimTimeStepFilter*> timeStepFilter = eclipseResultCase->descendantsIncludingThisOfType<RimTimeStepFilter>();


### PR DESCRIPTION
Was reading from a cached location.

Fixes #13220.