### PR TITLE
Lower log level for config and service init messages

### DIFF
--- a/ApplicationLibCode/Application/Tools/Cloud/RiaConnectorTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaConnectorTools.cpp
@@ -179,7 +179,7 @@ void RiaConnectorTools::readCloudConfigFiles( RiaPreferences* preferences )
         auto keyValuePairs = RiaConnectorTools::readKeyValuePairs( filePath );
         if ( !keyValuePairs.empty() )
         {
-            RiaLogging::info( QString( "Imported OSDU configuration from : '%1'" ).arg( filePath ) );
+            RiaLogging::debug( QString( "Imported OSDU configuration from : '%1'" ).arg( filePath ) );
             preferences->osduPreferences()->setData( keyValuePairs );
             preferences->osduPreferences()->setFieldsReadOnly();
             break;
@@ -192,7 +192,7 @@ void RiaConnectorTools::readCloudConfigFiles( RiaPreferences* preferences )
         auto keyValuePairs = RiaConnectorTools::readKeyValuePairs( filePath );
         if ( !keyValuePairs.empty() )
         {
-            RiaLogging::info( QString( "Imported SUMO configuration from : '%1'" ).arg( filePath ) );
+            RiaLogging::debug( QString( "Imported SUMO configuration from : '%1'" ).arg( filePath ) );
             preferences->sumoPreferences()->setData( keyValuePairs );
             preferences->sumoPreferences()->setFieldsReadOnly();
             break;
@@ -205,7 +205,7 @@ void RiaConnectorTools::readCloudConfigFiles( RiaPreferences* preferences )
         auto keyValuePairs = RiaConnectorTools::readKeyValuePairs( filePath );
         if ( !keyValuePairs.empty() )
         {
-            RiaLogging::info( QString( "Imported OpenTelemetry configuration from : '%1'" ).arg( filePath ) );
+            RiaLogging::debug( QString( "Imported OpenTelemetry configuration from : '%1'" ).arg( filePath ) );
             RiaPreferencesOpenTelemetry::current()->setData( keyValuePairs );
             RiaPreferencesOpenTelemetry::current()->setFieldsReadOnly();
             break;
@@ -221,22 +221,25 @@ void RiaConnectorTools::configureCloudServices()
     if ( auto preferences = RiaApplication::instance()->preferences() )
     {
         RiaConnectorTools::readCloudConfigFiles( preferences );
-    }
 
-    // Initialize OpenTelemetry after configuration is loaded
-    auto& otelManager = RiaOpenTelemetryManager::instance();
-    if ( otelManager.initialize() )
-    {
-        // Set system username for telemetry tracking
-        QString username = RiaOpenTelemetryManager::getSystemUsername();
-        if ( !username.isEmpty() )
+        if ( preferences->openTelemetryPreferences()->loggingState() != RiaPreferencesOpenTelemetry::LoggingState::DISABLED )
         {
-            otelManager.setUsername( username.toStdString() );
+            // Initialize OpenTelemetry after configuration is loaded
+            auto& otelManager = RiaOpenTelemetryManager::instance();
+            if ( otelManager.initialize() )
+            {
+                // Set system username for telemetry tracking
+                QString username = RiaOpenTelemetryManager::getSystemUsername();
+                if ( !username.isEmpty() )
+                {
+                    otelManager.setUsername( username.toStdString() );
+                }
+                RiaLogging::debug( "OpenTelemetry initialized successfully" );
+            }
+            else
+            {
+                RiaLogging::debug( "OpenTelemetry initialization failed or not configured" );
+            }
         }
-        RiaLogging::info( "OpenTelemetry initialized successfully" );
-    }
-    else
-    {
-        RiaLogging::debug( "OpenTelemetry initialization failed or not configured" );
     }
 }

--- a/ApplicationLibCode/Application/Tools/RiaToCafLogging.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaToCafLogging.cpp
@@ -126,7 +126,7 @@ void RiaCafLoggingManager::initializeCafLogging()
         s_isInitialized = true;
 
         // Log initialization success
-        RiaLogging::info( "CAF logging bridge initialized successfully" );
+        RiaLogging::debug( "CAF logging bridge initialized successfully" );
     }
 }
 
@@ -141,7 +141,7 @@ void RiaCafLoggingManager::shutdownCafLogging()
         s_isInitialized = false;
 
         // Log shutdown
-        RiaLogging::info( "CAF logging bridge shut down" );
+        RiaLogging::debug( "CAF logging bridge shut down" );
     }
 }
 

--- a/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp
+++ b/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp
@@ -74,7 +74,7 @@ RiaSocketServer::RiaSocketServer( QObject* parent )
     }
 
     QString txt = QString( "Octave is using port: %1" ).arg( portNumber );
-    RiaLogging::info( txt );
+    RiaLogging::debug( txt );
 
     connect( m_nextPendingConnectionTimer, SIGNAL( timeout() ), this, SLOT( slotNewClientConnection() ) );
     connect( m_tcpServer, SIGNAL( newConnection() ), this, SLOT( slotNewClientConnection() ) );

--- a/GrpcInterface/RiaGrpcServer.cpp
+++ b/GrpcInterface/RiaGrpcServer.cpp
@@ -164,7 +164,7 @@ void RiaGrpcServerImpl::initialize()
         return;
     }
 
-    RiaLogging::info( QString( "Server listening on %1" ).arg( serverAddress ) );
+    RiaLogging::debug( QString( "Server listening on %1" ).arg( serverAddress ) );
 
     // Spawn new CallData instances to serve new clients.
     for ( auto service : m_services )


### PR DESCRIPTION
Changed logging from info to debug for config imports, CAF logging, socket server, and gRPC server startup. OpenTelemetry initialization now only runs if enabled, with results logged at debug level.
