### PR TITLE
Well Target Mapping: Do not change time step in view during project file import

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
@@ -423,11 +423,12 @@ cvf::Vec3st RimWellTargetMapping::getResultGridCellCount() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimWellTargetMapping::generateCandidates( RimEclipseCase* eclipseCase )
+void RimWellTargetMapping::generateCandidates( RimEclipseCase* eclipseCase, bool setTimeStepInView )
 {
     RigWellTargetMapping::ClusteringLimits limits = getClusteringLimits();
     RigFloodingSettings floodingSettings( m_oilFloodingType(), m_userDefinedFloodingOil(), m_gasFloodingType(), m_userDefinedFloodingGas() );
 
+    bool skipUndefinedResults = true;
     RigWellTargetMapping::generateCandidates( eclipseCase,
                                               m_timeStep(),
                                               m_volumeType(),
@@ -435,7 +436,8 @@ void RimWellTargetMapping::generateCandidates( RimEclipseCase* eclipseCase )
                                               m_volumeResultType(),
                                               floodingSettings,
                                               limits,
-                                              true );
+                                              skipUndefinedResults,
+                                              setTimeStepInView );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -622,7 +624,8 @@ void RimWellTargetMapping::initAfterRead()
 
         // Automatically generate results on project load
         // Consider to also do this for ensemble cases, but this will be more expensive
-        generateCandidates( eclipseCase );
+        bool setTimeStepInView = false;
+        generateCandidates( eclipseCase, setTimeStepInView );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.h
+++ b/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.h
@@ -58,7 +58,7 @@ protected:
     void                          initAfterRead() override;
 
 private:
-    void        generateCandidates( RimEclipseCase* eclipseCase );
+    void        generateCandidates( RimEclipseCase* eclipseCase, bool setTimeStepInView = true );
     void        updateAllBoundaries();
     void        generateEnsembleStatistics();
     cvf::Vec3st getResultGridCellCount() const;

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellTargetMapping.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellTargetMapping.cpp
@@ -64,7 +64,8 @@ void RigWellTargetMapping::generateCandidates( RimEclipseCase*            eclips
                                                VolumeResultType           volumeResultType,
                                                const RigFloodingSettings& floodingSettings,
                                                const ClusteringLimits&    limits,
-                                               bool                       skipUndefinedResults )
+                                               bool                       skipUndefinedResults,
+                                               bool                       setTimeStepInView = true )
 {
     if ( !eclipseCase->ensureReservoirCaseIsOpen() ) return;
 
@@ -290,7 +291,10 @@ void RigWellTargetMapping::generateCandidates( RimEclipseCase*            eclips
     {
         if ( auto eclipseView = dynamic_cast<RimEclipseView*>( view ) )
         {
-            eclipseView->setCurrentTimeStep( (int)timeStepIdx );
+            if ( setTimeStepInView )
+            {
+                eclipseView->setCurrentTimeStep( (int)timeStepIdx );
+            }
             eclipseView->scheduleReservoirGridGeometryRegen();
             eclipseView->propertyFilterCollection()->updateConnectedEditors();
         }

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellTargetMapping.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellTargetMapping.h
@@ -102,7 +102,8 @@ public:
                                     VolumeResultType           volumeResultType,
                                     const RigFloodingSettings& floodingSettings,
                                     const ClusteringLimits&    limits,
-                                    bool                       skipUndefinedResults );
+                                    bool                       skipUndefinedResults,
+                                    bool                       setTimeStepInView );
 
     static std::vector<double> getVolumeVector( RigCaseCellResultsData&       resultsData,
                                                 RiaDefines::EclipseUnitSystem unitsType,


### PR DESCRIPTION
When well target mapping is triggered when loading a project file, the time step in the view is set to the date of the well target object. This should not happen, add logic to keep the view time step when loading project file.