### PR TITLE
#13281 Improve unit system handling for Eclipse files

### DIFF
--- a/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
@@ -20,6 +20,7 @@
 
 #include "RifEclipseOutputFileTools.h"
 
+#include "RiaLogging.h"
 #include "RiaOpmParserTools.h"
 #include "RiaQDateTimeTools.h"
 #include "RiaStringEncodingTools.h"
@@ -950,4 +951,91 @@ void RifEclipseOutputFileTools::extractResultValuesBasedOnPorosityModel( RigEcli
             sourceStartPosition += ( matrixActiveCellCount + fractureActiveCellCount );
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<RiaDefines::EclipseUnitSystem> RifEclipseOutputFileTools::unitValueToEnum( int unitValue )
+{
+    if ( unitValue == 1 )
+        return RiaDefines::EclipseUnitSystem::UNITS_METRIC;
+    else if ( unitValue == 2 )
+        return RiaDefines::EclipseUnitSystem::UNITS_FIELD;
+    else if ( unitValue == 3 )
+        return RiaDefines::EclipseUnitSystem::UNITS_LAB;
+
+    return std::nullopt;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::EclipseUnitSystem RifEclipseOutputFileTools::determineUnitSystem( const std::optional<RiaDefines::EclipseUnitSystem>& egridUnit,
+                                                                              const std::optional<RiaDefines::EclipseUnitSystem>& initUnit,
+                                                                              const std::optional<RiaDefines::EclipseUnitSystem>& unrstUnit )
+{
+    // Helper lambda to get unit name string
+    auto getUnitName = []( RiaDefines::EclipseUnitSystem unit ) -> QString
+    {
+        if ( unit == RiaDefines::EclipseUnitSystem::UNITS_METRIC ) return "METRIC";
+        if ( unit == RiaDefines::EclipseUnitSystem::UNITS_FIELD ) return "FIELD";
+        if ( unit == RiaDefines::EclipseUnitSystem::UNITS_LAB ) return "LAB";
+        return "UNKNOWN";
+    };
+
+    // Determine which unit to use based on priority: egrid > init > unrst
+    std::optional<RiaDefines::EclipseUnitSystem> selectedUnit;
+    QString                                      selectedSource;
+
+    if ( egridUnit.has_value() )
+    {
+        selectedUnit   = egridUnit;
+        selectedSource = "EGRID";
+    }
+    else if ( initUnit.has_value() )
+    {
+        selectedUnit   = initUnit;
+        selectedSource = "INIT";
+    }
+    else if ( unrstUnit.has_value() )
+    {
+        selectedUnit   = unrstUnit;
+        selectedSource = "UNRST";
+    }
+
+    // Check for mismatches and warn
+    if ( selectedUnit.has_value() )
+    {
+        // Build list of sources that differ from selected
+        QStringList conflicts;
+
+        if ( egridUnit.has_value() && initUnit.has_value() && egridUnit.value() != initUnit.value() )
+        {
+            conflicts.append( QString( "INIT file has %1" ).arg( getUnitName( initUnit.value() ) ) );
+        }
+        if ( egridUnit.has_value() && unrstUnit.has_value() && egridUnit.value() != unrstUnit.value() )
+        {
+            conflicts.append( QString( "UNRST file has %1" ).arg( getUnitName( unrstUnit.value() ) ) );
+        }
+        if ( !egridUnit.has_value() && initUnit.has_value() && unrstUnit.has_value() && initUnit.value() != unrstUnit.value() )
+        {
+            conflicts.append( QString( "UNRST file has %1" ).arg( getUnitName( unrstUnit.value() ) ) );
+        }
+
+        if ( !conflicts.isEmpty() )
+        {
+            QString warning = QString( "Unit system mismatch detected: Using %1 from %2 file, but %3. "
+                                       "Please verify your simulation files have consistent unit systems." )
+                                  .arg( getUnitName( selectedUnit.value() ) )
+                                  .arg( selectedSource )
+                                  .arg( conflicts.join( " and " ) );
+            RiaLogging::warning( warning );
+        }
+
+        return selectedUnit.value();
+    }
+
+    // Default to METRIC if no unit found
+    return RiaDefines::EclipseUnitSystem::UNITS_METRIC;
 }

--- a/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.h
@@ -35,6 +35,7 @@
 #include <QString>
 #include <QStringList>
 
+#include <optional>
 #include <vector>
 
 using ecl_file_type = struct ecl_file_struct;
@@ -113,6 +114,12 @@ public:
                                                          RiaDefines::PorosityModelType matrixOrFracture,
                                                          std::vector<double>*          values,
                                                          const std::vector<double>&    fileValues );
+
+    // Unit system handling utilities
+    static std::optional<RiaDefines::EclipseUnitSystem> unitValueToEnum( int unitValue );
+    static RiaDefines::EclipseUnitSystem                determineUnitSystem( const std::optional<RiaDefines::EclipseUnitSystem>& egridUnit,
+                                                                             const std::optional<RiaDefines::EclipseUnitSystem>& initUnit,
+                                                                             const std::optional<RiaDefines::EclipseUnitSystem>& unrstUnit );
 
 private:
     static void                     getDayMonthYear( const ecl_kw_type* intehead_kw, int* day, int* month, int* year );

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommonActive.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommonActive.cpp
@@ -77,13 +77,30 @@ bool RifReaderOpmCommonActive::importGrid( RigMainGrid* /* mainGrid*/, RigEclips
     activeGrid->setDualPorosity( opmGrid.porosity_mode() > 0 );
 
     // assign grid unit, if found (1 = Metric, 2 = Field, 3 = Lab)
+    // Note: Accepts "m" or "M" as abbreviation for "METRES" (METRIC units)
     auto gridUnitStr = RiaStdStringTools::toUpper( opmGrid.grid_unit() );
     if ( gridUnitStr.starts_with( 'M' ) )
+    {
         m_gridUnit = 1;
+        RiaLogging::debug(
+            QString( "Grid unit from EGRID file: '%1' (interpreted as METRIC)" ).arg( QString::fromStdString( opmGrid.grid_unit() ) ) );
+    }
     else if ( gridUnitStr.starts_with( 'F' ) )
+    {
         m_gridUnit = 2;
+        RiaLogging::debug(
+            QString( "Grid unit from EGRID file: '%1' (interpreted as FIELD)" ).arg( QString::fromStdString( opmGrid.grid_unit() ) ) );
+    }
     else if ( gridUnitStr.starts_with( 'C' ) )
+    {
         m_gridUnit = 3;
+        RiaLogging::debug(
+            QString( "Grid unit from EGRID file: '%1' (interpreted as LAB)" ).arg( QString::fromStdString( opmGrid.grid_unit() ) ) );
+    }
+    else if ( !gridUnitStr.empty() )
+    {
+        RiaLogging::warning( QString( "Unknown grid unit from EGRID file: '%1'" ).arg( QString::fromStdString( opmGrid.grid_unit() ) ) );
+    }
 
     auto totalCellCount           = opmGrid.totalNumberOfCells();
     auto totalActiveCellCount     = opmGrid.totalActiveCells();

--- a/ResInsightVersion.cmake
+++ b/ResInsightVersion.cmake
@@ -11,7 +11,7 @@ set(RESINSIGHT_VERSION_TEXT "-dev")
 # Must be unique and increasing within one combination of major/minor/patch version 
 # The uniqueness of this text is independent of RESINSIGHT_VERSION_TEXT 
 # Format of text must be ".xx"
-set(RESINSIGHT_DEV_VERSION ".03")
+set(RESINSIGHT_DEV_VERSION ".04")
 
 set(STRPRODUCTVER ${RESINSIGHT_MAJOR_VERSION}.${RESINSIGHT_MINOR_VERSION}.${RESINSIGHT_PATCH_VERSION}${RESINSIGHT_VERSION_TEXT}${RESINSIGHT_DEV_VERSION})
 


### PR DESCRIPTION
- Add shared utility functions in RifEclipseOutputFileTools:
  - unitValueToEnum(): Convert int unit value to optional enum
  - determineUnitSystem(): Apply unit preference hierarchy and log warnings
- Implement correct unit preference hierarchy: egrid > init > unrst (previously was unrst > init > egrid)
- Add validation and warning when different unit systems are detected across files
- Enhance grid unit parsing with debug logging to explicitly document support for "m" as abbreviation for "METRES"