### PR TITLE
Revert use of Azure for caching, use GitHub Cache

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -80,6 +80,7 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     steps:
       - name: Checkout
@@ -194,6 +195,13 @@ jobs:
         run: |
           ThirdParty/vcpkg/${{ matrix.config.vcpkg-bootstrap }}
 
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: TAServers/vcpkg-cache@f645f5b5c4a8a6546911a64b3b02ac86b76f584c
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: vcpkg-${{ matrix.config.cxx}}/
+          
       - name: Print CMake version
         shell: bash
         run: |
@@ -208,8 +216,8 @@ jobs:
       - name: Configure
         shell: bash
         env:
-          VCPKG_FEATURE_FLAGS: "binarycaching"
-          VCPKG_BINARY_SOURCES: ${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT && format('clear;x-azblob,https://{0}.blob.core.windows.net/vcpkg-binaries,{1},readwrite', secrets.AZURE_VCPKG_STORAGE_ACCOUNT, secrets.AZURE_VCPKG_SAS_TOKEN) || 'clear' }}
+          VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
         run: >

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           submodules: true
 
+      - uses: TAServers/vcpkg-cache@f645f5b5c4a8a6546911a64b3b02ac86b76f584c
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Linux dependencies
         run: |
           sudo apt-get update --option="APT::Acquire::Retries=3"
@@ -41,10 +45,17 @@ jobs:
       - name: vcpkg bootstrap
         run: ThirdParty/vcpkg/bootstrap-vcpkg.sh
   
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: TAServers/vcpkg-cache@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create compile commands and run clang-tidy
+        # https://clang.llvm.org/extra/doxygen/run-clang-tidy_8py_source.html
         env:
-          VCPKG_FEATURE_FLAGS: "binarycaching"
-          VCPKG_BINARY_SOURCES: "clear;x-azblob,https://${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}.blob.core.windows.net/vcpkg-binaries,${{ secrets.AZURE_VCPKG_SAS_TOKEN }},readwrite"
+          VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         run: |
           mkdir build
           cd build


### PR DESCRIPTION
Use of Azure for caching is not working well for private forks of ResInsight. Use a custom vcpkg-cache to store binaries on Github cache.

https://github.com/TAServers/vcpkg-cache

This reverts commit 006a3167492d37b9900ab0537863c4c3be489546.
This reverts commit 1101d74b69f45e1f4958687075bf840f7c732d85.
