### PR TITLE
#13467 Add model padding functionality for sector model export

### DIFF
--- a/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelFeature.cpp
@@ -25,6 +25,7 @@
 #include "RicExportEclipseSectorModelFeature.h"
 #include "RicExportSectorModelUi.h"
 
+#include "RigModelPaddingSettings.h"
 #include "RigSimulationInputSettings.h"
 #include "RigSimulationInputTool.h"
 
@@ -117,6 +118,7 @@ void RicExportSectorModelFeature::doExport( RicExportSectorModelUi* exportSettin
     settings.setBcpropKeywords( bcpropKeywords );
     settings.setBoundaryCondition( exportSettings->boundaryCondition() );
     settings.setPorvMultiplier( exportSettings->porvMultiplier() );
+    settings.setPaddingSettings( exportSettings->paddingSettings() );
 
     // Get input deck file name from eclipse case
     QFileInfo fi( view->eclipseCase()->gridFileName() );

--- a/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.cpp
@@ -24,6 +24,7 @@
 #include "RigEclipseCaseData.h"
 #include "RigEclipseResultTools.h"
 #include "RigMainGrid.h"
+#include "RigModelPaddingSettings.h"
 
 #include "Jobs/RimKeywordBcprop.h"
 #include "RimEclipseCase.h"
@@ -101,6 +102,38 @@ RicExportSectorModelUi::RicExportSectorModelUi()
     m_keywordsToRemove.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
     setDefaultKeywordsToRemove();
 
+    // Model padding fields
+    CAF_PDM_InitField( &m_enablePadding, "EnablePadding", false, "Enable Model Padding" );
+    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_enablePadding );
+
+    CAF_PDM_InitField( &m_paddingNzUpper, "PaddingNzUpper", 0, "Number of Z Layers" );
+    m_paddingNzUpper.setRange( 0, 100 );
+
+    CAF_PDM_InitField( &m_paddingTopUpper, "PaddingTopUpper", 0.0, "Top Depth" );
+
+    CAF_PDM_InitField( &m_paddingUpperPorosity, "PaddingUpperPorosity", 0.0, "Porosity" );
+    m_paddingUpperPorosity.setRange( 0.0, 1.0 );
+
+    CAF_PDM_InitField( &m_paddingUpperEquilnum, "PaddingUpperEquilnum", 1, "EQUILNUM" );
+    m_paddingUpperEquilnum.setMinValue( 1 );
+
+    CAF_PDM_InitField( &m_paddingNzLower, "PaddingNzLower", 0, "Number of Z Layers" );
+    m_paddingNzLower.setRange( 0, 100 );
+
+    CAF_PDM_InitField( &m_paddingBottomLower, "PaddingBottomLower", 0.0, "Bottom Depth" );
+
+    CAF_PDM_InitField( &m_paddingMinThickness, "PaddingMinThickness", 0.1, "Minimum Layer Thickness" );
+    m_paddingMinThickness.setMinValue( 0.001 );
+
+    CAF_PDM_InitField( &m_paddingFillGaps, "PaddingFillGaps", false, "Fill Gaps in Z Direction" );
+    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_paddingFillGaps );
+
+    CAF_PDM_InitField( &m_paddingMonotonicZcorn, "PaddingMonotonicZcorn", false, "Enforce Monotonic Z-Corners" );
+    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_paddingMonotonicZcorn );
+
+    CAF_PDM_InitField( &m_paddingVerticalPillars, "PaddingVerticalPillars", false, "Make Pillars Vertical" );
+    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_paddingVerticalPillars );
+
     CAF_PDM_InitField( &m_createSimulationJob, "CreateSimulationJob", false, "Create New Simulation Job" );
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_createSimulationJob );
     CAF_PDM_InitFieldNoDefault( &m_simulationJobFolder, "SimulationJobFolder", "Working Folder" );
@@ -134,6 +167,9 @@ RicExportSectorModelUi::RicExportSectorModelUi()
 
     m_pageNames << "Keyword Adjustments";
     m_pageSubtitles << "Set up special handling of certain keywords.";
+
+    m_pageNames << "Model Padding";
+    m_pageSubtitles << "Configure optional Z-direction padding for the sector model grid.";
 
     m_pageNames << "Simulation Job Settings";
     m_pageSubtitles << "Optionally create and/or run a simulation job using the exported sector model.";
@@ -234,6 +270,30 @@ void RicExportSectorModelUi::defineUiOrdering( QString uiConfigName, caf::PdmUiO
                                      setDefaultKeywordsToRemove();
                                      updateConnectedEditors();
                                  } );
+    }
+    else if ( uiConfigName == m_pageNames[WizardPageEnum::ModelPadding] )
+    {
+        uiOrdering.add( &m_enablePadding );
+        uiOrdering.addNewLabel( "" );
+
+        if ( m_enablePadding() )
+        {
+            auto upperGrp = uiOrdering.addNewGroup( "Upper Padding" );
+            upperGrp->add( &m_paddingNzUpper );
+            upperGrp->add( &m_paddingTopUpper );
+            upperGrp->add( &m_paddingUpperPorosity );
+            upperGrp->add( &m_paddingUpperEquilnum );
+
+            auto lowerGrp = uiOrdering.addNewGroup( "Lower Padding" );
+            lowerGrp->add( &m_paddingNzLower );
+            lowerGrp->add( &m_paddingBottomLower );
+
+            auto optionsGrp = uiOrdering.addNewGroup( "Grid Options" );
+            optionsGrp->add( &m_paddingMinThickness );
+            optionsGrp->add( &m_paddingFillGaps );
+            optionsGrp->add( &m_paddingMonotonicZcorn );
+            optionsGrp->add( &m_paddingVerticalPillars );
+        }
     }
     else if ( uiConfigName == m_pageNames[WizardPageEnum::SimulationJob] )
     {
@@ -478,7 +538,7 @@ void RicExportSectorModelUi::fieldChangedByUi( const caf::PdmFieldHandle* change
     {
         applyBoundaryDefaults();
     }
-    else if ( ( changedField == &m_boundaryCondition ) || ( changedField == &m_refineGrid ) )
+    else if ( ( changedField == &m_boundaryCondition ) || ( changedField == &m_refineGrid ) || ( changedField == &m_enablePadding ) )
     {
         updateConnectedEditors();
     }
@@ -595,6 +655,26 @@ QString RicExportSectorModelUi::newSimulationJobName() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RigModelPaddingSettings RicExportSectorModelUi::paddingSettings() const
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( m_enablePadding() );
+    settings.setNzUpper( m_paddingNzUpper() );
+    settings.setTopUpper( m_paddingTopUpper() );
+    settings.setUpperPorosity( m_paddingUpperPorosity() );
+    settings.setUpperEquilnum( m_paddingUpperEquilnum() );
+    settings.setNzLower( m_paddingNzLower() );
+    settings.setBottomLower( m_paddingBottomLower() );
+    settings.setMinLayerThickness( m_paddingMinThickness() );
+    settings.setFillGaps( m_paddingFillGaps() );
+    settings.setMonotonicZcorn( m_paddingMonotonicZcorn() );
+    settings.setVerticalPillars( m_paddingVerticalPillars() );
+    return settings;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::map<QString, QString> RicExportSectorModelUi::validate( const QString& configName ) const
 {
     std::map<QString, QString> fieldErrors;
@@ -693,6 +773,18 @@ std::map<QString, QString> RicExportSectorModelUi::validate( const QString& conf
             if ( kw.contains( ' ' ) )
             {
                 fieldErrors[m_keywordsToRemove.keyword()] = "Keywords to remove cannot contain spaces: " + kw;
+            }
+        }
+    }
+    else if ( configName == m_pageNames[WizardPageEnum::ModelPadding] )
+    {
+        if ( m_enablePadding() )
+        {
+            auto settings   = paddingSettings();
+            auto errMessage = settings.validate();
+            if ( !errMessage.isEmpty() )
+            {
+                fieldErrors[m_enablePadding.keyword()] = errMessage;
             }
         }
     }

--- a/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.h
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.h
@@ -31,6 +31,7 @@
 
 #include <map>
 
+class RigModelPaddingSettings;
 class RimKeywordBcprop;
 class RimEclipseCase;
 class RimEclipseView;
@@ -77,6 +78,9 @@ public:
     QString newSimulationJobFolder() const;
     QString newSimulationJobName() const;
 
+    // Model padding settings accessor
+    RigModelPaddingSettings paddingSettings() const;
+
 protected:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
@@ -93,8 +97,9 @@ private:
         GridRefinement     = 2,
         BoundaryConditions = 3,
         KeywordAdjustments = 4,
-        SimulationJob      = 5,
-        TotalPages         = 6
+        ModelPadding       = 5,
+        SimulationJob      = 6,
+        TotalPages         = 7
     };
 
     void           applyBoundaryDefaults();
@@ -124,6 +129,19 @@ private:
     caf::PdmField<double>                      m_porvMultiplier;
 
     caf::PdmField<std::vector<QString>> m_keywordsToRemove;
+
+    // Model padding fields
+    caf::PdmField<bool>   m_enablePadding;
+    caf::PdmField<int>    m_paddingNzUpper;
+    caf::PdmField<double> m_paddingTopUpper;
+    caf::PdmField<double> m_paddingUpperPorosity;
+    caf::PdmField<int>    m_paddingUpperEquilnum;
+    caf::PdmField<int>    m_paddingNzLower;
+    caf::PdmField<double> m_paddingBottomLower;
+    caf::PdmField<double> m_paddingMinThickness;
+    caf::PdmField<bool>   m_paddingFillGaps;
+    caf::PdmField<bool>   m_paddingMonotonicZcorn;
+    caf::PdmField<bool>   m_paddingVerticalPillars;
 
     caf::PdmField<bool>          m_createSimulationJob;
     caf::PdmField<caf::FilePath> m_simulationJobFolder;

--- a/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.cpp
@@ -754,6 +754,52 @@ bool RifOpmFlowDeckFile::setWsegdims( int maxMSWells, int maxSegmentsPerWell, in
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RifOpmFlowDeckFile::setSpecgrid( int nx, int ny, int nz )
+{
+    using S = Opm::ParserKeywords::SPECGRID;
+    if ( m_fileDeck.get() == nullptr ) return false;
+    auto idx = m_fileDeck->find( S::keywordName );
+    if ( !idx.has_value() ) return false;
+
+    auto& oldkw = m_fileDeck->operator[]( idx.value() );
+
+    Opm::DeckKeyword newKw( Opm::ParserKeyword( oldkw.name() ) );
+    newKw.addRecord( Opm::DeckRecord{ { RifOpmDeckTools::item( S::NX::itemName, nx ),
+                                        RifOpmDeckTools::item( S::NY::itemName, ny ),
+                                        RifOpmDeckTools::item( S::NZ::itemName, nz ),
+                                        RifOpmDeckTools::item( S::NUMRES::itemName, 1 ),
+                                        RifOpmDeckTools::item( S::COORD_TYPE::itemName, std::string( "F" ) ) } } );
+
+    m_fileDeck->erase( idx.value() );
+    m_fileDeck->insert( idx.value(), newKw );
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RifOpmFlowDeckFile::setDimens( int nx, int ny, int nz )
+{
+    using D = Opm::ParserKeywords::DIMENS;
+    if ( m_fileDeck.get() == nullptr ) return false;
+    auto idx = m_fileDeck->find( D::keywordName );
+    if ( !idx.has_value() ) return false;
+
+    auto& oldkw = m_fileDeck->operator[]( idx.value() );
+
+    Opm::DeckKeyword newKw( Opm::ParserKeyword( oldkw.name() ) );
+    newKw.addRecord( Opm::DeckRecord{ { RifOpmDeckTools::item( D::NX::itemName, nx ),
+                                        RifOpmDeckTools::item( D::NY::itemName, ny ),
+                                        RifOpmDeckTools::item( D::NZ::itemName, nz ) } } );
+
+    m_fileDeck->erase( idx.value() );
+    m_fileDeck->insert( idx.value(), newKw );
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<int> RifOpmFlowDeckFile::regdims()
 {
     using R = Opm::ParserKeywords::REGDIMS;

--- a/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.cpp
@@ -254,12 +254,14 @@ bool RifOpmFlowDeckFile::loadDeck( std::string filename )
     {
         auto deck = Opm::Parser{}.parseFile( filename, internal::defaultParseContext(), errors );
 
+        m_deck     = std::make_unique<Opm::Deck>( deck );
         m_fileDeck = std::make_unique<Opm::FileDeck>( deck );
 
         splitDatesIfNecessary();
     }
     catch ( ... )
     {
+        m_deck.reset();
         m_fileDeck.reset();
         return false;
     }
@@ -1048,6 +1050,22 @@ bool RifOpmFlowDeckFile::addIncludeKeyword( std::string section, std::string key
 
     m_fileDeck->insert( insertIdx.value(), includeKw );
     return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+Opm::FileDeck* RifOpmFlowDeckFile::fileDeck()
+{
+    return m_fileDeck.get();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+const Opm::Deck* RifOpmFlowDeckFile::deck() const
+{
+    return m_deck.get();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.h
+++ b/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.h
@@ -76,6 +76,9 @@ public:
     std::vector<int> wsegdims();
     bool             setWsegdims( int maxMSWells, int maxSegmentsPerWell, int maxBranchesPerWell );
 
+    bool setSpecgrid( int nx, int ny, int nz );
+    bool setDimens( int nx, int ny, int nz );
+
     std::vector<int> regdims();
     bool             setRegdims( int maxRegions,
                                  int maxRegionDefinitions,

--- a/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.h
+++ b/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.h
@@ -29,6 +29,7 @@
 
 namespace Opm
 {
+class Deck;
 class DeckKeyword;
 class DeckItem;
 class DeckRecord;
@@ -91,6 +92,9 @@ public:
 
     bool addIncludeKeyword( std::string section, std::string keyword, std::string filePath );
 
+    Opm::FileDeck*   fileDeck();
+    const Opm::Deck* deck() const;
+
     bool addKeyword( const std::string& section, const Opm::DeckKeyword& keyword );
 
     bool replaceKeyword( const std::string& section, const Opm::DeckKeyword& keyword );
@@ -106,5 +110,6 @@ private:
     void splitDatesIfNecessary();
 
 private:
+    std::unique_ptr<Opm::Deck>     m_deck;
     std::unique_ptr<Opm::FileDeck> m_fileDeck;
 };

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/CMakeLists_files.cmake
@@ -1,9 +1,13 @@
 set(SOURCE_GROUP_HEADER_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/RigModelPaddingSettings.h
+    ${CMAKE_CURRENT_LIST_DIR}/RigPadModel.h
     ${CMAKE_CURRENT_LIST_DIR}/RigSimulationInputSettings.h
     ${CMAKE_CURRENT_LIST_DIR}/RigSimulationInputTool.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/RigModelPaddingSettings.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigPadModel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigSimulationInputSettings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigSimulationInputTool.cpp
 )

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigModelPaddingSettings.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigModelPaddingSettings.cpp
@@ -16,178 +16,252 @@
 //
 /////////////////////////////////////////////////////////////////////////////////
 
-#include "RigSimulationInputSettings.h"
+#include "RigModelPaddingSettings.h"
 
-#include "opm/input/eclipse/Deck/DeckRecord.hpp"
+#include <QStringList>
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RigSimulationInputSettings::RigSimulationInputSettings()
-    : m_min( caf::VecIjk0::ZERO )
-    , m_max( caf::VecIjk0::ZERO )
-    , m_refinement( 1, 1, 1 )
-    , m_boundaryCondition( RiaModelExportDefines::BoundaryCondition::OPERNUM_OPERATER )
-    , m_porvMultiplier( 1.0e6 )
+RigModelPaddingSettings::RigModelPaddingSettings()
+    : m_enabled( false )
+    , m_nzUpper( 0 )
+    , m_topUpper( 0.0 )
+    , m_upperPorosity( 0.0 )
+    , m_upperEquilnum( 1 )
+    , m_nzLower( 0 )
+    , m_bottomLower( 0.0 )
+    , m_minLayerThickness( 0.1 )
+    , m_fillGaps( false )
+    , m_monotonicZcorn( false )
+    , m_verticalPillars( false )
 {
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-caf::VecIjk0 RigSimulationInputSettings::min() const
+bool RigModelPaddingSettings::isEnabled() const
 {
-    return m_min;
+    return m_enabled;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-caf::VecIjk0 RigSimulationInputSettings::max() const
+void RigModelPaddingSettings::setEnabled( bool enabled )
 {
-    return m_max;
+    m_enabled = enabled;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setMin( const caf::VecIjk0& min )
+int RigModelPaddingSettings::nzUpper() const
 {
-    m_min = min;
+    return m_nzUpper;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setMax( const caf::VecIjk0& max )
+void RigModelPaddingSettings::setNzUpper( int value )
 {
-    m_max = max;
+    m_nzUpper = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::Vec3st RigSimulationInputSettings::refinement() const
+double RigModelPaddingSettings::topUpper() const
 {
-    return m_refinement;
+    return m_topUpper;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setRefinement( const cvf::Vec3st& refinement )
+void RigModelPaddingSettings::setTopUpper( double value )
 {
-    m_refinement = refinement;
+    m_topUpper = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setKeywordsToRemove( const std::vector<std::string>& keywords )
+double RigModelPaddingSettings::upperPorosity() const
 {
-    m_keywordsToRemove = keywords;
+    return m_upperPorosity;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-const std::vector<std::string>& RigSimulationInputSettings::keywordsToRemove() const
+void RigModelPaddingSettings::setUpperPorosity( double value )
 {
-    return m_keywordsToRemove;
+    m_upperPorosity = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<Opm::DeckRecord> RigSimulationInputSettings::bcpropKeywords() const
+int RigModelPaddingSettings::upperEquilnum() const
 {
-    return m_bcpropKeywords;
+    return m_upperEquilnum;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setBcpropKeywords( const std::vector<Opm::DeckRecord>& keywords )
+void RigModelPaddingSettings::setUpperEquilnum( int value )
 {
-    m_bcpropKeywords = keywords;
+    m_upperEquilnum = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RiaModelExportDefines::BoundaryCondition RigSimulationInputSettings::boundaryCondition() const
+int RigModelPaddingSettings::nzLower() const
 {
-    return m_boundaryCondition;
+    return m_nzLower;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setBoundaryCondition( RiaModelExportDefines::BoundaryCondition value )
+void RigModelPaddingSettings::setNzLower( int value )
 {
-    m_boundaryCondition = value;
+    m_nzLower = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-double RigSimulationInputSettings::porvMultiplier() const
+double RigModelPaddingSettings::bottomLower() const
 {
-    return m_porvMultiplier;
+    return m_bottomLower;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setPorvMultiplier( double value )
+void RigModelPaddingSettings::setBottomLower( double value )
 {
-    m_porvMultiplier = value;
+    m_bottomLower = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RigSimulationInputSettings::inputDeckFileName() const
+double RigModelPaddingSettings::minLayerThickness() const
 {
-    return m_inputDeckFileName;
+    return m_minLayerThickness;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setInputDeckFileName( const QString& fileName )
+void RigModelPaddingSettings::setMinLayerThickness( double value )
 {
-    m_inputDeckFileName = fileName;
+    m_minLayerThickness = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RigSimulationInputSettings::outputDeckFileName() const
+bool RigModelPaddingSettings::fillGaps() const
 {
-    return m_outputDeckFileName;
+    return m_fillGaps;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setOutputDeckFileName( const QString& fileName )
+void RigModelPaddingSettings::setFillGaps( bool value )
 {
-    m_outputDeckFileName = fileName;
+    m_fillGaps = value;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-const RigModelPaddingSettings& RigSimulationInputSettings::paddingSettings() const
+bool RigModelPaddingSettings::monotonicZcorn() const
 {
-    return m_paddingSettings;
+    return m_monotonicZcorn;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigSimulationInputSettings::setPaddingSettings( const RigModelPaddingSettings& settings )
+void RigModelPaddingSettings::setMonotonicZcorn( bool value )
 {
-    m_paddingSettings = settings;
+    m_monotonicZcorn = value;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RigModelPaddingSettings::verticalPillars() const
+{
+    return m_verticalPillars;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RigModelPaddingSettings::setVerticalPillars( bool value )
+{
+    m_verticalPillars = value;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RigModelPaddingSettings::validate() const
+{
+    if ( !m_enabled )
+    {
+        return {};
+    }
+
+    QStringList errors;
+
+    // Check upper padding
+    if ( m_nzUpper < 0 )
+    {
+        errors << "Number of upper padding layers cannot be negative.";
+    }
+
+    if ( m_nzUpper > 0 )
+    {
+        if ( m_upperPorosity < 0.0 || m_upperPorosity > 1.0 )
+        {
+            errors << "Upper porosity must be between 0.0 and 1.0.";
+        }
+
+        if ( m_upperEquilnum < 1 )
+        {
+            errors << "Upper EQUILNUM must be at least 1.";
+        }
+    }
+
+    // Check lower padding
+    if ( m_nzLower < 0 )
+    {
+        errors << "Number of lower padding layers cannot be negative.";
+    }
+
+    // Check geometry options
+    if ( m_minLayerThickness <= 0.0 )
+    {
+        errors << "Minimum layer thickness must be positive.";
+    }
+
+    // Check that at least one padding direction is specified
+    if ( m_nzUpper == 0 && m_nzLower == 0 )
+    {
+        errors << "At least one padding direction (upper or lower) must have layers > 0.";
+    }
+
+    return errors.join( "\n" );
 }

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigModelPaddingSettings.h
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigModelPaddingSettings.h
@@ -1,0 +1,78 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <QString>
+
+//==================================================================================================
+///
+/// Settings for model padding (adding Z-direction layers to sector models)
+///
+//==================================================================================================
+class RigModelPaddingSettings
+{
+public:
+    RigModelPaddingSettings();
+
+    // Enable/disable
+    bool isEnabled() const;
+    void setEnabled( bool enabled );
+
+    // Upper padding
+    int    nzUpper() const;
+    void   setNzUpper( int value );
+    double topUpper() const;
+    void   setTopUpper( double value );
+    double upperPorosity() const;
+    void   setUpperPorosity( double value );
+    int    upperEquilnum() const;
+    void   setUpperEquilnum( int value );
+
+    // Lower padding
+    int    nzLower() const;
+    void   setNzLower( int value );
+    double bottomLower() const;
+    void   setBottomLower( double value );
+
+    // Geometry options
+    double minLayerThickness() const;
+    void   setMinLayerThickness( double value );
+    bool   fillGaps() const;
+    void   setFillGaps( bool value );
+    bool   monotonicZcorn() const;
+    void   setMonotonicZcorn( bool value );
+    bool   verticalPillars() const;
+    void   setVerticalPillars( bool value );
+
+    // Validation
+    QString validate() const;
+
+private:
+    bool   m_enabled;
+    int    m_nzUpper;
+    double m_topUpper;
+    double m_upperPorosity;
+    int    m_upperEquilnum;
+    int    m_nzLower;
+    double m_bottomLower;
+    double m_minLayerThickness;
+    bool   m_fillGaps;
+    bool   m_monotonicZcorn;
+    bool   m_verticalPillars;
+};

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.cpp
@@ -1,0 +1,1101 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RigPadModel.h"
+
+#include "RifOpmFlowDeckFile.h"
+#include "RigModelPaddingSettings.h"
+
+#include "RiaLogging.h"
+
+#include "cvfVector3.h"
+
+#include "opm/input/eclipse/Deck/Deck.hpp"
+#include "opm/input/eclipse/Deck/DeckKeyword.hpp"
+#include "opm/input/eclipse/Deck/DeckSection.hpp"
+#include "opm/input/eclipse/Deck/FileDeck.hpp"
+#include "opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp"
+#include "opm/input/eclipse/EclipseState/Runspec.hpp"
+#include "opm/input/eclipse/EclipseState/Tables/TableManager.hpp"
+
+#include "opm/input/eclipse/Parser/ParserKeywords/A.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/B.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/C.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/D.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/E.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/F.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/M.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/N.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/O.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/P.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/S.hpp"
+#include "opm/input/eclipse/Parser/ParserKeywords/W.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <regex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace
+{
+
+using GridSize = cvf::Vec3st;
+
+//--------------------------------------------------------------------------------------------------
+/// Section names for tracking which section a keyword belongs to
+//--------------------------------------------------------------------------------------------------
+static const std::unordered_set<std::string> sectionNames = { "RUNSPEC", "GRID", "EDIT", "PROPS", "REGIONS", "SOLUTION", "SUMMARY", "SCHEDULE" };
+
+static bool isSectionKeyword( const std::string& name )
+{
+    return sectionNames.count( name ) > 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Read NX/NY/NZ from DIMENS via FileDeck
+//--------------------------------------------------------------------------------------------------
+std::expected<GridSize, QString> getDimens( Opm::FileDeck& fileDeck )
+{
+    auto idx = fileDeck.find( Opm::ParserKeywords::DIMENS::keywordName );
+    if ( !idx.has_value() )
+    {
+        return std::unexpected( "Failed to read grid dimensions from DIMENS keyword" );
+    }
+
+    const auto& kw = fileDeck[idx.value()];
+    GridSize    gridSize( kw.getRecord( 0 ).getItem( "NX" ).get<int>( 0 ),
+                       kw.getRecord( 0 ).getItem( "NY" ).get<int>( 0 ),
+                       kw.getRecord( 0 ).getItem( "NZ" ).get<int>( 0 ) );
+
+    if ( gridSize.x() == 0 || gridSize.y() == 0 || gridSize.z() == 0 )
+    {
+        return std::unexpected( "Grid dimensions from DIMENS keyword contain zero values" );
+    }
+
+    return gridSize;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Modify DIMENS, EQLDIMS, SPECGRID NZ in-place
+//--------------------------------------------------------------------------------------------------
+int extendDimens( const GridSize& gridSize, const RigModelPaddingSettings& settings, Opm::FileDeck& fileDeck, int nzNew )
+{
+    int upperEquilnum = settings.upperEquilnum();
+
+    // Update DIMENS NZ
+    auto dimIdx = fileDeck.find( Opm::ParserKeywords::DIMENS::keywordName );
+    if ( dimIdx.has_value() )
+    {
+        auto&             NZit    = const_cast<Opm::DeckItem&>( fileDeck[dimIdx.value()].getRecord( 0 ).getItem( "NZ" ) );
+        std::vector<int>& dimData = NZit.getData<int>();
+        dimData[0]                = nzNew;
+    }
+
+    // Update EQLDIMS NTEQUL
+    auto eqlIdx = fileDeck.find( Opm::ParserKeywords::EQLDIMS::keywordName );
+    if ( eqlIdx.has_value() )
+    {
+        auto& eqldims = const_cast<Opm::DeckItem&>( fileDeck[eqlIdx.value()].getRecord( 0 ).getItem( "NTEQUL" ) );
+
+        std::vector<int>& data = eqldims.getData<int>();
+
+        std::vector<Opm::value::status>& value_status = const_cast<std::vector<Opm::value::status>&>( eqldims.getValueStatus() );
+
+        if ( value_status[0] == Opm::value::status::deck_value )
+        {
+            data[0] += 1;
+        }
+        else
+        {
+            value_status[0] = Opm::value::status::deck_value;
+            data[0]         = 2;
+        }
+
+        upperEquilnum = data[0];
+    }
+
+    // Update SPECGRID NZ
+    auto specIdx = fileDeck.find( Opm::ParserKeywords::SPECGRID::keywordName );
+    if ( specIdx.has_value() )
+    {
+        auto&             NZit     = const_cast<Opm::DeckItem&>( fileDeck[specIdx.value()].getRecord( 0 ).getItem( "NZ" ) );
+        std::vector<int>& specData = NZit.getData<int>();
+        specData[0]                = nzNew;
+    }
+
+    return upperEquilnum;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Template: extend DeckItem data via swap
+//--------------------------------------------------------------------------------------------------
+template <typename T>
+void extendPropertyArray( const GridSize&                gridSize,
+                          const RigModelPaddingSettings& settings,
+                          const Opm::type_tag            type,
+                          const T                        default_value,
+                          const Opm::DeckItem&           property )
+{
+    if ( property.getType() != type )
+    {
+        return;
+    }
+
+    const auto input_nc =
+        static_cast<std::size_t>( gridSize.x() ) * static_cast<std::size_t>( gridSize.y() ) * static_cast<std::size_t>( gridSize.z() );
+
+    auto& value = const_cast<Opm::DeckItem&>( property ).template getData<T>();
+    if ( std::size( value ) != input_nc )
+    {
+        return;
+    }
+
+    auto& status = const_cast<std::vector<Opm::value::status>&>( property.getValueStatus() );
+
+    const auto output_nc = static_cast<std::size_t>( gridSize.x() ) * static_cast<std::size_t>( gridSize.y() ) *
+                           static_cast<std::size_t>( settings.nzUpper() + gridSize.z() + settings.nzLower() );
+
+    const auto value_offset = static_cast<std::size_t>( gridSize.x() ) * static_cast<std::size_t>( gridSize.y() ) *
+                              static_cast<std::size_t>( settings.nzUpper() );
+
+    auto remapped_value  = std::vector<T>( output_nc, default_value );
+    auto remapped_status = std::vector<Opm::value::status>( output_nc, Opm::value::status::deck_value );
+
+    std::copy( value.begin(), value.end(), remapped_value.begin() + value_offset );
+    std::copy( status.begin(), status.end(), remapped_status.begin() + value_offset );
+
+    value.swap( remapped_value );
+    status.swap( remapped_status );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Iterate keywords in GRID section, extend matching data arrays (padmodel lines 417-441)
+//--------------------------------------------------------------------------------------------------
+template <typename T>
+void extendGridSection( Opm::FileDeck& fileDeck, const GridSize& gridSize, const RigModelPaddingSettings& settings, const Opm::type_tag type )
+{
+    bool inGridSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& keyword = fileDeck[it];
+
+        if ( keyword.name() == "GRID" )
+        {
+            inGridSection = true;
+            continue;
+        }
+        if ( inGridSection && isSectionKeyword( keyword.name() ) )
+        {
+            break;
+        }
+
+        if ( !inGridSection ) continue;
+        if ( keyword.size() != 1 || !keyword.isDataKeyword() ) continue;
+
+        T default_value{};
+        if ( keyword.name() == "PORO" )
+        {
+            default_value = static_cast<T>( settings.upperPorosity() );
+        }
+        else if ( keyword.name() == "NTG" )
+        {
+            default_value = T{ 1 };
+        }
+
+        extendPropertyArray( gridSize, settings, type, default_value, keyword.getRecord( 0 ).getItem( 0 ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Shift BCCON K1/K2 based on direction (padmodel lines 443-474)
+//--------------------------------------------------------------------------------------------------
+void extendBCCon( Opm::FileDeck& fileDeck, const RigModelPaddingSettings& settings )
+{
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+        if ( kw.name() != "BCCON" ) continue;
+
+        for ( size_t r = 0; r < kw.size(); ++r )
+        {
+            const auto& record = kw.getRecord( r );
+
+            int& K1 = const_cast<int&>( record.getItem( "K1" ).getData<int>()[0] );
+            int& K2 = const_cast<int&>( record.getItem( "K2" ).getData<int>()[0] );
+
+            const auto direction = record.getItem( "DIRECTION" ).getTrimmedString( 0 );
+
+            if ( direction == "Z+" )
+            {
+                const int shift = settings.nzUpper() + settings.nzLower();
+                K1 += shift;
+                K2 += shift;
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Shift FAULTS IZ1/IZ2 by nz_upper (padmodel lines 476-488)
+//--------------------------------------------------------------------------------------------------
+void extendFaults( const RigModelPaddingSettings& settings, Opm::FileDeck& fileDeck )
+{
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+        if ( kw.name() != Opm::ParserKeywords::FAULTS::keywordName ) continue;
+
+        for ( size_t r = 0; r < kw.size(); ++r )
+        {
+            const auto& face = kw.getRecord( r );
+
+            const_cast<int&>( face.getItem<Opm::ParserKeywords::FAULTS::IZ1>().getData<int>().front() ) += settings.nzUpper();
+            const_cast<int&>( face.getItem<Opm::ParserKeywords::FAULTS::IZ2>().getData<int>().front() ) += settings.nzUpper();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Shift K1/K2 in ADD/BOX/EQUALS/MAXVALUE/MINVALUE/MULTIPLY/OPERATE
+//--------------------------------------------------------------------------------------------------
+void extendOperators( const RigModelPaddingSettings& settings, Opm::FileDeck& fileDeck )
+{
+    const std::vector<std::string> opKws = { Opm::ParserKeywords::ADD::keywordName,
+                                             Opm::ParserKeywords::BOX::keywordName,
+                                             Opm::ParserKeywords::EQUALS::keywordName,
+                                             Opm::ParserKeywords::MAXVALUE::keywordName,
+                                             Opm::ParserKeywords::MINVALUE::keywordName,
+                                             Opm::ParserKeywords::MULTIPLY::keywordName,
+                                             Opm::ParserKeywords::OPERATE::keywordName };
+
+    std::unordered_set<std::string> opKwSet( opKws.begin(), opKws.end() );
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+        if ( opKwSet.count( kw.name() ) == 0 ) continue;
+
+        for ( size_t r = 0; r < kw.size(); ++r )
+        {
+            const auto& record = kw.getRecord( r );
+            for ( const auto* kname : { "K1", "K2" } )
+            {
+                // Some keywords may not have K1/K2 items - check by name
+                if ( !record.hasItem( kname ) ) continue;
+
+                const auto& k = record.getItem( kname );
+                if ( !k.defaultApplied( 0 ) )
+                {
+                    const_cast<Opm::DeckItem&>( k ).getData<int>().front() += settings.nzUpper();
+                }
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Set inactive cells active, zero perm, set poro (padmodel lines 518-595)
+//--------------------------------------------------------------------------------------------------
+void extendSpecialGridProperties( Opm::FileDeck& fileDeck, const GridSize& gridSize, const RigModelPaddingSettings& settings )
+{
+    // Find ACTNUM keyword
+    std::vector<int>*    actnumPtr = nullptr;
+    std::vector<double>* poroPtr   = nullptr;
+    std::vector<double>* permxPtr  = nullptr;
+    std::vector<double>* permyPtr  = nullptr;
+    std::vector<double>* permzPtr  = nullptr;
+    std::vector<double>* ntgPtr    = nullptr;
+
+    bool inGridSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+
+        if ( kw.name() == "GRID" )
+        {
+            inGridSection = true;
+            continue;
+        }
+        if ( inGridSection && isSectionKeyword( kw.name() ) ) break;
+        if ( !inGridSection ) continue;
+
+        if ( kw.name() == "ACTNUM" && kw.isDataKeyword() )
+        {
+            actnumPtr = &const_cast<std::vector<int>&>( kw.getIntData() );
+        }
+        else if ( kw.name() == "PORO" && kw.isDataKeyword() )
+        {
+            poroPtr = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+        }
+        else if ( kw.name() == "PERMX" && kw.isDataKeyword() )
+        {
+            permxPtr = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+        }
+        else if ( kw.name() == "PERMY" && kw.isDataKeyword() )
+        {
+            permyPtr = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+        }
+        else if ( kw.name() == "PERMZ" && kw.isDataKeyword() )
+        {
+            permzPtr = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+        }
+        else if ( kw.name() == "NTG" && kw.isDataKeyword() )
+        {
+            ntgPtr = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+        }
+    }
+
+    if ( actnumPtr == nullptr ) return;
+
+    auto& actnum = *actnumPtr;
+
+    // Fix value_status for ACTNUM
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+        if ( kw.name() == "ACTNUM" && kw.isDataKeyword() )
+        {
+            auto& actnum_status = const_cast<std::vector<Opm::value::status>&>( kw.getValueStatus() );
+            actnum_status.assign( actnum.size(), Opm::value::status::deck_value );
+            break;
+        }
+    }
+
+    for ( size_t i = 0; i < actnum.size(); ++i )
+    {
+        if ( actnum[i] == 1 ) continue;
+
+        actnum[i] = 1;
+
+        if ( poroPtr != nullptr ) ( *poroPtr )[i] = settings.upperPorosity();
+        if ( permxPtr != nullptr ) ( *permxPtr )[i] = 0.0;
+        if ( permyPtr != nullptr ) ( *permyPtr )[i] = 0.0;
+        if ( permzPtr != nullptr ) ( *permzPtr )[i] = 0.0;
+        if ( ntgPtr != nullptr ) ( *ntgPtr )[i] = 1.0;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Per-column ZCORN + COORD vertical pillars
+//--------------------------------------------------------------------------------------------------
+void extendGRDECL( Opm::FileDeck& fileDeck, const GridSize& gridSize, const RigModelPaddingSettings& settings, int nzNew )
+{
+    const int    nx           = static_cast<int>( gridSize.x() );
+    const int    ny           = static_cast<int>( gridSize.y() );
+    const int    nz           = static_cast<int>( gridSize.z() );
+    const int    nz_upper     = settings.nzUpper();
+    const int    nz_lower     = settings.nzLower();
+    const double top_upper    = settings.topUpper();
+    const double bottom_lower = settings.bottomLower();
+    const double min_dist     = settings.minLayerThickness();
+    const bool   no_gap       = settings.fillGaps();
+    const int    nz_new       = nzNew;
+
+    // Find COORD and ZCORN in GRID section
+    std::vector<double>*             coordPtr       = nullptr;
+    std::vector<double>*             zcornPtr       = nullptr;
+    std::vector<Opm::value::status>* zcornStatusPtr = nullptr;
+
+    bool inGridSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+
+        if ( kw.name() == "GRID" )
+        {
+            inGridSection = true;
+            continue;
+        }
+        if ( inGridSection && isSectionKeyword( kw.name() ) ) break;
+        if ( !inGridSection ) continue;
+
+        if ( kw.name() == "COORD" && kw.isDataKeyword() )
+        {
+            coordPtr = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+        }
+        else if ( kw.name() == "ZCORN" && kw.isDataKeyword() )
+        {
+            zcornPtr       = const_cast<std::vector<double>*>( &kw.getRawDoubleData() );
+            zcornStatusPtr = const_cast<std::vector<Opm::value::status>*>( &kw.getValueStatus() );
+        }
+    }
+
+    if ( coordPtr == nullptr || zcornPtr == nullptr || zcornStatusPtr == nullptr ) return;
+
+    auto& coord        = *coordPtr;
+    auto& zcorn        = *zcornPtr;
+    auto& zcorn_status = *zcornStatusPtr;
+
+    // Make pillars vertical
+    if ( settings.verticalPillars() )
+    {
+        const int ncoord = static_cast<int>( coord.size() );
+        const int nxny   = ncoord / 6;
+
+        assert( ( nx + 1 ) * ( ny + 1 ) == nxny );
+        assert( ncoord % 6 == 0 );
+
+        for ( int i = 0; i < nxny; ++i )
+        {
+            coord[6 * i + 3] = coord[6 * i + 0];
+            coord[6 * i + 4] = coord[6 * i + 1];
+        }
+    }
+
+    // Extend ZCORN per-column (padmodel lines 638-718)
+    // Always extend ZCORN when padding is requested. The monotonic_zcorn flag
+    // controls whether monotonic enforcement (dz < min_dist) is applied.
+    {
+        const bool use_monotonic = settings.monotonicZcorn();
+        auto       zcorn_status_new =
+            std::vector<Opm::value::status>( (size_t)( 2 * nx ) * ( 2 * ny ) * ( 2 * nz_new ), Opm::value::status::deck_value );
+        auto zcorn_new = std::vector<double>( (size_t)( 2 * nx ) * ( 2 * ny ) * ( 2 * nz_new ), 0.0 );
+
+        for ( int i = 0; i < 2 * nx; ++i )
+        {
+            for ( int j = 0; j < 2 * ny; ++j )
+            {
+                double minz = 1e20;
+                double maxz = -1e20;
+
+                for ( int k = 0; k < 2 * nz; ++k )
+                {
+                    const int    index = i + j * ( 2 * nx ) + k * ( 2 * nx ) * ( 2 * ny );
+                    const double z     = zcorn[index];
+                    if ( z > 0.0 )
+                    {
+                        minz = std::min( minz, z );
+                        maxz = std::max( maxz, z );
+                    }
+                }
+
+                const double dz_upper = ( nz_upper > 0 ) ? std::max( 0.0, ( minz - top_upper ) / nz_upper ) : 0.0;
+                const double dz_lower = ( nz_lower > 0 ) ? std::max( 0.0, ( bottom_lower - maxz ) / nz_lower ) : 0.0;
+
+                std::vector<double> zcornvert( 2 * nz_new );
+                if ( nz_upper > 0 )
+                {
+                    zcornvert[0] = std::min( top_upper, minz );
+                }
+                else
+                {
+                    zcornvert[0] = minz;
+                }
+
+                double z_prev = zcornvert[0];
+                for ( int k = 1; k < 2 * nz_new; k++ )
+                {
+                    const int k_old   = k - 2 * nz_upper;
+                    const int ind_old = i + j * ( 2 * nx ) + k_old * ( 2 * nx ) * ( 2 * ny );
+
+                    if ( k_old >= 0 && k_old < 2 * nz )
+                    {
+                        double z  = zcorn[ind_old];
+                        double dz = z - z_prev;
+
+                        if ( use_monotonic && dz < min_dist )
+                        {
+                            dz = 0;
+                        }
+
+                        if ( z == 0.0 )
+                        {
+                            dz = 0;
+                        }
+
+                        if ( no_gap )
+                        {
+                            if ( k % 2 == 0 )
+                            {
+                                dz = 0;
+                            }
+                        }
+
+                        zcornvert[k] = zcornvert[k - 1] + dz;
+                        z_prev       = zcornvert[k];
+                    }
+                    else
+                    {
+                        double dz_cell = dz_lower;
+                        if ( k < 2 * nz_upper )
+                        {
+                            dz_cell = dz_upper;
+                        }
+
+                        if ( k % 2 == 1 )
+                        {
+                            zcornvert[k] = zcornvert[k - 1] + dz_cell;
+                        }
+                        else
+                        {
+                            zcornvert[k] = zcornvert[k - 1];
+                        }
+
+                        z_prev = zcornvert[k];
+                    }
+                }
+
+                for ( int k = 0; k < 2 * nz_new; k++ )
+                {
+                    int ind        = i + j * ( 2 * nx ) + k * ( 2 * nx ) * ( 2 * ny );
+                    zcorn_new[ind] = zcornvert[k];
+                }
+            }
+        }
+
+        zcorn_status = zcorn_status_new;
+        zcorn        = zcorn_new;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Compute keyword-specific default values from saturation function tables.
+/// Modeled on padmodel.cpp PropsSectionDefaultValue (lines 101-196).
+//--------------------------------------------------------------------------------------------------
+std::unordered_map<std::string, double> computePropsDefaultValues( const Opm::Deck& deck )
+{
+    using namespace std::string_literals;
+
+    const auto tables = Opm::TableManager{ deck };
+    const auto rspec  = Opm::Runspec{ deck };
+
+    const auto rtep =
+        Opm::satfunc::getRawTableEndpoints( tables, rspec.phases(), rspec.saturationFunctionControls().minimumRelpermMobilityThreshold() );
+
+    const auto rfunc = Opm::satfunc::getRawFunctionValues( tables, rspec.phases(), rtep );
+
+    auto cvrtPress = [&usys = deck.getActiveUnitSystem()]( const double p ) { return usys.from_si( Opm::UnitSystem::measure::pressure, p ); };
+
+    std::unordered_map<std::string, double> defaults;
+    defaults.insert( {
+        // Horizontally scaled end-points for gas
+        std::pair{ "SGL"s, rtep.connate.gas.front() },
+        std::pair{ "SGLPC"s, rtep.connate.gas.front() },
+        std::pair{ "SGCR"s, rtep.critical.gas.front() },
+        std::pair{ "SGU"s, rtep.maximum.gas.front() },
+
+        // Horizontally scaled end-points for oil
+        std::pair{ "SOGCR"s, rtep.critical.oil_in_gas.front() },
+        std::pair{ "SOWCR"s, rtep.critical.oil_in_water.front() },
+
+        // Horizontally scaled end-points for water
+        std::pair{ "SWL"s, rtep.connate.water.front() },
+        std::pair{ "SWLPC"s, rtep.connate.water.front() },
+        std::pair{ "SWCR"s, rtep.critical.water.front() },
+        std::pair{ "SWU"s, rtep.maximum.water.front() },
+
+        // Vertically scaled end-points for gas
+        std::pair{ "KRGR"s, rfunc.krg.r.front() },
+        std::pair{ "KRG"s, rfunc.krg.max.front() },
+        std::pair{ "PCG"s, cvrtPress( rfunc.pc.g.front() ) },
+
+        // Vertically scaled end-points for oil
+        std::pair{ "KRORG"s, rfunc.kro.rg.front() },
+        std::pair{ "KRORW"s, rfunc.kro.rw.front() },
+        std::pair{ "KRO"s, rfunc.kro.max.front() },
+
+        // Vertically scaled end-points for water
+        std::pair{ "KRWR"s, rfunc.krw.r.front() },
+        std::pair{ "KRW"s, rfunc.krw.max.front() },
+        std::pair{ "PCW"s, cvrtPress( rfunc.pc.w.front() ) },
+    } );
+
+    return defaults;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Look up the default value for a PROPS keyword, handling imbibition (I-prefix)
+/// and directional (X/Y/Z suffix) variants via regex stripping.
+/// Falls back to 0.0 for unknown keywords, except SWATINIT which defaults to 1.0.
+//--------------------------------------------------------------------------------------------------
+static const std::unordered_map<std::string, double> fallbackDefaults = { { "SWATINIT", 1.0 } };
+
+static const std::regex epsKwRegEx( R"(I?([SKP].+?)([XYZ]-?)?$)" );
+
+double lookupPropsDefault( const std::unordered_map<std::string, double>& defaults, const std::string& keyword )
+{
+    std::smatch m;
+    if ( std::regex_match( keyword, m, epsKwRegEx ) )
+    {
+        auto it = defaults.find( m[1].str() );
+        if ( it != defaults.end() )
+        {
+            return it->second;
+        }
+    }
+
+    auto fbIt = fallbackDefaults.find( keyword );
+    return ( fbIt != fallbackDefaults.end() ) ? fbIt->second : 0.0;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extend PROPS section data keywords (padmodel lines 721-738)
+//--------------------------------------------------------------------------------------------------
+void extendProps( const GridSize& gridSize, const RigModelPaddingSettings& settings, Opm::FileDeck& fileDeck, const Opm::Deck* deck )
+{
+    // Compute keyword-specific defaults from saturation function tables if Deck is available
+    std::unordered_map<std::string, double> propsDefaults;
+    if ( deck != nullptr )
+    {
+        try
+        {
+            propsDefaults = computePropsDefaultValues( *deck );
+        }
+        catch ( ... )
+        {
+            // If table computation fails, fall back to empty map (will use 0.0 defaults)
+        }
+    }
+
+    bool inPropsSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& keyword = fileDeck[it];
+
+        if ( keyword.name() == "PROPS" )
+        {
+            inPropsSection = true;
+            continue;
+        }
+        if ( inPropsSection && isSectionKeyword( keyword.name() ) ) break;
+        if ( !inPropsSection ) continue;
+
+        if ( keyword.size() != 1 || !keyword.isDataKeyword() ) continue;
+
+        // Only extend double-valued data keywords
+        const auto& item = keyword.getRecord( 0 ).getItem( 0 );
+        if ( item.getType() != Opm::type_tag::fdouble ) continue;
+
+        const auto input_nc = static_cast<size_t>( gridSize.x() * gridSize.y() * gridSize.z() );
+        if ( item.data_size() != input_nc ) continue;
+
+        double default_value = ( deck != nullptr ) ? lookupPropsDefault( propsDefaults, keyword.name() ) : 0.0;
+
+        extendPropertyArray( gridSize, settings, Opm::type_tag::fdouble, default_value, item );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extend region int arrays with actnum_old filtering (padmodel lines 741-811)
+//--------------------------------------------------------------------------------------------------
+void extendRegions( Opm::FileDeck&                 fileDeck,
+                    const GridSize&                gridSize,
+                    const RigModelPaddingSettings& settings,
+                    const std::vector<int>&        actnum_old,
+                    int                            upperEquilnum )
+{
+    const auto input_nc = static_cast<size_t>( gridSize.x() * gridSize.y() * gridSize.z() );
+
+    const auto output_nc = static_cast<std::size_t>( gridSize.x() ) * static_cast<std::size_t>( gridSize.y() ) *
+                           static_cast<std::size_t>( settings.nzUpper() + gridSize.z() + settings.nzLower() );
+
+    const auto value_offset = static_cast<std::size_t>( gridSize.x() ) * static_cast<std::size_t>( gridSize.y() ) *
+                              static_cast<std::size_t>( settings.nzUpper() );
+
+    bool inRegionsSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& keyword = fileDeck[it];
+
+        if ( keyword.name() == "REGIONS" )
+        {
+            inRegionsSection = true;
+            continue;
+        }
+        if ( inRegionsSection && isSectionKeyword( keyword.name() ) ) break;
+        if ( !inRegionsSection ) continue;
+
+        if ( keyword.size() != 1 || !keyword.isDataKeyword() ) continue;
+
+        const auto& record = keyword.getRecord( 0 );
+        if ( record.size() != 1 ) continue;
+
+        const auto& item = record.getItem( 0 );
+        if ( item.getType() != Opm::type_tag::integer || item.data_size() != input_nc ) continue;
+
+        auto& value = const_cast<Opm::DeckItem&>( item ).getData<int>();
+
+        const auto default_value = [&value, upperEquilnum, is_eqlnum = keyword.name() == "EQLNUM"]()
+        {
+            if ( is_eqlnum )
+            {
+                return upperEquilnum;
+            }
+
+            return std::max( 1, *std::min_element( value.begin(), value.end() ) );
+        }();
+
+        auto& status = const_cast<std::vector<Opm::value::status>&>( item.getValueStatus() );
+
+        auto remapped_value  = std::vector<int>( output_nc, default_value );
+        auto remapped_status = std::vector<Opm::value::status>( output_nc, Opm::value::status::deck_value );
+
+        for ( auto i = decltype( input_nc ){ 0 }; i != input_nc; ++i )
+        {
+            if ( actnum_old[i] == 1 )
+            {
+                remapped_value[value_offset + i]  = value[i];
+                remapped_status[value_offset + i] = status[i];
+            }
+        }
+
+        value.swap( remapped_value );
+        status.swap( remapped_status );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Add EQUIL record with GOC=WOC=0 (padmodel lines 813-830)
+//--------------------------------------------------------------------------------------------------
+void extendEQUIL( Opm::DeckKeyword& equil )
+{
+    using Kw = Opm::ParserKeywords::EQUIL;
+
+    assert( !equil.empty() );
+
+    auto record = equil.getRecord( 0 );
+
+    double& goc = const_cast<double&>( record.getItem<Kw::GOC>().getData<double>()[0] );
+    double& woc = const_cast<double&>( record.getItem<Kw::OWC>().getData<double>()[0] );
+
+    goc = woc = 0.0;
+
+    equil.addRecord( std::move( record ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extend RSVD/RTEMPVD/PBVD/PDVD tables (padmodel lines 832-867)
+//--------------------------------------------------------------------------------------------------
+void extendDepthTable( const RigModelPaddingSettings& settings, Opm::DeckKeyword& propertyVD )
+{
+    assert( !propertyVD.empty() );
+
+    auto newPropertyVD = propertyVD.emptyStructuralCopy();
+
+    for ( size_t t = 0; t < propertyVD.size(); ++t )
+    {
+        const auto& table = propertyVD.getRecord( t );
+        auto        i     = std::vector{ table.getItem( 0 ).emptyStructuralCopy() };
+
+        const auto& values = table.getItem( 0 ).getData<double>();
+
+        i.front().push_back( settings.topUpper() );
+        i.front().push_back( values[0 + 1] );
+
+        for ( const auto& value : values )
+        {
+            i.front().push_back( value );
+        }
+
+        i.front().push_back( settings.bottomLower() );
+        i.front().push_back( values.back() );
+
+        newPropertyVD.addRecord( Opm::DeckRecord{ std::move( i ) } );
+    }
+
+    {
+        auto first = newPropertyVD.getRecord( 0 );
+        newPropertyVD.addRecord( std::move( first ) );
+    }
+
+    propertyVD = newPropertyVD;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extend EQUIL + depth tables in SOLUTION section (padmodel lines 869-886)
+//--------------------------------------------------------------------------------------------------
+void extendSolution( const RigModelPaddingSettings& settings, Opm::FileDeck& fileDeck )
+{
+    bool inSolutionSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& keyword = fileDeck[it];
+
+        if ( keyword.name() == "SOLUTION" )
+        {
+            inSolutionSection = true;
+            continue;
+        }
+        if ( inSolutionSection && isSectionKeyword( keyword.name() ) ) break;
+        if ( !inSolutionSection ) continue;
+
+        if ( keyword.name() == "EQUIL" )
+        {
+            extendEQUIL( const_cast<Opm::DeckKeyword&>( keyword ) );
+        }
+        else if ( keyword.name() == "RSVD" || keyword.name() == "RTEMPVD" || keyword.name() == "PBVD" || keyword.name() == "PDVD" )
+        {
+            extendDepthTable( settings, const_cast<Opm::DeckKeyword&>( keyword ) );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Shift COMPDAT K1/K2, COMPSEGS K, WSEED K
+//--------------------------------------------------------------------------------------------------
+void extendSchedule( Opm::FileDeck& fileDeck, const RigModelPaddingSettings& settings )
+{
+    const int nz_upper = settings.nzUpper();
+
+    bool inScheduleSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& records = fileDeck[it];
+
+        if ( records.name() == "SCHEDULE" )
+        {
+            inScheduleSection = true;
+            continue;
+        }
+        if ( !inScheduleSection ) continue;
+
+        if ( records.name() != "COMPDAT" && records.name() != "WSEED" && records.name() != "COMPSEGS" )
+        {
+            continue;
+        }
+
+        if ( records.name() == "WSEED" )
+        {
+            for ( size_t r = 0; r < records.size(); ++r )
+            {
+                const auto& record = records.getRecord( r );
+                int&        K      = const_cast<int&>( record.getItem( "K" ).getData<int>()[0] );
+                K += nz_upper;
+            }
+        }
+        else if ( records.name() == "COMPSEGS" )
+        {
+            bool is_first = true;
+            for ( size_t r = 0; r < records.size(); ++r )
+            {
+                if ( is_first )
+                {
+                    is_first = false;
+                    continue;
+                }
+                const auto& record = records.getRecord( r );
+                int&        K      = const_cast<int&>( record.getItem( "K" ).getData<int>()[0] );
+                K += nz_upper;
+            }
+        }
+        else
+        {
+            // COMPDAT
+            for ( size_t r = 0; r < records.size(); ++r )
+            {
+                const auto& record = records.getRecord( r );
+                int&        K1     = const_cast<int&>( record.getItem( "K1" ).getData<int>()[0] );
+                int&        K2     = const_cast<int&>( record.getItem( "K2" ).getData<int>()[0] );
+                K1 += nz_upper;
+                K2 += nz_upper;
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Get ACTNUM before property extension for region filtering
+//--------------------------------------------------------------------------------------------------
+std::vector<int> getActnumOld( Opm::FileDeck& fileDeck, const GridSize& gridSize )
+{
+    bool inGridSection = false;
+
+    for ( auto it = fileDeck.start(); it != fileDeck.stop(); ++it )
+    {
+        const auto& kw = fileDeck[it];
+
+        if ( kw.name() == "GRID" )
+        {
+            inGridSection = true;
+            continue;
+        }
+        if ( inGridSection && isSectionKeyword( kw.name() ) ) break;
+        if ( !inGridSection ) continue;
+
+        if ( kw.name() == "ACTNUM" && kw.isDataKeyword() )
+        {
+            return kw.getIntData();
+        }
+    }
+
+    // No ACTNUM: all cells active
+    return std::vector<int>( static_cast<size_t>( gridSize.x() ) * gridSize.y() * gridSize.z(), 1 );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Check if a section exists in the FileDeck
+//--------------------------------------------------------------------------------------------------
+bool hasSection( Opm::FileDeck& fileDeck, const std::string& sectionName )
+{
+    return fileDeck.find( sectionName ).has_value();
+}
+
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+/// Main entry point (matching padmodel's manipulate_deck() lines 931-1024)
+//--------------------------------------------------------------------------------------------------
+std::expected<void, QString> RigPadModel::extendGrid( RifOpmFlowDeckFile& deckFile, const RigModelPaddingSettings& settings )
+{
+    if ( !settings.isEnabled() )
+    {
+        return {};
+    }
+
+    auto* fileDeck = deckFile.fileDeck();
+    if ( fileDeck == nullptr )
+    {
+        return std::unexpected( "No FileDeck available for model padding" );
+    }
+
+    auto gridSizeResult = getDimens( *fileDeck );
+    if ( !gridSizeResult.has_value() )
+    {
+        return std::unexpected( gridSizeResult.error() );
+    }
+
+    const auto gridSize = gridSizeResult.value();
+
+    if ( settings.nzUpper() == 0 && settings.nzLower() == 0 )
+    {
+        RiaLogging::info( "Model padding enabled but no padding layers specified - skipping" );
+        return {};
+    }
+
+    const int nzNew = static_cast<int>( gridSize.z() ) + settings.nzUpper() + settings.nzLower();
+
+    RiaLogging::info(
+        QString( "Applying model padding: %1 upper layers, %2 lower layers" ).arg( settings.nzUpper() ).arg( settings.nzLower() ) );
+    RiaLogging::info(
+        QString( "Grid dimensions: %1 x %2 x %3 -> %1 x %2 x %4" ).arg( gridSize.x() ).arg( gridSize.y() ).arg( gridSize.z() ).arg( nzNew ) );
+
+    // Save actnum before any extensions for region filtering
+    auto actnumOld = getActnumOld( *fileDeck, gridSize );
+
+    // Step 1: DIMENS, EQLDIMS, SPECGRID
+    const int upperEquilnum = extendDimens( gridSize, settings, *fileDeck, nzNew );
+
+    // Step 2: BCCON K-shift
+    extendBCCon( *fileDeck, settings );
+
+    // Step 3: Extend GRID section data arrays (double and int)
+    extendGridSection<double>( *fileDeck, gridSize, settings, Opm::type_tag::fdouble );
+    extendGridSection<int>( *fileDeck, gridSize, settings, Opm::type_tag::integer );
+
+    // Step 4: Special grid properties (ACTNUM + inactive cell handling)
+    extendSpecialGridProperties( *fileDeck, gridSize, settings );
+
+    // Step 5: FAULTS K-shift
+    extendFaults( settings, *fileDeck );
+
+    // Step 6: COORD + ZCORN per-column
+    extendGRDECL( *fileDeck, gridSize, settings, nzNew );
+
+    // Step 7: Extend PROPS section arrays
+    if ( hasSection( *fileDeck, "PROPS" ) )
+    {
+        extendProps( gridSize, settings, *fileDeck, deckFile.deck() );
+    }
+
+    // Step 8: Extend REGIONS with actnum filtering
+    if ( hasSection( *fileDeck, "REGIONS" ) )
+    {
+        extendRegions( *fileDeck, gridSize, settings, actnumOld, upperEquilnum );
+    }
+
+    // Step 9: Extend SOLUTION (EQUIL + depth tables)
+    if ( hasSection( *fileDeck, "SOLUTION" ) )
+    {
+        extendSolution( settings, *fileDeck );
+    }
+
+    // Step 10: Extend SCHEDULE (COMPDAT/COMPSEGS/WSEED)
+    if ( hasSection( *fileDeck, "SCHEDULE" ) )
+    {
+        extendSchedule( *fileDeck, settings );
+    }
+
+    // Step 11: Operators K-shift (ADD/BOX/EQUALS etc.)
+    extendOperators( settings, *fileDeck );
+
+    RiaLogging::info( QString( "Model padding applied successfully: %1 x %2 x %3" ).arg( gridSize.x() ).arg( gridSize.y() ).arg( nzNew ) );
+
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extend a property array with default values for padding layers (exposed for testing)
+//--------------------------------------------------------------------------------------------------
+std::vector<double> RigPadModel::extendPropertyArray( const std::vector<double>& original,
+                                                      int                        nx,
+                                                      int                        ny,
+                                                      int                        nz,
+                                                      int                        nzUpper,
+                                                      int                        nzLower,
+                                                      double                     upperDefault,
+                                                      double                     lowerDefault )
+{
+    int    xyCount = nx * ny;
+    int    newNz   = nz + nzUpper + nzLower;
+    size_t newSize = static_cast<size_t>( xyCount ) * newNz;
+
+    std::vector<double> result;
+    result.reserve( newSize );
+
+    for ( int k = 0; k < nzUpper; k++ )
+    {
+        for ( int i = 0; i < xyCount; i++ )
+        {
+            result.push_back( upperDefault );
+        }
+    }
+
+    result.insert( result.end(), original.begin(), original.end() );
+
+    for ( int k = 0; k < nzLower; k++ )
+    {
+        for ( int i = 0; i < xyCount; i++ )
+        {
+            result.push_back( lowerDefault );
+        }
+    }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Public static: compute the proper default value for a PROPS keyword from the Deck's
+/// saturation function tables. Used by extendProps() and exposed for unit testing.
+//--------------------------------------------------------------------------------------------------
+double RigPadModel::getPropsDefaultValue( const Opm::Deck& deck, const std::string& keyword )
+{
+    auto defaults = computePropsDefaultValues( deck );
+    return lookupPropsDefault( defaults, keyword );
+}

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.h
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.h
@@ -1,0 +1,61 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <QString>
+
+#include <expected>
+#include <string>
+#include <vector>
+
+namespace Opm
+{
+class Deck;
+class FileDeck;
+} // namespace Opm
+
+class RifOpmFlowDeckFile;
+class RigModelPaddingSettings;
+
+//==================================================================================================
+/// Grid padding utilities adapted from OPM-Flow's padmodel.cpp
+/// Source: https://github.com/hnil/opm-flowgeomechanics/blob/geomech_hypre_cgal/examples/padmodel.cpp
+///
+/// This class provides functions to extend eclipse grid data in the Z-direction by adding
+/// padding layers above and/or below the existing grid. This is useful for sector models
+/// that need additional layers for geomechanical simulations.
+//==================================================================================================
+class RigPadModel
+{
+public:
+    // Main entry point - extends all grid data via FileDeck in-place modification
+    static std::expected<void, QString> extendGrid( RifOpmFlowDeckFile& deckFile, const RigModelPaddingSettings& settings );
+
+    // Helper functions for property array extension
+    static double getPropsDefaultValue( const Opm::Deck& deck, const std::string& keyword );
+
+    static std::vector<double> extendPropertyArray( const std::vector<double>& original,
+                                                    int                        nx,
+                                                    int                        ny,
+                                                    int                        nz,
+                                                    int                        nzUpper,
+                                                    int                        nzLower,
+                                                    double                     upperDefault,
+                                                    double                     lowerDefault );
+};

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputSettings.h
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputSettings.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "RiaModelExportDefines.h"
+#include "RigModelPaddingSettings.h"
 
 #include "cafAppEnum.h"
 #include "cafVecIjk.h"
@@ -76,6 +77,10 @@ public:
     QString outputDeckFileName() const;
     void    setOutputDeckFileName( const QString& fileName );
 
+    // Model padding
+    const RigModelPaddingSettings& paddingSettings() const;
+    void                           setPaddingSettings( const RigModelPaddingSettings& settings );
+
 private:
     caf::VecIjk0                 m_min;
     caf::VecIjk0                 m_max;
@@ -86,4 +91,5 @@ private:
     double                       m_porvMultiplier;
     QString                      m_inputDeckFileName;
     QString                      m_outputDeckFileName;
+    RigModelPaddingSettings      m_paddingSettings;
 };

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.cpp
@@ -191,28 +191,23 @@ std::expected<void, QString> RigSimulationInputTool::updateCornerPointGridInDeck
     auto keywords = deckFile.keywords( false );
 
     // Sector dimensions (after refinement)
-    std::vector<int> dimens = { static_cast<int>( gridAdapter.cellCountI() ),
-                                static_cast<int>( gridAdapter.cellCountJ() ),
-                                static_cast<int>( gridAdapter.cellCountK() ) };
+    int dimenNx = static_cast<int>( gridAdapter.cellCountI() );
+    int dimenNy = static_cast<int>( gridAdapter.cellCountJ() );
+    int dimenNz = static_cast<int>( gridAdapter.cellCountK() );
 
-    if ( !deckFile.replaceKeyword( "DIMENS", dimens ) )
+    if ( !deckFile.setDimens( dimenNx, dimenNy, dimenNz ) )
     {
         return std::unexpected( "Failed to replace DIMENS keyword in deck file" );
     }
 
     // SPECGRID has the same dimensions plus NUMRES and COORD_TYPE
-    // Format: NX NY NZ (use defaults for NUMRES (1) and  COORD_TYPE: 'F'=Cartesian)
     if ( std::find( keywords.begin(), keywords.end(), "SPECGRID" ) == keywords.end() )
     {
         Opm::DeckKeyword newKw( ( Opm::ParserKeywords::SPECGRID() ) );
         deckFile.addKeyword( "GRID", newKw );
     }
 
-    std::vector<int> specgrid = { static_cast<int>( gridAdapter.cellCountI() ),
-                                  static_cast<int>( gridAdapter.cellCountJ() ),
-                                  static_cast<int>( gridAdapter.cellCountK() ) };
-
-    if ( !deckFile.replaceKeyword( "SPECGRID", specgrid ) )
+    if ( !deckFile.setSpecgrid( dimenNx, dimenNy, dimenNz ) )
     {
         return std::unexpected( "Failed to replace SPECGRID keyword in deck file" );
     }

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.cpp
@@ -21,6 +21,9 @@
 #include "RiaLogging.h"
 #include "RiaNncDefines.h"
 
+#include "RigModelPaddingSettings.h"
+#include "RigPadModel.h"
+
 #include "RifEclipseInputFileTools.h"
 #include "RifOpmDeckTools.h"
 #include "RifOpmFlowDeckFile.h"
@@ -150,6 +153,15 @@ std::expected<void, QString> RigSimulationInputTool::exportSimulationInput( RimE
     if ( auto result = exportEditNncKeyword( &eclipseCase, settings, deckFile ); !result )
     {
         return result;
+    }
+
+    // Apply model padding if enabled
+    if ( settings.paddingSettings().isEnabled() )
+    {
+        if ( auto result = applyModelPadding( deckFile, settings.paddingSettings() ); !result )
+        {
+            return result;
+        }
     }
 
     // Remove SKIP keywords that were used as placeholders for filtered-out keywords
@@ -1776,4 +1788,13 @@ std::expected<void, QString> RigSimulationInputTool::exportEditNncKeyword( RimEc
     deckFile.replaceKeyword( "EDIT", editnncKw );
 
     return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::expected<void, QString> RigSimulationInputTool::applyModelPadding( RifOpmFlowDeckFile&            deckFile,
+                                                                        const RigModelPaddingSettings& paddingSettings )
+{
+    return RigPadModel::extendGrid( deckFile, paddingSettings );
 }

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.h
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigSimulationInputTool.h
@@ -31,6 +31,7 @@
 
 class RimEclipseView;
 class RimEclipseCase;
+class RigModelPaddingSettings;
 class RigSimulationInputSettings;
 class RifOpmFlowDeckFile;
 class RigSimWellData;
@@ -152,6 +153,8 @@ private:
 
     static std::expected<void, QString>
         exportEditNncKeyword( RimEclipseCase* eclipseCase, const RigSimulationInputSettings& settings, RifOpmFlowDeckFile& deckFile );
+
+    static std::expected<void, QString> applyModelPadding( RifOpmFlowDeckFile& deckFile, const RigModelPaddingSettings& paddingSettings );
 
     // Utility: Transform global IJK to sector-relative coordinates with refinement
     static caf::VecIjk0 transformToSectorCoordinates( const caf::VecIjk0& globalIjk, const caf::VecIjk0& min, const cvf::Vec3st& refinement );

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -8,6 +8,8 @@ endif(MSVC)
 set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/cvfGeometryTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Ert-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigModelPaddingSettings-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigPadModel-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigSimulationInputTool-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigBoundingBoxIjk-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifcCommandCore-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigModelPaddingSettings-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigModelPaddingSettings-Test.cpp
@@ -1,0 +1,275 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RigModelPaddingSettings.h"
+
+//--------------------------------------------------------------------------------------------------
+/// Test default values
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, DefaultValues )
+{
+    RigModelPaddingSettings settings;
+
+    EXPECT_FALSE( settings.isEnabled() );
+    EXPECT_EQ( 0, settings.nzUpper() );
+    EXPECT_DOUBLE_EQ( 0.0, settings.topUpper() );
+    EXPECT_DOUBLE_EQ( 0.0, settings.upperPorosity() );
+    EXPECT_EQ( 1, settings.upperEquilnum() );
+    EXPECT_EQ( 0, settings.nzLower() );
+    EXPECT_DOUBLE_EQ( 0.0, settings.bottomLower() );
+    EXPECT_DOUBLE_EQ( 0.1, settings.minLayerThickness() );
+    EXPECT_FALSE( settings.fillGaps() );
+    EXPECT_FALSE( settings.monotonicZcorn() );
+    EXPECT_FALSE( settings.verticalPillars() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test setters and getters
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, SettersAndGetters )
+{
+    RigModelPaddingSettings settings;
+
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setTopUpper( 1000.0 );
+    settings.setUpperPorosity( 0.25 );
+    settings.setUpperEquilnum( 2 );
+    settings.setNzLower( 3 );
+    settings.setBottomLower( 3500.0 );
+    settings.setMinLayerThickness( 0.5 );
+    settings.setFillGaps( true );
+    settings.setMonotonicZcorn( true );
+    settings.setVerticalPillars( true );
+
+    EXPECT_TRUE( settings.isEnabled() );
+    EXPECT_EQ( 5, settings.nzUpper() );
+    EXPECT_DOUBLE_EQ( 1000.0, settings.topUpper() );
+    EXPECT_DOUBLE_EQ( 0.25, settings.upperPorosity() );
+    EXPECT_EQ( 2, settings.upperEquilnum() );
+    EXPECT_EQ( 3, settings.nzLower() );
+    EXPECT_DOUBLE_EQ( 3500.0, settings.bottomLower() );
+    EXPECT_DOUBLE_EQ( 0.5, settings.minLayerThickness() );
+    EXPECT_TRUE( settings.fillGaps() );
+    EXPECT_TRUE( settings.monotonicZcorn() );
+    EXPECT_TRUE( settings.verticalPillars() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation when disabled
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_WhenDisabled )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( false );
+
+    QString errors = settings.validate();
+
+    EXPECT_TRUE( errors.isEmpty() ) << "Validation should pass when padding is disabled";
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation with valid upper padding settings
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_ValidUpperPadding )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setTopUpper( 1000.0 );
+    settings.setUpperPorosity( 0.25 );
+    settings.setUpperEquilnum( 1 );
+    settings.setMinLayerThickness( 0.1 );
+
+    QString errors = settings.validate();
+
+    EXPECT_TRUE( errors.isEmpty() ) << "Validation should pass with valid upper padding: " << errors.toStdString();
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation with valid lower padding settings
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_ValidLowerPadding )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzLower( 3 );
+    settings.setBottomLower( 3500.0 );
+    settings.setMinLayerThickness( 0.1 );
+
+    QString errors = settings.validate();
+
+    EXPECT_TRUE( errors.isEmpty() ) << "Validation should pass with valid lower padding: " << errors.toStdString();
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation with valid both upper and lower padding
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_ValidBothPadding )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 2 );
+    settings.setTopUpper( 1000.0 );
+    settings.setUpperPorosity( 0.3 );
+    settings.setUpperEquilnum( 1 );
+    settings.setNzLower( 3 );
+    settings.setBottomLower( 3500.0 );
+    settings.setMinLayerThickness( 0.5 );
+
+    QString errors = settings.validate();
+
+    EXPECT_TRUE( errors.isEmpty() ) << "Validation should pass with valid both padding: " << errors.toStdString();
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails when no layers specified
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_NoLayersSpecified )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 0 );
+    settings.setNzLower( 0 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "At least one padding direction" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails with negative upper layers
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_NegativeUpperLayers )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( -1 );
+    settings.setNzLower( 5 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "cannot be negative" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails with negative lower layers
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_NegativeLowerLayers )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setNzLower( -2 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "cannot be negative" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails with invalid porosity (< 0)
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_InvalidPorosityNegative )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setUpperPorosity( -0.1 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "porosity" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails with invalid porosity (> 1)
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_InvalidPorosityTooHigh )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setUpperPorosity( 1.5 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "porosity" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails with invalid EQUILNUM
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_InvalidEquilnum )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setUpperPorosity( 0.25 );
+    settings.setUpperEquilnum( 0 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "EQUILNUM" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation fails with non-positive layer thickness
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_NonPositiveLayerThickness )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setUpperPorosity( 0.25 );
+    settings.setMinLayerThickness( 0.0 );
+
+    QString errors = settings.validate();
+
+    EXPECT_FALSE( errors.isEmpty() );
+    EXPECT_TRUE( errors.contains( "thickness" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test validation with edge case porosity values (0 and 1)
+//--------------------------------------------------------------------------------------------------
+TEST( RigModelPaddingSettings, Validation_EdgeCasePorosity )
+{
+    RigModelPaddingSettings settings;
+    settings.setEnabled( true );
+    settings.setNzUpper( 5 );
+    settings.setMinLayerThickness( 0.1 );
+
+    // Test porosity = 0 (valid)
+    settings.setUpperPorosity( 0.0 );
+    QString errors = settings.validate();
+    EXPECT_TRUE( errors.isEmpty() ) << "Porosity 0.0 should be valid: " << errors.toStdString();
+
+    // Test porosity = 1 (valid)
+    settings.setUpperPorosity( 1.0 );
+    errors = settings.validate();
+    EXPECT_TRUE( errors.isEmpty() ) << "Porosity 1.0 should be valid: " << errors.toStdString();
+}

--- a/ApplicationLibCode/UnitTests/RigPadModel-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigPadModel-Test.cpp
@@ -1,0 +1,311 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RigPadModel.h"
+
+#include "opm/input/eclipse/Deck/Deck.hpp"
+#include "opm/input/eclipse/Parser/Parser.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+//--------------------------------------------------------------------------------------------------
+/// Test extendPropertyArray with only upper padding
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_UpperOnly )
+{
+    // Create a 2x2x2 grid (8 cells)
+    int                 nx = 2, ny = 2, nz = 2;
+    std::vector<double> original( nx * ny * nz, 0.25 ); // PORO = 0.25
+
+    // Add 2 upper padding layers
+    int    nzUpper      = 2;
+    int    nzLower      = 0;
+    double upperDefault = 0.1;
+    double lowerDefault = 0.0;
+
+    auto result = RigPadModel::extendPropertyArray( original, nx, ny, nz, nzUpper, nzLower, upperDefault, lowerDefault );
+
+    // Expected size: nx * ny * (nz + nzUpper + nzLower) = 2 * 2 * 4 = 16
+    EXPECT_EQ( 16u, result.size() );
+
+    // First 8 values (2 upper layers * 4 cells) should be upperDefault
+    for ( int i = 0; i < 8; i++ )
+    {
+        EXPECT_DOUBLE_EQ( upperDefault, result[i] ) << "Upper padding cell " << i << " should be " << upperDefault;
+    }
+
+    // Next 8 values should be original data
+    for ( int i = 8; i < 16; i++ )
+    {
+        EXPECT_DOUBLE_EQ( 0.25, result[i] ) << "Original cell " << ( i - 8 ) << " should be 0.25";
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test extendPropertyArray with only lower padding
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_LowerOnly )
+{
+    // Create a 2x2x2 grid (8 cells)
+    int                 nx = 2, ny = 2, nz = 2;
+    std::vector<double> original( nx * ny * nz, 0.25 ); // PORO = 0.25
+
+    // Add 3 lower padding layers
+    int    nzUpper      = 0;
+    int    nzLower      = 3;
+    double upperDefault = 0.1;
+    double lowerDefault = 0.0;
+
+    auto result = RigPadModel::extendPropertyArray( original, nx, ny, nz, nzUpper, nzLower, upperDefault, lowerDefault );
+
+    // Expected size: nx * ny * (nz + nzUpper + nzLower) = 2 * 2 * 5 = 20
+    EXPECT_EQ( 20u, result.size() );
+
+    // First 8 values should be original data
+    for ( int i = 0; i < 8; i++ )
+    {
+        EXPECT_DOUBLE_EQ( 0.25, result[i] ) << "Original cell " << i << " should be 0.25";
+    }
+
+    // Last 12 values (3 lower layers * 4 cells) should be lowerDefault
+    for ( int i = 8; i < 20; i++ )
+    {
+        EXPECT_DOUBLE_EQ( lowerDefault, result[i] ) << "Lower padding cell " << ( i - 8 ) << " should be " << lowerDefault;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test extendPropertyArray with both upper and lower padding
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_BothPadding )
+{
+    // Create a 3x3x2 grid (18 cells)
+    int                 nx = 3, ny = 3, nz = 2;
+    std::vector<double> original( nx * ny * nz );
+    for ( int i = 0; i < nx * ny * nz; i++ )
+    {
+        original[i] = 0.3; // PORO = 0.3
+    }
+
+    // Add 1 upper and 2 lower padding layers
+    int    nzUpper      = 1;
+    int    nzLower      = 2;
+    double upperDefault = 0.05;
+    double lowerDefault = 0.02;
+
+    auto result = RigPadModel::extendPropertyArray( original, nx, ny, nz, nzUpper, nzLower, upperDefault, lowerDefault );
+
+    // Expected size: 3 * 3 * (2 + 1 + 2) = 45
+    EXPECT_EQ( 45u, result.size() );
+
+    // First 9 values (1 upper layer * 9 cells) should be upperDefault
+    for ( int i = 0; i < 9; i++ )
+    {
+        EXPECT_DOUBLE_EQ( upperDefault, result[i] );
+    }
+
+    // Middle 18 values should be original data
+    for ( int i = 9; i < 27; i++ )
+    {
+        EXPECT_DOUBLE_EQ( 0.3, result[i] );
+    }
+
+    // Last 18 values (2 lower layers * 9 cells) should be lowerDefault
+    for ( int i = 27; i < 45; i++ )
+    {
+        EXPECT_DOUBLE_EQ( lowerDefault, result[i] );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test extendPropertyArray with zero padding (no change)
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_NoPadding )
+{
+    int                 nx = 2, ny = 2, nz = 2;
+    std::vector<double> original( nx * ny * nz, 0.5 );
+
+    auto result = RigPadModel::extendPropertyArray( original, nx, ny, nz, 0, 0, 0.0, 0.0 );
+
+    EXPECT_EQ( original.size(), result.size() );
+    for ( size_t i = 0; i < original.size(); i++ )
+    {
+        EXPECT_DOUBLE_EQ( original[i], result[i] );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test extendPropertyArray preserves original data order
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_DataOrder )
+{
+    // Create a 2x2x2 grid with sequential values
+    int                 nx = 2, ny = 2, nz = 2;
+    std::vector<double> original( nx * ny * nz );
+    for ( int i = 0; i < nx * ny * nz; i++ )
+    {
+        original[i] = static_cast<double>( i + 1 );
+    }
+
+    // Add 1 upper and 1 lower padding layer
+    auto result = RigPadModel::extendPropertyArray( original, nx, ny, nz, 1, 1, 0.0, 99.0 );
+
+    // Check that original data is preserved in the middle
+    int xyCount = nx * ny;
+    for ( int i = 0; i < nx * ny * nz; i++ )
+    {
+        EXPECT_DOUBLE_EQ( original[i], result[xyCount + i] ) << "Original data at index " << i << " should be preserved";
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test empty input arrays
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_EmptyInput )
+{
+    std::vector<double> empty;
+
+    auto result = RigPadModel::extendPropertyArray( empty, 2, 2, 0, 2, 2, 0.5, 0.5 );
+
+    // Should have 2*2*(0+2+2) = 16 elements, all with padding values
+    EXPECT_EQ( 16u, result.size() );
+    for ( const auto& v : result )
+    {
+        EXPECT_DOUBLE_EQ( 0.5, v );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test large grid dimensions
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendPropertyArray_LargeGrid )
+{
+    // Simulate a typical sector model size
+    int                 nx = 50, ny = 50, nz = 20;
+    std::vector<double> original( nx * ny * nz, 0.2 );
+
+    // Add padding
+    int nzUpper = 5;
+    int nzLower = 10;
+
+    auto result = RigPadModel::extendPropertyArray( original, nx, ny, nz, nzUpper, nzLower, 0.1, 0.0 );
+
+    size_t expectedSize = static_cast<size_t>( nx ) * ny * ( nz + nzUpper + nzLower );
+    EXPECT_EQ( expectedSize, result.size() );
+
+    // Verify structure: upper padding, original, lower padding
+    int xyCount = nx * ny;
+
+    // Sample check on upper padding
+    EXPECT_DOUBLE_EQ( 0.1, result[0] );
+    EXPECT_DOUBLE_EQ( 0.1, result[nzUpper * xyCount - 1] );
+
+    // Sample check on original
+    EXPECT_DOUBLE_EQ( 0.2, result[nzUpper * xyCount] );
+    EXPECT_DOUBLE_EQ( 0.2, result[( nzUpper + nz ) * xyCount - 1] );
+
+    // Sample check on lower padding
+    EXPECT_DOUBLE_EQ( 0.0, result[( nzUpper + nz ) * xyCount] );
+    EXPECT_DOUBLE_EQ( 0.0, result[result.size() - 1] );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test getPropsDefaultValue returns physically correct defaults from saturation tables.
+/// A minimal deck with SWOF/SGOF tables is parsed, and the function should return
+/// non-zero values for saturation endpoint keywords (not the old hardcoded 0.0).
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, GetPropsDefaultValue_FromSaturationTables )
+{
+    // Minimal deck with OIL/WATER/GAS phases and SWOF+SGOF tables
+    std::string deckString = R"(
+RUNSPEC
+OIL
+WATER
+GAS
+TABDIMS
+  1 /
+EQLDIMS
+  1 /
+DIMENS
+  2 2 1 /
+
+GRID
+DX
+  4*100 /
+DY
+  4*100 /
+DZ
+  4*10 /
+TOPS
+  4*2000 /
+
+PROPS
+SWOF
+  0.2  0.0  1.0  0.0
+  0.5  0.3  0.5  0.0
+  1.0  1.0  0.0  0.0
+/
+SGOF
+  0.0  0.0  1.0  0.0
+  0.3  0.2  0.5  0.0
+  0.8  1.0  0.0  0.0
+/
+
+SOLUTION
+EQUIL
+  2000 200 2200 0 1800 0 /
+
+SCHEDULE
+)";
+
+    auto deck = Opm::Parser{}.parseString( deckString );
+
+    // SWATINIT should default to 1.0 (padding cells fully water-saturated)
+    EXPECT_DOUBLE_EQ( 1.0, RigPadModel::getPropsDefaultValue( deck, "SWATINIT" ) );
+
+    // SWU (max water saturation) should be 1.0 from the SWOF table (last Sw entry)
+    EXPECT_DOUBLE_EQ( 1.0, RigPadModel::getPropsDefaultValue( deck, "SWU" ) );
+
+    // SWL (connate water) should be 0.2 from the SWOF table (first Sw entry)
+    EXPECT_DOUBLE_EQ( 0.2, RigPadModel::getPropsDefaultValue( deck, "SWL" ) );
+
+    // SGU (max gas saturation) should be 0.8 from the SGOF table (last Sg entry)
+    EXPECT_DOUBLE_EQ( 0.8, RigPadModel::getPropsDefaultValue( deck, "SGU" ) );
+
+    // KRW (max water relperm) should be 1.0 from the SWOF table
+    EXPECT_DOUBLE_EQ( 1.0, RigPadModel::getPropsDefaultValue( deck, "KRW" ) );
+
+    // KRG (max gas relperm) should be 1.0 from the SGOF table
+    EXPECT_DOUBLE_EQ( 1.0, RigPadModel::getPropsDefaultValue( deck, "KRG" ) );
+
+    // KRO (max oil relperm) should be 1.0 from the SWOF table
+    EXPECT_DOUBLE_EQ( 1.0, RigPadModel::getPropsDefaultValue( deck, "KRO" ) );
+
+    // Directional variant (SWL with X suffix) should map to same value as SWL
+    EXPECT_DOUBLE_EQ( 0.2, RigPadModel::getPropsDefaultValue( deck, "SWLX" ) );
+
+    // Imbibition variant (ISWL) should map to SWL
+    EXPECT_DOUBLE_EQ( 0.2, RigPadModel::getPropsDefaultValue( deck, "ISWL" ) );
+
+    // Unknown keyword should return 0.0
+    EXPECT_DOUBLE_EQ( 0.0, RigPadModel::getPropsDefaultValue( deck, "UNKNOWN_KEYWORD" ) );
+}

--- a/ApplicationLibCode/UnitTests/RigSimulationInputTool-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigSimulationInputTool-Test.cpp
@@ -27,6 +27,7 @@
 #include "RigEclipseCaseData.h"
 #include "RigEclipseCaseDataTools.h"
 #include "RigMainGrid.h"
+#include "RigModelPaddingSettings.h"
 #include "RigSimulationInputSettings.h"
 #include "RimEclipseResultCase.h"
 
@@ -1305,4 +1306,126 @@ TEST( RigSimulationInputTool, RefineEDITNNCConnection_CorrespondingSubcells )
     // Connection 3: (1,1,0) -> (1,1,0): (7,9,5) -> (13,17,7)
     EXPECT_EQ( caf::VecIjk0( 7, 9, 5 ), refined[3].cell1 );
     EXPECT_EQ( caf::VecIjk0( 13, 17, 7 ), refined[3].cell2 );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Test exportSimulationInput with model5 data and model padding
+//--------------------------------------------------------------------------------------------------
+TEST( RigSimulationInputTool, ExportModel5WithPadding )
+{
+    // Load model5 test data
+    QDir baseFolder( TEST_DATA_DIR );
+    bool subFolderExists = baseFolder.cd( "RigSimulationInputTool/model5" );
+    ASSERT_TRUE( subFolderExists );
+
+    QString egridFilename( "0_BASE_MODEL5.EGRID" );
+    QString egridFilePath = baseFolder.absoluteFilePath( egridFilename );
+    ASSERT_TRUE( QFile::exists( egridFilePath ) );
+
+    QString dataFilename( "0_BASE_MODEL5.DATA" );
+    QString dataFilePath = baseFolder.absoluteFilePath( dataFilename );
+    ASSERT_TRUE( QFile::exists( dataFilePath ) );
+
+    // Create Eclipse case and load grid
+    std::unique_ptr<RimEclipseResultCase> resultCase( new RimEclipseResultCase );
+    cvf::ref<RigEclipseCaseData>          caseData = new RigEclipseCaseData( resultCase.get() );
+
+    cvf::ref<RifReaderEclipseOutput> reader     = new RifReaderEclipseOutput;
+    bool                             loadResult = reader->open( egridFilePath, caseData.p() );
+    ASSERT_TRUE( loadResult );
+
+    // Verify grid dimensions (20x30x10)
+    ASSERT_TRUE( caseData->mainGrid() != nullptr );
+    EXPECT_EQ( 20u, caseData->mainGrid()->cellCountI() );
+    EXPECT_EQ( 30u, caseData->mainGrid()->cellCountJ() );
+    EXPECT_EQ( 10u, caseData->mainGrid()->cellCountK() );
+
+    // Create temporary directory for export
+    QTemporaryDir tempDir;
+    ASSERT_TRUE( tempDir.isValid() );
+
+    QString exportFilePath = tempDir.path() + "/exported_model_padded.DATA";
+
+    // Set up export settings for sector export with padding
+    RigSimulationInputSettings settings;
+    settings.setMin( caf::VecIjk0( 0, 0, 0 ) );
+    settings.setMax( caf::VecIjk0( 19, 14, 9 ) ); // Sector (0-based inclusive) -> 20x15x10
+    settings.setRefinement( cvf::Vec3st( 1, 1, 1 ) ); // No refinement
+    settings.setInputDeckFileName( dataFilePath );
+    settings.setOutputDeckFileName( exportFilePath );
+
+    // Configure padding: 2 upper, 3 lower
+    RigModelPaddingSettings paddingSettings;
+    paddingSettings.setEnabled( true );
+    paddingSettings.setNzUpper( 2 );
+    paddingSettings.setNzLower( 3 );
+    paddingSettings.setTopUpper( 1000.0 );
+    paddingSettings.setBottomLower( 3600.0 );
+    paddingSettings.setUpperPorosity( 0.1 );
+    paddingSettings.setMinLayerThickness( 10.0 );
+    paddingSettings.setVerticalPillars( true );
+    paddingSettings.setMonotonicZcorn( true );
+    paddingSettings.setFillGaps( true );
+    settings.setPaddingSettings( paddingSettings );
+
+    // Create visibility from IJK bounds
+    cvf::ref<cvf::UByteArray> visibility =
+        RigEclipseCaseDataTools::createVisibilityFromIjkBounds( caseData.p(), settings.min(), settings.max() );
+
+    // Export simulation input
+    resultCase->setReservoirData( caseData.p() );
+    auto exportResult = RigSimulationInputTool::exportSimulationInput( *resultCase, settings, visibility.p() );
+    ASSERT_TRUE( exportResult.has_value() ) << "Export failed: " << exportResult.error().toStdString();
+
+    // Verify exported file exists
+    ASSERT_TRUE( QFile::exists( exportFilePath ) );
+
+    // Load the exported deck file using RifOpmFlowDeckFile
+    RifOpmFlowDeckFile deckFile;
+    bool               deckLoadResult = deckFile.loadDeck( exportFilePath.toStdString() );
+    ASSERT_TRUE( deckLoadResult ) << "Failed to load exported deck file";
+
+    // Get all keywords from the deck
+    std::vector<std::string> allKeywords = deckFile.keywords( false );
+
+    // Verify key keywords exist in the file
+    EXPECT_TRUE( std::find( allKeywords.begin(), allKeywords.end(), "DIMENS" ) != allKeywords.end() );
+    EXPECT_TRUE( std::find( allKeywords.begin(), allKeywords.end(), "SPECGRID" ) != allKeywords.end() )
+        << "SPECGRID keyword missing from exported file";
+    EXPECT_TRUE( std::find( allKeywords.begin(), allKeywords.end(), "COORD" ) != allKeywords.end() );
+    EXPECT_TRUE( std::find( allKeywords.begin(), allKeywords.end(), "ZCORN" ) != allKeywords.end() );
+    EXPECT_TRUE( std::find( allKeywords.begin(), allKeywords.end(), "ACTNUM" ) != allKeywords.end() );
+    EXPECT_TRUE( std::find( allKeywords.begin(), allKeywords.end(), "PORO" ) != allKeywords.end() );
+
+    // Read the file content to verify padded dimensions
+    QFile file( exportFilePath );
+    ASSERT_TRUE( file.open( QIODevice::ReadOnly | QIODevice::Text ) );
+    QString fileContent = file.readAll();
+    file.close();
+
+    // Verify dimensions are correct for the padded sector (20x15x15)
+    // Original sector: 20x15x10, with nzUpper=2, nzLower=3: 20x15x(10+2+3) = 20x15x15
+    EXPECT_TRUE( fileContent.contains( " 20 15 15 /" ) ) << "File does not contain expected padded dimensions 20 15 15";
+
+    // Verify SPECGRID/DIMENS show correct padded dimensions
+    auto specgridKw = deckFile.findKeyword( "SPECGRID" );
+    ASSERT_TRUE( specgridKw.has_value() );
+    EXPECT_EQ( 20, specgridKw->getRecord( 0 ).getItem( 0 ).get<int>( 0 ) );
+    EXPECT_EQ( 15, specgridKw->getRecord( 0 ).getItem( 1 ).get<int>( 0 ) );
+    EXPECT_EQ( 15, specgridKw->getRecord( 0 ).getItem( 2 ).get<int>( 0 ) );
+
+    // Verify COORD array size: (NX+1)*(NY+1)*6 = 21*16*6 = 2016 (unchanged by padding)
+    auto coordKw = deckFile.findKeyword( "COORD" );
+    ASSERT_TRUE( coordKw.has_value() );
+    EXPECT_EQ( 2016u, coordKw->getRecord( 0 ).getItem( 0 ).data_size() );
+
+    // Verify ZCORN array size: NX*NY*NZ_new*8 = 20*15*15*8 = 36000
+    auto zcornKw = deckFile.findKeyword( "ZCORN" );
+    ASSERT_TRUE( zcornKw.has_value() );
+    EXPECT_EQ( 36000u, zcornKw->getRecord( 0 ).getItem( 0 ).data_size() );
+
+    // Verify ACTNUM array size: NX*NY*NZ_new = 20*15*15 = 4500
+    auto actnumKw = deckFile.findKeyword( "ACTNUM" );
+    ASSERT_TRUE( actnumKw.has_value() );
+    EXPECT_EQ( 4500u, actnumKw->getRecord( 0 ).getItem( 0 ).data_size() );
 }


### PR DESCRIPTION
Add Z-direction padding support for sector models based on OPM-Flow's padmodel.cpp. This feature enables users to add padding layers above and/or below the exported sector model grid.

Adapts padmodel.cpp from
https://github.com/hnil/opm-flowgeomechanics/blob/geomech_hypre_cgal/examples/padmodel.cpp Commit: 5ee483e

Fixes #13467.