### PR TITLE
Improve performance for summary vector addresses

### DIFF
--- a/ApplicationLibCode/Application/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Application/CMakeLists_files.cmake
@@ -23,6 +23,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaEclipseFileNameTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaFeatureCommandContext.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaStringListSerializer.h
+    ${CMAKE_CURRENT_LIST_DIR}/RiaStringPool.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaNncDefines.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaPlotDefines.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaStimPlanModelDefines.h
@@ -67,6 +68,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaEclipseFileNameTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaFeatureCommandContext.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaStringListSerializer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaStringPool.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaNncDefines.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaPlotDefines.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaStimPlanModelDefines.cpp

--- a/ApplicationLibCode/Application/RiaStringPool.cpp
+++ b/ApplicationLibCode/Application/RiaStringPool.cpp
@@ -1,0 +1,87 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RiaStringPool.h"
+
+#include <mutex>
+#include <stdexcept>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaStringPool& RiaStringPool::instance()
+{
+    static RiaStringPool pool;
+    return pool;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaStringPool::RiaStringPool()
+{
+    // Pre-allocate empty string at index 0
+    m_strings.push_back( "" );
+    m_stringToIndex[""] = 0;
+    m_emptyIndex        = 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaStringPool::IndexType RiaStringPool::getIndex( const std::string& str )
+{
+    // First try with shared lock for reading
+    {
+        std::shared_lock<std::shared_mutex> lock( m_mutex );
+        auto                                it = m_stringToIndex.find( str );
+        if ( it != m_stringToIndex.end() )
+        {
+            return it->second;
+        }
+    }
+
+    // Need to insert, acquire exclusive lock
+    std::unique_lock<std::shared_mutex> lock( m_mutex );
+
+    // Double-check after acquiring exclusive lock (another thread might have inserted it)
+    auto it = m_stringToIndex.find( str );
+    if ( it != m_stringToIndex.end() )
+    {
+        return it->second;
+    }
+
+    IndexType newIndex = static_cast<IndexType>( m_strings.size() );
+    m_strings.push_back( str );
+    m_stringToIndex[m_strings.back()] = newIndex;
+    return newIndex;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+const std::string& RiaStringPool::getString( IndexType index ) const
+{
+    std::shared_lock<std::shared_mutex> lock( m_mutex );
+
+    if ( index >= m_strings.size() )
+    {
+        throw std::out_of_range( "String pool index out of range" );
+    }
+    return m_strings[index];
+}

--- a/ApplicationLibCode/Application/RiaStringPool.h
+++ b/ApplicationLibCode/Application/RiaStringPool.h
@@ -1,0 +1,57 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstdint>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+//==================================================================================================
+/// String pool for memory-efficient storage of shared strings
+/// Stores strings once and returns indices for lookups
+//==================================================================================================
+class RiaStringPool
+{
+public:
+    using IndexType                          = uint32_t;
+    static constexpr IndexType INVALID_INDEX = static_cast<IndexType>( -1 );
+
+    static RiaStringPool& instance();
+
+    // Get or create an index for a string
+    IndexType getIndex( const std::string& str );
+
+    // Get string by index
+    const std::string& getString( IndexType index ) const;
+
+    // Get empty string index
+    IndexType getEmptyIndex() const { return m_emptyIndex; }
+
+private:
+    RiaStringPool();
+    RiaStringPool( const RiaStringPool& )            = delete;
+    RiaStringPool& operator=( const RiaStringPool& ) = delete;
+
+    mutable std::shared_mutex                  m_mutex;
+    std::vector<std::string>                   m_strings;
+    std::unordered_map<std::string, IndexType> m_stringToIndex;
+    IndexType                                  m_emptyIndex;
+};

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryAddress.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryAddress.cpp
@@ -21,6 +21,7 @@
 #include "RiaStdStringTools.h"
 #include "RiaTextStringTools.h"
 
+#include "RiaStringPool.h"
 #include "RifEclEclipseSummary.h"
 #include "RiuSummaryQuantityNameInfoProvider.h"
 
@@ -35,6 +36,9 @@
 RifEclipseSummaryAddress::RifEclipseSummaryAddress( SummaryCategory category, std::map<SummaryIdentifierType, std::string>& identifiers )
     : m_category( category )
     , m_statisticsType( StatisticsType::NONE )
+    , m_vectorNameIdx( RiaStringPool::instance().getEmptyIndex() )
+    , m_nameIdx( RiaStringPool::instance().getEmptyIndex() )
+    , m_lgrNameIdx( RiaStringPool::instance().getEmptyIndex() )
     , m_number0( -1 )
     , m_number1( -1 )
     , m_number2( -1 )
@@ -53,40 +57,40 @@ RifEclipseSummaryAddress::RifEclipseSummaryAddress( SummaryCategory category, st
             m_number1   = reg2regPair.second;
             break;
         case SummaryCategory::SUMMARY_GROUP:
-            m_name = identifiers[SummaryIdentifierType::INPUT_GROUP_NAME];
+            m_nameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_GROUP_NAME] );
             break;
         case SummaryCategory::SUMMARY_NETWORK:
-            m_name = identifiers[SummaryIdentifierType::INPUT_NETWORK_NAME];
+            m_nameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_NETWORK_NAME] );
             break;
         case SummaryCategory::SUMMARY_WELL:
-            m_name = identifiers[SummaryIdentifierType::INPUT_WELL_NAME];
+            m_nameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_WELL_NAME] );
             break;
         case SummaryCategory::SUMMARY_WELL_COMPLETION:
-            m_name    = identifiers[SummaryIdentifierType::INPUT_WELL_NAME];
+            m_nameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_WELL_NAME] );
             m_number0 = RiaStdStringTools::toInt( identifiers[SummaryIdentifierType::INPUT_WELL_COMPLETION_NUMBER] );
             break;
         case SummaryCategory::SUMMARY_WELL_CONNECTION:
-            m_name = identifiers[SummaryIdentifierType::INPUT_WELL_NAME];
+            m_nameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_WELL_NAME] );
             setCellIjk( ijkTupleFromUiText( identifiers[SummaryIdentifierType::INPUT_CELL_IJK] ) );
             break;
         case SummaryCategory::SUMMARY_WELL_LGR:
-            m_lgrName = identifiers[SummaryIdentifierType::INPUT_LGR_NAME];
-            m_name    = identifiers[SummaryIdentifierType::INPUT_WELL_NAME];
+            m_lgrNameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_LGR_NAME] );
+            m_nameIdx    = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_WELL_NAME] );
             break;
         case SummaryCategory::SUMMARY_WELL_CONNECTION_LGR:
-            m_lgrName = identifiers[SummaryIdentifierType::INPUT_LGR_NAME];
-            m_name    = identifiers[SummaryIdentifierType::INPUT_WELL_NAME];
+            m_lgrNameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_LGR_NAME] );
+            m_nameIdx    = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_WELL_NAME] );
             setCellIjk( ijkTupleFromUiText( identifiers[SummaryIdentifierType::INPUT_CELL_IJK] ) );
             break;
         case SummaryCategory::SUMMARY_WELL_SEGMENT:
-            m_name    = identifiers[SummaryIdentifierType::INPUT_WELL_NAME];
+            m_nameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_WELL_NAME] );
             m_number0 = RiaStdStringTools::toInt( identifiers[SummaryIdentifierType::INPUT_SEGMENT_NUMBER] );
             break;
         case SummaryCategory::SUMMARY_BLOCK:
             setCellIjk( ijkTupleFromUiText( identifiers[SummaryIdentifierType::INPUT_CELL_IJK] ) );
             break;
         case SummaryCategory::SUMMARY_BLOCK_LGR:
-            m_lgrName = identifiers[SummaryIdentifierType::INPUT_LGR_NAME];
+            m_lgrNameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_LGR_NAME] );
             setCellIjk( ijkTupleFromUiText( identifiers[SummaryIdentifierType::INPUT_CELL_IJK] ) );
             break;
         case SummaryCategory::SUMMARY_AQUIFER:
@@ -94,8 +98,8 @@ RifEclipseSummaryAddress::RifEclipseSummaryAddress( SummaryCategory category, st
             break;
     }
 
-    m_vectorName = identifiers[SummaryIdentifierType::INPUT_VECTOR_NAME];
-    m_id         = RiaStdStringTools::toInt( identifiers[SummaryIdentifierType::INPUT_ID] );
+    m_vectorNameIdx = RiaStringPool::instance().getIndex( identifiers[SummaryIdentifierType::INPUT_VECTOR_NAME] );
+    m_id            = RiaStdStringTools::toInt( identifiers[SummaryIdentifierType::INPUT_ID] );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -120,8 +124,9 @@ RifEclipseSummaryAddress::RifEclipseSummaryAddress( SummaryCategory    category,
                                                     int                id )
     : m_category( category )
     , m_statisticsType( statisticsType )
-    , m_vectorName( vectorName )
-    , m_lgrName( lgrName )
+    , m_vectorNameIdx( RiaStringPool::instance().getIndex( vectorName ) )
+    , m_nameIdx( RiaStringPool::instance().getEmptyIndex() )
+    , m_lgrNameIdx( RiaStringPool::instance().getIndex( lgrName ) )
     , m_number0( -1 )
     , m_number1( -1 )
     , m_number2( -1 )
@@ -138,31 +143,31 @@ RifEclipseSummaryAddress::RifEclipseSummaryAddress( SummaryCategory    category,
             m_number1 = regionNumber2;
             break;
         case SummaryCategory::SUMMARY_GROUP:
-            m_name = groupName;
+            m_nameIdx = RiaStringPool::instance().getIndex( groupName );
             break;
         case SummaryCategory::SUMMARY_NETWORK:
-            m_name = networkName;
+            m_nameIdx = RiaStringPool::instance().getIndex( networkName );
             break;
         case SummaryCategory::SUMMARY_WELL:
-            m_name = wellName;
+            m_nameIdx = RiaStringPool::instance().getIndex( wellName );
             break;
         case SummaryCategory::SUMMARY_WELL_COMPLETION:
-            m_name    = wellName;
+            m_nameIdx = RiaStringPool::instance().getIndex( wellName );
             m_number0 = completionNumber;
             break;
         case SummaryCategory::SUMMARY_WELL_CONNECTION:
-            m_name = wellName;
+            m_nameIdx = RiaStringPool::instance().getIndex( wellName );
             setCellIjk( cellI, cellJ, cellK );
             break;
         case SummaryCategory::SUMMARY_WELL_LGR:
-            m_name = wellName;
+            m_nameIdx = RiaStringPool::instance().getIndex( wellName );
             break;
         case SummaryCategory::SUMMARY_WELL_CONNECTION_LGR:
-            m_name = wellName;
+            m_nameIdx = RiaStringPool::instance().getIndex( wellName );
             setCellIjk( cellI, cellJ, cellK );
             break;
         case SummaryCategory::SUMMARY_WELL_SEGMENT:
-            m_name    = wellName;
+            m_nameIdx = RiaStringPool::instance().getIndex( wellName );
             m_number0 = wellSegmentNumber;
             break;
         case SummaryCategory::SUMMARY_BLOCK:
@@ -183,6 +188,9 @@ RifEclipseSummaryAddress::RifEclipseSummaryAddress( SummaryCategory    category,
 RifEclipseSummaryAddress::RifEclipseSummaryAddress()
     : m_category( SummaryCategory::SUMMARY_INVALID )
     , m_statisticsType( StatisticsType::NONE )
+    , m_vectorNameIdx( RiaStringPool::instance().getEmptyIndex() )
+    , m_nameIdx( RiaStringPool::instance().getEmptyIndex() )
+    , m_lgrNameIdx( RiaStringPool::instance().getEmptyIndex() )
     , m_number0( -1 )
     , m_number1( -1 )
     , m_number2( -1 )
@@ -240,9 +248,9 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::fromEclipseTextAddress( const
 RifEclipseSummaryAddress RifEclipseSummaryAddress::fieldAddress( const std::string& vectorName, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_FIELD;
-    addr.m_vectorName = vectorName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_FIELD;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -252,10 +260,10 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::fieldAddress( const std::stri
 RifEclipseSummaryAddress RifEclipseSummaryAddress::aquiferAddress( const std::string& vectorName, int aquiferNumber, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_AQUIFER;
-    addr.m_vectorName = vectorName;
-    addr.m_number0    = aquiferNumber;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_AQUIFER;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_number0       = aquiferNumber;
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -266,10 +274,10 @@ RifEclipseSummaryAddress
     RifEclipseSummaryAddress::networkAddress( const std::string& vectorName, const std::string& networkName, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_NETWORK;
-    addr.m_vectorName = vectorName;
-    addr.m_name       = networkName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_NETWORK;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( networkName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -279,9 +287,9 @@ RifEclipseSummaryAddress
 RifEclipseSummaryAddress RifEclipseSummaryAddress::miscAddress( const std::string& vectorName, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_MISC;
-    addr.m_vectorName = vectorName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_MISC;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -291,10 +299,10 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::miscAddress( const std::strin
 RifEclipseSummaryAddress RifEclipseSummaryAddress::regionAddress( const std::string& vectorName, int regionNumber, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_REGION;
-    addr.m_vectorName = vectorName;
-    addr.m_number0    = regionNumber;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_REGION;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_number0       = regionNumber;
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -305,11 +313,11 @@ RifEclipseSummaryAddress
     RifEclipseSummaryAddress::regionToRegionAddress( const std::string& vectorName, int regionNumber, int region2Number, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_REGION_2_REGION;
-    addr.m_vectorName = vectorName;
-    addr.m_number0    = regionNumber;
-    addr.m_number1    = region2Number;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_REGION_2_REGION;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_number0       = regionNumber;
+    addr.m_number1       = region2Number;
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -319,10 +327,10 @@ RifEclipseSummaryAddress
 RifEclipseSummaryAddress RifEclipseSummaryAddress::groupAddress( const std::string& vectorName, const std::string& groupName, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_GROUP;
-    addr.m_vectorName = vectorName;
-    addr.m_name       = groupName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_GROUP;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( groupName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -332,10 +340,10 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::groupAddress( const std::stri
 RifEclipseSummaryAddress RifEclipseSummaryAddress::wellAddress( const std::string& vectorName, const std::string& wellName, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_WELL;
-    addr.m_vectorName = vectorName;
-    addr.m_name       = wellName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_WELL;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( wellName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -348,11 +356,11 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::wellCompletionAddress( const 
                                                                           int                calculationId /*= -1 */ )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_WELL_COMPLETION;
-    addr.m_vectorName = vectorName;
-    addr.m_name       = wellName;
-    addr.m_number0    = completionNumber;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_WELL_COMPLETION;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( wellName );
+    addr.m_number0       = completionNumber;
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -363,9 +371,9 @@ RifEclipseSummaryAddress
     RifEclipseSummaryAddress::wellConnectionAddress( const std::string& vectorName, const std::string& wellName, int i, int j, int k, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_WELL_CONNECTION;
-    addr.m_vectorName = vectorName;
-    addr.m_name       = wellName;
+    addr.m_category      = SummaryCategory::SUMMARY_WELL_CONNECTION;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( wellName );
     addr.setCellIjk( i, j, k );
     addr.m_id = calculationId;
     return addr;
@@ -380,11 +388,11 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::wellLgrAddress( const std::st
                                                                    int                calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_WELL_LGR;
-    addr.m_vectorName = vectorName;
-    addr.m_lgrName    = lgrName;
-    addr.m_name       = wellName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_WELL_LGR;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_lgrNameIdx    = RiaStringPool::instance().getIndex( lgrName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( wellName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -400,10 +408,10 @@ RifEclipseSummaryAddress RifEclipseSummaryAddress::wellCompletionLgrAddress( con
                                                                              int                calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_WELL_CONNECTION_LGR;
-    addr.m_vectorName = vectorName;
-    addr.m_lgrName    = lgrName;
-    addr.m_name       = wellName;
+    addr.m_category      = SummaryCategory::SUMMARY_WELL_CONNECTION_LGR;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_lgrNameIdx    = RiaStringPool::instance().getIndex( lgrName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( wellName );
     addr.setCellIjk( i, j, k );
     addr.m_id = calculationId;
     return addr;
@@ -416,11 +424,11 @@ RifEclipseSummaryAddress
     RifEclipseSummaryAddress::wellSegmentAddress( const std::string& vectorName, const std::string& wellName, int segmentNumber, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_WELL_SEGMENT;
-    addr.m_vectorName = vectorName;
-    addr.m_name       = wellName;
-    addr.m_number0    = segmentNumber;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_WELL_SEGMENT;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_nameIdx       = RiaStringPool::instance().getIndex( wellName );
+    addr.m_number0       = segmentNumber;
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -430,8 +438,8 @@ RifEclipseSummaryAddress
 RifEclipseSummaryAddress RifEclipseSummaryAddress::blockAddress( const std::string& vectorName, int i, int j, int k, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_BLOCK;
-    addr.m_vectorName = vectorName;
+    addr.m_category      = SummaryCategory::SUMMARY_BLOCK;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
     addr.setCellIjk( i, j, k );
     addr.m_id = calculationId;
     return addr;
@@ -444,9 +452,9 @@ RifEclipseSummaryAddress
     RifEclipseSummaryAddress::blockLgrAddress( const std::string& vectorName, const std::string& lgrName, int i, int j, int k, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_BLOCK_LGR;
-    addr.m_vectorName = vectorName;
-    addr.m_lgrName    = lgrName;
+    addr.m_category      = SummaryCategory::SUMMARY_BLOCK_LGR;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_lgrNameIdx    = RiaStringPool::instance().getIndex( lgrName );
     addr.setCellIjk( i, j, k );
     addr.m_id = calculationId;
     return addr;
@@ -458,9 +466,9 @@ RifEclipseSummaryAddress
 RifEclipseSummaryAddress RifEclipseSummaryAddress::importedAddress( const std::string& vectorName, int calculationId )
 {
     RifEclipseSummaryAddress addr;
-    addr.m_category   = SummaryCategory::SUMMARY_IMPORTED;
-    addr.m_vectorName = vectorName;
-    addr.m_id         = calculationId;
+    addr.m_category      = SummaryCategory::SUMMARY_IMPORTED;
+    addr.m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
+    addr.m_id            = calculationId;
     return addr;
 }
 
@@ -520,7 +528,7 @@ SummaryCategory RifEclipseSummaryAddress::category() const
 //--------------------------------------------------------------------------------------------------
 std::string RifEclipseSummaryAddress::vectorName() const
 {
-    return m_vectorName;
+    return RiaStringPool::instance().getString( m_vectorNameIdx );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -530,7 +538,9 @@ bool RifEclipseSummaryAddress::isHistoryVector() const
 {
     const std::string historyIdentifier = "H";
 
-    return RiaStdStringTools::endsWith( m_vectorName, historyIdentifier );
+    // Optimize by using direct pool access and const reference
+    const auto& vecName = RiaStringPool::instance().getString( m_vectorNameIdx );
+    return RiaStdStringTools::endsWith( vecName, historyIdentifier );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -554,7 +564,7 @@ int RifEclipseSummaryAddress::regionNumber2() const
 //--------------------------------------------------------------------------------------------------
 std::string RifEclipseSummaryAddress::groupName() const
 {
-    return ( m_category == SummaryCategory::SUMMARY_GROUP ) ? m_name : std::string();
+    return ( m_category == SummaryCategory::SUMMARY_GROUP ) ? RiaStringPool::instance().getString( m_nameIdx ) : std::string();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -562,7 +572,7 @@ std::string RifEclipseSummaryAddress::groupName() const
 //--------------------------------------------------------------------------------------------------
 std::string RifEclipseSummaryAddress::networkName() const
 {
-    return ( m_category == SummaryCategory::SUMMARY_NETWORK ) ? m_name : std::string();
+    return ( m_category == SummaryCategory::SUMMARY_NETWORK ) ? RiaStringPool::instance().getString( m_nameIdx ) : std::string();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -570,7 +580,7 @@ std::string RifEclipseSummaryAddress::networkName() const
 //--------------------------------------------------------------------------------------------------
 std::string RifEclipseSummaryAddress::wellName() const
 {
-    return isDependentOnWellName( m_category ) ? m_name : std::string();
+    return isDependentOnWellName( m_category ) ? RiaStringPool::instance().getString( m_nameIdx ) : std::string();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -594,7 +604,7 @@ int RifEclipseSummaryAddress::wellSegmentNumber() const
 //--------------------------------------------------------------------------------------------------
 std::string RifEclipseSummaryAddress::lgrName() const
 {
-    return m_lgrName;
+    return RiaStringPool::instance().getString( m_lgrNameIdx );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -649,7 +659,7 @@ std::string RifEclipseSummaryAddress::uiText() const
 
     if ( m_isErrorResult ) text += "ERR:";
 
-    text += m_vectorName;
+    text += vectorName();
 
     std::string itemText = itemUiText();
     if ( !itemText.empty() )
@@ -765,9 +775,9 @@ std::string RifEclipseSummaryAddress::toEclipseTextAddress() const
 {
     std::string noVectorName = itemUiText();
     if ( noVectorName.empty() )
-        return m_vectorName;
+        return vectorName();
     else
-        return m_vectorName + ":" + noVectorName;
+        return vectorName() + ":" + noVectorName;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -782,15 +792,15 @@ std::string RifEclipseSummaryAddress::addressComponentUiText( SummaryIdentifierT
         case SummaryIdentifierType::INPUT_REGION_2_REGION:
             return formatUiTextRegionToRegion();
         case SummaryIdentifierType::INPUT_WELL_NAME:
-            return m_name;
+            return RiaStringPool::instance().getString( m_nameIdx );
         case SummaryIdentifierType::INPUT_GROUP_NAME:
-            return m_name;
+            return RiaStringPool::instance().getString( m_nameIdx );
         case SummaryIdentifierType::INPUT_NETWORK_NAME:
-            return m_name;
+            return RiaStringPool::instance().getString( m_nameIdx );
         case SummaryIdentifierType::INPUT_CELL_IJK:
             return blockAsString();
         case SummaryIdentifierType::INPUT_LGR_NAME:
-            return m_lgrName;
+            return RiaStringPool::instance().getString( m_lgrNameIdx );
         case SummaryIdentifierType::INPUT_SEGMENT_NUMBER:
             return std::to_string( wellSegmentNumber() );
         case SummaryIdentifierType::INPUT_WELL_COMPLETION_NUMBER:
@@ -798,7 +808,7 @@ std::string RifEclipseSummaryAddress::addressComponentUiText( SummaryIdentifierT
         case SummaryIdentifierType::INPUT_AQUIFER_NUMBER:
             return std::to_string( aquiferNumber() );
         case SummaryIdentifierType::INPUT_VECTOR_NAME:
-            return m_vectorName;
+            return RiaStringPool::instance().getString( m_vectorNameIdx );
         case SummaryIdentifierType::INPUT_ID:
             return std::to_string( id() );
     }
@@ -825,7 +835,7 @@ bool RifEclipseSummaryAddress::isUiTextMatchingFilterText( const QString& filter
 //--------------------------------------------------------------------------------------------------
 bool RifEclipseSummaryAddress::isValid() const
 {
-    if ( m_vectorName.empty() ) return false;
+    if ( RiaStringPool::instance().getString( m_vectorNameIdx ).empty() ) return false;
 
     switch ( category() )
     {
@@ -840,36 +850,36 @@ bool RifEclipseSummaryAddress::isValid() const
             return m_number1 != -1;
 
         case SummaryCategory::SUMMARY_GROUP:
-            return !m_name.empty();
+            return !RiaStringPool::instance().getString( m_nameIdx ).empty();
 
         case SummaryCategory::SUMMARY_WELL:
-            return !m_name.empty();
+            return !RiaStringPool::instance().getString( m_nameIdx ).empty();
 
         case SummaryCategory::SUMMARY_WELL_COMPLETION:
-            if ( m_name.empty() ) return false;
+            if ( RiaStringPool::instance().getString( m_nameIdx ).empty() ) return false;
             return m_number0 != -1;
 
         case SummaryCategory::SUMMARY_WELL_CONNECTION:
-            if ( m_name.empty() ) return false;
+            if ( RiaStringPool::instance().getString( m_nameIdx ).empty() ) return false;
             if ( m_number0 == -1 ) return false;
             if ( m_number1 == -1 ) return false;
             if ( m_number2 == -1 ) return false;
             return true;
 
         case SummaryCategory::SUMMARY_WELL_LGR:
-            if ( m_lgrName.empty() ) return false;
-            return !m_name.empty();
+            if ( RiaStringPool::instance().getString( m_lgrNameIdx ).empty() ) return false;
+            return !RiaStringPool::instance().getString( m_nameIdx ).empty();
 
         case SummaryCategory::SUMMARY_WELL_CONNECTION_LGR:
-            if ( m_lgrName.empty() ) return false;
-            if ( m_name.empty() ) return false;
+            if ( RiaStringPool::instance().getString( m_lgrNameIdx ).empty() ) return false;
+            if ( RiaStringPool::instance().getString( m_nameIdx ).empty() ) return false;
             if ( m_number0 == -1 ) return false;
             if ( m_number1 == -1 ) return false;
             if ( m_number2 == -1 ) return false;
             return true;
 
         case SummaryCategory::SUMMARY_WELL_SEGMENT:
-            if ( m_name.empty() ) return false;
+            if ( RiaStringPool::instance().getString( m_nameIdx ).empty() ) return false;
             return m_number0 != -1;
 
         case SummaryCategory::SUMMARY_BLOCK:
@@ -879,7 +889,7 @@ bool RifEclipseSummaryAddress::isValid() const
             return true;
 
         case SummaryCategory::SUMMARY_BLOCK_LGR:
-            if ( m_lgrName.empty() ) return false;
+            if ( RiaStringPool::instance().getString( m_lgrNameIdx ).empty() ) return false;
             if ( m_number0 == -1 ) return false;
             if ( m_number1 == -1 ) return false;
             if ( m_number2 == -1 ) return false;
@@ -897,7 +907,7 @@ bool RifEclipseSummaryAddress::isValid() const
 //--------------------------------------------------------------------------------------------------
 void RifEclipseSummaryAddress::setVectorName( const std::string& vectorName )
 {
-    m_vectorName = vectorName;
+    m_vectorNameIdx = RiaStringPool::instance().getIndex( vectorName );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -905,7 +915,7 @@ void RifEclipseSummaryAddress::setVectorName( const std::string& vectorName )
 //--------------------------------------------------------------------------------------------------
 void RifEclipseSummaryAddress::setWellName( const std::string& wellName )
 {
-    m_name = wellName;
+    m_nameIdx = RiaStringPool::instance().getIndex( wellName );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -913,7 +923,7 @@ void RifEclipseSummaryAddress::setWellName( const std::string& wellName )
 //--------------------------------------------------------------------------------------------------
 void RifEclipseSummaryAddress::setGroupName( const std::string& groupName )
 {
-    m_name = groupName;
+    m_nameIdx = RiaStringPool::instance().getIndex( groupName );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -921,7 +931,7 @@ void RifEclipseSummaryAddress::setGroupName( const std::string& groupName )
 //--------------------------------------------------------------------------------------------------
 void RifEclipseSummaryAddress::setNetworkName( const std::string& networkName )
 {
-    m_name = networkName;
+    m_nameIdx = RiaStringPool::instance().getIndex( networkName );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/FileInterface/RifEclipseSummaryAddress.h
+++ b/ApplicationLibCode/FileInterface/RifEclipseSummaryAddress.h
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>
@@ -179,9 +180,9 @@ private:
 
     SummaryCategory m_category;
     StatisticsType  m_statisticsType;
-    std::string     m_vectorName;
-    std::string     m_name;
-    std::string     m_lgrName;
+    uint32_t        m_vectorNameIdx;
+    uint32_t        m_nameIdx;
+    uint32_t        m_lgrNameIdx;
     int             m_number0;
     int             m_number1;
     int             m_number2;

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RifCsvDataTableFormatter-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryAddressAnalyzer-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaStdStringTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaStringPool-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaInterpolationTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifWellMeasurementReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaDateStringParser-Test.cpp

--- a/ApplicationLibCode/UnitTests/RiaStringPool-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaStringPool-Test.cpp
@@ -1,0 +1,349 @@
+#include "gtest/gtest.h"
+
+#include "RiaStringPool.h"
+
+#include <algorithm>
+#include <set>
+#include <thread>
+#include <vector>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, EmptyStringPreAllocated )
+{
+    auto& pool = RiaStringPool::instance();
+
+    auto emptyIndex = pool.getIndex( "" );
+    EXPECT_EQ( pool.getEmptyIndex(), emptyIndex );
+    EXPECT_EQ( "", pool.getString( emptyIndex ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, BasicStringStorage )
+{
+    auto& pool = RiaStringPool::instance();
+
+    std::string testStr = "FOPT";
+    auto        index   = pool.getIndex( testStr );
+
+    EXPECT_EQ( testStr, pool.getString( index ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, DuplicateStringsReturnSameIndex )
+{
+    auto& pool = RiaStringPool::instance();
+
+    std::string testStr = "WOPT:WELL1";
+    auto        index1  = pool.getIndex( testStr );
+    auto        index2  = pool.getIndex( testStr );
+    auto        index3  = pool.getIndex( testStr );
+
+    EXPECT_EQ( index1, index2 );
+    EXPECT_EQ( index2, index3 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, MultipleUniqueStrings )
+{
+    auto& pool = RiaStringPool::instance();
+
+    std::vector<std::string> testStrings = { "FOPT", "WOPT:WELL1", "GOPT:GROUP1", "BPR:10,20,30", "ROPR" };
+
+    std::vector<RiaStringPool::IndexType> indices;
+    for ( const auto& str : testStrings )
+    {
+        indices.push_back( pool.getIndex( str ) );
+    }
+
+    // All indices should be unique
+    std::set<RiaStringPool::IndexType> uniqueIndices( indices.begin(), indices.end() );
+    EXPECT_EQ( testStrings.size(), uniqueIndices.size() );
+
+    // Verify retrieval
+    for ( size_t i = 0; i < testStrings.size(); ++i )
+    {
+        EXPECT_EQ( testStrings[i], pool.getString( indices[i] ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, OutOfRangeThrows )
+{
+    auto& pool = RiaStringPool::instance();
+
+    // Attempt to access index far beyond current size
+    EXPECT_THROW( pool.getString( 9999999 ), std::out_of_range );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, ThreadSafety )
+{
+    auto& pool = RiaStringPool::instance();
+
+    const int numThreads       = 10;
+    const int stringsPerThread = 100;
+
+    std::vector<std::thread>                         threads;
+    std::vector<std::vector<RiaStringPool::IndexType>> threadResults( numThreads );
+
+    // Create threads that all add the same strings
+    for ( int t = 0; t < numThreads; ++t )
+    {
+        threads.emplace_back(
+            [&pool, &threadResults, t, stringsPerThread]()
+            {
+                for ( int i = 0; i < stringsPerThread; ++i )
+                {
+                    std::string str   = "STRING_" + std::to_string( i );
+                    auto        index = pool.getIndex( str );
+                    threadResults[t].push_back( index );
+                }
+            } );
+    }
+
+    // Wait for all threads to complete
+    for ( auto& thread : threads )
+    {
+        thread.join();
+    }
+
+    // Verify all threads got the same indices for the same strings
+    for ( int i = 1; i < numThreads; ++i )
+    {
+        EXPECT_EQ( threadResults[0].size(), threadResults[i].size() );
+        for ( size_t j = 0; j < threadResults[0].size(); ++j )
+        {
+            EXPECT_EQ( threadResults[0][j], threadResults[i][j] );
+        }
+    }
+
+    // Verify string retrieval
+    for ( int i = 0; i < stringsPerThread; ++i )
+    {
+        std::string expectedStr = "STRING_" + std::to_string( i );
+        auto        index       = threadResults[0][i];
+        EXPECT_EQ( expectedStr, pool.getString( index ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, LargeNumberOfStrings )
+{
+    auto& pool = RiaStringPool::instance();
+
+    const int                             numStrings = 10000;
+    std::vector<RiaStringPool::IndexType> indices;
+
+    // Add many unique strings
+    for ( int i = 0; i < numStrings; ++i )
+    {
+        std::string str = "VECTOR_" + std::to_string( i ) + "_DATA";
+        indices.push_back( pool.getIndex( str ) );
+    }
+
+    // Verify all can be retrieved
+    for ( int i = 0; i < numStrings; ++i )
+    {
+        std::string expectedStr = "VECTOR_" + std::to_string( i ) + "_DATA";
+        EXPECT_EQ( expectedStr, pool.getString( indices[i] ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, SpecialCharacters )
+{
+    auto& pool = RiaStringPool::instance();
+
+    std::vector<std::string> specialStrings = { "String with spaces",
+                                                "String:with:colons",
+                                                "String/with/slashes",
+                                                "String,with,commas",
+                                                "String-with-dashes",
+                                                "String_with_underscores",
+                                                "String.with.dots",
+                                                "String|with|pipes",
+                                                "String@with@at",
+                                                "String#with#hash" };
+
+    for ( const auto& str : specialStrings )
+    {
+        auto index = pool.getIndex( str );
+        EXPECT_EQ( str, pool.getString( index ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, VeryLongStrings )
+{
+    auto& pool = RiaStringPool::instance();
+
+    // Create a very long string
+    std::string longStr( 10000, 'A' );
+    longStr += "_UNIQUE";
+
+    auto index = pool.getIndex( longStr );
+    EXPECT_EQ( longStr, pool.getString( index ) );
+
+    // Verify same index on duplicate
+    auto index2 = pool.getIndex( longStr );
+    EXPECT_EQ( index, index2 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, ConcurrentInsertAndRead )
+{
+    auto& pool = RiaStringPool::instance();
+
+    const int numWriteThreads = 5;
+    const int numReadThreads  = 5;
+    const int stringsPerWrite = 50;
+
+    std::vector<std::thread> threads;
+
+    // Create strings in multiple write threads
+    for ( int t = 0; t < numWriteThreads; ++t )
+    {
+        threads.emplace_back(
+            [&pool, t, stringsPerWrite]()
+            {
+                for ( int i = 0; i < stringsPerWrite; ++i )
+                {
+                    std::string str = "WRITE_" + std::to_string( t ) + "_" + std::to_string( i );
+                    pool.getIndex( str );
+                }
+            } );
+    }
+
+    // Read strings concurrently
+    for ( int t = 0; t < numReadThreads; ++t )
+    {
+        threads.emplace_back(
+            [&pool, t, stringsPerWrite]()
+            {
+                for ( int i = 0; i < stringsPerWrite; ++i )
+                {
+                    // Try to read strings that might be being created
+                    std::string str   = "WRITE_0_" + std::to_string( i );
+                    auto        index = pool.getIndex( str );
+                    // Should not crash even if racing with writes
+                    EXPECT_EQ( str, pool.getString( index ) );
+                }
+            } );
+    }
+
+    for ( auto& thread : threads )
+    {
+        thread.join();
+    }
+
+    // Verify all written strings are accessible
+    for ( int t = 0; t < numWriteThreads; ++t )
+    {
+        for ( int i = 0; i < stringsPerWrite; ++i )
+        {
+            std::string str   = "WRITE_" + std::to_string( t ) + "_" + std::to_string( i );
+            auto        index = pool.getIndex( str );
+            EXPECT_EQ( str, pool.getString( index ) );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, InvalidIndex )
+{
+    auto& pool = RiaStringPool::instance();
+
+    // Test with INVALID_INDEX constant
+    EXPECT_THROW( pool.getString( RiaStringPool::INVALID_INDEX ), std::out_of_range );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, SimilarStrings )
+{
+    auto& pool = RiaStringPool::instance();
+
+    // Test strings that are similar but not identical
+    std::vector<std::string> similarStrings = { "WOPT:WELL-1",
+                                                "WOPT:WELL-2",
+                                                "WOPT:WELL-10",
+                                                "WOPT:WELL-1A",
+                                                "WOPT:WELL_1",
+                                                "WOPT: WELL-1" };
+
+    std::vector<RiaStringPool::IndexType> indices;
+    for ( const auto& str : similarStrings )
+    {
+        indices.push_back( pool.getIndex( str ) );
+    }
+
+    // All should have different indices
+    std::set<RiaStringPool::IndexType> uniqueIndices( indices.begin(), indices.end() );
+    EXPECT_EQ( similarStrings.size(), uniqueIndices.size() );
+
+    // Verify each string retrieval
+    for ( size_t i = 0; i < similarStrings.size(); ++i )
+    {
+        EXPECT_EQ( similarStrings[i], pool.getString( indices[i] ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaStringPoolTest, CommonSummaryVectorNames )
+{
+    auto& pool = RiaStringPool::instance();
+
+    // Test with realistic summary vector names
+    std::vector<std::string> vectorNames = { "FOPT",
+                                             "FWPT",
+                                             "FGPT",
+                                             "FOPR",
+                                             "FWPR",
+                                             "FGPR",
+                                             "WOPT:PROD-1",
+                                             "WWPT:PROD-1",
+                                             "WBHP:PROD-1",
+                                             "WOPT:INJ-1",
+                                             "GOPT:FIELD",
+                                             "BPR:10,15,20" };
+
+    // Store indices
+    std::vector<RiaStringPool::IndexType> indices;
+    for ( const auto& name : vectorNames )
+    {
+        indices.push_back( pool.getIndex( name ) );
+    }
+
+    // Request same strings again - should get same indices
+    for ( size_t i = 0; i < vectorNames.size(); ++i )
+    {
+        auto index = pool.getIndex( vectorNames[i] );
+        EXPECT_EQ( indices[i], index );
+        EXPECT_EQ( vectorNames[i], pool.getString( index ) );
+    }
+}

--- a/ApplicationLibCode/UnitTests/RiaStringPool-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaStringPool-Test.cpp
@@ -95,7 +95,7 @@ TEST( RiaStringPoolTest, ThreadSafety )
     const int numThreads       = 10;
     const int stringsPerThread = 100;
 
-    std::vector<std::thread>                         threads;
+    std::vector<std::thread>                           threads;
     std::vector<std::vector<RiaStringPool::IndexType>> threadResults( numThreads );
 
     // Create threads that all add the same strings
@@ -287,12 +287,7 @@ TEST( RiaStringPoolTest, SimilarStrings )
     auto& pool = RiaStringPool::instance();
 
     // Test strings that are similar but not identical
-    std::vector<std::string> similarStrings = { "WOPT:WELL-1",
-                                                "WOPT:WELL-2",
-                                                "WOPT:WELL-10",
-                                                "WOPT:WELL-1A",
-                                                "WOPT:WELL_1",
-                                                "WOPT: WELL-1" };
+    std::vector<std::string> similarStrings = { "WOPT:WELL-1", "WOPT:WELL-2", "WOPT:WELL-10", "WOPT:WELL-1A", "WOPT:WELL_1", "WOPT: WELL-1" };
 
     std::vector<RiaStringPool::IndexType> indices;
     for ( const auto& str : similarStrings )
@@ -319,18 +314,8 @@ TEST( RiaStringPoolTest, CommonSummaryVectorNames )
     auto& pool = RiaStringPool::instance();
 
     // Test with realistic summary vector names
-    std::vector<std::string> vectorNames = { "FOPT",
-                                             "FWPT",
-                                             "FGPT",
-                                             "FOPR",
-                                             "FWPR",
-                                             "FGPR",
-                                             "WOPT:PROD-1",
-                                             "WWPT:PROD-1",
-                                             "WBHP:PROD-1",
-                                             "WOPT:INJ-1",
-                                             "GOPT:FIELD",
-                                             "BPR:10,15,20" };
+    std::vector<std::string> vectorNames =
+        { "FOPT", "FWPT", "FGPT", "FOPR", "FWPR", "FGPR", "WOPT:PROD-1", "WWPT:PROD-1", "WBHP:PROD-1", "WOPT:INJ-1", "GOPT:FIELD", "BPR:10,15,20" };
 
     // Store indices
     std::vector<RiaStringPool::IndexType> indices;


### PR DESCRIPTION
Refactor `RifEclipseSummaryAddress` to use string pool indices

Replaced direct string members with indices into RiaStringPool .This change reduces memory usage and improves performance for repeated string values.