### PR TITLE
#12199 Python: Add validation error messages for set_summary_values()

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp
@@ -342,18 +342,32 @@ void RimFileSummaryCase::setIncludeRestartFiles( bool includeRestartFiles )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimFileSummaryCase::setSummaryData( const std::string& keyword, const std::string& unit, const std::vector<float>& values )
+std::expected<void, QString>
+    RimFileSummaryCase::setSummaryData( const std::string& keyword, const std::string& unit, const std::vector<float>& values )
 {
+    // Validate keyword length (Eclipse SMSPEC format limitation)
+    constexpr size_t MAX_KEYWORD_LENGTH = 8;
+    if ( keyword.length() > MAX_KEYWORD_LENGTH )
+    {
+        QString errorMsg = QString( "Keyword '%1' exceeds the maximum length of %2 characters (SMSPEC format limitation). "
+                                    "Keyword has %3 characters. Please use a shorter keyword name." )
+                               .arg( QString::fromStdString( keyword ) )
+                               .arg( MAX_KEYWORD_LENGTH )
+                               .arg( keyword.length() );
+        RiaLogging::error( errorMsg );
+        return std::unexpected( errorMsg );
+    }
+
+    // Validate value count matches main summary file
     size_t mainSummaryFileValueCount = m_multiSummaryReader->timeSteps( RifEclipseSummaryAddress() ).size();
     if ( values.size() != mainSummaryFileValueCount )
     {
-        QString txt = QString( "Wrong size of summary data for keyword %1. Expected %2 values, received %3 values" )
-                          .arg( QString::fromStdString( keyword ) )
-                          .arg( mainSummaryFileValueCount )
-                          .arg( values.size() );
-        RiaLogging::error( txt );
-
-        return;
+        QString errorMsg = QString( "Wrong size of summary data for keyword %1. Expected %2 values, received %3 values" )
+                               .arg( QString::fromStdString( keyword ) )
+                               .arg( mainSummaryFileValueCount )
+                               .arg( values.size() );
+        RiaLogging::error( errorMsg );
+        return std::unexpected( errorMsg );
     }
 
     m_multiSummaryReader->removeReader( m_additionalSummaryReaderId );
@@ -385,14 +399,27 @@ void RimFileSummaryCase::setSummaryData( const std::string& keyword, const std::
     std::string outputFilePath = tmpAdditionalSummaryFilePath.toStdString();
     projectSummaryDataWriter.writeDataToFile( outputFilePath );
 
-    for ( const auto& txt : projectSummaryDataWriter.errorMessages() )
+    // Check for errors during write operation
+    auto errorMessages = projectSummaryDataWriter.errorMessages();
+    if ( !errorMessages.empty() )
     {
-        RiaLogging::error( QString::fromStdString( txt ) );
+        QString combinedErrors;
+        for ( const auto& txt : errorMessages )
+        {
+            QString errorMsg = QString::fromStdString( txt );
+            RiaLogging::error( errorMsg );
+            if ( !combinedErrors.isEmpty() ) combinedErrors += "; ";
+            combinedErrors += errorMsg;
+        }
+        projectSummaryDataWriter.clearErrorMessages();
+        return std::unexpected( combinedErrors );
     }
     projectSummaryDataWriter.clearErrorMessages();
 
     openAndAttachAdditionalReader();
     m_multiSummaryReader->createAndSetAddresses();
+
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.h
@@ -23,6 +23,7 @@
 
 #include "cafPdmField.h"
 
+#include <expected>
 #include <memory>
 
 class RifReaderRftInterface;
@@ -59,8 +60,8 @@ public:
 
     void setIncludeRestartFiles( bool includeRestartFiles );
 
-    void setSummaryData( const std::string& keyword, const std::string& unit, const std::vector<float>& values );
-    void onProjectBeingSaved();
+    std::expected<void, QString> setSummaryData( const std::string& keyword, const std::string& unit, const std::vector<float>& values );
+    void                         onProjectBeingSaved();
 
     static std::unique_ptr<RifSummaryReaderInterface> findRelatedFilesAndCreateReader( const QString&          headerFileName,
                                                                                        bool                    lookForRestartFiles,

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcSummaryCase.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcSummaryCase.cpp
@@ -261,7 +261,11 @@ std::expected<caf::PdmObjectHandle*, QString> RimSummaryCase_setSummaryVectorVal
             }
         }
 
-        fileSummaryCase->setSummaryData( m_addressString().toStdString(), m_unitString().toStdString(), m_values() );
+        auto result = fileSummaryCase->setSummaryData( m_addressString().toStdString(), m_unitString().toStdString(), m_values() );
+        if ( !result.has_value() )
+        {
+            return std::unexpected( result.error() );
+        }
 
         if ( rebuildUserInterface )
         {

--- a/GrpcInterface/Python/rips/tests/test_summary_cases.py
+++ b/GrpcInterface/Python/rips/tests/test_summary_cases.py
@@ -3,6 +3,7 @@ import os
 import contextlib
 import shutil
 import tempfile
+import pytest
 
 sys.path.insert(1, os.path.join(sys.path[0], "../../"))
 
@@ -115,8 +116,66 @@ def test_summary_set_values(rips_instance, initialize_test):
     current_keyword_count = len(addresses.values)
     assert current_keyword_count == original_keyword_count + 1
 
-    # invalid value count, check that available addresses are unchanged
-    summary_case.set_summary_values("FOPT_2", "", [])
+    # invalid value count should now raise an error (no longer fails silently)
+    with pytest.raises(Exception) as exc_info:
+        summary_case.set_summary_values("FOPT_2", "", [])
+    # Verify error message is informative
+    assert "size" in str(exc_info.value).lower() or "Expected" in str(exc_info.value)
+
+    # Verify addresses are unchanged after failed operation
     addresses = summary_case.available_addresses()
     current_keyword_count = len(addresses.values)
     assert current_keyword_count == original_keyword_count + 1
+
+
+def test_summary_set_values_with_long_keyword(rips_instance, initialize_test):
+    """Test that setting summary values with a keyword exceeding 8 characters fails with an informative error."""
+    casePath = dataroot.PATH + "/flow_diagnostics_test/SIMPLE_SUMMARY2.SMSPEC"
+    summary_case = rips_instance.project.import_summary_case(casePath)
+    assert summary_case.id == 1
+
+    summary_data = summary_case.summary_vector_values("FOPT")
+    assert len(summary_data.values) == 60
+
+    # This keyword exceeds the 8-character SMSPEC limit
+    long_keyword = "ROPR_FROM_1_TO_23"
+
+    # Currently this fails silently - after fix, it should raise an exception with a clear error message
+    with pytest.raises(Exception) as exc_info:
+        summary_case.set_summary_values(long_keyword, "", summary_data.values)
+
+    # Check that the error message is informative
+    error_message = str(exc_info.value)
+    assert (
+        "8" in error_message
+        or "character" in error_message
+        or "length" in error_message
+    ), f"Error message should mention the 8-character limit, but got: {error_message}"
+
+
+def test_summary_set_values_with_wrong_size(rips_instance, initialize_test):
+    """Test that setting summary values with wrong vector size fails with an informative error."""
+    casePath = dataroot.PATH + "/flow_diagnostics_test/SIMPLE_SUMMARY2.SMSPEC"
+    summary_case = rips_instance.project.import_summary_case(casePath)
+    assert summary_case.id == 1
+
+    summary_data = summary_case.summary_vector_values("FOPT")
+    expected_size = len(summary_data.values)
+    assert expected_size == 60
+
+    # Try to set values with wrong size
+    wrong_size_values = [1.0, 2.0, 3.0]  # Only 3 values instead of 60
+
+    # Currently this fails silently - after fix, it should raise an exception with a clear error message
+    with pytest.raises(Exception) as exc_info:
+        summary_case.set_summary_values("TEST_KW", "", wrong_size_values)
+
+    # Check that the error message is informative
+    error_message = str(exc_info.value)
+    assert (
+        "size" in error_message.lower() or "length" in error_message.lower()
+    ), f"Error message should mention size/length mismatch, but got: {error_message}"
+    assert (
+        str(expected_size) in error_message
+        or str(len(wrong_size_values)) in error_message
+    ), f"Error message should mention expected ({expected_size}) or received ({len(wrong_size_values)}) size, but got: {error_message}"


### PR DESCRIPTION
The set_summary_values() Python API method now provides clear error messages when validation fails instead of failing silently.

Changes:
- Add keyword length validation (8-character SMSPEC format limit)
- Add value vector size validation with informative messages
- Add test cases for both validation scenarios
- Update existing test to expect exceptions for invalid inputs

Fixes #12199.