### PR TITLE
Update vcpkg to 2025.12.12

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -184,6 +184,19 @@ jobs:
          echo "Executable path: $EXEC_PATH"
          "$EXEC_PATH" --version    
 
+      - name: Check vcpkg secrets
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}" ]; then
+            echo "Error: AZURE_VCPKG_STORAGE_ACCOUNT secret is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.AZURE_VCPKG_SAS_TOKEN }}" ]; then
+            echo "Error: AZURE_VCPKG_SAS_TOKEN secret is not set"
+            exit 1
+          fi
+          echo "All required vcpkg secrets are present"
+
       - name: Configure
         shell: bash
         env:

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -150,10 +150,30 @@ jobs:
       - name: Install clang-19
         if: contains( matrix.config.cc, 'clang')
         run: |
-          sudo apt-get upgrade
-          wget https://apt.llvm.org/llvm.sh
-          sudo chmod +x llvm.sh
-          sudo ./llvm.sh 19 all
+          set -e
+          
+          # Add LLVM repository
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee /etc/apt/sources.list.d/llvm-19.list
+          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee -a /etc/apt/sources.list.d/llvm-19.list
+          
+          # Update package list and install clang-19
+          sudo apt-get update --option="APT::Acquire::Retries=3"
+          sudo apt-get install --option="APT::Acquire::Retries=3" -y \
+            clang-19 \
+            lldb-19 \
+            lld-19 \
+            clangd-19 \
+            clang-tidy-19 \
+            clang-format-19 \
+            clang-tools-19 \
+            libc++-19-dev \
+            libc++abi-19-dev
+          
+          # Verify installation
+          clang-19 --version
+          clang++-19 --version
+          echo "clang-19 installation completed successfully"
 
       - name: Install gcc-14
         if: contains( matrix.config.cc, 'gcc-14')

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -80,7 +80,6 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     steps:
       - name: Checkout
@@ -169,13 +168,6 @@ jobs:
         run: |
           ThirdParty/vcpkg/${{ matrix.config.vcpkg-bootstrap }}
 
-      - name: Restore vcpkg cache
-        id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@e5c219f91ccf7908fc284fb64f4d928715f4a154
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: vcpkg-${{ matrix.config.cxx}}/
-          
       - name: Print CMake version
         shell: bash
         run: |
@@ -190,8 +182,8 @@ jobs:
       - name: Configure
         shell: bash
         env:
-          VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
-          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
+          VCPKG_FEATURE_FLAGS: "binarycaching"
+          VCPKG_BINARY_SOURCES: "clear;x-azblob,https://${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}.blob.core.windows.net/vcpkg-binaries,${{ secrets.AZURE_VCPKG_SAS_TOKEN }},readwrite"
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
         run: >

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -49,10 +49,10 @@ jobs:
               ri-unit-test-path: "ResInsight-tests",
             }
           - {
-              name: "Ubuntu 24.04 gcc",
+              name: "Ubuntu 24.04 gcc-14",
               os: ubuntu-24.04,
-              cc: "gcc",
-              cxx: "g++",
+              cc: "gcc-14",
+              cxx: "g++-14",
               build-python-module: true,
               execute-unit-tests: true,
               execute-pytests: true,
@@ -154,6 +154,11 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           sudo chmod +x llvm.sh
           sudo ./llvm.sh 19 all
+
+      - name: Install gcc-14
+        if: contains( matrix.config.cc, 'gcc-14')
+        run: |
+          sudo apt-get install --option="APT::Acquire::Retries=3" gcc-14 g++-14
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -168,7 +168,8 @@ jobs:
             clang-format-19 \
             clang-tools-19 \
             libc++-19-dev \
-            libc++abi-19-dev
+            libc++abi-19-dev \
+            libomp-19-dev
           
           # Verify installation
           clang-19 --version

--- a/ApplicationLibCode/FileInterface/RifArrowTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifArrowTools.cpp
@@ -33,11 +33,12 @@ QString RifArrowTools::readFirstRowsOfTable( const QByteArray& contents )
     std::shared_ptr<arrow::io::RandomAccessFile> input = std::make_shared<RifByteArrayArrowRandomAccessFile>( contents );
 
     // Open Parquet file reader
-    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    if ( !parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() )
+    auto result = parquet::arrow::OpenFile( input, pool );
+    if ( !result.ok() )
     {
         return {};
     }
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader = std::move( result ).ValueOrDie();
 
     // Read entire file as a single Arrow table
     std::shared_ptr<arrow::Table> table;

--- a/ApplicationLibCode/FileInterface/RifOsduWellLogReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellLogReader.cpp
@@ -45,11 +45,12 @@ std::pair<cvf::ref<RigOsduWellLogData>, QString> RifOsduWellLogReader::readWellL
     std::shared_ptr<arrow::io::RandomAccessFile> input = std::make_shared<RifByteArrayArrowRandomAccessFile>( contents );
 
     // Open Parquet file reader
-    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    if ( !parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() )
+    auto result = parquet::arrow::OpenFile( input, pool );
+    if ( !result.ok() )
     {
         return { nullptr, "Unable to read parquet data." };
     }
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader = std::move( result ).ValueOrDie();
 
     // Read entire file as a single Arrow table
     std::shared_ptr<arrow::Table> table;

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -116,11 +116,12 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
     std::shared_ptr<arrow::io::RandomAccessFile> input = std::make_shared<RifByteArrayArrowRandomAccessFile>( content );
 
     // Open Parquet file reader
-    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    if ( !parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() )
+    auto result = parquet::arrow::OpenFile( input, pool );
+    if ( !result.ok() )
     {
         return { nullptr, "Unable to read parquet data." };
     }
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader = std::move( result ).ValueOrDie();
 
     // Read entire file as a single Arrow table
     std::shared_ptr<arrow::Table> table;

--- a/ApplicationLibCode/ProjectDataModel/Summary/Sumo/RimSummaryEnsembleSumo.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/Sumo/RimSummaryEnsembleSumo.cpp
@@ -159,10 +159,11 @@ std::shared_ptr<arrow::Table> RimSummaryEnsembleSumo::readParquetTable( const QB
 
     std::shared_ptr<arrow::io::RandomAccessFile> input = std::make_shared<RifByteArrayArrowRandomAccessFile>( contents );
 
-    std::shared_ptr<arrow::Table>               table;
-    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    if ( auto openResult = parquet::arrow::OpenFile( input, pool, &arrow_reader ); openResult.ok() )
+    std::shared_ptr<arrow::Table> table;
+    auto                          openResult = parquet::arrow::OpenFile( input, pool );
+    if ( openResult.ok() )
     {
+        std::unique_ptr<parquet::arrow::FileReader> arrow_reader = std::move( openResult ).ValueOrDie();
         if ( auto readResult = arrow_reader->ReadTable( &table ); readResult.ok() )
         {
             RiaLogging::info( QString( "Parquet: Read table successfully for %1" ).arg( messageTag ) );
@@ -176,7 +177,7 @@ std::shared_ptr<arrow::Table> RimSummaryEnsembleSumo::readParquetTable( const QB
     else
     {
         RiaLogging::warning(
-            QString( "Parquet: Not able to open data stream. Message: %1" ).arg( QString::fromStdString( openResult.ToString() ) ) );
+            QString( "Parquet: Not able to open data stream. Message: %1" ).arg( QString::fromStdString( openResult.status().ToString() ) ) );
     }
 
     return table;

--- a/ApplicationLibCode/UnitTests/RifParquetReader-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifParquetReader-Test.cpp
@@ -31,8 +31,9 @@ TEST( RifParquetReaderTest, ReadValidFile )
     std::shared_ptr<arrow::io::RandomAccessFile> input = std::move( openResult ).ValueOrDie();
 
     // Open Parquet file reader
-    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    EXPECT_TRUE( parquet::arrow::OpenFile( input, pool, &arrow_reader ).ok() );
+    auto readerResult = parquet::arrow::OpenFile( input, pool );
+    EXPECT_TRUE( readerResult.ok() );
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader = std::move( readerResult ).ValueOrDie();
 
     // Read entire file as a single Arrow table
     std::shared_ptr<arrow::Table> table;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,9 +1,9 @@
 {
-    "default-registry": {
-        "kind": "git",
-        "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
-        "repository": "https://github.com/microsoft/vcpkg"
-    },
+  "default-registry": {
+    "kind": "git",
+    "baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
   "registries": [
     {
       "kind": "artifact",


### PR DESCRIPTION
Updates vcpkg to 2025.12.12
Fixes API changes Parquet

Introduces vcpkg caching from Azure. This caching can also be used from developer PCs.

Closes #13365
