### PR TITLE
#13347 Remove duplicate FAULTS keywords before adding to GRID section

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.cpp
@@ -561,6 +561,9 @@ std::expected<void, QString> RigSimulationInputTool::addFaultsToDeckFile( RimEcl
                                                                           const RigSimulationInputSettings& settings,
                                                                           RifOpmFlowDeckFile&               deckFile )
 {
+    // Remove FAULTS to handle deck where it appears more than once.
+    deckFile.removeKeywords( "FAULTS" );
+
     // Create FAULTS keyword using the factory
     Opm::DeckKeyword faultsKw =
         RimKeywordFactory::faultsKeyword( eclipseCase->mainGrid(), settings.min(), settings.max(), settings.refinement() );


### PR DESCRIPTION
Apply the same pattern used for ACTNUM keyword: remove all occurrences of FAULTS before adding a single instance to the GRID section. This handles deck files where FAULTS appears more than once.

Fixes #13347 