### PR TITLE
Add SurfaceColorMode setting to control surface visualization

### DIFF
--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.cpp
@@ -27,6 +27,7 @@
 #include "RimRegularLegendConfig.h"
 #include "RimSurface.h"
 #include "RimSurfaceInView.h"
+#include "RimSurfaceInViewCollection.h"
 #include "RimSurfaceResultDefinition.h"
 
 #include "RivIntersectionGeometryGeneratorInterface.h"
@@ -131,7 +132,16 @@ void RivSurfacePartMgr::updateCellResultColor( int timeStepIndex )
 //--------------------------------------------------------------------------------------------------
 void RivSurfacePartMgr::appendIntersectionGeometryPartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform )
 {
-    if ( m_surfaceInView->surface() && m_surfaceInView->surface()->showIntersectionCellResults() &&
+    if ( !m_surfaceInView ) return;
+
+    using SurfaceColorMode = RimSurfaceInView::SurfaceColorMode;
+
+    SurfaceColorMode surfaceColorMode = m_surfaceInView->effectiveSurfaceColorMode();
+
+    bool includeCellResults  = ( surfaceColorMode == SurfaceColorMode::BOTH || surfaceColorMode == SurfaceColorMode::RESULT_COLORS );
+    bool includeSurfaceColor = ( surfaceColorMode == SurfaceColorMode::BOTH || surfaceColorMode == SurfaceColorMode::SURFACE_COLOR );
+
+    if ( includeCellResults && m_surfaceInView->surface() && m_surfaceInView->surface()->showIntersectionCellResults() &&
          !m_surfaceInView->surfaceResultDefinition()->isChecked() )
     {
         if ( m_intersectionFaces.isNull() )
@@ -165,7 +175,10 @@ void RivSurfacePartMgr::appendIntersectionGeometryPartsToModel( cvf::ModelBasicL
         }
     }
 
-    appendNativeGeometryPartsToModel( model, scaleTransform );
+    if ( includeSurfaceColor )
+    {
+        appendNativeGeometryPartsToModel( model, scaleTransform );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "cafPdmPointer.h"
+
 #include "cvfArray.h"
 #include "cvfObject.h"
 

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp
@@ -27,6 +27,7 @@
 #include "RimGridView.h"
 #include "RimRegularLegendConfig.h"
 #include "RimSurface.h"
+#include "RimSurfaceInViewCollection.h"
 #include "RimSurfaceResultDefinition.h"
 
 #include "RiuViewer.h"
@@ -34,6 +35,21 @@
 #include "RivSurfacePartMgr.h"
 
 CAF_PDM_SOURCE_INIT( RimSurfaceInView, "SurfaceInView" );
+
+namespace caf
+{
+template <>
+void caf::AppEnum<RimSurfaceInView::SurfaceColorMode>::setUp()
+{
+    addItem( RimSurfaceInView::SurfaceColorMode::DEFAULT, "DEFAULT", "Default (from Collection)" );
+    addItem( RimSurfaceInView::SurfaceColorMode::BOTH, "BOTH", "Both" );
+    addItem( RimSurfaceInView::SurfaceColorMode::SURFACE_COLOR, "SURFACE_COLOR", "Surface Color" );
+    addItem( RimSurfaceInView::SurfaceColorMode::RESULT_COLORS, "RESULT_COLORS", "Result Colors" );
+
+    setDefault( RimSurfaceInView::SurfaceColorMode::DEFAULT );
+}
+
+} // namespace caf
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -50,6 +66,8 @@ RimSurfaceInView::RimSurfaceInView()
     m_surface.uiCapability()->setUiHidden( true );
 
     CAF_PDM_InitField( &m_showMeshLines, "ShowMeshLines", false, "Show Mesh Lines" );
+
+    CAF_PDM_InitField( &m_surfaceColorMode, "SurfaceColorMode", caf::AppEnum<SurfaceColorMode>( SurfaceColorMode::DEFAULT ), "Color Mode" );
 
     CAF_PDM_InitFieldNoDefault( &m_resultDefinition, "ResultDefinition", "Result Definition" );
     m_resultDefinition.uiCapability()->setUiTreeChildrenHidden( true );
@@ -104,6 +122,30 @@ void RimSurfaceInView::setSurface( RimSurface* surf )
     }
 
     m_resultDefinition->updateMinMaxValues( -1 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceInView::SurfaceColorMode RimSurfaceInView::surfaceColorMode() const
+{
+    return m_surfaceColorMode();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceInView::SurfaceColorMode RimSurfaceInView::effectiveSurfaceColorMode() const
+{
+    if ( m_surfaceColorMode() == SurfaceColorMode::DEFAULT )
+    {
+        if ( auto collection = firstAncestorOfType<RimSurfaceInViewCollection>() )
+        {
+            return collection->surfaceColorMode();
+        }
+        return SurfaceColorMode::BOTH;
+    }
+    return m_surfaceColorMode();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -255,7 +297,7 @@ void RimSurfaceInView::fieldChangedByUi( const caf::PdmFieldHandle* changedField
         scheduleRedraw = true;
     }
 
-    if ( changedField == &m_showInactiveCells || changedField == &m_showMeshLines )
+    if ( changedField == &m_showInactiveCells || changedField == &m_showMeshLines || changedField == &m_surfaceColorMode )
     {
         clearGeometry();
         scheduleRedraw = true;
@@ -274,6 +316,7 @@ void RimSurfaceInView::fieldChangedByUi( const caf::PdmFieldHandle* changedField
 void RimSurfaceInView::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
     uiOrdering.add( &m_name );
+    uiOrdering.add( &m_surfaceColorMode );
     uiOrdering.add( &m_showInactiveCells );
 
     defineSeparateDataSourceUi( uiConfigName, uiOrdering );

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.h
@@ -17,6 +17,9 @@
 /////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "RimIntersection.h"
+
+#include "cafAppEnum.h"
 #include "cafPdmChildField.h"
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
@@ -24,8 +27,6 @@
 #include "cafPdmPtrField.h"
 
 #include "cvfObject.h"
-
-#include "RimIntersection.h"
 
 class RimSurface;
 class RimSurfaceResultDefinition;
@@ -41,12 +42,24 @@ class RimSurfaceInView : public RimIntersection
     CAF_PDM_HEADER_INIT;
 
 public:
+    enum class SurfaceColorMode
+    {
+        DEFAULT,
+        BOTH,
+        SURFACE_COLOR,
+        RESULT_COLORS
+    };
+
+public:
     RimSurfaceInView();
     ~RimSurfaceInView() override;
 
     QString     name() const override;
     RimSurface* surface() const;
     void        setSurface( RimSurface* surf );
+
+    SurfaceColorMode surfaceColorMode() const;
+    SurfaceColorMode effectiveSurfaceColorMode() const;
 
     bool                        isNativeSurfaceResultsActive() const;
     RimSurfaceResultDefinition* surfaceResultDefinition();
@@ -76,6 +89,8 @@ private:
     caf::PdmProxyValueField<QString> m_name;
     caf::PdmPtrField<RimSurface*>    m_surface;
     caf::PdmField<bool>              m_showMeshLines;
+
+    caf::PdmField<caf::AppEnum<SurfaceColorMode>> m_surfaceColorMode;
 
     caf::PdmChildField<RimSurfaceResultDefinition*> m_resultDefinition;
 

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp
@@ -33,6 +33,7 @@
 #include "RivSurfacePartMgr.h"
 
 #include "cafPdmUiTreeOrdering.h"
+
 #include "cvfModelBasicList.h"
 
 CAF_PDM_SOURCE_INIT( RimSurfaceInViewCollection, "SurfaceInViewCollection" );
@@ -54,6 +55,10 @@ RimSurfaceInViewCollection::RimSurfaceInViewCollection()
 
     CAF_PDM_InitFieldNoDefault( &m_surfaceCollection, "SurfaceCollectionRef", "SurfaceCollection" );
     m_surfaceCollection.uiCapability()->setUiHidden( true );
+
+    CAF_PDM_InitField( &m_surfaceColorMode, "SurfaceColorMode", caf::AppEnum<SurfaceColorMode>( SurfaceColorMode::BOTH ), "Color Mode" );
+    caf::AppEnum<SurfaceColorMode>::setEnumSubset( &m_surfaceColorMode,
+                                                   { SurfaceColorMode::BOTH, SurfaceColorMode::SURFACE_COLOR, SurfaceColorMode::RESULT_COLORS } );
 
     nameField()->uiCapability()->setUiHidden( true );
 }
@@ -97,6 +102,14 @@ QString RimSurfaceInViewCollection::name() const
     if ( m_surfaceCollection ) return m_surfaceCollection->collectionName();
 
     return "";
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceInViewCollection::SurfaceColorMode RimSurfaceInViewCollection::surfaceColorMode() const
+{
+    return m_surfaceColorMode();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -316,7 +329,7 @@ void RimSurfaceInViewCollection::fieldChangedByUi( const caf::PdmFieldHandle* ch
 {
     updateUiIconFromToggleField();
 
-    if ( changedField == &m_isChecked )
+    if ( changedField == &m_isChecked || changedField == &m_surfaceColorMode )
     {
         auto ownerView = firstAncestorOrThisOfTypeAsserted<Rim3dView>();
         ownerView->scheduleCreateDisplayModelAndRedraw();

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "RimCheckableNamedObject.h"
+#include "RimSurfaceInView.h"
 
 #include "cafPdmChildArrayField.h"
 #include "cafPdmField.h"
@@ -44,12 +45,15 @@ class RimSurfaceInViewCollection : public RimCheckableNamedObject
 {
     CAF_PDM_HEADER_INIT;
 
+    using SurfaceColorMode = RimSurfaceInView::SurfaceColorMode;
+
 public:
     RimSurfaceInViewCollection();
     ~RimSurfaceInViewCollection() override;
 
     QString name() const override;
 
+    SurfaceColorMode      surfaceColorMode() const;
     RimSurfaceCollection* surfaceCollection() const;
     void                  setSurfaceCollection( RimSurfaceCollection* surfcoll );
 
@@ -89,5 +93,6 @@ private:
     caf::PdmChildArrayField<RimSurfaceInView*>           m_surfacesInView;
     caf::PdmChildArrayField<RimSurfaceInViewCollection*> m_collectionsInView;
 
-    caf::PdmPtrField<RimSurfaceCollection*> m_surfaceCollection;
+    caf::PdmPtrField<RimSurfaceCollection*>       m_surfaceCollection;
+    caf::PdmField<caf::AppEnum<SurfaceColorMode>> m_surfaceColorMode;
 };


### PR DESCRIPTION
Closes #13473

The combo box selection for individual surfaces depends on the appenum fix in https://github.com/OPM/ResInsight/pull/13493

Add a Color Mode dropdown to surfaces and surface collections that controls how surfaces are rendered:
- Both: Show surface color and cell result colors
- Surface Color: Show only the uniform surface color
- Cell Result Colors: Show only cell results mapped to surface

Individual surfaces default to inherit from their parent collection but can override with their own setting.

If visual noise appears, try using "Result Colors" on the surface.


<img width="881" height="418" alt="image" src="https://github.com/user-attachments/assets/c0e07510-ffbe-4a02-85b2-04e01e5cd644" />

<img width="989" height="408" alt="image" src="https://github.com/user-attachments/assets/17c4fcf2-dcbe-4bb9-b3c8-192378027237" />

<img width="979" height="364" alt="image" src="https://github.com/user-attachments/assets/f4b20e89-3b79-4da0-8a8a-af268f74ddb2" />
