### PR TITLE
Add file-based surface interface to enable polymorphic file path hand…

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimEnsembleSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimEnsembleSurface.cpp
@@ -89,18 +89,14 @@ void RimEnsembleSurface::addSurface( RimSurface* surface )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimFileSurface*> RimEnsembleSurface::sourceFileSurfaces() const
+std::vector<RimSurface*> RimEnsembleSurface::sourceFileSurfaces() const
 {
-    std::vector<RimFileSurface*> fileSurfs;
+    std::vector<RimSurface*> fileSurfs;
     for ( auto& w : sourceFileSurfaceCollection()->surfaces() )
     {
-        if ( auto fsurf = dynamic_cast<RimFileSurface*>( w ) )
+        if ( w->isFileBased() )
         {
-            fileSurfs.push_back( fsurf );
-        }
-        else
-        {
-            RiaLogging::warning( QString( "Detected unknown surface type in File Surface collection" ) );
+            fileSurfs.push_back( w );
         }
     }
 
@@ -123,7 +119,7 @@ void RimEnsembleSurface::loadDataAndUpdate()
         }
     }
 
-    std::vector<RimFileSurface*> sourceSurfaceForStatistics = sourceFileSurfaces();
+    std::vector<RimSurface*> sourceSurfaceForStatistics = sourceFileSurfaces();
     if ( m_ensembleCurveSet != nullptr )
     {
         sourceSurfaceForStatistics = filterByEnsembleCurveSet( sourceSurfaceForStatistics );
@@ -172,9 +168,9 @@ void RimEnsembleSurface::loadDataAndUpdate()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimFileSurface*> RimEnsembleSurface::filterByEnsembleCurveSet( const std::vector<RimFileSurface*>& fileSurfaces ) const
+std::vector<RimSurface*> RimEnsembleSurface::filterByEnsembleCurveSet( const std::vector<RimSurface*>& fileSurfaces ) const
 {
-    std::vector<RimFileSurface*> filteredCases;
+    std::vector<RimSurface*> filteredCases;
 
     if ( m_ensembleCurveSet != nullptr )
     {
@@ -205,10 +201,10 @@ std::vector<RimFileSurface*> RimEnsembleSurface::filterByEnsembleCurveSet( const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RimEnsembleSurface::isSameRealization( RimSummaryCase* summaryCase, RimFileSurface* fileSurface ) const
+bool RimEnsembleSurface::isSameRealization( RimSummaryCase* summaryCase, RimSurface* fileSurface ) const
 {
     // TODO: duplication with RimEnsembleWellLogCurveSet::isSameRealization
-    QString fileSurfaceName = fileSurface->surfaceFilePath();
+    QString fileSurfaceName = fileSurface->filePath();
     if ( summaryCase->hasCaseRealizationParameters() )
     {
         // TODO: make less naive..

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimEnsembleSurface.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimEnsembleSurface.h
@@ -61,16 +61,16 @@ protected:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void initAfterRead() override;
 
-    std::vector<RimFileSurface*> filterByEnsembleCurveSet( const std::vector<RimFileSurface*>& fileSurfaces ) const;
+    std::vector<RimSurface*> filterByEnsembleCurveSet( const std::vector<RimSurface*>& fileSurfaces ) const;
 
-    bool isSameRealization( RimSummaryCase* summaryCase, RimFileSurface* fileSurface ) const;
+    bool isSameRealization( RimSummaryCase* summaryCase, RimSurface* fileSurface ) const;
 
 private:
     void connectEnsembleCurveSetFilterSignals();
     void onFilterSourceChanged( const caf::SignalEmitter* emitter );
 
-    RimSurfaceCollection*        sourceFileSurfaceCollection() const;
-    std::vector<RimFileSurface*> sourceFileSurfaces() const;
+    RimSurfaceCollection*    sourceFileSurfaceCollection() const;
+    std::vector<RimSurface*> sourceFileSurfaces() const;
 
 private:
     caf::PdmPtrField<RimEnsembleCurveSet*> m_ensembleCurveSet;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimFileSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimFileSurface.cpp
@@ -57,7 +57,7 @@ RimFileSurface::~RimFileSurface()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimFileSurface::setSurfaceFilePath( const QString& filePath )
+void RimFileSurface::setFilePath( const QString& filePath )
 {
     m_surfaceDefinitionFilePath = filePath;
 
@@ -67,7 +67,7 @@ void RimFileSurface::setSurfaceFilePath( const QString& filePath )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RimFileSurface::surfaceFilePath()
+QString RimFileSurface::filePath() const
 {
     return m_surfaceDefinitionFilePath().path();
 }
@@ -167,24 +167,24 @@ bool RimFileSurface::loadDataFromFile()
 {
     m_triangleMeshData = std::make_unique<RigTriangleMeshData>();
 
-    QString filePath = surfaceFilePath();
-    if ( filePath.endsWith( "ptl", Qt::CaseInsensitive ) )
+    QString path = filePath();
+    if ( path.endsWith( "ptl", Qt::CaseInsensitive ) )
     {
-        auto surface = RifSurfaceImporter::readPetrelFile( filePath );
+        auto surface = RifSurfaceImporter::readPetrelFile( path );
         m_triangleMeshData->setGeometryData( surface.first, surface.second );
     }
-    else if ( filePath.endsWith( "ts", Qt::CaseInsensitive ) )
+    else if ( path.endsWith( "ts", Qt::CaseInsensitive ) )
     {
-        RifSurfaceImporter::readGocadFile( filePath, m_triangleMeshData.get() );
+        RifSurfaceImporter::readGocadFile( path, m_triangleMeshData.get() );
     }
-    else if ( filePath.endsWith( "vtu", Qt::CaseInsensitive ) )
+    else if ( path.endsWith( "vtu", Qt::CaseInsensitive ) )
     {
-        m_triangleMeshData = RifVtkSurfaceImporter::importFromFile( filePath.toStdString() );
+        m_triangleMeshData = RifVtkSurfaceImporter::importFromFile( path.toStdString() );
     }
-    else if ( filePath.endsWith( "dat", Qt::CaseInsensitive ) || filePath.endsWith( "xyz", Qt::CaseInsensitive ) )
+    else if ( path.endsWith( "dat", Qt::CaseInsensitive ) || path.endsWith( "xyz", Qt::CaseInsensitive ) )
     {
         double resamplingDistance = RiaPreferences::current()->surfaceImportResamplingDistance();
-        auto   surface            = RifSurfaceImporter::readOpenWorksXyzFile( filePath, resamplingDistance );
+        auto   surface            = RifSurfaceImporter::readOpenWorksXyzFile( path, resamplingDistance );
         m_triangleMeshData->setGeometryData( surface.first, surface.second );
     }
 

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimFileSurface.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimFileSurface.h
@@ -32,11 +32,13 @@ public:
     RimFileSurface();
     ~RimFileSurface() override;
 
-    void    setSurfaceFilePath( const QString& filePath );
-    QString surfaceFilePath();
-
     bool        onLoadData() override;
     RimSurface* createCopy() override;
+
+    // File-based surface interface
+    bool    isFileBased() const override { return true; }
+    QString filePath() const override;
+    void    setFilePath( const QString& path ) override;
 
 protected:
     bool updateSurfaceData() override;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularFileSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularFileSurface.cpp
@@ -47,6 +47,14 @@ void RimRegularFileSurface::setFilePath( const QString& filePath )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+QString RimRegularFileSurface::filePath() const
+{
+    return m_surfaceFilePath().path();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RimRegularFileSurface::onLoadData()
 {
     auto surfaceData = RifSurfio::importSurfaceData( m_surfaceFilePath().path().toStdString() );

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularFileSurface.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularFileSurface.h
@@ -26,9 +26,13 @@ class RimRegularFileSurface : public RimRegularSurface
 
 public:
     RimRegularFileSurface();
-    void setFilePath( const QString& filePath );
 
     bool onLoadData() override;
+
+    // File-based surface interface (from RimSurface)
+    bool    isFileBased() const override { return true; }
+    QString filePath() const override;
+    void    setFilePath( const QString& path ) override;
 
 private:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurface.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurface.h
@@ -72,6 +72,11 @@ public:
     void loadDataIfRequired();
     void reloadData();
 
+    // File-based surface interface (override in subclasses that load from files)
+    virtual bool    isFileBased() const { return false; }
+    virtual QString filePath() const { return QString(); }
+    virtual void    setFilePath( const QString& path ) {}
+
     virtual void updateMinMaxValues( RimRegularLegendConfig* legend, const QString& propertyName, int currentTimeStep ) const;
 
     virtual bool isMeshLinesEnabledDefault() const;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceCollection.cpp
@@ -156,7 +156,7 @@ RimSurface* RimSurfaceCollection::createSurfaceFromFile( const QString& fileName
     else
     {
         RimFileSurface* fileSurface = new RimFileSurface;
-        fileSurface->setSurfaceFilePath( fileName );
+        fileSurface->setFilePath( fileName );
         newSurface = fileSurface;
     }
 
@@ -446,7 +446,7 @@ void RimSurfaceCollection::removeMissingFileSurfaces()
         RimFileSurface* fileSurface = dynamic_cast<RimFileSurface*>( surface );
         if ( fileSurface == nullptr ) continue;
 
-        QString filename = fileSurface->surfaceFilePath();
+        QString filename = fileSurface->filePath();
         if ( !QFile::exists( filename ) )
         {
             missingSurfaces.push_back( fileSurface );
@@ -579,7 +579,7 @@ bool RimSurfaceCollection::containsFileSurface( QString filename )
     {
         RimFileSurface* fileSurface = dynamic_cast<RimFileSurface*>( surface );
         if ( fileSurface == nullptr ) continue;
-        if ( fileSurface->surfaceFilePath() == filename ) return true;
+        if ( fileSurface->filePath() == filename ) return true;
     }
 
     return false;


### PR DESCRIPTION
…ling

Add virtual methods (isFileBased, filePath, setFilePath) to RimSurface base class. Implement these in RimFileSurface and RimRegularFileSurface to provide a common interface for all file-based surfaces.

Replace class-specific methods (setSurfaceFilePath/surfaceFilePath) with the common interface methods (setFilePath/filePath) in both RimFileSurface and RimRegularFileSurface. Update RimEnsembleSurface to use the common interface.

This enables polymorphic treatment of file-based surfaces without changing the inheritance hierarchy or breaking backward compatibility.