### PR TITLE
RHEL8: Build libstdc++ with backtrace support

### DIFF
--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install GCC Toolset 13
         run: |
-          dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel gcc-toolset-13-libstdc++-devel
+          dnf install -y gcc-toolset-14 gcc-toolset-14-gcc-c++ gcc-toolset-14-libatomic-devel gcc-toolset-14-libstdc++-devel
 
       - name: Configure git safe directory
         run: |
@@ -90,7 +90,7 @@ jobs:
 
       - name: Bootstrap vcpkg
         run: |
-          source /opt/rh/gcc-toolset-13/enable
+          source /opt/rh/gcc-toolset-14/enable
           cd ThirdParty/vcpkg
           ./bootstrap-vcpkg.sh
 
@@ -109,12 +109,12 @@ jobs:
 
       - name: Configure CMake
         env:
-          CC: /opt/rh/gcc-toolset-13/root/usr/bin/gcc
-          CXX: /opt/rh/gcc-toolset-13/root/usr/bin/g++
+          CC: /opt/rh/gcc-toolset-14/root/usr/bin/gcc
+          CXX: /opt/rh/gcc-toolset-14/root/usr/bin/g++
           VCPKG_FEATURE_FLAGS: "binarycaching"
           VCPKG_BINARY_SOURCES: "clear;x-azblob,https://${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}.blob.core.windows.net/vcpkg-binaries,${{ secrets.AZURE_VCPKG_SAS_TOKEN }},readwrite"
         run: |
-          source /opt/rh/gcc-toolset-13/enable
+          source /opt/rh/gcc-toolset-14/enable
           cmake -S . -B cmakebuild -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DRESINSIGHT_INCLUDE_APPLICATION_UNIT_TESTS=true \
@@ -125,10 +125,10 @@ jobs:
 
       - name: Build
         run: |
-          source /opt/rh/gcc-toolset-13/enable
+          source /opt/rh/gcc-toolset-14/enable
           cmake --build cmakebuild --target ResInsight-tests -- -j$(nproc)
 
       - name: Run Unit Tests
         run: |
-          source /opt/rh/gcc-toolset-13/enable
+          source /opt/rh/gcc-toolset-14/enable
           ./cmakebuild/ResInsight-tests

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -87,8 +87,8 @@ jobs:
             --disable-libstdcxx-pch \
             --with-gxx-include-dir=/opt/rh/gcc-toolset-14/root/usr/include/c++/${GCC_VERSION}
 
-          # Build only the experimental library
-          make -C src/experimental -j$(nproc)
+          # Build dependencies and experimental library
+          make -j$(nproc)
 
           # Install the library
           mkdir -p /opt/libstdcxx-exp/lib

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -1,0 +1,112 @@
+name: RHEL8 Unit Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 2am UTC
+    - cron: "0 2 * * *"
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  rhel8-build-and-test:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.access.redhat.com/ubi8/ubi:latest
+
+    steps:
+      - name: Install EPEL and development tools
+        run: |
+          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+          dnf config-manager --set-enabled codeready-builder-for-rhel-8-x86_64-rpms || true
+          dnf install -y dnf-plugins-core
+          dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled codeready-builder-for-rhel-8-$(arch)-rpms || true
+          dnf groupinstall -y "Development Tools"
+          dnf install -y \
+            cmake \
+            ninja-build \
+            git \
+            curl \
+            zip \
+            unzip \
+            tar \
+            pkg-config \
+            perl \
+            which \
+            python39 \
+            python39-devel \
+            python39-pip \
+            mesa-libGL-devel \
+            mesa-libEGL-devel \
+            libxkbcommon-devel \
+            libxkbcommon-x11-devel \
+            xcb-util-keysyms-devel \
+            xcb-util-image-devel \
+            xcb-util-wm-devel \
+            xcb-util-renderutil-devel \
+            fontconfig-devel \
+            freetype-devel \
+            libX11-devel \
+            libXext-devel \
+            libXrender-devel
+
+      - name: Install GCC Toolset 13
+        run: |
+          dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        run: |
+          alternatives --set python3 /usr/bin/python3.9
+          python3 --version
+          python3 -m pip install --upgrade pip
+          python3 -m pip install grpcio-tools
+
+      - name: Get Python executable path
+        id: python-path
+        run: |
+          echo "PYTHON_EXECUTABLE=$(python3 -c 'import sys; import pathlib; print(pathlib.PurePath(sys.executable).as_posix())')" >> $GITHUB_OUTPUT
+
+      - name: Install Qt 6 using aqtinstall
+        run: |
+          python3 -m pip install aqtinstall
+          python3 -m aqt install-qt linux desktop 6.6.3 gcc_64 -O /opt/Qt --modules qtnetworkauth
+          echo "Qt6_DIR=/opt/Qt/6.6.3/gcc_64" >> $GITHUB_ENV
+          echo "CMAKE_PREFIX_PATH=/opt/Qt/6.6.3/gcc_64" >> $GITHUB_ENV
+          echo "/opt/Qt/6.6.3/gcc_64/bin" >> $GITHUB_PATH
+
+      - name: Bootstrap vcpkg
+        run: |
+          source /opt/rh/gcc-toolset-13/enable
+          cd ThirdParty/vcpkg
+          ./bootstrap-vcpkg.sh
+
+      - name: Configure CMake
+        env:
+          CC: /opt/rh/gcc-toolset-13/root/usr/bin/gcc
+          CXX: /opt/rh/gcc-toolset-13/root/usr/bin/g++
+        run: |
+          source /opt/rh/gcc-toolset-13/enable
+          cmake -S . -B cmakebuild -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DRESINSIGHT_INCLUDE_APPLICATION_UNIT_TESTS=true \
+            -DRESINSIGHT_ENABLE_UNITY_BUILD=true \
+            -DRESINSIGHT_ENABLE_HDF5=false \
+            -DRESINSIGHT_ENABLE_GRPC=false \
+            -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+      - name: Build
+        run: |
+          source /opt/rh/gcc-toolset-13/enable
+          cmake --build cmakebuild --target ResInsight-tests -- -j$(nproc)
+
+      - name: Run Unit Tests
+        run: |
+          source /opt/rh/gcc-toolset-13/enable
+          ./cmakebuild/ResInsight-tests

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -59,6 +59,39 @@ jobs:
         run: |
           dnf install -y gcc-toolset-14 gcc-toolset-14-gcc-c++ gcc-toolset-14-libatomic-devel gcc-toolset-14-libstdc++-devel
 
+      - name: Build libstdc++exp
+        run: |
+          source /opt/rh/gcc-toolset-14/enable
+
+          # Get GCC version
+          GCC_VERSION=$(gcc -dumpversion)
+          echo "GCC version: $GCC_VERSION"
+
+          # Download GCC source
+          cd /tmp
+          curl -LO https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
+          tar xf gcc-${GCC_VERSION}.tar.xz
+
+          # Build libstdc++exp
+          mkdir -p gcc-${GCC_VERSION}/build-libstdcxx
+          cd gcc-${GCC_VERSION}/build-libstdcxx
+
+          ../libstdc++-v3/configure \
+            --prefix=/opt/libstdcxx-exp \
+            --disable-multilib \
+            --disable-libstdcxx-pch \
+            --with-gxx-include-dir=/opt/rh/gcc-toolset-14/root/usr/include/c++/${GCC_VERSION}
+
+          # Build only the experimental library
+          make -C src/experimental -j$(nproc)
+
+          # Install the library
+          mkdir -p /opt/libstdcxx-exp/lib
+          cp src/experimental/.libs/libstdc++exp.a /opt/libstdcxx-exp/lib/
+
+          echo "libstdc++exp built successfully"
+          ls -la /opt/libstdcxx-exp/lib/
+
       - name: Configure git safe directory
         run: |
           git config --global --add safe.directory '*'
@@ -121,7 +154,7 @@ jobs:
             -DRESINSIGHT_ENABLE_UNITY_BUILD=true \
             -DRESINSIGHT_ENABLE_HDF5=false \
             -DRESINSIGHT_ENABLE_GRPC=false \
-            -DRESINSIGHT_GCC_STDCPP_EXP_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64 \
+            -DRESINSIGHT_GCC_STDCPP_EXP_PATH=/opt/libstdcxx-exp/lib \
             -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake
 
       - name: Build

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -58,6 +58,10 @@ jobs:
         run: |
           dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++
 
+      - name: Configure git safe directory
+        run: |
+          git config --global --add safe.directory '*'
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           dnf install -y gcc-toolset-14 gcc-toolset-14-gcc-c++ gcc-toolset-14-libatomic-devel gcc-toolset-14-libstdc++-devel
 
-      - name: Build libstdc++exp
+      - name: Build libstdc++ with backtrace support
         run: |
           source /opt/rh/gcc-toolset-14/enable
 
@@ -72,29 +72,51 @@ jobs:
           echo "GCC full version: $GCC_FULL_VERSION"
           echo "GCC download version: $GCC_VERSION"
 
+          # Install additional dependencies for backtrace support
+          dnf install -y gmp-devel mpfr-devel libmpc-devel libunwind libunwind-devel elfutils-libelf-devel
+
           # Download GCC source
           cd /tmp
           curl -LO https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
           tar xf gcc-${GCC_VERSION}.tar.xz
 
-          # Build libstdc++exp
-          mkdir -p gcc-${GCC_VERSION}/build-libstdcxx
-          cd gcc-${GCC_VERSION}/build-libstdcxx
+          # Download prerequisites
+          cd gcc-${GCC_VERSION}
+          ./contrib/download_prerequisites
+          cd ..
 
-          ../libstdc++-v3/configure \
-            --prefix=/opt/libstdcxx-exp \
+          # Configure GCC build with backtrace support
+          mkdir -p gcc-${GCC_VERSION}-build
+          cd gcc-${GCC_VERSION}-build
+
+          ../gcc-${GCC_VERSION}/configure \
+            --prefix=/opt/gcc-${GCC_VERSION} \
+            --enable-languages=c++ \
             --disable-multilib \
-            --disable-libstdcxx-pch \
-            --with-gxx-include-dir=/opt/rh/gcc-toolset-14/root/usr/include/c++/${GCC_VERSION}
+            --with-system-zlib \
+            --disable-bootstrap \
+            --enable-libstdcxx-backtrace \
+            --enable-__cxa_atexit \
+            --with-libunwind
 
-          # Build dependencies and experimental library
-          make -j$(nproc)
+          # Build just enough of GCC to get libstdc++
+          echo "Building basic GCC components..."
+          make -j$(nproc) all-gcc
 
-          # Install the library
+          # Build libstdc++ with backtrace support
+          echo "Building libstdc++ with backtrace support..."
+          make -j$(nproc) all-target-libstdc++-v3
+
+          # Install libstdc++
+          echo "Installing libstdc++..."
+          make install-target-libstdc++-v3
+
+          # Copy libstdc++exp.a to expected location
           mkdir -p /opt/libstdcxx-exp/lib
-          cp src/experimental/.libs/libstdc++exp.a /opt/libstdcxx-exp/lib/
+          cp /opt/gcc-${GCC_VERSION}/lib64/libstdc++exp.a /opt/libstdcxx-exp/lib/
 
-          echo "libstdc++exp built successfully"
+          echo "libstdc++ with backtrace support built successfully"
+          ls -la /opt/gcc-${GCC_VERSION}/lib64/
           ls -la /opt/libstdcxx-exp/lib/
 
       - name: Configure git safe directory

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -53,7 +53,8 @@ jobs:
             libXext-devel \
             libXrender-devel \
             flex \
-            bison
+            bison \
+            xz
 
       - name: Install GCC Toolset 14
         run: |
@@ -63,9 +64,13 @@ jobs:
         run: |
           source /opt/rh/gcc-toolset-14/enable
 
-          # Get GCC version
-          GCC_VERSION=$(gcc -dumpversion)
-          echo "GCC version: $GCC_VERSION"
+          # Get full GCC version (e.g., 14.2.1)
+          GCC_FULL_VERSION=$(gcc -dumpfullversion)
+          # Get major.minor version for download (e.g., 14.2.0 - releases use .0 patch)
+          GCC_MAJOR_MINOR=$(echo $GCC_FULL_VERSION | cut -d. -f1,2)
+          GCC_VERSION="${GCC_MAJOR_MINOR}.0"
+          echo "GCC full version: $GCC_FULL_VERSION"
+          echo "GCC download version: $GCC_VERSION"
 
           # Download GCC source
           cd /tmp

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install GCC Toolset 13
         run: |
-          dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
+          dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel gcc-toolset-13-libstdc++-devel
 
       - name: Configure git safe directory
         run: |

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -50,7 +50,9 @@ jobs:
             freetype-devel \
             libX11-devel \
             libXext-devel \
-            libXrender-devel
+            libXrender-devel \
+            flex \
+            bison
 
       - name: Install GCC Toolset 13
         run: |

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -87,10 +87,25 @@ jobs:
           cd ThirdParty/vcpkg
           ./bootstrap-vcpkg.sh
 
+      - name: Check vcpkg secrets
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}" ]; then
+            echo "Error: AZURE_VCPKG_STORAGE_ACCOUNT secret is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.AZURE_VCPKG_SAS_TOKEN }}" ]; then
+            echo "Error: AZURE_VCPKG_SAS_TOKEN secret is not set"
+            exit 1
+          fi
+          echo "All required vcpkg secrets are present"
+
       - name: Configure CMake
         env:
           CC: /opt/rh/gcc-toolset-13/root/usr/bin/gcc
           CXX: /opt/rh/gcc-toolset-13/root/usr/bin/g++
+          VCPKG_FEATURE_FLAGS: "binarycaching"
+          VCPKG_BINARY_SOURCES: "clear;x-azblob,https://${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}.blob.core.windows.net/vcpkg-binaries,${{ secrets.AZURE_VCPKG_SAS_TOKEN }},readwrite"
         run: |
           source /opt/rh/gcc-toolset-13/enable
           cmake -S . -B cmakebuild -G Ninja \

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -39,6 +39,7 @@ jobs:
             python39-devel \
             python39-pip \
             mesa-libGL-devel \
+            mesa-libGLU-devel \
             mesa-libEGL-devel \
             libxkbcommon-devel \
             libxkbcommon-x11-devel \

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install GCC Toolset 13
         run: |
-          dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++
+          dnf install -y gcc-toolset-13 gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
 
       - name: Configure git safe directory
         run: |

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
             flex \
             bison
 
-      - name: Install GCC Toolset 13
+      - name: Install GCC Toolset 14
         run: |
           dnf install -y gcc-toolset-14 gcc-toolset-14-gcc-c++ gcc-toolset-14-libatomic-devel gcc-toolset-14-libstdc++-devel
 
@@ -121,6 +121,7 @@ jobs:
             -DRESINSIGHT_ENABLE_UNITY_BUILD=true \
             -DRESINSIGHT_ENABLE_HDF5=false \
             -DRESINSIGHT_ENABLE_GRPC=false \
+            -DRESINSIGHT_GCC_STDCPP_EXP_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64 \
             -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake
 
       - name: Build

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Install EPEL and development tools
         run: |
           dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-          dnf config-manager --set-enabled codeready-builder-for-rhel-8-x86_64-rpms || true
-          dnf install -y dnf-plugins-core
-          dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled codeready-builder-for-rhel-8-$(arch)-rpms || true
-          dnf groupinstall -y "Development Tools"
+          /usr/bin/crb enable || true
           dnf install -y \
+            gcc \
+            gcc-c++ \
+            make \
             cmake \
             ninja-build \
             git \

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -14,13 +14,13 @@ jobs:
   rhel8-build-and-test:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/ubi:latest
+      image: rockylinux:8
 
     steps:
       - name: Install EPEL and development tools
         run: |
-          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-          /usr/bin/crb enable || true
+          dnf install -y epel-release
+          dnf config-manager --set-enabled powertools
           dnf install -y \
             gcc \
             gcc-c++ \
@@ -32,7 +32,7 @@ jobs:
             zip \
             unzip \
             tar \
-            pkg-config \
+            pkgconfig \
             perl \
             which \
             python39 \


### PR DESCRIPTION
## Summary
- Build full libstdc++ from GCC source with backtrace support enabled
- Adds dependencies for backtrace: libunwind, elfutils-libelf-devel, gmp-devel, mpfr-devel, libmpc-devel
- Uses `--enable-libstdcxx-backtrace` configure flag for std::stacktrace support

## Test plan
- [ ] Verify workflow completes successfully
- [ ] Verify libstdc++exp.a is built with backtrace support
- [ ] Verify unit tests pass