### PR TITLE
Set PdmUiButton default alignment to right

### DIFF
--- a/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.cpp
@@ -31,7 +31,6 @@
 #include "RimTools.h"
 #include "Tools/RimEclipseViewTools.h"
 
-#include "cafPdmUiButton.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiFilePathEditor.h"
 #include "cafPdmUiGroup.h"
@@ -229,13 +228,12 @@ void RicExportSectorModelUi::defineUiOrdering( QString uiConfigName, caf::PdmUiO
     else if ( uiConfigName == m_pageNames[WizardPageEnum::KeywordAdjustments] )
     {
         uiOrdering.add( &m_keywordsToRemove );
-        auto button = uiOrdering.addNewButton( "Reset to Default",
-                                               [this]()
-                                               {
-                                                   setDefaultKeywordsToRemove();
-                                                   updateConnectedEditors();
-                                               } );
-        button->setAlignment( Qt::AlignRight );
+        uiOrdering.addNewButton( "Reset to Default",
+                                 [this]()
+                                 {
+                                     setDefaultKeywordsToRemove();
+                                     updateConnectedEditors();
+                                 } );
     }
     else if ( uiConfigName == m_pageNames[WizardPageEnum::SimulationJob] )
     {

--- a/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/AnalysisPlots/RimAnalysisPlot.cpp
@@ -53,7 +53,6 @@
 #include "qwt_scale_draw.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
-#include "cafPdmUiButton.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiGroup.h"
@@ -517,10 +516,7 @@ void RimAnalysisPlot::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
 
     caf::PdmUiGroup* selVectorsGrp = uiOrdering.addNewGroup( "Selected Vectors" );
     selVectorsGrp->addNewLabel( createLabelText(), { .newRow = false, .totalColumnSpan = 4 } );
-    auto showVectorSelection = selVectorsGrp->addNewButton( "...",
-                                                            [this]() { RimAnalysisPlot::showSelectVariablesDialog(); },
-                                                            { .newRow = false, .totalColumnSpan = 1 } );
-    showVectorSelection->setAlignment( Qt::AlignRight );
+    selVectorsGrp->addNewButton( "...", [this]() { RimAnalysisPlot::showSelectVariablesDialog(); }, { .newRow = false, .totalColumnSpan = 1 } );
 
     selVectorsGrp->add( &m_referenceCase );
 

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp
@@ -33,8 +33,6 @@
 #include "RimWellPathCompletionSettings.h"
 #include "RimWellPathCompletions.h"
 
-#include "cafPdmUiButton.h"
-
 #include <algorithm>
 #include <map>
 

--- a/ApplicationLibCode/ProjectDataModel/Jobs/RimOpmFlowJob.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Jobs/RimOpmFlowJob.cpp
@@ -360,8 +360,7 @@ void RimOpmFlowJob::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& 
 
             if ( createOpenPostionButton )
             {
-                auto openSelectButton = wellGrp->addNewButton( "Select Open Keyword Position", [this]() { selectOpenWellPosition(); } );
-                openSelectButton->setAlignment( Qt::AlignRight );
+                wellGrp->addNewButton( "Select Open Keyword Position", [this]() { selectOpenWellPosition(); } );
             }
         }
     }
@@ -399,8 +398,7 @@ void RimOpmFlowJob::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& 
     auto advGrp = uiOrdering.addNewGroup( "Advanced" );
     advGrp->setCollapsedByDefault();
     advGrp->add( &m_currentRunId );
-    auto resetRunIdButton = advGrp->addNewButton( "Reset Ensemble Run Id", [this]() { resetEnsembleRunId(); } );
-    resetRunIdButton->setAlignment( Qt::AlignRight );
+    advGrp->addNewButton( "Reset Ensemble Run Id", [this]() { resetEnsembleRunId(); } );
 
     uiOrdering.skipRemainingFields();
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
@@ -70,7 +70,6 @@
 #include "cafDataLoader.h"
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
-#include "cafPdmUiButton.h"
 #include "cafPdmUiEditorHandle.h"
 #include "cafPdmUiTreeOrdering.h"
 #include "cafProgressInfo.h"
@@ -557,8 +556,7 @@ void RimWellPathCollection::defineUiOrdering( QString uiConfigName, caf::PdmUiOr
     caf::PdmUiGroup* mswSegmentGroup = uiOrdering.addNewGroup( "MSW Segment Visualization" );
     mswSegmentGroup->add( &m_mswShowBands );
     mswSegmentGroup->add( &m_mswEclipseCase );
-    auto updateButton = mswSegmentGroup->addNewButton( "Update Segments", [this]() { updateMswSegments(); } );
-    updateButton->setAlignment( Qt::AlignRight );
+    mswSegmentGroup->addNewButton( "Update Segments", [this]() { updateMswSegments(); } );
     uiOrdering.skipRemainingFields();
 }
 

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiButton.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiButton.cpp
@@ -43,7 +43,7 @@ namespace caf
 ///
 //--------------------------------------------------------------------------------------------------
 PdmUiButton::PdmUiButton()
-    : m_alignment( Qt::AlignLeft | Qt::AlignTop )
+    : m_alignment( Qt::AlignRight )
 {
 }
 
@@ -51,7 +51,7 @@ PdmUiButton::PdmUiButton()
 ///
 //--------------------------------------------------------------------------------------------------
 PdmUiButton::PdmUiButton( const QString& buttonText, const ClickCallback& callback )
-    : m_alignment( Qt::AlignLeft | Qt::AlignTop )
+    : m_alignment( Qt::AlignRight )
     , m_clickCallback( callback )
 {
     setUiName( buttonText );

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.cpp
@@ -80,7 +80,6 @@ void LabelsAndHyperlinks::defineUiOrdering( QString uiConfigName, caf::PdmUiOrde
                                                         msgBox->show();
                                                     } );
         iconButton->setIconFromResourceString( ":/cafCommandFeatures/Delete.svg" );
-        iconButton->setAlignment( Qt::AlignRight );
     }
     else
     {


### PR DESCRIPTION
Often, when a push button is used, the client code calls `setAlignment(Qt::AlignRight)`. Use this setting as default as this is the most common pattern.

Removed manual setAlignment(Qt::AlignRight) calls for UI buttons, as PdmUiButton now defaults to right alignment. Also removed unused cafPdmUiButton.h includes from several files.
