### PR TITLE
#13484 Auto-import PVD surfaces for command line and replace case

### DIFF
--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -41,10 +41,10 @@
 #include "RiaViewRedrawScheduler.h"
 #include "Summary/RiaSummaryTools.h"
 
+#include "EclipseCommands/RicImportEclipseCaseFeature.h"
 #include "ExportCommands/RicSnapshotAllPlotsToFileFeature.h"
 #include "ExportCommands/RicSnapshotAllViewsToFileFeature.h"
 #include "ExportCommands/RicSnapshotViewToFileFeature.h"
-#include "EclipseCommands/RicImportEclipseCaseFeature.h"
 #include "HoloLensCommands/RicHoloLensSessionManager.h"
 #include "RicImportGeneralDataFeature.h"
 #include "SummaryPlotCommands/RicSummaryPlotFeatureImpl.h"

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -44,6 +44,7 @@
 #include "ExportCommands/RicSnapshotAllPlotsToFileFeature.h"
 #include "ExportCommands/RicSnapshotAllViewsToFileFeature.h"
 #include "ExportCommands/RicSnapshotViewToFileFeature.h"
+#include "EclipseCommands/RicImportEclipseCaseFeature.h"
 #include "HoloLensCommands/RicHoloLensSessionManager.h"
 #include "RicImportGeneralDataFeature.h"
 #include "SummaryPlotCommands/RicSummaryPlotFeatureImpl.h"
@@ -777,6 +778,9 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( gsl::not_n
         {
             getOrCreateAndShowMainPlotWindow();
         }
+
+        // Auto-import matching PVD surface files for command-line loaded cases
+        RicImportEclipseCaseFeature::importPvdSurfacesForGridFiles( fileNames, {} );
     }
 
     if ( cvf::Option o = progOpt->option( "savesnapshots" ) )

--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
@@ -77,9 +77,18 @@ void RicImportEclipseCaseFeature::onActionTriggered( bool isChecked )
     }
 
     // Auto-import matching PVD surface files
+    importPvdSurfacesForGridFiles( fileNames, allViewsBefore );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportEclipseCaseFeature::importPvdSurfacesForGridFiles( const QStringList&                  gridFileNames,
+                                                                 const std::vector<RimEclipseView*>& viewsBeforeImport )
+{
     if ( RimSurfaceCollection* surfColl = RimTools::surfaceCollection() )
     {
-        QStringList pvdFilesToImport = findPvdFilesToImport( fileNames );
+        QStringList pvdFilesToImport = findPvdFilesToImport( gridFileNames );
 
         if ( !pvdFilesToImport.isEmpty() )
         {
@@ -100,6 +109,7 @@ void RicImportEclipseCaseFeature::onActionTriggered( bool isChecked )
             }
 
             // Enable newly imported surfaces in new views, disable them in old views
+            RimProject* project = RimProject::current();
             if ( project && !newlyImportedSurfaces.empty() )
             {
                 // Process all views (both old and new)
@@ -110,7 +120,8 @@ void RicImportEclipseCaseFeature::onActionTriggered( bool isChecked )
                         if ( RimSurfaceInViewCollection* surfInViewColl = view->surfaceInViewCollection() )
                         {
                             // Check if this is a new view or an existing view
-                            bool isNewView = std::find( allViewsBefore.begin(), allViewsBefore.end(), view ) == allViewsBefore.end();
+                            bool isNewView =
+                                std::find( viewsBeforeImport.begin(), viewsBeforeImport.end(), view ) == viewsBeforeImport.end();
 
                             // Get all surface-in-view objects
                             auto allSurfacesInView = surfInViewColl->descendantsIncludingThisOfType<RimSurfaceInView>();

--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
@@ -120,8 +120,7 @@ void RicImportEclipseCaseFeature::importPvdSurfacesForGridFiles( const QStringLi
                         if ( RimSurfaceInViewCollection* surfInViewColl = view->surfaceInViewCollection() )
                         {
                             // Check if this is a new view or an existing view
-                            bool isNewView =
-                                std::find( viewsBeforeImport.begin(), viewsBeforeImport.end(), view ) == viewsBeforeImport.end();
+                            bool isNewView = std::find( viewsBeforeImport.begin(), viewsBeforeImport.end(), view ) == viewsBeforeImport.end();
 
                             // Get all surface-in-view objects
                             auto allSurfacesInView = surfInViewColl->descendantsIncludingThisOfType<RimSurfaceInView>();

--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.h
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.h
@@ -31,10 +31,13 @@ class RicImportEclipseCaseFeature : public RicImportGeneralDataFeature
 {
     CAF_CMD_HEADER_INIT;
 
+public:
+    static void importPvdSurfacesForGridFiles( const QStringList&                  gridFileNames,
+                                               const std::vector<RimEclipseView*>& viewsBeforeImport );
+    static std::vector<RimEclipseView*> allEclipseViews( RimProject* project );
+    static QStringList                  findPvdFilesToImport( const QStringList& fileNames );
+
 protected:
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
-
-    static std::vector<RimEclipseView*> allEclipseViews( RimProject* project );
-    static QStringList                  findPvdFilesToImport( const QStringList& fileNames );
 };

--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.h
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.h
@@ -32,8 +32,7 @@ class RicImportEclipseCaseFeature : public RicImportGeneralDataFeature
     CAF_CMD_HEADER_INIT;
 
 public:
-    static void importPvdSurfacesForGridFiles( const QStringList&                  gridFileNames,
-                                               const std::vector<RimEclipseView*>& viewsBeforeImport );
+    static void importPvdSurfacesForGridFiles( const QStringList& gridFileNames, const std::vector<RimEclipseView*>& viewsBeforeImport );
     static std::vector<RimEclipseView*> allEclipseViews( RimProject* project );
     static QStringList                  findPvdFilesToImport( const QStringList& fileNames );
 

--- a/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp
@@ -24,6 +24,7 @@
 #include "RiaGuiApplication.h"
 #include "Summary/RiaSummaryTools.h"
 
+#include "EclipseCommands/RicImportEclipseCaseFeature.h"
 #include "RicImportGeneralDataFeature.h"
 
 #include "RimEclipseCase.h"
@@ -90,6 +91,11 @@ void RicReplaceCaseFeature::onActionTriggered( bool isChecked )
     // Use the file base name as case user description
     QFileInfo fileInfoNew( fileName );
     eclipseResultCase->setCaseUserDescription( fileInfoNew.baseName() );
+
+    // Auto-import matching PVD surface files for the replaced case
+    QStringList gridFileNames;
+    gridFileNames << fileName;
+    RicImportEclipseCaseFeature::importPvdSurfacesForGridFiles( gridFileNames, {} );
 
     RiaEclipseFileNameTools helper( fileName );
     auto                    summaryFileNames = helper.findSummaryFileCandidates();


### PR DESCRIPTION
Extract auto-import logic into public static method importPvdSurfacesForGridFiles() and call it from:
- Command line case loading (--case argument)
- Replace case menu action