### PR TITLE
Fixes crash reporting for empty lines that might happen 

### DIFF
--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
@@ -24,6 +24,7 @@
 
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
@@ -255,31 +256,36 @@ void RiaOpenTelemetryManager::reportCrash( int signalCode, const std::stacktrace
     std::string rawStackTrace = ss.str();
 
     // Store structured stack trace data for Application Insights parsedStack
-    std::stringstream jsonFrames;
-    jsonFrames << "[";
-    int frameIndex = 0;
+    QJsonArray jsonFrames;
+    int        frameIndex = 0;
     for ( const auto& entry : trace )
     {
-        if ( frameIndex > 0 ) jsonFrames << ",";
-
         std::string relevantPath = extractRelevantPath( entry.source_file() );
         std::string methodName   = entry.description();
-        int         lineNumber   = static_cast<int>( entry.source_line() );
 
-        jsonFrames << "{"
-                   << "\"level\":" << frameIndex << ","
-                   << "\"method\":\"" << methodName << "\","
-                   << "\"fileName\":\"" << relevantPath << "\","
-                   << "\"line\":" << lineNumber << "}";
+        // Ensure method name is never empty (Application Insights requirement)
+        if ( methodName.empty() )
+        {
+            methodName = "UnknownMethod";
+        }
+
+        int lineNumber = static_cast<int>( entry.source_line() );
+
+        QJsonObject frame;
+        frame["level"]    = frameIndex;
+        frame["method"]   = QString::fromStdString( methodName );
+        frame["fileName"] = QString::fromStdString( relevantPath );
+        frame["line"]     = lineNumber;
+
+        jsonFrames.append( frame );
         frameIndex++;
     }
-    jsonFrames << "]";
 
     std::map<std::string, std::string> attributes;
     attributes["crash.signal"]            = std::to_string( signalCode );
     attributes["crash.thread_id"]         = std::to_string( std::hash<std::thread::id>{}( std::this_thread::get_id() ) );
     attributes["crash.stack_trace"]       = rawStackTrace;
-    attributes["crash.parsed_stack_json"] = jsonFrames.str();
+    attributes["crash.parsed_stack_json"] = QString::fromUtf8( QJsonDocument( jsonFrames ).toJson( QJsonDocument::Compact ) ).toStdString();
     attributes["service.name"]            = RiaPreferencesOpenTelemetry::current()->serviceName().toStdString();
     attributes["service.version"]         = RiaPreferencesOpenTelemetry::current()->serviceVersion().toStdString();
 


### PR DESCRIPTION
This pull request updates the crash reporting logic in `RiaOpenTelemetryManager.cpp` to improve how stack traces are serialized and ensure compatibility with Application Insights requirements. The main changes involve switching from manual string construction to using Qt's `QJsonArray` and `QJsonObject` for structured JSON output, and guaranteeing that method names are never empty.

Crash reporting improvements:

* Stack trace frames are now serialized using `QJsonArray` and `QJsonObject` instead of manually building a JSON string, resulting in more reliable and maintainable code.
* Method names in stack trace frames are set to `"UnknownMethod"` if empty, ensuring compliance with Application Insights requirements.

Dependency update:

* Added `#include <QJsonObject>` to support the new JSON serialization logic.