### PR TITLE
Improve telementry reporting

### DIFF
--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
@@ -22,6 +22,7 @@
 #include "RiaPreferencesOpenTelemetry.h"
 #include "RifJsonEncodeDecode.h"
 
+#include <QCryptographicHash>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -199,6 +200,24 @@ bool RiaOpenTelemetryManager::reinitialize()
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Create a stable, anonymized hash of username for privacy-preserving telemetry
+/// Uses SHA-256 to ensure consistent hashing across sessions while protecting user identity
+//--------------------------------------------------------------------------------------------------
+static std::string hashUsername( const std::string& username )
+{
+    if ( username.empty() )
+    {
+        return "";
+    }
+
+    QByteArray usernameBytes = QString::fromStdString( username ).toUtf8();
+    QByteArray hash          = QCryptographicHash::hash( usernameBytes, QCryptographicHash::Sha256 );
+    
+    // Convert to hex string for readability in telemetry
+    return hash.toHex().toStdString();
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RiaOpenTelemetryManager::reportEventAsync( const std::string& eventName, const std::map<std::string, std::string>& attributes )
@@ -217,7 +236,21 @@ void RiaOpenTelemetryManager::reportEventAsync( const std::string& eventName, co
         return;
     }
 
-    m_eventQueue.emplace( eventName, attributes );
+    // Create mutable copy and add hashed username if configured (privacy-preserving for regular events)
+    // Note: crash events already have real username added in reportCrash()
+    std::map<std::string, std::string> enrichedAttributes = attributes;
+    
+    bool isCrashEvent = ( eventName == "crash.signal_handler" );
+    if ( !isCrashEvent )
+    {
+        std::lock_guard<std::mutex> configLock( m_configMutex );
+        if ( !m_username.empty() )
+        {
+            enrichedAttributes["user.hash"] = hashUsername( m_username );
+        }
+    }
+
+    m_eventQueue.emplace( eventName, enrichedAttributes );
     m_healthMetrics.eventsQueued++;
 }
 
@@ -289,6 +322,20 @@ void RiaOpenTelemetryManager::reportCrash( int signalCode, const std::stacktrace
     attributes["service.name"]            = RiaPreferencesOpenTelemetry::current()->serviceName().toStdString();
     attributes["service.version"]         = RiaPreferencesOpenTelemetry::current()->serviceVersion().toStdString();
 
+    // Add system information
+    attributes["os.type"]    = QSysInfo::productType().toStdString();
+    attributes["os.version"] = QSysInfo::productVersion().toStdString();
+    attributes["os.name"]    = QSysInfo::prettyProductName().toStdString();
+
+    // Add real username for crash reports (not hashed - needed for debugging critical issues)
+    {
+        std::lock_guard<std::mutex> lock( m_configMutex );
+        if ( !m_username.empty() )
+        {
+            attributes["user.name"] = m_username;
+        }
+    }
+
     reportEventAsync( "crash.signal_handler", attributes );
     flushPendingEvents();
 
@@ -326,6 +373,7 @@ void RiaOpenTelemetryManager::setErrorCallback( ErrorCallback callback )
 void RiaOpenTelemetryManager::setUsername( const std::string& username )
 {
     std::lock_guard<std::mutex> lock( m_configMutex );
+    // Store original username - will be hashed for regular events but kept plain for crash reports
     m_username = username;
 }
 
@@ -568,20 +616,6 @@ void RiaOpenTelemetryManager::processEvent( const Event& event )
         for ( const auto& [key, value] : event.attributes )
         {
             properties[QString::fromStdString( key )] = QString::fromStdString( value );
-        }
-
-        // Add system information
-        properties["os.type"]    = QSysInfo::productType();
-        properties["os.version"] = QSysInfo::productVersion();
-        properties["os.name"]    = QSysInfo::prettyProductName();
-
-        // Add username if configured
-        {
-            std::lock_guard<std::mutex> lock( m_configMutex );
-            if ( !m_username.empty() )
-            {
-                properties["user.name"] = QString::fromStdString( m_username );
-            }
         }
 
         // Determine if this is a crash event

--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
@@ -212,7 +212,7 @@ static std::string hashUsername( const std::string& username )
 
     QByteArray usernameBytes = QString::fromStdString( username ).toUtf8();
     QByteArray hash          = QCryptographicHash::hash( usernameBytes, QCryptographicHash::Sha256 );
-    
+
     // Convert to hex string for readability in telemetry
     return hash.toHex().toStdString();
 }
@@ -239,7 +239,7 @@ void RiaOpenTelemetryManager::reportEventAsync( const std::string& eventName, co
     // Create mutable copy and add hashed username if configured (privacy-preserving for regular events)
     // Note: crash events already have real username added in reportCrash()
     std::map<std::string, std::string> enrichedAttributes = attributes;
-    
+
     bool isCrashEvent = ( eventName == "crash.signal_handler" );
     if ( !isCrashEvent )
     {

--- a/GrpcInterface/RiaGrpcCommandService.cpp
+++ b/GrpcInterface/RiaGrpcCommandService.cpp
@@ -15,9 +15,11 @@
 //  for more details.
 //
 //////////////////////////////////////////////////////////////////////////////////
+
 #include "RiaGrpcCommandService.h"
 
 #include "RiaGrpcCallbacks.h"
+#include "RiaOpenTelemetryManager.h"
 
 #include "RicfReplaceCase.h"
 #include "RicfSetTimeStep.h"
@@ -54,8 +56,13 @@ grpc::Status RiaGrpcCommandService::Execute( grpc::ServerContext* context, const
         CAF_ASSERT( grpcOneOfMessage->type() == FieldDescriptor::TYPE_MESSAGE );
 
         QString grpcOneOfMessageName = QString::fromStdString( grpcOneOfMessage->name() );
-        auto    pdmObjectHandle      = caf::PdmDefaultObjectFactory::instance()->create( grpcOneOfMessageName );
-        auto    commandHandle        = dynamic_cast<RicfCommandObject*>( pdmObjectHandle );
+
+        // Prepare telemetry attributes
+        std::map<std::string, std::string> telemetryAttributes;
+        telemetryAttributes["command.name"] = grpcOneOfMessageName.toStdString();
+
+        auto pdmObjectHandle = caf::PdmDefaultObjectFactory::instance()->create( grpcOneOfMessageName );
+        auto commandHandle   = dynamic_cast<RicfCommandObject*>( pdmObjectHandle );
 
         if ( commandHandle )
         {
@@ -72,30 +79,56 @@ grpc::Status RiaGrpcCommandService::Execute( grpc::ServerContext* context, const
                                                           QString::fromStdString( caseGridFilePair.newgridfile() ) ) );
                 }
                 multiCaseReplaceCommand->setCaseReplacePairs( caseIdFileMap );
+                telemetryAttributes["command.type"]       = "multi_case_replace";
+                telemetryAttributes["command.case_count"] = std::to_string( caseIdFileMap.size() );
             }
             else
             {
                 assignPdmObjectValues( commandHandle, *request, grpcOneOfMessage );
+                telemetryAttributes["command.type"] = "standard";
             }
 
             // Execute command
             caf::PdmScriptResponse response = commandHandle->execute();
 
-            // Copy results
+            // Copy results and log based on status
             if ( response.status() == caf::PdmScriptResponse::COMMAND_ERROR )
             {
+                telemetryAttributes["command.status"] = "error";
+                telemetryAttributes["command.error"]  = response.sanitizedResponseMessage().toStdString();
+                RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.command_execute", telemetryAttributes );
+
                 return grpc::Status( grpc::FAILED_PRECONDITION, response.sanitizedResponseMessage().toStdString() );
             }
             else if ( response.status() == caf::PdmScriptResponse::COMMAND_WARNING )
             {
+                telemetryAttributes["command.status"]  = "warning";
+                telemetryAttributes["command.warning"] = response.sanitizedResponseMessage().toStdString();
+                RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.command_execute", telemetryAttributes );
+
                 context->AddTrailingMetadata( "warning", response.sanitizedResponseMessage().toStdString() );
+            }
+            else
+            {
+                telemetryAttributes["command.status"] = "success";
+                RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.command_execute", telemetryAttributes );
             }
 
             assignResultToReply( response.result(), reply );
 
             return Status::OK;
         }
+
+        telemetryAttributes["command.status"] = "error";
+        telemetryAttributes["command.error"]  = "Invalid command handle";
+        RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.command_execute", telemetryAttributes );
     }
+
+    std::map<std::string, std::string> telemetryAttributes;
+    telemetryAttributes["command.status"] = "error";
+    telemetryAttributes["command.error"]  = "Command not found";
+    RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.command_execute", telemetryAttributes );
+
     return grpc::Status( grpc::NOT_FOUND, "Command not found" );
 }
 

--- a/GrpcInterface/RiaGrpcPdmObjectService.cpp
+++ b/GrpcInterface/RiaGrpcPdmObjectService.cpp
@@ -22,6 +22,7 @@
 #include "RiaGrpcCallbacks.h"
 #include "RiaGrpcHelper.h"
 #include "RiaLogging.h"
+#include "RiaOpenTelemetryManager.h"
 
 #include "RimEclipseResultDefinition.h"
 #include "RimProject.h"
@@ -547,6 +548,12 @@ grpc::Status RiaGrpcPdmObjectService::CallPdmObjectMethod( grpc::ServerContext* 
     {
         QString methodKeyword = QString::fromStdString( request->method() );
 
+        // Prepare telemetry attributes
+        std::map<std::string, std::string> telemetryAttributes;
+        QString objectClassName           = QString::fromStdString( request->object().class_keyword() );
+        telemetryAttributes["pdm.class"]  = objectClassName.toStdString();
+        telemetryAttributes["pdm.method"] = methodKeyword.toStdString();
+
         std::shared_ptr<caf::PdmObjectMethod> method =
             caf::PdmObjectMethodFactory::instance()->createMethod( matchingObject, methodKeyword );
         if ( method )
@@ -561,6 +568,10 @@ grpc::Status RiaGrpcPdmObjectService::CallPdmObjectMethod( grpc::ServerContext* 
             auto result = method->execute();
             if ( !result.has_value() )
             {
+                telemetryAttributes["pdm.status"] = "failed";
+                telemetryAttributes["pdm.error"]  = result.error().toStdString();
+                RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
+
                 RiaLogging::error( QString( "Method '%1' failed. Error: %2" ).arg( methodKeyword ).arg( result.error() ) );
                 return grpc::Status( grpc::NOT_FOUND, result.error().toStdString() );
             }
@@ -569,6 +580,10 @@ grpc::Status RiaGrpcPdmObjectService::CallPdmObjectMethod( grpc::ServerContext* 
                 caf::PdmObjectHandle* object = result.value();
                 if ( object )
                 {
+                    telemetryAttributes["pdm.status"]       = "success";
+                    telemetryAttributes["pdm.result_class"] = object->classKeywordStatic().toStdString();
+                    RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
+
                     copyPdmObjectFromCafToRips( object, reply );
                     if ( !method->resultIsPersistent() )
                     {
@@ -579,14 +594,29 @@ grpc::Status RiaGrpcPdmObjectService::CallPdmObjectMethod( grpc::ServerContext* 
 
                 if ( method->isNullptrValidResult() )
                 {
+                    telemetryAttributes["pdm.status"]       = "success";
+                    telemetryAttributes["pdm.result_class"] = "null";
+                    RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
                     return grpc::Status::OK;
                 }
 
+                telemetryAttributes["pdm.status"] = "failed";
+                telemetryAttributes["pdm.error"]  = "No result returned from Method";
+                RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
                 return grpc::Status( grpc::NOT_FOUND, "No result returned from Method" );
             }
         }
+
+        telemetryAttributes["pdm.status"] = "failed";
+        telemetryAttributes["pdm.error"]  = "Could not find Method";
+        RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
         return grpc::Status( grpc::NOT_FOUND, "Could not find Method" );
     }
+
+    std::map<std::string, std::string> telemetryAttributes;
+    telemetryAttributes["pdm.status"] = "failed";
+    telemetryAttributes["pdm.error"]  = "Could not find PdmObject";
+    RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
     return grpc::Status( grpc::NOT_FOUND, "Could not find PdmObject" );
 }
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Use a hash key instead of user name for application event.
- Include user name for crash reports. 
- Add telemetry for selected Python function calls.