### PR TITLE
Refactor well log track settings into modular classes

### DIFF
--- a/ApplicationLibCode/Application/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Application/CMakeLists_files.cmake
@@ -38,6 +38,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaOsduDefines.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaCloudDefines.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaWellFlowDefines.h
+    ${CMAKE_CURRENT_LIST_DIR}/RiaWellLogTrackDefines.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaQuickAccessScheduler.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaGridDefines.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaModelExportDefines.h
@@ -83,6 +84,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaOsduDefines.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaCloudDefines.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWellFlowDefines.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaWellLogTrackDefines.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaQuickAccessScheduler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaGridDefines.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaModelExportDefines.cpp

--- a/ApplicationLibCode/Application/RiaDefines.cpp
+++ b/ApplicationLibCode/Application/RiaDefines.cpp
@@ -82,14 +82,14 @@ void caf::AppEnum<RiaDefines::EclipseUnitSystem>::setUp()
 }
 
 template <>
-void caf::AppEnum<RiaDefines::DepthTypeEnum>::setUp()
+void caf::AppEnum<RiaDefines::DepthType>::setUp()
 {
-    addItem( RiaDefines::DepthTypeEnum::MEASURED_DEPTH, "MEASURED_DEPTH", "Measured Depth" );
-    addItem( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, "TRUE_VERTICAL_DEPTH", "True Vertical Depth (MSL)" );
-    addItem( RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, "PSEUDO_LENGTH", "Pseudo Length" );
-    addItem( RiaDefines::DepthTypeEnum::CONNECTION_NUMBER, "CONNECTION_NUMBER", "Connection Number" );
-    addItem( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB, "TRUE_VERTICAL_DEPTH_RKB", "True Vertical Depth (RKB)" );
-    setDefault( RiaDefines::DepthTypeEnum::MEASURED_DEPTH );
+    addItem( RiaDefines::DepthType::MEASURED_DEPTH, "MEASURED_DEPTH", "Measured Depth" );
+    addItem( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, "TRUE_VERTICAL_DEPTH", "True Vertical Depth (MSL)" );
+    addItem( RiaDefines::DepthType::PSEUDO_LENGTH, "PSEUDO_LENGTH", "Pseudo Length" );
+    addItem( RiaDefines::DepthType::CONNECTION_NUMBER, "CONNECTION_NUMBER", "Connection Number" );
+    addItem( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB, "TRUE_VERTICAL_DEPTH_RKB", "True Vertical Depth (RKB)" );
+    setDefault( RiaDefines::DepthType::MEASURED_DEPTH );
 }
 
 template <>

--- a/ApplicationLibCode/Application/RiaDefines.h
+++ b/ApplicationLibCode/Application/RiaDefines.h
@@ -109,7 +109,7 @@ DepthUnitType     fromEclipseUnit( EclipseUnitSystem eclipseUnit );
 EclipseUnitSystem fromDepthUnit( DepthUnitType depthUnit );
 
 // Depth types used for well log plots
-enum class DepthTypeEnum
+enum class DepthType
 {
     MEASURED_DEPTH,
     TRUE_VERTICAL_DEPTH,

--- a/ApplicationLibCode/Application/RiaPlotDefines.cpp
+++ b/ApplicationLibCode/Application/RiaPlotDefines.cpp
@@ -107,6 +107,26 @@ void caf::AppEnum<RiaDefines::ReadOutType>::setUp()
     setDefault( RiaDefines::ReadOutType::SNAP_TO_POINT );
 }
 
+template <>
+void AppEnum<RiaDefines::RegionAnnotationType>::setUp()
+{
+    addItem( RiaDefines::RegionAnnotationType::NO_ANNOTATIONS, "NO_ANNOTATIONS", "No Annotations" );
+    addItem( RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS, "FORMATIONS", "Formations" );
+    addItem( RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS, "RESULT_PROPERTY", "Result Property" );
+    setDefault( RiaDefines::RegionAnnotationType::NO_ANNOTATIONS );
+}
+
+template <>
+void AppEnum<RiaDefines::RegionDisplay>::setUp()
+{
+    addItem( RiaDefines::DARK_LINES, "DARK_LINES", "Dark Lines" );
+    addItem( RiaDefines::LIGHT_LINES, "LIGHT_LINES", "Light Lines" );
+    addItem( RiaDefines::COLORED_LINES, "COLORED_LINES", "Colored Lines" );
+    addItem( RiaDefines::COLOR_SHADING, "COLOR_SHADING", "Color Shading" );
+    addItem( RiaDefines::COLOR_SHADING_AND_LINES, "SHADING_AND_LINES", "Color Shading and Lines" );
+    setDefault( RiaDefines::COLOR_SHADING_AND_LINES );
+}
+
 }; // namespace caf
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaWellLogTrackDefines.cpp
+++ b/ApplicationLibCode/Application/RiaWellLogTrackDefines.cpp
@@ -1,0 +1,59 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RiaWellLogTrackDefines.h"
+
+namespace caf
+{
+template <>
+void AppEnum<RiaDefines::WellLogTrackTrajectoryType>::setUp()
+{
+    addItem( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH, "WELL_PATH", "Well Path" );
+    addItem( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL, "SIMULATION_WELL", "Simulation Well" );
+    setDefault( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH );
+}
+
+template <>
+void AppEnum<RiaDefines::WellLogTrackFormationSource>::setUp()
+{
+    addItem( RiaDefines::WellLogTrackFormationSource::CASE, "CASE", "Case" );
+    addItem( RiaDefines::WellLogTrackFormationSource::WELL_PICK_FILTER, "WELL_PICK_FILTER", "Well Picks for Well Path" );
+    setDefault( RiaDefines::WellLogTrackFormationSource::CASE );
+}
+
+template <>
+void AppEnum<RiaDefines::WellLogTrackFormationLevel>::setUp()
+{
+    addItem( RiaDefines::WellLogTrackFormationLevel::NONE, "NONE", "None" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::ALL, "ALL", "All" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::GROUP, "GROUP", "Formation Group" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL0, "LEVEL0", "Formation" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL1, "LEVEL1", "Formation 1" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL2, "LEVEL2", "Formation 2" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL3, "LEVEL3", "Formation 3" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL4, "LEVEL4", "Formation 4" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL5, "LEVEL5", "Formation 5" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL6, "LEVEL6", "Formation 6" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL7, "LEVEL7", "Formation 7" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL8, "LEVEL8", "Formation 8" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL9, "LEVEL9", "Formation 9" );
+    addItem( RiaDefines::WellLogTrackFormationLevel::LEVEL10, "LEVEL10", "Formation 10" );
+    setDefault( RiaDefines::WellLogTrackFormationLevel::ALL );
+}
+
+} // namespace caf

--- a/ApplicationLibCode/Application/RiaWellLogTrackDefines.h
+++ b/ApplicationLibCode/Application/RiaWellLogTrackDefines.h
@@ -1,0 +1,57 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cafAppEnum.h"
+
+namespace RiaDefines
+{
+
+enum class WellLogTrackTrajectoryType
+{
+    WELL_PATH,
+    SIMULATION_WELL
+};
+
+enum class WellLogTrackFormationSource
+{
+    CASE,
+    WELL_PICK_FILTER
+};
+
+enum class WellLogTrackFormationLevel
+{
+    GROUP,
+    LEVEL0,
+    LEVEL1,
+    LEVEL2,
+    LEVEL3,
+    LEVEL4,
+    LEVEL5,
+    LEVEL6,
+    LEVEL7,
+    LEVEL8,
+    LEVEL9,
+    LEVEL10,
+    ALL,
+    UNKNOWN,
+    NONE
+};
+
+} // namespace RiaDefines

--- a/ApplicationLibCode/CMakeLists.txt
+++ b/ApplicationLibCode/CMakeLists.txt
@@ -128,6 +128,7 @@ list(
   ProjectDataModel/ProcessControl/CMakeLists_files.cmake
   ProjectDataModel/Polygons/CMakeLists_files.cmake
   ProjectDataModel/WellLog/CMakeLists_files.cmake
+  ProjectDataModel/WellLog/WellLogTrack/CMakeLists_files.cmake
   ProjectDataModel/WellMeasurement/CMakeLists_files.cmake
   ProjectDataModel/WellPath/CMakeLists_files.cmake
   ProjectDataModel/Tools/CMakeLists_files.cmake
@@ -397,6 +398,7 @@ target_include_directories(
          ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModel/CellFilters
          ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModel/ProcessControl
          ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModel/WellLog
+         ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModel/WellLog/WellLogTrack
          ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModel/WellMeasurement
          ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModel/WellPath
          ${CMAKE_CURRENT_SOURCE_DIR}/ProjectDataModelCommands

--- a/ApplicationLibCode/Commands/CompletionCommands/RicNewStimPlanModelPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicNewStimPlanModelPlotFeature.cpp
@@ -159,7 +159,7 @@ RimStimPlanModelPlot* RicNewStimPlanModelPlotFeature::createPlot( RimStimPlanMod
         plot->setPlotTitleVisible( true );
         plot->setLegendsVisible( true );
         plot->setLegendsHorizontal( false );
-        plot->setDepthType( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH );
+        plot->setDepthType( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH );
         plot->setAutoScaleDepthValuesEnabled( true );
     }
 

--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -224,9 +224,9 @@ ExtractionCurveType* RicWellLogTools::addExtractionCurve( RimWellLogTrack*      
         {
             caseToApply = commonDataSource->caseToApply();
         }
-        else if ( plotTrack->formationNamesCase() )
+        else if ( plotTrack->formationCase() )
         {
-            caseToApply = plotTrack->formationNamesCase();
+            caseToApply = plotTrack->formationCase();
         }
         else
         {

--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -386,7 +386,7 @@ RimWellLogRftCurve* RicWellLogTools::addRftCurve( RimWellLogTrack* plotTrack, co
     curve->setColor( curveColor );
 
     plotTrack->addCurve( curve );
-    plotTrack->setFormationTrajectoryType( RimWellLogTrack::SIMULATION_WELL );
+    plotTrack->setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL );
     plotTrack->updateConnectedEditors();
 
     RiaGuiApplication::instance()->getOrCreateMainPlotWindow();

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellBoreStabilityPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellBoreStabilityPlotFeature.cpp
@@ -122,7 +122,7 @@ RimWellBoreStabilityPlot* RicNewWellBoreStabilityPlotFeature::createPlot( RimGeo
         plot->setPlotTitleVisible( true );
         plot->setLegendsVisible( true );
         plot->setLegendsHorizontal( true );
-        plot->setDepthType( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB );
+        plot->setDepthType( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB );
         plot->setAutoScaleDepthValuesEnabled( true );
 
         RicNewWellLogPlotFeatureImpl::updateAfterCreation( plot );

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogExtractionCurveFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogExtractionCurveFeature.cpp
@@ -96,12 +96,12 @@ void RicNewWellLogExtractionCurveFeature::onActionTriggered( bool isChecked )
             if ( wellPath )
             {
                 newWellLogPlotTrack->setFormationWellPath( wellPath );
-                newWellLogPlotTrack->setFormationTrajectoryType( RimWellLogTrack::WELL_PATH );
+                newWellLogPlotTrack->setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH );
             }
             else
             {
                 newWellLogPlotTrack->setFormationSimWellName( simWell->name() );
-                newWellLogPlotTrack->setFormationTrajectoryType( RimWellLogTrack::SIMULATION_WELL );
+                newWellLogPlotTrack->setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL );
                 newWellLogPlotTrack->setFormationBranchIndex( branchIndex );
                 newWellLogPlotTrack->setFormationBranchDetection( useBranchDetection );
             }

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogPlotFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogPlotFeatureImpl.cpp
@@ -232,11 +232,11 @@ RimWellLogTrack*
 
     if ( wellPathToApply )
     {
-        plotTrack->setFormationTrajectoryType( RimWellLogTrack::WELL_PATH );
+        plotTrack->setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH );
     }
     else if ( !simWellToApply.isEmpty() )
     {
-        plotTrack->setFormationTrajectoryType( RimWellLogTrack::SIMULATION_WELL );
+        plotTrack->setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL );
     }
 
     if ( !branchDetectionToApply.isPartiallyTrue() )

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -108,7 +108,7 @@ RimWellAllocationPlot::RimWellAllocationPlot()
     CAF_PDM_InitFieldNoDefault( &m_accumulatedWellFlowPlot, "AccumulatedWellFlowPlot", "Accumulated Well Flow" );
     m_accumulatedWellFlowPlot = new RimWellLogPlot;
     m_accumulatedWellFlowPlot->setDepthUnit( RiaDefines::DepthUnitType::UNIT_NONE );
-    m_accumulatedWellFlowPlot->setDepthType( RiaDefines::DepthTypeEnum::CONNECTION_NUMBER );
+    m_accumulatedWellFlowPlot->setDepthType( RiaDefines::DepthType::CONNECTION_NUMBER );
     m_accumulatedWellFlowPlot->setLegendsVisible( false );
     m_accumulatedWellFlowPlot->uiCapability()->setUiIconFromResourceString( ":/WellFlowPlot16x16.png" );
 
@@ -124,9 +124,9 @@ RimWellAllocationPlot::RimWellAllocationPlot()
     setAsPlotMdiWindow();
 
     m_accumulatedWellFlowPlot->setAvailableDepthUnits( {} );
-    m_accumulatedWellFlowPlot->setAvailableDepthTypes( { RiaDefines::DepthTypeEnum::CONNECTION_NUMBER,
-                                                         RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH,
-                                                         RiaDefines::DepthTypeEnum::PSEUDO_LENGTH } );
+    m_accumulatedWellFlowPlot->setAvailableDepthTypes( { RiaDefines::DepthType::CONNECTION_NUMBER,
+                                                         RiaDefines::DepthType::TRUE_VERTICAL_DEPTH,
+                                                         RiaDefines::DepthType::PSEUDO_LENGTH } );
 
     m_accumulatedWellFlowPlot->setCommonDataSourceEnabled( false );
     m_accumulatedWellFlowPlot->nameConfig()->setCustomName( "Accumulated Flow Chart" );
@@ -351,7 +351,7 @@ void RimWellAllocationPlot::updateFromWell()
 
     auto depthType = accumulatedWellFlowPlot()->depthType();
 
-    if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH ) return;
+    if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH ) return;
 
     // Create tracks and curves from the calculated data
 
@@ -370,9 +370,9 @@ void RimWellAllocationPlot::updateFromWell()
         accumulatedWellFlowPlot()->addPlot( plotTrack );
 
         const std::vector<double>& depthValues =
-            depthType == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER     ? wfCalculator->connectionNumbersFromTop( brIdx )
-            : depthType == RiaDefines::DepthTypeEnum::PSEUDO_LENGTH       ? wfCalculator->pseudoLengthFromTop( brIdx )
-            : depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH ? wfCalculator->trueVerticalDepth( brIdx )
+            depthType == RiaDefines::DepthType::CONNECTION_NUMBER     ? wfCalculator->connectionNumbersFromTop( brIdx )
+            : depthType == RiaDefines::DepthType::PSEUDO_LENGTH       ? wfCalculator->pseudoLengthFromTop( brIdx )
+            : depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ? wfCalculator->trueVerticalDepth( brIdx )
                                                                           : std::vector<double>();
 
         if ( !depthValues.empty() )
@@ -382,7 +382,7 @@ void RimWellAllocationPlot::updateFromWell()
             {
                 std::vector<double> curveDepthValues = depthValues;
                 std::vector<double> accFlow;
-                if ( depthType == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER )
+                if ( depthType == RiaDefines::DepthType::CONNECTION_NUMBER )
                 {
                     accFlow = ( m_flowType == ACCUMULATED ? wfCalculator->accumulatedTracerFlowPrConnection( tracerName, brIdx )
                                                           : wfCalculator->tracerFlowPrConnection( tracerName, brIdx ) );
@@ -404,7 +404,7 @@ void RimWellAllocationPlot::updateFromWell()
                         }
                     }
                 }
-                else if ( depthType == RiaDefines::DepthTypeEnum::PSEUDO_LENGTH || depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+                else if ( depthType == RiaDefines::DepthType::PSEUDO_LENGTH || depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
                 {
                     accFlow = ( m_flowType == ACCUMULATED ? wfCalculator->accumulatedTracerFlowPrPseudoLength( tracerName, brIdx )
                                                           : wfCalculator->tracerFlowPrPseudoLength( tracerName, brIdx ) );
@@ -502,7 +502,7 @@ void RimWellAllocationPlot::updateWellFlowPlotXAxisTitle( RimWellLogTrack* plotT
 ///
 //--------------------------------------------------------------------------------------------------
 void RimWellAllocationPlot::addStackedCurve( const QString&             tracerName,
-                                             RiaDefines::DepthTypeEnum  depthType,
+                                             RiaDefines::DepthType  depthType,
                                              const std::vector<double>& depthValues,
                                              const std::vector<double>& accFlow,
                                              RimWellLogTrack*           plotTrack,

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -124,9 +124,8 @@ RimWellAllocationPlot::RimWellAllocationPlot()
     setAsPlotMdiWindow();
 
     m_accumulatedWellFlowPlot->setAvailableDepthUnits( {} );
-    m_accumulatedWellFlowPlot->setAvailableDepthTypes( { RiaDefines::DepthType::CONNECTION_NUMBER,
-                                                         RiaDefines::DepthType::TRUE_VERTICAL_DEPTH,
-                                                         RiaDefines::DepthType::PSEUDO_LENGTH } );
+    m_accumulatedWellFlowPlot->setAvailableDepthTypes(
+        { RiaDefines::DepthType::CONNECTION_NUMBER, RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, RiaDefines::DepthType::PSEUDO_LENGTH } );
 
     m_accumulatedWellFlowPlot->setCommonDataSourceEnabled( false );
     m_accumulatedWellFlowPlot->nameConfig()->setCustomName( "Accumulated Flow Chart" );
@@ -373,7 +372,7 @@ void RimWellAllocationPlot::updateFromWell()
             depthType == RiaDefines::DepthType::CONNECTION_NUMBER     ? wfCalculator->connectionNumbersFromTop( brIdx )
             : depthType == RiaDefines::DepthType::PSEUDO_LENGTH       ? wfCalculator->pseudoLengthFromTop( brIdx )
             : depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ? wfCalculator->trueVerticalDepth( brIdx )
-                                                                          : std::vector<double>();
+                                                                      : std::vector<double>();
 
         if ( !depthValues.empty() )
         {
@@ -502,7 +501,7 @@ void RimWellAllocationPlot::updateWellFlowPlotXAxisTitle( RimWellLogTrack* plotT
 ///
 //--------------------------------------------------------------------------------------------------
 void RimWellAllocationPlot::addStackedCurve( const QString&             tracerName,
-                                             RiaDefines::DepthType  depthType,
+                                             RiaDefines::DepthType      depthType,
                                              const std::vector<double>& depthValues,
                                              const std::vector<double>& accFlow,
                                              RimWellLogTrack*           plotTrack,

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.h
@@ -114,7 +114,7 @@ private:
     void updateWellFlowPlotXAxisTitle( RimWellLogTrack* plotTrack );
 
     void addStackedCurve( const QString&             tracerName,
-                          RiaDefines::DepthType  depthType,
+                          RiaDefines::DepthType      depthType,
                           const std::vector<double>& depthValues,
                           const std::vector<double>& accFlow,
                           RimWellLogTrack*           plotTrack,

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.h
@@ -114,7 +114,7 @@ private:
     void updateWellFlowPlotXAxisTitle( RimWellLogTrack* plotTrack );
 
     void addStackedCurve( const QString&             tracerName,
-                          RiaDefines::DepthTypeEnum  depthType,
+                          RiaDefines::DepthType  depthType,
                           const std::vector<double>& depthValues,
                           const std::vector<double>& accFlow,
                           RimWellLogTrack*           plotTrack,

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp
@@ -270,7 +270,7 @@ void RimWellFlowRateCurve::fieldChangedByUi( const caf::PdmFieldHandle* changedF
 bool RimWellFlowRateCurve::isUsingConnectionNumberDepthType() const
 {
     auto wellLogPlot = firstAncestorOrThisOfType<RimWellLogPlot>();
-    return wellLogPlot && wellLogPlot->depthType() == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER;
+    return wellLogPlot && wellLogPlot->depthType() == RiaDefines::DepthType::CONNECTION_NUMBER;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -285,7 +285,7 @@ RimWellAllocationPlot* RimWellFlowRateCurve::wellAllocationPlot() const
 ///
 //--------------------------------------------------------------------------------------------------
 void RimWellFlowRateCurve::setFlowValuesPrDepthValue( const QString&             curveName,
-                                                      RiaDefines::DepthTypeEnum  depthType,
+                                                      RiaDefines::DepthType  depthType,
                                                       const std::vector<double>& depthValues,
                                                       const std::vector<double>& flowRates )
 {

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp
@@ -285,7 +285,7 @@ RimWellAllocationPlot* RimWellFlowRateCurve::wellAllocationPlot() const
 ///
 //--------------------------------------------------------------------------------------------------
 void RimWellFlowRateCurve::setFlowValuesPrDepthValue( const QString&             curveName,
-                                                      RiaDefines::DepthType  depthType,
+                                                      RiaDefines::DepthType      depthType,
                                                       const std::vector<double>& depthValues,
                                                       const std::vector<double>& flowRates )
 {

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.h
@@ -39,7 +39,7 @@ public:
     ~RimWellFlowRateCurve() override;
 
     void setFlowValuesPrDepthValue( const QString&             curveName,
-                                    RiaDefines::DepthTypeEnum  depthType,
+                                    RiaDefines::DepthType      depthType,
                                     const std::vector<double>& depthValues,
                                     const std::vector<double>& flowRates );
 

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellPltPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellPltPlot.cpp
@@ -141,7 +141,7 @@ RimWellPltPlot::RimWellPltPlot()
     m_isOnLoad              = true;
     m_plotLegendsHorizontal = false;
 
-    setAvailableDepthTypes( { RiaDefines::DepthTypeEnum::MEASURED_DEPTH } );
+    setAvailableDepthTypes( { RiaDefines::DepthType::MEASURED_DEPTH } );
     setPlotTitleVisible( true );
 }
 
@@ -225,7 +225,7 @@ void RimWellPltPlot::updateFormationsOnPlot() const
         RimWellLogTrack* track = dynamic_cast<RimWellLogTrack*>( plotByIndex( 0 ) );
         if ( track )
         {
-            RimCase* formationNamesCase = track->formationNamesCase();
+            RimCase* formationNamesCase = track->formationCase();
 
             if ( !formationNamesCase )
             {

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp
@@ -93,7 +93,7 @@ RimWellRftPlot::RimWellRftPlot()
     CAF_PDM_InitFieldNoDefault( &m_wellLogPlot_OBSOLETE, "WellLog", "Well Log" );
     m_wellLogPlot_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    m_depthType = RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH;
+    m_depthType = RiaDefines::DepthType::TRUE_VERTICAL_DEPTH;
 
     CAF_PDM_InitFieldNoDefault( &m_wellPathNameOrSimWellName, "WellName", "Well Name" );
     CAF_PDM_InitField( &m_branchIndex, "BranchIndex", 0, "Branch Index" );
@@ -126,7 +126,7 @@ RimWellRftPlot::RimWellRftPlot()
 
     // TODO: may want to support TRUE_VERTICAL_DEPTH_RKB in the future
     // It was developed for regular well log plots and requires some more work for RFT plots.
-    setAvailableDepthTypes( { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH } );
+    setAvailableDepthTypes( { RiaDefines::DepthType::MEASURED_DEPTH, RiaDefines::DepthType::TRUE_VERTICAL_DEPTH } );
 
     m_nameConfig->setCustomName( "RFT Plot" );
     setNamingMethod( RiaDefines::ObjectNamingMethod::CUSTOM );
@@ -199,7 +199,7 @@ void RimWellRftPlot::updateFormationsOnPlot() const
         RimWellLogTrack* track              = dynamic_cast<RimWellLogTrack*>( plotByIndex( 0 ) );
         if ( track )
         {
-            formationNamesCase = track->formationNamesCase();
+            formationNamesCase = track->formationCase();
 
             if ( !formationNamesCase )
             {
@@ -747,7 +747,7 @@ void RimWellRftPlot::updateCurvesInPlot( const std::set<RiaRftPltCurveDefinition
         }
     }
 
-    if ( depthType() == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    if ( depthType() == RiaDefines::DepthType::MEASURED_DEPTH )
     {
         assignWellPathToExtractionCurves();
     }
@@ -1276,7 +1276,7 @@ void RimWellRftPlot::onLoadDataAndUpdate()
     updateMdiWindowVisibility();
     updateFormationsOnPlot();
 
-    if ( depthType() == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    if ( depthType() == RiaDefines::DepthType::MEASURED_DEPTH )
     {
         assignWellPathToExtractionCurves();
     }

--- a/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNames.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNames.cpp
@@ -128,7 +128,7 @@ void RimFormationNames::updateConnectedViews()
             for ( RimWellLogTrack* track : tracks )
             {
                 // The track may be referring to the case for other reasons than formations.
-                if ( track->formationNamesCase() == caseObj )
+                if ( track->formationCase() == caseObj )
                 {
                     track->loadDataAndUpdate();
                 }

--- a/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp
@@ -114,7 +114,7 @@ RimDepthTrackPlot::RimDepthTrackPlot()
     CAF_PDM_InitField( &m_nameTemplateText, "TemplateText", templateText, "Template Text" );
     CAF_PDM_InitFieldNoDefault( &m_namingMethod, "PlotNamingMethod", "Plot Name" );
 
-    caf::AppEnum<RimDepthTrackPlot::DepthTypeEnum> depthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    caf::AppEnum<RimDepthTrackPlot::DepthTypeEnum> depthType = RiaDefines::DepthType::MEASURED_DEPTH;
     CAF_PDM_InitScriptableField( &m_depthType, "DepthType", depthType, "Type" );
 
     caf::AppEnum<RiaDefines::DepthUnitType> depthUnit = RiaDefines::DepthUnitType::UNIT_METER;
@@ -158,9 +158,9 @@ RimDepthTrackPlot::RimDepthTrackPlot()
     CAF_PDM_InitFieldNoDefault( &m_depthOrientation, "DepthOrientation", "Orientation" );
 
     m_availableDepthUnits = { RiaDefines::DepthUnitType::UNIT_METER, RiaDefines::DepthUnitType::UNIT_FEET };
-    m_availableDepthTypes = { RiaDefines::DepthTypeEnum::MEASURED_DEPTH,
-                              RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH,
-                              RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB };
+    m_availableDepthTypes = { RiaDefines::DepthType::MEASURED_DEPTH,
+                              RiaDefines::DepthType::TRUE_VERTICAL_DEPTH,
+                              RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB };
 
     m_minAvailableDepth = HUGE_VAL;
     m_maxAvailableDepth = -HUGE_VAL;
@@ -1373,28 +1373,28 @@ QString RimDepthTrackPlot::depthAxisTitle() const
 
     switch ( m_depthType.value() )
     {
-        case RiaDefines::DepthTypeEnum::MEASURED_DEPTH:
+        case RiaDefines::DepthType::MEASURED_DEPTH:
             depthTitle = "MD";
             break;
 
-        case RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH:
+        case RiaDefines::DepthType::TRUE_VERTICAL_DEPTH:
             depthTitle = "TVDMSL";
             break;
 
-        case RiaDefines::DepthTypeEnum::PSEUDO_LENGTH:
+        case RiaDefines::DepthType::PSEUDO_LENGTH:
             depthTitle = "PL";
             break;
 
-        case RiaDefines::DepthTypeEnum::CONNECTION_NUMBER:
+        case RiaDefines::DepthType::CONNECTION_NUMBER:
             depthTitle = "Connection";
             break;
 
-        case RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB:
+        case RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB:
             depthTitle = "TVDRKB";
             break;
     }
 
-    if ( m_depthType() == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER ) return depthTitle;
+    if ( m_depthType() == RiaDefines::DepthType::CONNECTION_NUMBER ) return depthTitle;
 
     if ( m_depthUnit == RiaDefines::DepthUnitType::UNIT_METER )
     {

--- a/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h
@@ -70,7 +70,7 @@ public:
     };
 
     using AxisGridEnum  = caf::AppEnum<AxisGridVisibility>;
-    using DepthTypeEnum = RiaDefines::DepthTypeEnum;
+    using DepthTypeEnum = RiaDefines::DepthType;
 
     enum class DepthOrientation_OBSOLETE
     {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/CMakeLists_files.cmake
@@ -15,7 +15,6 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimEnsembleWellLogStatisticsCurve.h
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogPlotCollection.h
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogPlot.h
-    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogTrack.h
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogLasCurve.h
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogExtractionCurve.h
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogLasFile.h
@@ -41,7 +40,6 @@ set(SOURCE_GROUP_HEADER_FILES
 set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogPlotCollection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogPlot.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogTrack.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogCurve.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogExtractionCurve.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogLasFile.cpp

--- a/ApplicationLibCode/ProjectDataModel/WellLog/Rim3dWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/Rim3dWellLogRftCurve.cpp
@@ -82,7 +82,7 @@ void Rim3dWellLogRftCurve::curveValuesAndMds( std::vector<double>* values, std::
 
     // These values are for a simulation well
     *values              = curveData->propertyValues();
-    *measuredDepthValues = curveData->depths( RiaDefines::DepthTypeEnum::MEASURED_DEPTH );
+    *measuredDepthValues = curveData->depths( RiaDefines::DepthType::MEASURED_DEPTH );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogStatisticsCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogStatisticsCurve.cpp
@@ -137,15 +137,15 @@ void RimEnsembleWellLogStatisticsCurve::performDataExtraction( bool* isUsingPseu
                 addDatapointsForBottomOfSegment( tvDepthValues, dummyValues );
             }
 
-            std::map<RiaDefines::DepthTypeEnum, std::vector<double>> validDepths;
+            std::map<RiaDefines::DepthType, std::vector<double>> validDepths;
             if ( values.size() == measuredDepthValues.size() )
             {
-                validDepths.insert( std::make_pair( RiaDefines::DepthTypeEnum::MEASURED_DEPTH, measuredDepthValues ) );
+                validDepths.insert( std::make_pair( RiaDefines::DepthType::MEASURED_DEPTH, measuredDepthValues ) );
             }
             if ( values.size() == tvDepthValues.size() )
             {
-                validDepths.insert( std::make_pair( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, tvDepthValues ) );
-                validDepths.insert( std::make_pair( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB, tvDepthValues ) );
+                validDepths.insert( std::make_pair( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvDepthValues ) );
+                validDepths.insert( std::make_pair( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB, tvDepthValues ) );
             }
 
             bool useLogarithmicScale = false;

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.cpp
@@ -164,7 +164,7 @@ void RimWellLogCalculatedCurve::onLoadDataAndUpdate( bool updateParentPlot )
     }
 
     // Find the data for resampling
-    const auto                depthType    = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    const auto                depthType    = RiaDefines::DepthType::MEASURED_DEPTH;
     const std::vector<double> depthValues  = depthValuesFromSource( depthType );
     const auto                depthUnit    = firstCurveData->depthUnit();
     const auto                propertyUnit = firstCurveData->propertyValueUnit();
@@ -207,7 +207,7 @@ void RimWellLogCalculatedCurve::onLoadDataAndUpdate( bool updateParentPlot )
     const bool isExtractionCurve   = false;
 
     // Set curve data
-    auto depthsMap       = std::map<RiaDefines::DepthTypeEnum, std::vector<double>>();
+    auto depthsMap       = std::map<RiaDefines::DepthType, std::vector<double>>();
     depthsMap[depthType] = calculatedDepthValues;
     setPropertyValuesAndDepths( calculatedPropertyValues, depthsMap, 0.0, depthUnit, isExtractionCurve, useLogarithmicScale, propertyUnit );
 
@@ -281,7 +281,7 @@ double RimWellLogCalculatedCurve::calculateValue( double firstValue, double seco
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RimWellLogCalculatedCurve::depthValuesFromSource( RiaDefines::DepthTypeEnum depthType ) const
+std::vector<double> RimWellLogCalculatedCurve::depthValuesFromSource( RiaDefines::DepthType depthType ) const
 {
     if ( !m_firstWellLogCurve || !m_firstWellLogCurve->curveData() || !m_secondWellLogCurve || !m_secondWellLogCurve->curveData() )
     {
@@ -351,7 +351,7 @@ std::vector<double> RimWellLogCalculatedCurve::unionDepthValuesFromVectors( cons
 /// indicates enter and exit of k-layer. However, when curves are resampled, this info is not
 /// representative and duplicated depth values are not needed.
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RimWellLogCalculatedCurve::unionDepthValuesFromCurves( RiaDefines::DepthTypeEnum depthType ) const
+std::vector<double> RimWellLogCalculatedCurve::unionDepthValuesFromCurves( RiaDefines::DepthType depthType ) const
 {
     if ( !m_firstWellLogCurve || !m_firstWellLogCurve->curveData() || !m_secondWellLogCurve || !m_secondWellLogCurve->curveData() )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCalculatedCurve.h
@@ -82,8 +82,8 @@ private:
     void connectWellLogCurveChangedToSlots( RimWellLogCurve* wellLogCurve );
     void disconnectWellLogCurveChangedFromSlots( RimWellLogCurve* wellLogCurve );
 
-    std::vector<double> depthValuesFromSource( RiaDefines::DepthTypeEnum depthType ) const;
-    std::vector<double> unionDepthValuesFromCurves( RiaDefines::DepthTypeEnum depthType ) const;
+    std::vector<double> depthValuesFromSource( RiaDefines::DepthType depthType ) const;
+    std::vector<double> unionDepthValuesFromCurves( RiaDefines::DepthType depthType ) const;
 
 private:
     caf::PdmPtrField<RimCase*> m_case;

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.cpp
@@ -122,7 +122,7 @@ bool RimWellLogCurve::depthValueRangeInData( double* minimumValue, double* maxim
 //--------------------------------------------------------------------------------------------------
 void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>& propertyValues,
                                                   const std::vector<double>& depths,
-                                                  RiaDefines::DepthTypeEnum  depthType,
+                                                  RiaDefines::DepthType  depthType,
                                                   double                     rkbDiff,
                                                   RiaDefines::DepthUnitType  depthUnit,
                                                   bool                       isExtractionCurve,
@@ -138,7 +138,7 @@ void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>& pro
 ///
 //--------------------------------------------------------------------------------------------------
 void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>&                                      propertyValues,
-                                                  const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& depths,
+                                                  const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
                                                   double                                                          rkbDiff,
                                                   RiaDefines::DepthUnitType                                       depthUnit,
                                                   bool                                                            isExtractionCurve,
@@ -207,8 +207,8 @@ void RimWellLogCurve::setPropertyValuesWithMdAndTVD( const std::vector<double>& 
                                                      bool                       useLogarithmicScale,
                                                      const QString&             propertyUnit )
 {
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> depths = { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, measuredDepths },
-                                                                        { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, tvdMSL } };
+    std::map<RiaDefines::DepthType, std::vector<double>> depths = { { RiaDefines::DepthType::MEASURED_DEPTH, measuredDepths },
+                                                                        { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvdMSL } };
     setPropertyValuesAndDepths( propertyValues, depths, rkbDiff, depthUnit, isExtractionCurve, useLogarithmicScale, propertyUnit );
 }
 
@@ -301,7 +301,7 @@ double RimWellLogCurve::closestYValueForX( double xValue ) const
 {
     if ( m_curveData.isNull() ) return std::numeric_limits<double>::infinity();
 
-    auto depths = m_curveData->depths( RiaDefines::DepthTypeEnum::MEASURED_DEPTH );
+    auto depths = m_curveData->depths( RiaDefines::DepthType::MEASURED_DEPTH );
     auto values = m_curveData->propertyValues();
 
     if ( depths.empty() || values.empty() ) return std::numeric_limits<double>::infinity();

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.cpp
@@ -122,7 +122,7 @@ bool RimWellLogCurve::depthValueRangeInData( double* minimumValue, double* maxim
 //--------------------------------------------------------------------------------------------------
 void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>& propertyValues,
                                                   const std::vector<double>& depths,
-                                                  RiaDefines::DepthType  depthType,
+                                                  RiaDefines::DepthType      depthType,
                                                   double                     rkbDiff,
                                                   RiaDefines::DepthUnitType  depthUnit,
                                                   bool                       isExtractionCurve,
@@ -137,12 +137,12 @@ void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>& pro
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>&                                      propertyValues,
+void RimWellLogCurve::setPropertyValuesAndDepths( const std::vector<double>&                                  propertyValues,
                                                   const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
-                                                  double                                                          rkbDiff,
-                                                  RiaDefines::DepthUnitType                                       depthUnit,
-                                                  bool                                                            isExtractionCurve,
-                                                  bool                                                            useLogarithmicScale,
+                                                  double                                                      rkbDiff,
+                                                  RiaDefines::DepthUnitType                                   depthUnit,
+                                                  bool                                                        isExtractionCurve,
+                                                  bool                                                        useLogarithmicScale,
 
                                                   const QString& propertyUnit )
 {
@@ -208,7 +208,7 @@ void RimWellLogCurve::setPropertyValuesWithMdAndTVD( const std::vector<double>& 
                                                      const QString&             propertyUnit )
 {
     std::map<RiaDefines::DepthType, std::vector<double>> depths = { { RiaDefines::DepthType::MEASURED_DEPTH, measuredDepths },
-                                                                        { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvdMSL } };
+                                                                    { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvdMSL } };
     setPropertyValuesAndDepths( propertyValues, depths, rkbDiff, depthUnit, isExtractionCurve, useLogarithmicScale, propertyUnit );
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.h
@@ -76,7 +76,7 @@ protected:
 
     void setPropertyValuesAndDepths( const std::vector<double>& propertyValues,
                                      const std::vector<double>& depths,
-                                     RiaDefines::DepthType  depthType,
+                                     RiaDefines::DepthType      depthType,
                                      double                     rkbDiff,
                                      RiaDefines::DepthUnitType  depthUnit,
                                      bool                       isExtractionCurve,
@@ -94,12 +94,12 @@ protected:
 
     void setPropertyAndDepthValuesToPlotCurve( const std::vector<double>& propertyValues, const std::vector<double>& depthValues );
 
-    void setPropertyValuesAndDepths( const std::vector<double>&                                      propertyValues,
+    void setPropertyValuesAndDepths( const std::vector<double>&                                  propertyValues,
                                      const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
-                                     double                                                          rkbDiff,
-                                     RiaDefines::DepthUnitType                                       depthUnit,
-                                     bool                                                            isExtractionCurve,
-                                     bool                                                            useLogarithmicScale,
+                                     double                                                      rkbDiff,
+                                     RiaDefines::DepthUnitType                                   depthUnit,
+                                     bool                                                        isExtractionCurve,
+                                     bool                                                        useLogarithmicScale,
                                      const QString& propertyUnit = RiaWellLogUnitTools<double>::noUnitString() );
 
     void setPropertyAndDepthsAndErrors( const std::vector<double>& propertyValues,

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurve.h
@@ -76,7 +76,7 @@ protected:
 
     void setPropertyValuesAndDepths( const std::vector<double>& propertyValues,
                                      const std::vector<double>& depths,
-                                     RiaDefines::DepthTypeEnum  depthType,
+                                     RiaDefines::DepthType  depthType,
                                      double                     rkbDiff,
                                      RiaDefines::DepthUnitType  depthUnit,
                                      bool                       isExtractionCurve,
@@ -95,7 +95,7 @@ protected:
     void setPropertyAndDepthValuesToPlotCurve( const std::vector<double>& propertyValues, const std::vector<double>& depthValues );
 
     void setPropertyValuesAndDepths( const std::vector<double>&                                      propertyValues,
-                                     const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& depths,
+                                     const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
                                      double                                                          rkbDiff,
                                      RiaDefines::DepthUnitType                                       depthUnit,
                                      bool                                                            isExtractionCurve,

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurveCommonDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurveCommonDataSource.cpp
@@ -421,7 +421,7 @@ void RimWellLogCurveCommonDataSource::analyseCurvesAndTracks( const std::vector<
             m_uniqueBranchDetection.insert( track->formationBranchDetection() );
             m_uniqueBranchIndices.insert( track->formationBranchIndex() );
 
-            m_uniqueCases.insert( track->formationNamesCase() );
+            m_uniqueCases.insert( track->formationCase() );
             m_uniqueWellPaths.insert( track->formationWellPath() );
         }
     }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurveCommonDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogCurveCommonDataSource.cpp
@@ -409,12 +409,12 @@ void RimWellLogCurveCommonDataSource::analyseCurvesAndTracks( const std::vector<
         }
         if ( track->showFormations() )
         {
-            m_uniqueTrajectoryTypes.insert( track->formationTrajectoryType() );
-            if ( track->formationTrajectoryType() == RimWellLogTrack::WELL_PATH )
+            m_uniqueTrajectoryTypes.insert( static_cast<int>( track->formationTrajectoryType() ) );
+            if ( track->formationTrajectoryType() == RiaDefines::WellLogTrackTrajectoryType::WELL_PATH )
             {
                 m_uniqueWellPaths.insert( track->formationWellPath() );
             }
-            else if ( track->formationTrajectoryType() == RimWellLogTrack::SIMULATION_WELL )
+            else if ( track->formationTrajectoryType() == RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL )
             {
                 m_uniqueWellNames.insert( track->formationSimWellName() );
             }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp
@@ -349,7 +349,7 @@ void RimWellLogExtractionCurve::onLoadDataAndUpdate( bool updateParentPlot )
             RimDepthTrackPlot* wellLogPlot = firstAncestorOrThisOfType<RimDepthTrackPlot>();
             if ( !wellLogPlot ) return;
 
-            RiaDefines::DepthType depthType   = wellLogPlot->depthType();
+            RiaDefines::DepthType     depthType   = wellLogPlot->depthType();
             RiaDefines::DepthUnitType displayUnit = wellLogPlot->depthUnit();
             if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH || depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
             {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp
@@ -349,9 +349,9 @@ void RimWellLogExtractionCurve::onLoadDataAndUpdate( bool updateParentPlot )
             RimDepthTrackPlot* wellLogPlot = firstAncestorOrThisOfType<RimDepthTrackPlot>();
             if ( !wellLogPlot ) return;
 
-            RiaDefines::DepthTypeEnum depthType   = wellLogPlot->depthType();
+            RiaDefines::DepthType depthType   = wellLogPlot->depthType();
             RiaDefines::DepthUnitType displayUnit = wellLogPlot->depthUnit();
-            if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH || depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+            if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH || depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
             {
                 isUsingPseudoLength = false;
             }
@@ -476,7 +476,7 @@ void RimWellLogExtractionCurve::extractData( bool*                        isUsin
         {
             setPropertyValuesAndDepths( curveData.values,
                                         curveData.measuredDepthValues,
-                                        RiaDefines::DepthTypeEnum::MEASURED_DEPTH,
+                                        RiaDefines::DepthType::MEASURED_DEPTH,
                                         0.0,
                                         curveData.depthUnit,
                                         !performDataSmoothing,

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogLasFileCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogLasFileCurve.cpp
@@ -136,18 +136,18 @@ void RimWellLogLasFileCurve::onLoadDataAndUpdate( bool updateParentPlot )
                     }
                 }
 
-                std::map<RiaDefines::DepthTypeEnum, std::vector<double>> validDepths;
+                std::map<RiaDefines::DepthType, std::vector<double>> validDepths;
                 if ( values.size() == measuredDepthValues.size() )
                 {
-                    validDepths.insert( std::make_pair( RiaDefines::DepthTypeEnum::MEASURED_DEPTH, measuredDepthValues ) );
+                    validDepths.insert( std::make_pair( RiaDefines::DepthType::MEASURED_DEPTH, measuredDepthValues ) );
                 }
                 if ( values.size() == tvdMslValues.size() )
                 {
-                    validDepths.insert( std::make_pair( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, tvdMslValues ) );
+                    validDepths.insert( std::make_pair( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvdMslValues ) );
                 }
                 if ( values.size() == tvdRkbValues.size() )
                 {
-                    validDepths.insert( std::make_pair( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB, tvdRkbValues ) );
+                    validDepths.insert( std::make_pair( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB, tvdRkbValues ) );
                 }
 
                 bool useLogarithmicScale = false;
@@ -189,7 +189,7 @@ void RimWellLogLasFileCurve::onLoadDataAndUpdate( bool updateParentPlot )
             displayUnit = wellLogPlot->depthUnit();
         }
 
-        RiaDefines::DepthTypeEnum depthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+        RiaDefines::DepthType depthType = RiaDefines::DepthType::MEASURED_DEPTH;
         if ( wellLogPlot && curveData()->availableDepthTypes().count( wellLogPlot->depthType() ) )
         {
             depthType = wellLogPlot->depthType();

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -756,12 +756,12 @@ void RimWellLogRftCurve::onLoadDataAndUpdate( bool updateParentPlot )
 
         if ( m_plotCurve )
         {
-            if ( wellLogPlot->depthType() == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+            if ( wellLogPlot->depthType() == RiaDefines::DepthType::MEASURED_DEPTH )
             {
                 m_plotCurve->setPerPointLabels( perPointLabels );
 
                 auto propertyValues = curveData()->propertyValuesByIntervals();
-                auto depthValues    = curveData()->depthValuesByIntervals( RiaDefines::DepthTypeEnum::MEASURED_DEPTH, displayUnit );
+                auto depthValues    = curveData()->depthValuesByIntervals( RiaDefines::DepthType::MEASURED_DEPTH, displayUnit );
 
                 if ( !errors.empty() )
                 {
@@ -789,7 +789,7 @@ void RimWellLogRftCurve::onLoadDataAndUpdate( bool updateParentPlot )
                 m_plotCurve->setPerPointLabels( perPointLabels );
 
                 auto propertyValues = curveData()->propertyValuesByIntervals();
-                auto depthValues    = curveData()->depthValuesByIntervals( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, displayUnit );
+                auto depthValues    = curveData()->depthValuesByIntervals( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, displayUnit );
                 bool useLogarithmicScale = false;
 
                 if ( !errors.empty() )

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -788,8 +788,8 @@ void RimWellLogRftCurve::onLoadDataAndUpdate( bool updateParentPlot )
             {
                 m_plotCurve->setPerPointLabels( perPointLabels );
 
-                auto propertyValues = curveData()->propertyValuesByIntervals();
-                auto depthValues    = curveData()->depthValuesByIntervals( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, displayUnit );
+                auto propertyValues      = curveData()->propertyValuesByIntervals();
+                auto depthValues         = curveData()->depthValuesByIntervals( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, displayUnit );
                 bool useLogarithmicScale = false;
 
                 if ( !errors.empty() )

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/CMakeLists_files.cmake
@@ -1,0 +1,19 @@
+set(SOURCE_GROUP_HEADER_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogTrack.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogPropertyAxisSettings.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogFormationSettings.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogRegionAnnotationSettings.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogWellPathAttributeSettings.h
+)
+
+set(SOURCE_GROUP_SOURCE_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogTrack.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogPropertyAxisSettings.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogFormationSettings.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogRegionAnnotationSettings.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellLogWellPathAttributeSettings.cpp
+)
+
+list(APPEND CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})
+
+list(APPEND CODE_SOURCE_FILES ${SOURCE_GROUP_SOURCE_FILES})

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.cpp
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -66,13 +66,6 @@ RimWellLogFormationSettings::RimWellLogFormationSettings()
     CAF_PDM_InitFieldNoDefault( &m_formationLevel, "FormationLevel", "Well Pick Filter" );
 
     CAF_PDM_InitField( &m_showFormationFluids, "ShowFormationFluids", false, "Show Fluids" );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RimWellLogFormationSettings::~RimWellLogFormationSettings()
-{
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -314,19 +307,7 @@ QList<caf::PdmOptionItemInfo> RimWellLogFormationSettings::calculateValueOptions
 {
     QList<caf::PdmOptionItemInfo> options;
 
-    if ( fieldNeedingOptions == &m_formationSource )
-    {
-        options.push_back( caf::PdmOptionItemInfo( "Case", static_cast<int>( RiaDefines::WellLogTrackFormationSource::CASE ) ) );
-        options.push_back( caf::PdmOptionItemInfo( "Well Picks for Well Path",
-                                                   static_cast<int>( RiaDefines::WellLogTrackFormationSource::WELL_PICK_FILTER ) ) );
-    }
-    else if ( fieldNeedingOptions == &m_formationTrajectoryType )
-    {
-        options.push_back( caf::PdmOptionItemInfo( "Well Path", static_cast<int>( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH ) ) );
-        options.push_back(
-            caf::PdmOptionItemInfo( "Simulation Well", static_cast<int>( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL ) ) );
-    }
-    else if ( fieldNeedingOptions == &m_formationWellPathForSourceCase )
+    if ( fieldNeedingOptions == &m_formationWellPathForSourceCase )
     {
         RimTools::wellPathOptionItems( &options );
     }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.cpp
@@ -1,0 +1,386 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimWellLogFormationSettings.h"
+
+#include "RiaSimWellBranchTools.h"
+
+#include "RiaWellLogTrackDefines.h"
+#include "RimCase.h"
+#include "RimEclipseCase.h"
+#include "RimTools.h"
+#include "RimWellLogTrack.h"
+#include "RimWellPath.h"
+
+#include "RigEclipseCaseData.h"
+
+#include "cafPdmUiGroup.h"
+
+CAF_PDM_SOURCE_INIT( RimWellLogFormationSettings, "RimWellLogFormationSettings" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogFormationSettings::RimWellLogFormationSettings()
+{
+    CAF_PDM_InitObject( "Formation Settings" );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationSource, "FormationSource", "Source" );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationTrajectoryType, "FormationTrajectoryType", "Trajectory" );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationWellPathForSourceCase, "FormationWellPath", "Well Path" );
+    m_formationWellPathForSourceCase.uiCapability()->setUiTreeChildrenHidden( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationWellPathForSourceWellPath, "FormationWellPathForSourceWellPath", "Well Path" );
+    m_formationWellPathForSourceWellPath.uiCapability()->setUiTreeChildrenHidden( true );
+
+    CAF_PDM_InitField( &m_formationSimWellName, "FormationSimulationWellName", QString( "None" ), "Simulation Well" );
+    CAF_PDM_InitField( &m_formationBranchIndex, "FormationBranchIndex", 0, " " );
+    CAF_PDM_InitField( &m_formationBranchDetection,
+                       "FormationBranchDetection",
+                       true,
+                       "Branch Detection",
+                       "",
+                       "Compute branches based on how simulation well cells are organized",
+                       "" );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationCase, "FormationCase", "Formation Case" );
+    m_formationCase.uiCapability()->setUiTreeChildrenHidden( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationLevel, "FormationLevel", "Well Pick Filter" );
+
+    CAF_PDM_InitField( &m_showFormationFluids, "ShowFormationFluids", false, "Show Fluids" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogFormationSettings::~RimWellLogFormationSettings()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::WellLogTrackFormationSource RimWellLogFormationSettings::formationSource() const
+{
+    return m_formationSource();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setFormationSource( RiaDefines::WellLogTrackFormationSource source )
+{
+    m_formationSource = source;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimCase* RimWellLogFormationSettings::formationCase() const
+{
+    return m_formationCase();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setFormationCase( RimCase* rimCase )
+{
+    m_formationCase = rimCase;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::WellLogTrackTrajectoryType RimWellLogFormationSettings::trajectoryType() const
+{
+    return m_formationTrajectoryType();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setTrajectoryType( RiaDefines::WellLogTrackTrajectoryType trajectoryType )
+{
+    m_formationTrajectoryType = trajectoryType;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPath* RimWellLogFormationSettings::wellPathForSourceCase() const
+{
+    return m_formationWellPathForSourceCase();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setWellPathForSourceCase( RimWellPath* wellPath )
+{
+    m_formationWellPathForSourceCase = wellPath;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPath* RimWellLogFormationSettings::wellPathForSourceWellPath() const
+{
+    return m_formationWellPathForSourceWellPath();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setWellPathForSourceWellPath( RimWellPath* wellPath )
+{
+    m_formationWellPathForSourceWellPath = wellPath;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RimWellLogFormationSettings::simWellName() const
+{
+    return m_formationSimWellName();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setSimWellName( const QString& simWellName )
+{
+    m_formationSimWellName = simWellName;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+int RimWellLogFormationSettings::branchIndex() const
+{
+    return m_formationBranchIndex();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setBranchIndex( int branchIndex )
+{
+    m_formationBranchIndex = branchIndex;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogFormationSettings::branchDetection() const
+{
+    return m_formationBranchDetection();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setBranchDetection( bool branchDetection )
+{
+    m_formationBranchDetection = branchDetection;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::WellLogTrackFormationLevel RimWellLogFormationSettings::formationLevel() const
+{
+    return m_formationLevel();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setFormationLevel( RiaDefines::WellLogTrackFormationLevel level )
+{
+    m_formationLevel = level;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogFormationSettings::showFormationFluids() const
+{
+    return m_showFormationFluids();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::setShowFormationFluids( bool show )
+{
+    m_showFormationFluids = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering, bool formationsForCaseWithSimWellOnly )
+{
+    if ( !formationsForCaseWithSimWellOnly )
+    {
+        uiOrdering.add( &m_formationSource );
+    }
+
+    if ( m_formationSource() == RiaDefines::WellLogTrackFormationSource::CASE )
+    {
+        uiOrdering.add( &m_formationCase );
+
+        if ( !formationsForCaseWithSimWellOnly )
+        {
+            uiOrdering.add( &m_formationTrajectoryType );
+
+            if ( m_formationTrajectoryType() == RiaDefines::WellLogTrackTrajectoryType::WELL_PATH )
+            {
+                uiOrdering.add( &m_formationWellPathForSourceCase );
+            }
+        }
+
+        if ( formationsForCaseWithSimWellOnly || m_formationTrajectoryType() == RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL )
+        {
+            uiOrdering.add( &m_formationSimWellName );
+
+            RiaSimWellBranchTools::appendSimWellBranchFieldsIfRequiredFromSimWellName( &uiOrdering,
+                                                                                       m_formationSimWellName,
+                                                                                       m_formationBranchDetection,
+                                                                                       m_formationBranchIndex );
+        }
+    }
+    else if ( m_formationSource() == RiaDefines::WellLogTrackFormationSource::WELL_PICK_FILTER )
+    {
+        uiOrdering.add( &m_formationWellPathForSourceWellPath );
+        if ( m_formationWellPathForSourceWellPath() )
+        {
+            uiOrdering.add( &m_formationLevel );
+            uiOrdering.add( &m_showFormationFluids );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogFormationSettings::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
+{
+    if ( changedField == &m_formationSource && m_formationSource() == RiaDefines::WellLogTrackFormationSource::WELL_PICK_FILTER )
+    {
+        std::vector<RimWellPath*> wellPaths;
+        RimTools::wellPathWithFormations( &wellPaths );
+        for ( RimWellPath* wellPath : wellPaths )
+        {
+            if ( wellPath == m_formationWellPathForSourceCase )
+            {
+                m_formationWellPathForSourceWellPath = m_formationWellPathForSourceCase();
+                break;
+            }
+        }
+    }
+
+    auto track = firstAncestorOrThisOfType<RimWellLogTrack>();
+    if ( track )
+    {
+        track->loadDataAndUpdate();
+        track->updateConnectedEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RimWellLogFormationSettings::calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions )
+{
+    QList<caf::PdmOptionItemInfo> options;
+
+    if ( fieldNeedingOptions == &m_formationSource )
+    {
+        options.push_back( caf::PdmOptionItemInfo( "Case", static_cast<int>( RiaDefines::WellLogTrackFormationSource::CASE ) ) );
+        options.push_back( caf::PdmOptionItemInfo( "Well Picks for Well Path",
+                                                   static_cast<int>( RiaDefines::WellLogTrackFormationSource::WELL_PICK_FILTER ) ) );
+    }
+    else if ( fieldNeedingOptions == &m_formationTrajectoryType )
+    {
+        options.push_back( caf::PdmOptionItemInfo( "Well Path", static_cast<int>( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH ) ) );
+        options.push_back(
+            caf::PdmOptionItemInfo( "Simulation Well", static_cast<int>( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL ) ) );
+    }
+    else if ( fieldNeedingOptions == &m_formationWellPathForSourceCase )
+    {
+        RimTools::wellPathOptionItems( &options );
+    }
+    else if ( fieldNeedingOptions == &m_formationWellPathForSourceWellPath )
+    {
+        RimTools::wellPathWithFormationsOptionItems( &options );
+    }
+    else if ( fieldNeedingOptions == &m_formationCase )
+    {
+        RimTools::caseOptionItems( &options );
+    }
+    else if ( fieldNeedingOptions == &m_formationSimWellName )
+    {
+        std::set<QString> sortedWellNames;
+
+        RimEclipseCase* eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationCase.value() );
+        if ( eclipseCase && eclipseCase->eclipseCaseData() )
+        {
+            sortedWellNames = eclipseCase->eclipseCaseData()->findSortedWellNames();
+        }
+
+        caf::IconProvider simWellIcon( ":/Well.svg" );
+        for ( const QString& wname : sortedWellNames )
+        {
+            options.push_back( caf::PdmOptionItemInfo( wname, wname, false, simWellIcon ) );
+        }
+    }
+    else if ( fieldNeedingOptions == &m_formationBranchIndex )
+    {
+        auto simulationWellBranches = RiaSimWellBranchTools::simulationWellBranches( m_formationSimWellName(), m_formationBranchDetection );
+        options                     = RiaSimWellBranchTools::valueOptionsForBranchIndexField( simulationWellBranches );
+    }
+    else if ( fieldNeedingOptions == &m_formationLevel )
+    {
+        if ( m_formationWellPathForSourceWellPath )
+        {
+            const RigWellPathFormations* formations = m_formationWellPathForSourceWellPath->formationsGeometry();
+            if ( formations )
+            {
+                using FormationLevelEnum = caf::AppEnum<RiaDefines::WellLogTrackFormationLevel>;
+
+                options.push_back( caf::PdmOptionItemInfo( FormationLevelEnum::uiText( RiaDefines::WellLogTrackFormationLevel::NONE ),
+                                                           RiaDefines::WellLogTrackFormationLevel::NONE ) );
+
+                options.push_back( caf::PdmOptionItemInfo( FormationLevelEnum::uiText( RiaDefines::WellLogTrackFormationLevel::ALL ),
+                                                           RiaDefines::WellLogTrackFormationLevel::ALL ) );
+
+                for ( const auto& level : formations->formationsLevelsPresent() )
+                {
+                    options.push_back( caf::PdmOptionItemInfo( FormationLevelEnum::uiText( level ), level ) );
+                }
+            }
+        }
+    }
+
+    return options;
+}

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -42,7 +42,6 @@ class RimWellLogFormationSettings : public caf::PdmObject
 
 public:
     RimWellLogFormationSettings();
-    ~RimWellLogFormationSettings() override;
 
     // Formation source
     RiaDefines::WellLogTrackFormationSource formationSource() const;

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogFormationSettings.h
@@ -1,0 +1,102 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RiaWellLogTrackDefines.h"
+
+#include "Well/RigWellPathFormations.h"
+
+#include "cafAppEnum.h"
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+#include "cafPdmPtrField.h"
+
+class RimCase;
+class RimWellPath;
+class RimWellLogTrack;
+
+//==================================================================================================
+///
+/// Settings class for formation/trajectory configuration in well log tracks
+///
+//==================================================================================================
+class RimWellLogFormationSettings : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RimWellLogFormationSettings();
+    ~RimWellLogFormationSettings() override;
+
+    // Formation source
+    RiaDefines::WellLogTrackFormationSource formationSource() const;
+    void                                    setFormationSource( RiaDefines::WellLogTrackFormationSource source );
+
+    // Formation case
+    RimCase* formationCase() const;
+    void     setFormationCase( RimCase* rimCase );
+
+    // Trajectory type
+    RiaDefines::WellLogTrackTrajectoryType trajectoryType() const;
+    void                                   setTrajectoryType( RiaDefines::WellLogTrackTrajectoryType trajectoryType );
+
+    // Well paths
+    RimWellPath* wellPathForSourceCase() const;
+    void         setWellPathForSourceCase( RimWellPath* wellPath );
+
+    RimWellPath* wellPathForSourceWellPath() const;
+    void         setWellPathForSourceWellPath( RimWellPath* wellPath );
+
+    // Simulation well
+    QString simWellName() const;
+    void    setSimWellName( const QString& simWellName );
+
+    int  branchIndex() const;
+    void setBranchIndex( int branchIndex );
+
+    bool branchDetection() const;
+    void setBranchDetection( bool branchDetection );
+
+    // Formation level
+    RiaDefines::WellLogTrackFormationLevel formationLevel() const;
+    void                                   setFormationLevel( RiaDefines::WellLogTrackFormationLevel level );
+
+    // Show fluids
+    bool showFormationFluids() const;
+    void setShowFormationFluids( bool show );
+
+    // UI ordering helper
+    void uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering, bool formationsForCaseWithSimWellOnly );
+
+protected:
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
+
+private:
+    caf::PdmField<caf::AppEnum<RiaDefines::WellLogTrackFormationSource>> m_formationSource;
+    caf::PdmPtrField<RimCase*>                                           m_formationCase;
+    caf::PdmField<caf::AppEnum<RiaDefines::WellLogTrackTrajectoryType>>  m_formationTrajectoryType;
+    caf::PdmPtrField<RimWellPath*>                                       m_formationWellPathForSourceCase;
+    caf::PdmPtrField<RimWellPath*>                                       m_formationWellPathForSourceWellPath;
+    caf::PdmField<QString>                                               m_formationSimWellName;
+    caf::PdmField<int>                                                   m_formationBranchIndex;
+    caf::PdmField<bool>                                                  m_formationBranchDetection;
+    caf::PdmField<caf::AppEnum<RiaDefines::WellLogTrackFormationLevel>>  m_formationLevel;
+    caf::PdmField<bool>                                                  m_showFormationFluids;
+};

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.cpp
@@ -1,0 +1,296 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimWellLogPropertyAxisSettings.h"
+
+#include "RimWellLogTrack.h"
+
+#include "cafPdmUiDoubleValueEditor.h"
+
+#define RI_LOGPLOTTRACK_MINX_DEFAULT -10.0
+#define RI_LOGPLOTTRACK_MAXX_DEFAULT 100.0
+
+CAF_PDM_SOURCE_INIT( RimWellLogPropertyAxisSettings, "RimWellLogPropertyAxisSettings" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogPropertyAxisSettings::RimWellLogPropertyAxisSettings()
+{
+    CAF_PDM_InitObject( "Property Axis Settings" );
+
+    CAF_PDM_InitField( &m_isEnabled, "IsEnabled", true, "Show Axis" );
+
+    CAF_PDM_InitField( &m_visibleRangeMin, "VisibleRangeMin", RI_LOGPLOTTRACK_MINX_DEFAULT, "Min" );
+    m_visibleRangeMin.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+
+    CAF_PDM_InitField( &m_visibleRangeMax, "VisibleRangeMax", RI_LOGPLOTTRACK_MAXX_DEFAULT, "Max" );
+    m_visibleRangeMax.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+
+    CAF_PDM_InitField( &m_isAutoScaleEnabled, "IsAutoScaleEnabled", true, "Auto Scale" );
+    m_isAutoScaleEnabled.uiCapability()->setUiHidden( true );
+
+    CAF_PDM_InitField( &m_isLogarithmicScaleEnabled, "IsLogarithmicScaleEnabled", false, "Logarithmic Scale" );
+    CAF_PDM_InitField( &m_isAxisInverted, "IsAxisInverted", false, "Invert Axis Range" );
+
+    CAF_PDM_InitFieldNoDefault( &m_gridVisibility, "GridVisibility", "Show Grid Lines" );
+
+    CAF_PDM_InitField( &m_minAndMaxTicksOnly, "MinAndMaxTicksOnly", false, "Show Ticks at Min and Max" );
+    CAF_PDM_InitField( &m_explicitTickIntervals, "ExplicitTickIntervals", false, "Manually Set Tick Intervals" );
+
+    CAF_PDM_InitField( &m_majorTickInterval, "MajorTickInterval", 0.0, "Major Tick Interval" );
+    m_majorTickInterval.uiCapability()->setUiHidden( true );
+
+    CAF_PDM_InitField( &m_minorTickInterval, "MinorTickInterval", 0.0, "Minor Tick Interval" );
+    m_minorTickInterval.uiCapability()->setUiHidden( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogPropertyAxisSettings::~RimWellLogPropertyAxisSettings()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogPropertyAxisSettings::isEnabled() const
+{
+    return m_isEnabled();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setEnabled( bool enable )
+{
+    m_isEnabled = enable;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimWellLogPropertyAxisSettings::visibleRangeMin() const
+{
+    return m_visibleRangeMin();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimWellLogPropertyAxisSettings::visibleRangeMax() const
+{
+    return m_visibleRangeMax();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setVisibleRange( double minValue, double maxValue )
+{
+    m_visibleRangeMin = minValue;
+    m_visibleRangeMax = maxValue;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogPropertyAxisSettings::isAutoScaleEnabled() const
+{
+    return m_isAutoScaleEnabled();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setAutoScaleEnabled( bool enabled )
+{
+    m_isAutoScaleEnabled = enabled;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogPropertyAxisSettings::isLogarithmicScaleEnabled() const
+{
+    return m_isLogarithmicScaleEnabled();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setLogarithmicScaleEnabled( bool enabled )
+{
+    m_isLogarithmicScaleEnabled = enabled;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogPropertyAxisSettings::isAxisInverted() const
+{
+    return m_isAxisInverted();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setAxisInverted( bool inverted )
+{
+    m_isAxisInverted = inverted;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimDepthTrackPlot::AxisGridVisibility RimWellLogPropertyAxisSettings::gridVisibility() const
+{
+    return m_gridVisibility();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setGridVisibility( RimDepthTrackPlot::AxisGridVisibility visibility )
+{
+    m_gridVisibility = visibility;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogPropertyAxisSettings::isMinAndMaxTicksOnly() const
+{
+    return m_minAndMaxTicksOnly();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setMinAndMaxTicksOnly( bool enable )
+{
+    m_minAndMaxTicksOnly = enable;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogPropertyAxisSettings::isExplicitTickIntervals() const
+{
+    return m_explicitTickIntervals();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setExplicitTickIntervals( bool enable )
+{
+    m_explicitTickIntervals = enable;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimWellLogPropertyAxisSettings::majorTickInterval() const
+{
+    return m_majorTickInterval();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimWellLogPropertyAxisSettings::minorTickInterval() const
+{
+    return m_minorTickInterval();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::setTickIntervals( double majorInterval, double minorInterval )
+{
+    m_majorTickInterval     = majorInterval;
+    m_minorTickInterval     = minorInterval;
+    m_explicitTickIntervals = true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    caf::PdmUiGroup* propertyAxisGroup = uiOrdering.addNewGroup( "Property Axis" );
+
+    propertyAxisGroup->add( &m_isEnabled );
+    propertyAxisGroup->add( &m_isLogarithmicScaleEnabled );
+    propertyAxisGroup->add( &m_isAxisInverted );
+    propertyAxisGroup->add( &m_visibleRangeMin );
+    propertyAxisGroup->add( &m_visibleRangeMax );
+
+    propertyAxisGroup->add( &m_gridVisibility );
+
+    propertyAxisGroup->add( &m_explicitTickIntervals );
+    if ( m_explicitTickIntervals() )
+    {
+        m_majorTickInterval.uiCapability()->setUiHidden( false );
+        m_minorTickInterval.uiCapability()->setUiHidden( false );
+        propertyAxisGroup->add( &m_majorTickInterval );
+        propertyAxisGroup->add( &m_minorTickInterval );
+    }
+    else
+    {
+        m_majorTickInterval.uiCapability()->setUiHidden( true );
+        m_minorTickInterval.uiCapability()->setUiHidden( true );
+    }
+
+    propertyAxisGroup->add( &m_minAndMaxTicksOnly );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogPropertyAxisSettings::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
+{
+    auto track = firstAncestorOrThisOfType<RimWellLogTrack>();
+    if ( track )
+    {
+        if ( changedField == &m_isEnabled )
+        {
+            track->updateAxes();
+            track->updateConnectedEditors();
+        }
+        else if ( changedField == &m_isLogarithmicScaleEnabled || changedField == &m_isAxisInverted )
+        {
+            track->loadDataAndUpdate();
+            track->updateConnectedEditors();
+        }
+        else if ( changedField == &m_visibleRangeMin || changedField == &m_visibleRangeMax )
+        {
+            m_isAutoScaleEnabled = false;
+            track->updatePlotWidgetFromAxisRanges();
+            track->updateConnectedEditors();
+        }
+        else if ( changedField == &m_gridVisibility || changedField == &m_explicitTickIntervals || changedField == &m_majorTickInterval ||
+                  changedField == &m_minorTickInterval || changedField == &m_minAndMaxTicksOnly )
+        {
+            track->updatePropertyValueAxisAndGridTickIntervals();
+            track->updateConnectedEditors();
+        }
+    }
+}

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.cpp
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogPropertyAxisSettings.h
@@ -1,0 +1,92 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RimDepthTrackPlot.h"
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+
+//==================================================================================================
+///
+/// Settings class for property axis configuration in well log tracks
+///
+//==================================================================================================
+class RimWellLogPropertyAxisSettings : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RimWellLogPropertyAxisSettings();
+    ~RimWellLogPropertyAxisSettings() override;
+
+    // Axis visibility
+    bool isEnabled() const;
+    void setEnabled( bool enable );
+
+    // Value range
+    double visibleRangeMin() const;
+    double visibleRangeMax() const;
+    void   setVisibleRange( double minValue, double maxValue );
+
+    // Auto scale
+    bool isAutoScaleEnabled() const;
+    void setAutoScaleEnabled( bool enabled );
+
+    // Logarithmic scale
+    bool isLogarithmicScaleEnabled() const;
+    void setLogarithmicScaleEnabled( bool enabled );
+
+    // Axis inversion
+    bool isAxisInverted() const;
+    void setAxisInverted( bool inverted );
+
+    // Grid visibility
+    RimDepthTrackPlot::AxisGridVisibility gridVisibility() const;
+    void                                  setGridVisibility( RimDepthTrackPlot::AxisGridVisibility visibility );
+
+    // Tick settings
+    bool isMinAndMaxTicksOnly() const;
+    void setMinAndMaxTicksOnly( bool enable );
+
+    bool isExplicitTickIntervals() const;
+    void setExplicitTickIntervals( bool enable );
+
+    double majorTickInterval() const;
+    double minorTickInterval() const;
+    void   setTickIntervals( double majorInterval, double minorInterval );
+
+    void uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering );
+
+protected:
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+
+private:
+    caf::PdmField<bool>                            m_isEnabled;
+    caf::PdmField<double>                          m_visibleRangeMin;
+    caf::PdmField<double>                          m_visibleRangeMax;
+    caf::PdmField<bool>                            m_isAutoScaleEnabled;
+    caf::PdmField<bool>                            m_isLogarithmicScaleEnabled;
+    caf::PdmField<bool>                            m_isAxisInverted;
+    caf::PdmField<RimDepthTrackPlot::AxisGridEnum> m_gridVisibility;
+    caf::PdmField<bool>                            m_minAndMaxTicksOnly;
+    caf::PdmField<bool>                            m_explicitTickIntervals;
+    caf::PdmField<double>                          m_majorTickInterval;
+    caf::PdmField<double>                          m_minorTickInterval;
+};

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.cpp
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.cpp
@@ -1,0 +1,233 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimWellLogRegionAnnotationSettings.h"
+
+#include "RimColorLegend.h"
+#include "RimRegularLegendConfig.h"
+#include "RimTools.h"
+#include "RimWellLogTrack.h"
+
+#include "cafPdmUiSliderEditor.h"
+
+CAF_PDM_SOURCE_INIT( RimWellLogRegionAnnotationSettings, "RimWellLogRegionAnnotationSettings" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogRegionAnnotationSettings::RimWellLogRegionAnnotationSettings()
+{
+    CAF_PDM_InitObject( "Region Annotation Settings" );
+
+    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationType, "AnnotationType", "Region Annotations" );
+    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationDisplay, "RegionDisplay", "Region Display" );
+
+    CAF_PDM_InitFieldNoDefault( &m_colorShadingLegend, "ColorShadingLegend", "Colors" );
+    m_colorShadingLegend = RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::NORMAL );
+
+    CAF_PDM_InitField( &m_colorShadingTransparency, "ColorShadingTransparency", 50, "Color Transparency" );
+    m_colorShadingTransparency.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+
+    CAF_PDM_InitField( &m_showRegionLabels, "ShowFormationLabels", true, "Show Labels" );
+
+    caf::FontTools::RelativeSizeEnum regionLabelFontSizeDefault = caf::FontTools::RelativeSize::Small;
+    CAF_PDM_InitField( &m_regionLabelFontSize, "RegionLabelFontSize", regionLabelFontSizeDefault, "Font Size" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogRegionAnnotationSettings::~RimWellLogRegionAnnotationSettings()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::RegionAnnotationType RimWellLogRegionAnnotationSettings::annotationType() const
+{
+    return m_regionAnnotationType();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::setAnnotationType( RiaDefines::RegionAnnotationType type )
+{
+    m_regionAnnotationType = type;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaDefines::RegionDisplay RimWellLogRegionAnnotationSettings::annotationDisplay() const
+{
+    return m_regionAnnotationDisplay();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::setAnnotationDisplay( RiaDefines::RegionDisplay display )
+{
+    m_regionAnnotationDisplay = display;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimColorLegend* RimWellLogRegionAnnotationSettings::colorShadingLegend() const
+{
+    return m_colorShadingLegend();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::setColorShadingLegend( RimColorLegend* legend )
+{
+    m_colorShadingLegend = legend;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+int RimWellLogRegionAnnotationSettings::colorShadingTransparency() const
+{
+    return m_colorShadingTransparency();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::setColorShadingTransparency( int transparency )
+{
+    m_colorShadingTransparency = transparency;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogRegionAnnotationSettings::showRegionLabels() const
+{
+    return m_showRegionLabels();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::setShowRegionLabels( bool show )
+{
+    m_showRegionLabels = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::FontTools::RelativeSize RimWellLogRegionAnnotationSettings::regionLabelFontSize() const
+{
+    return m_regionLabelFontSize();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::setRegionLabelFontSize( caf::FontTools::RelativeSize fontSize )
+{
+    m_regionLabelFontSize = fontSize;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogRegionAnnotationSettings::showFormations() const
+{
+    return m_regionAnnotationType() == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    uiOrdering.add( &m_regionAnnotationType );
+    uiOrdering.add( &m_regionAnnotationDisplay );
+    uiOrdering.add( &m_showRegionLabels );
+
+    if ( m_regionAnnotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
+    {
+        uiOrdering.add( &m_regionLabelFontSize );
+    }
+
+    if ( m_regionAnnotationDisplay() & RiaDefines::COLOR_SHADING || m_regionAnnotationDisplay() & RiaDefines::COLORED_LINES )
+    {
+        uiOrdering.add( &m_colorShadingLegend );
+        if ( m_regionAnnotationDisplay() & RiaDefines::COLOR_SHADING )
+        {
+            uiOrdering.add( &m_colorShadingTransparency );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
+                                                           const QVariant&            oldValue,
+                                                           const QVariant&            newValue )
+{
+    auto track = firstAncestorOrThisOfType<RimWellLogTrack>();
+    if ( track )
+    {
+        track->loadDataAndUpdate();
+        track->updateConnectedEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogRegionAnnotationSettings::defineEditorAttribute( const caf::PdmFieldHandle* field,
+                                                                QString                    uiConfigName,
+                                                                caf::PdmUiEditorAttribute* attribute )
+{
+    if ( field == &m_colorShadingTransparency )
+    {
+        auto sliderAttrib = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute );
+        if ( sliderAttrib )
+        {
+            sliderAttrib->m_minimum = 0;
+            sliderAttrib->m_maximum = 100;
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RimWellLogRegionAnnotationSettings::calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions )
+{
+    QList<caf::PdmOptionItemInfo> options;
+
+    if ( fieldNeedingOptions == &m_colorShadingLegend )
+    {
+        RimTools::colorLegendOptionItems( &options );
+    }
+
+    return options;
+}

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.h
@@ -1,0 +1,85 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RiaPlotDefines.h"
+
+#include "cafAppEnum.h"
+#include "cafFontTools.h"
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+#include "cafPdmPtrField.h"
+
+class RimColorLegend;
+
+//==================================================================================================
+///
+/// Settings class for region annotation configuration in well log tracks
+///
+//==================================================================================================
+class RimWellLogRegionAnnotationSettings : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    using RegionAnnotationTypeEnum    = caf::AppEnum<RiaDefines::RegionAnnotationType>;
+    using RegionAnnotationDisplayEnum = caf::AppEnum<RiaDefines::RegionDisplay>;
+
+    RimWellLogRegionAnnotationSettings();
+    ~RimWellLogRegionAnnotationSettings() override;
+
+    // Annotation type
+    RiaDefines::RegionAnnotationType annotationType() const;
+    void                             setAnnotationType( RiaDefines::RegionAnnotationType type );
+
+    // Annotation display
+    RiaDefines::RegionDisplay annotationDisplay() const;
+    void                      setAnnotationDisplay( RiaDefines::RegionDisplay display );
+
+    // Color shading
+    RimColorLegend* colorShadingLegend() const;
+    void            setColorShadingLegend( RimColorLegend* legend );
+
+    int  colorShadingTransparency() const;
+    void setColorShadingTransparency( int transparency );
+
+    // Region labels
+    bool showRegionLabels() const;
+    void setShowRegionLabels( bool show );
+
+    caf::FontTools::RelativeSize regionLabelFontSize() const;
+    void                         setRegionLabelFontSize( caf::FontTools::RelativeSize fontSize );
+
+    // Helpers
+    bool showFormations() const;
+    void uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering );
+
+protected:
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
+    QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
+
+private:
+    caf::PdmField<RegionAnnotationTypeEnum>                   m_regionAnnotationType;
+    caf::PdmField<RegionAnnotationDisplayEnum>                m_regionAnnotationDisplay;
+    caf::PdmPtrField<RimColorLegend*>                         m_colorShadingLegend;
+    caf::PdmField<int>                                        m_colorShadingTransparency;
+    caf::PdmField<bool>                                       m_showRegionLabels;
+    caf::PdmField<caf::AppEnum<caf::FontTools::RelativeSize>> m_regionLabelFontSize;
+};

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogRegionAnnotationSettings.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -589,9 +589,6 @@ void RimWellLogTrack::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
     {
         updateParentLayout();
     }
-    // Region annotation field changes are now handled by RimWellLogRegionAnnotationSettings
-    // Well path attribute field changes are now handled by RimWellLogWellPathAttributeSettings
-
     else if ( changedField == &m_autoCheckStateBasedOnCurveData )
     {
         updateCheckStateBasedOnCurveData();
@@ -825,23 +822,23 @@ QString RimWellLogTrack::asciiDataForPlotExport() const
 
     // Header
 
-    if ( depthType == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER )
+    if ( depthType == RiaDefines::DepthType::CONNECTION_NUMBER )
     {
         out += "Connection";
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    else if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH )
     {
         out += "MD   ";
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::PSEUDO_LENGTH )
+    else if ( depthType == RiaDefines::DepthType::PSEUDO_LENGTH )
     {
         out += "PL   ";
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
     {
         out += "TVDMSL  ";
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
     {
         out += "TVDRKB  ";
     }
@@ -874,7 +871,7 @@ QString RimWellLogTrack::asciiDataForPlotExport() const
         size_t i          = dIdx;
         double curveDepth = curveDepths[i];
 
-        if ( depthType == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER )
+        if ( depthType == RiaDefines::DepthType::CONNECTION_NUMBER )
         {
             if ( dIdx == 0 )
                 continue; // Skip the first line. (shallow depth, which is last)
@@ -1446,7 +1443,7 @@ void RimWellLogTrack::setRegionPropertyResultType( RiaDefines::ResultCatType res
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimCase* RimWellLogTrack::formationNamesCase() const
+RimCase* RimWellLogTrack::formationCase() const
 {
     return m_formationSettings->formationCase();
 }
@@ -1884,14 +1881,6 @@ void RimWellLogTrack::initAfterRead()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimWellLogTrack::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
-{
-    // Editor attributes are now handled by the individual settings objects
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 caf::PdmFieldHandle* RimWellLogTrack::userDescriptionField()
 {
     return &m_description;
@@ -2079,7 +2068,7 @@ void RimWellLogTrack::handleWheelEvent( QWheelEvent* wheelEvent )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<std::pair<double, double>> RimWellLogTrack::waterAndRockRegions( RiaDefines::DepthTypeEnum         depthType,
+std::vector<std::pair<double, double>> RimWellLogTrack::waterAndRockRegions( RiaDefines::DepthType             depthType,
                                                                              const RigGeoMechWellLogExtractor* extractor ) const
 {
     double waterEndTVD = extractor->waterDepth();
@@ -2088,7 +2077,7 @@ std::vector<std::pair<double, double>> RimWellLogTrack::waterAndRockRegions( Ria
         waterEndTVD = extractor->estimateWaterDepth();
     }
 
-    if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH )
     {
         double waterStartMD = 0.0;
         if ( extractor->wellPathGeometry()->rkbDiff() != std::numeric_limits<double>::infinity() )
@@ -2099,13 +2088,13 @@ std::vector<std::pair<double, double>> RimWellLogTrack::waterAndRockRegions( Ria
         double rockEndMD  = extractor->cellIntersectionMDs().back();
         return { { waterStartMD, waterEndMD }, { waterEndMD, rockEndMD } };
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
     {
         double waterStartTVD = 0.0;
         double rockEndTVD    = extractor->cellIntersectionTVDs().back();
         return { { waterStartTVD, waterEndTVD }, { waterEndTVD, rockEndTVD } };
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
     {
         double waterStartTVDRKB = extractor->wellPathGeometry()->rkbDiff();
         double waterEndTVDRKB   = waterEndTVD + extractor->wellPathGeometry()->rkbDiff();
@@ -2355,14 +2344,14 @@ void RimWellLogTrack::findRegionNamesToPlot( const CurveSamplingPointData&      
 
     std::vector<double> depthVector;
 
-    if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH || depthType == RiaDefines::DepthTypeEnum::PSEUDO_LENGTH )
+    if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH || depthType == RiaDefines::DepthType::PSEUDO_LENGTH )
     {
         depthVector = curveData.md;
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH || depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH || depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
     {
         depthVector = curveData.tvd;
-        if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+        if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
         {
             for ( double& depthValue : depthVector )
             {
@@ -2432,7 +2421,7 @@ void RimWellLogTrack::updateStackedCurveData()
 
     RimWellLogPlot::DepthTypeEnum depthType   = wellLogPlot->depthType();
     RiaDefines::DepthUnitType     displayUnit = wellLogPlot->depthUnit();
-    if ( depthType == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER )
+    if ( depthType == RiaDefines::DepthType::CONNECTION_NUMBER )
     {
         displayUnit = RiaDefines::DepthUnitType::UNIT_NONE;
     }
@@ -2593,9 +2582,8 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
     {
         if ( m_formationSettings->wellPathForSourceWellPath() == nullptr ) return;
 
-        if ( plot->depthType() != RiaDefines::DepthTypeEnum::MEASURED_DEPTH &&
-             plot->depthType() != RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH &&
-             plot->depthType() != RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+        if ( plot->depthType() != RiaDefines::DepthType::MEASURED_DEPTH && plot->depthType() != RiaDefines::DepthType::TRUE_VERTICAL_DEPTH &&
+             plot->depthType() != RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
         {
             return;
         }
@@ -2613,7 +2601,7 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
                                                      m_formationSettings->showFormationFluids(),
                                                      plot->depthType() );
 
-        if ( plot->depthType() == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+        if ( plot->depthType() == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
         {
             for ( double& depthValue : yValues )
             {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -68,7 +68,11 @@
 #include "RimWellLogCurve.h"
 #include "RimWellLogCurveCommonDataSource.h"
 #include "RimWellLogExtractionCurve.h"
+#include "RimWellLogFormationSettings.h"
 #include "RimWellLogPlotCollection.h"
+#include "RimWellLogPropertyAxisSettings.h"
+#include "RimWellLogRegionAnnotationSettings.h"
+#include "RimWellLogWellPathAttributeSettings.h"
 #include "RimWellPath.h"
 #include "RimWellPathAttribute.h"
 #include "RimWellPathAttributeCollection.h"
@@ -113,66 +117,6 @@
 
 CAF_PDM_SOURCE_INIT( RimWellLogTrack, "WellLogPlotTrack" );
 
-namespace caf
-{
-template <>
-void AppEnum<RimWellLogTrack::TrajectoryType>::setUp()
-{
-    addItem( RimWellLogTrack::WELL_PATH, "WELL_PATH", "Well Path" );
-    addItem( RimWellLogTrack::SIMULATION_WELL, "SIMULATION_WELL", "Simulation Well" );
-    setDefault( RimWellLogTrack::WELL_PATH );
-}
-
-template <>
-void AppEnum<RimWellLogTrack::FormationSource>::setUp()
-{
-    addItem( RimWellLogTrack::FormationSource::CASE, "CASE", "Case" );
-    addItem( RimWellLogTrack::FormationSource::WELL_PICK_FILTER, "WELL_PICK_FILTER", "Well Picks for Well Path" );
-    setDefault( RimWellLogTrack::FormationSource::CASE );
-}
-
-template <>
-void AppEnum<RigWellPathFormations::FormationLevel>::setUp()
-{
-    addItem( RigWellPathFormations::NONE, "NONE", "None" );
-    addItem( RigWellPathFormations::ALL, "ALL", "All" );
-    addItem( RigWellPathFormations::GROUP, "GROUP", "Formation Group" );
-    addItem( RigWellPathFormations::LEVEL0, "LEVEL0", "Formation" );
-    addItem( RigWellPathFormations::LEVEL1, "LEVEL1", "Formation 1" );
-    addItem( RigWellPathFormations::LEVEL2, "LEVEL2", "Formation 2" );
-    addItem( RigWellPathFormations::LEVEL3, "LEVEL3", "Formation 3" );
-    addItem( RigWellPathFormations::LEVEL4, "LEVEL4", "Formation 4" );
-    addItem( RigWellPathFormations::LEVEL5, "LEVEL5", "Formation 5" );
-    addItem( RigWellPathFormations::LEVEL6, "LEVEL6", "Formation 6" );
-    addItem( RigWellPathFormations::LEVEL7, "LEVEL7", "Formation 7" );
-    addItem( RigWellPathFormations::LEVEL8, "LEVEL8", "Formation 8" );
-    addItem( RigWellPathFormations::LEVEL9, "LEVEL9", "Formation 9" );
-    addItem( RigWellPathFormations::LEVEL10, "LEVEL10", "Formation 10" );
-    setDefault( RigWellPathFormations::ALL );
-}
-
-template <>
-void AppEnum<RiaDefines::RegionAnnotationType>::setUp()
-{
-    addItem( RiaDefines::RegionAnnotationType::NO_ANNOTATIONS, "NO_ANNOTATIONS", "No Annotations" );
-    addItem( RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS, "FORMATIONS", "Formations" );
-    addItem( RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS, "RESULT_PROPERTY", "Result Property" );
-    setDefault( RiaDefines::RegionAnnotationType::NO_ANNOTATIONS );
-}
-
-template <>
-void AppEnum<RiaDefines::RegionDisplay>::setUp()
-{
-    addItem( RiaDefines::DARK_LINES, "DARK_LINES", "Dark Lines" );
-    addItem( RiaDefines::LIGHT_LINES, "LIGHT_LINES", "Light Lines" );
-    addItem( RiaDefines::COLORED_LINES, "COLORED_LINES", "Colored Lines" );
-    addItem( RiaDefines::COLOR_SHADING, "COLOR_SHADING", "Color Shading" );
-    addItem( RiaDefines::COLOR_SHADING_AND_LINES, "SHADING_AND_LINES", "Color Shading and Lines" );
-    setDefault( RiaDefines::COLOR_SHADING_AND_LINES );
-}
-
-} // namespace caf
-
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -191,10 +135,16 @@ RimWellLogTrack::RimWellLogTrack()
     auto reorderability = caf::PdmFieldReorderCapability::addToField( &m_curves );
     reorderability->orderChanged.connect( this, &RimWellLogTrack::curveDataChanged );
 
-    CAF_PDM_InitField( &m_visiblePropertyValueRangeMin, "VisibleXRangeMin", RI_LOGPLOTTRACK_MINX_DEFAULT, "Min" );
-    m_visiblePropertyValueRangeMin.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
-    CAF_PDM_InitField( &m_visiblePropertyValueRangeMax, "VisibleXRangeMax", RI_LOGPLOTTRACK_MAXX_DEFAULT, "Max" );
-    m_visiblePropertyValueRangeMax.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    // Property axis settings
+    CAF_PDM_InitFieldNoDefault( &m_propertyAxisSettings, "PropertyAxisSettings", "" );
+    m_propertyAxisSettings = new RimWellLogPropertyAxisSettings();
+    m_propertyAxisSettings.uiCapability()->setUiTreeChildrenHidden( true );
+
+    // OBSOLETE property axis fields - kept for migration from older project files
+    CAF_PDM_InitField( &m_visiblePropertyValueRangeMin_OBSOLETE, "VisibleXRangeMin", RI_LOGPLOTTRACK_MINX_DEFAULT, "Min" );
+    m_visiblePropertyValueRangeMin_OBSOLETE.xmlCapability()->setIOWritable( false );
+    CAF_PDM_InitField( &m_visiblePropertyValueRangeMax_OBSOLETE, "VisibleXRangeMax", RI_LOGPLOTTRACK_MAXX_DEFAULT, "Max" );
+    m_visiblePropertyValueRangeMax_OBSOLETE.xmlCapability()->setIOWritable( false );
 
     CAF_PDM_InitField( &m_visibleDepthRangeMin, "VisibleYRangeMin", RI_LOGPLOTTRACK_MINX_DEFAULT, "Min" );
     CAF_PDM_InitField( &m_visibleDepthRangeMax, "VisibleYRangeMax", RI_LOGPLOTTRACK_MAXX_DEFAULT, "Max" );
@@ -203,80 +153,128 @@ RimWellLogTrack::RimWellLogTrack()
     m_visibleDepthRangeMax.uiCapability()->setUiHidden( true );
     m_visibleDepthRangeMax.xmlCapability()->disableIO();
 
-    CAF_PDM_InitField( &m_isAutoScalePropertyValuesEnabled, "AutoScaleX", true, "Auto Scale" );
-    m_isAutoScalePropertyValuesEnabled.uiCapability()->setUiHidden( true );
+    CAF_PDM_InitField( &m_isAutoScalePropertyValuesEnabled_OBSOLETE, "AutoScaleX", true, "Auto Scale" );
+    m_isAutoScalePropertyValuesEnabled_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_isPropertyLogarithmicScaleEnabled, "LogarithmicScaleX", false, "Logarithmic Scale" );
-    CAF_PDM_InitField( &m_invertPropertyValueAxis, "InvertPropertyValueAxis", false, "Invert Axis Range" );
-    CAF_PDM_InitField( &m_isPropertyAxisEnabled, "IsPropertyAxisEnabled", true, "Show Axis" );
+    CAF_PDM_InitField( &m_isPropertyLogarithmicScaleEnabled_OBSOLETE, "LogarithmicScaleX", false, "Logarithmic Scale" );
+    m_isPropertyLogarithmicScaleEnabled_OBSOLETE.xmlCapability()->setIOWritable( false );
+    CAF_PDM_InitField( &m_invertPropertyValueAxis_OBSOLETE, "InvertPropertyValueAxis", false, "Invert Axis Range" );
+    m_invertPropertyValueAxis_OBSOLETE.xmlCapability()->setIOWritable( false );
+    CAF_PDM_InitField( &m_isPropertyAxisEnabled_OBSOLETE, "IsPropertyAxisEnabled", true, "Show Axis" );
+    m_isPropertyAxisEnabled_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitFieldNoDefault( &m_propertyValueAxisGridVisibility, "ShowXGridLines", "Show Grid Lines" );
+    CAF_PDM_InitFieldNoDefault( &m_propertyValueAxisGridVisibility_OBSOLETE, "ShowXGridLines", "Show Grid Lines" );
+    m_propertyValueAxisGridVisibility_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_explicitTickIntervalsPropertyValueAxis, "ExplicitTickIntervals", false, "Manually Set Tick Intervals" );
-    CAF_PDM_InitField( &m_propertyAxisMinAndMaxTicksOnly, "MinAndMaxTicksOnly", false, "Show Ticks at Min and Max" );
-    CAF_PDM_InitField( &m_majorTickIntervalPropertyAxis, "MajorTickIntervals", 0.0, "Major Tick Interval" );
-    CAF_PDM_InitField( &m_minorTickIntervalPropertyAxis, "MinorTickIntervals", 0.0, "Minor Tick Interval" );
-    m_majorTickIntervalPropertyAxis.uiCapability()->setUiHidden( true );
-    m_minorTickIntervalPropertyAxis.uiCapability()->setUiHidden( true );
+    CAF_PDM_InitField( &m_explicitTickIntervalsPropertyValueAxis_OBSOLETE, "ExplicitTickIntervals", false, "Manually Set Tick Intervals" );
+    m_explicitTickIntervalsPropertyValueAxis_OBSOLETE.xmlCapability()->setIOWritable( false );
+    CAF_PDM_InitField( &m_propertyAxisMinAndMaxTicksOnly_OBSOLETE, "MinAndMaxTicksOnly", false, "Show Ticks at Min and Max" );
+    m_propertyAxisMinAndMaxTicksOnly_OBSOLETE.xmlCapability()->setIOWritable( false );
+    CAF_PDM_InitField( &m_majorTickIntervalPropertyAxis_OBSOLETE, "MajorTickIntervals", 0.0, "Major Tick Interval" );
+    m_majorTickIntervalPropertyAxis_OBSOLETE.xmlCapability()->setIOWritable( false );
+    CAF_PDM_InitField( &m_minorTickIntervalPropertyAxis_OBSOLETE, "MinorTickIntervals", 0.0, "Minor Tick Interval" );
+    m_minorTickIntervalPropertyAxis_OBSOLETE.xmlCapability()->setIOWritable( false );
 
     CAF_PDM_InitFieldNoDefault( &m_axisFontSize, "AxisFontSize", "Axis Font Size" );
 
-    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationType, "AnnotationType", "Region Annotations" );
-    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationDisplay, "RegionDisplay", "Region Display" );
+    // Region annotation settings
+    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationSettings, "RegionAnnotationSettings", "" );
+    m_regionAnnotationSettings = new RimWellLogRegionAnnotationSettings();
+    m_regionAnnotationSettings.uiCapability()->setUiTreeChildrenHidden( true );
 
-    CAF_PDM_InitFieldNoDefault( &m_colorShadingLegend, "ColorShadingLegend", "Colors" );
-    m_colorShadingLegend = RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::NORMAL );
+    // OBSOLETE region annotation fields
+    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationType_OBSOLETE, "AnnotationType", "Region Annotations" );
+    m_regionAnnotationType_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_colorShadingTransparency, "ColorShadingTransparency", 50, "Color Transparency" );
-    m_colorShadingTransparency.uiCapability()->setUiEditorTypeName( caf::PdmUiSliderEditor::uiEditorTypeName() );
+    CAF_PDM_InitFieldNoDefault( &m_regionAnnotationDisplay_OBSOLETE, "RegionDisplay", "Region Display" );
+    m_regionAnnotationDisplay_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_showRegionLabels, "ShowFormationLabels", true, "Show Labels" );
+    CAF_PDM_InitFieldNoDefault( &m_colorShadingLegend_OBSOLETE, "ColorShadingLegend", "Colors" );
+    m_colorShadingLegend_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_colorShadingTransparency_OBSOLETE, "ColorShadingTransparency", 50, "Color Transparency" );
+    m_colorShadingTransparency_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_showRegionLabels_OBSOLETE, "ShowFormationLabels", true, "Show Labels" );
+    m_showRegionLabels_OBSOLETE.xmlCapability()->setIOWritable( false );
 
     caf::FontTools::RelativeSizeEnum regionLabelFontSizeDefault = caf::FontTools::RelativeSize::Small;
-    CAF_PDM_InitField( &m_regionLabelFontSize, "RegionLabelFontSize", regionLabelFontSizeDefault, "Font Size" );
+    CAF_PDM_InitField( &m_regionLabelFontSize_OBSOLETE, "RegionLabelFontSize", regionLabelFontSizeDefault, "Font Size" );
+    m_regionLabelFontSize_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitFieldNoDefault( &m_formationSource, "FormationSource", "Source" );
+    // Formation settings
+    CAF_PDM_InitFieldNoDefault( &m_formationSettings, "FormationSettings", "" );
+    m_formationSettings = new RimWellLogFormationSettings();
+    m_formationSettings.uiCapability()->setUiTreeChildrenHidden( true );
 
-    CAF_PDM_InitFieldNoDefault( &m_formationTrajectoryType, "FormationTrajectoryType", "Trajectory" );
+    // OBSOLETE formation fields
+    CAF_PDM_InitFieldNoDefault( &m_formationSource_OBSOLETE, "FormationSource", "Source" );
+    m_formationSource_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitFieldNoDefault( &m_formationWellPathForSourceCase, "FormationWellPath", "Well Path" );
-    m_formationWellPathForSourceCase.uiCapability()->setUiTreeChildrenHidden( true );
+    CAF_PDM_InitFieldNoDefault( &m_formationTrajectoryType_OBSOLETE, "FormationTrajectoryType", "Trajectory" );
+    m_formationTrajectoryType_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitFieldNoDefault( &m_formationWellPathForSourceWellPath, "FormationWellPathForSourceWellPath", "Well Path" );
-    m_formationWellPathForSourceWellPath.uiCapability()->setUiTreeChildrenHidden( true );
+    CAF_PDM_InitFieldNoDefault( &m_formationWellPathForSourceCase_OBSOLETE, "FormationWellPath", "Well Path" );
+    m_formationWellPathForSourceCase_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_formationSimWellName, "FormationSimulationWellName", QString( "None" ), "Simulation Well" );
-    CAF_PDM_InitField( &m_formationBranchIndex, "FormationBranchIndex", 0, " " );
-    CAF_PDM_InitField( &m_formationBranchDetection,
-                       "FormationBranchDetection",
-                       true,
-                       "Branch Detection",
-                       "",
-                       "Compute branches based on how simulation well cells are organized",
-                       "" );
+    CAF_PDM_InitFieldNoDefault( &m_formationWellPathForSourceWellPath_OBSOLETE, "FormationWellPathForSourceWellPath", "Well Path" );
+    m_formationWellPathForSourceWellPath_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitFieldNoDefault( &m_formationCase, "FormationCase", "Formation Case" );
-    m_formationCase.uiCapability()->setUiTreeChildrenHidden( true );
+    CAF_PDM_InitField( &m_formationSimWellName_OBSOLETE, "FormationSimulationWellName", QString( "None" ), "Simulation Well" );
+    m_formationSimWellName_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitFieldNoDefault( &m_formationLevel, "FormationLevel", "Well Pick Filter" );
+    CAF_PDM_InitField( &m_formationBranchIndex_OBSOLETE, "FormationBranchIndex", 0, " " );
+    m_formationBranchIndex_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_showformationFluids, "ShowFormationFluids", false, "Show Fluids" );
+    CAF_PDM_InitField( &m_formationBranchDetection_OBSOLETE, "FormationBranchDetection", true, "Branch Detection" );
+    m_formationBranchDetection_OBSOLETE.xmlCapability()->setIOWritable( false );
 
-    CAF_PDM_InitField( &m_showWellPathAttributes, "ShowWellPathAttributes", false, "Show Well Attributes" );
-    CAF_PDM_InitField( &m_wellPathAttributesInLegend, "WellPathAttributesInLegend", true, "Attributes in Legend" );
-    CAF_PDM_InitField( &m_showWellPathCompletions, "ShowWellPathCompletions", true, "Show Well Completions" );
-    CAF_PDM_InitField( &m_wellPathCompletionsInLegend, "WellPathCompletionsInLegend", true, "Completions in Legend" );
-    CAF_PDM_InitField( &m_showWellPathComponentsBothSides, "ShowWellPathAttrBothSides", true, "Show Both Sides" );
-    CAF_PDM_InitField( &m_showWellPathComponentLabels, "ShowWellPathAttrLabels", false, "Show Labels" );
-    CAF_PDM_InitFieldNoDefault( &m_wellPathComponentSource, "AttributesWellPathSource", "Well Path" );
-    CAF_PDM_InitFieldNoDefault( &m_wellPathAttributeCollection, "AttributesCollection", "Well Attributes" );
+    CAF_PDM_InitFieldNoDefault( &m_formationCase_OBSOLETE, "FormationCase", "Formation Case" );
+    m_formationCase_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitFieldNoDefault( &m_formationLevel_OBSOLETE, "FormationLevel", "Well Pick Filter" );
+    m_formationLevel_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_showformationFluids_OBSOLETE, "ShowFormationFluids", false, "Show Fluids" );
+    m_showformationFluids_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    // Well path attribute settings
+    CAF_PDM_InitFieldNoDefault( &m_wellPathAttributeSettings, "WellPathAttributeSettings", "" );
+    m_wellPathAttributeSettings = new RimWellLogWellPathAttributeSettings();
+    m_wellPathAttributeSettings.uiCapability()->setUiTreeChildrenHidden( true );
+
+    // OBSOLETE well path attribute fields
+    CAF_PDM_InitField( &m_showWellPathAttributes_OBSOLETE, "ShowWellPathAttributes", false, "Show Well Attributes" );
+    m_showWellPathAttributes_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_wellPathAttributesInLegend_OBSOLETE, "WellPathAttributesInLegend", true, "Attributes in Legend" );
+    m_wellPathAttributesInLegend_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_showWellPathCompletions_OBSOLETE, "ShowWellPathCompletions", true, "Show Well Completions" );
+    m_showWellPathCompletions_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_wellPathCompletionsInLegend_OBSOLETE, "WellPathCompletionsInLegend", true, "Completions in Legend" );
+    m_wellPathCompletionsInLegend_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_showWellPathComponentsBothSides_OBSOLETE, "ShowWellPathAttrBothSides", true, "Show Both Sides" );
+    m_showWellPathComponentsBothSides_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_showWellPathComponentLabels_OBSOLETE, "ShowWellPathAttrLabels", false, "Show Labels" );
+    m_showWellPathComponentLabels_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitFieldNoDefault( &m_wellPathComponentSource_OBSOLETE, "AttributesWellPathSource", "Well Path" );
+    m_wellPathComponentSource_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitFieldNoDefault( &m_wellPathAttributeCollection_OBSOLETE, "AttributesCollection", "Well Attributes" );
+    m_wellPathAttributeCollection_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_overburdenHeight_OBSOLETE, "OverburdenHeight", 0.0, "Overburden Height" );
+    m_overburdenHeight_OBSOLETE.xmlCapability()->setIOWritable( false );
+
+    CAF_PDM_InitField( &m_underburdenHeight_OBSOLETE, "UnderburdenHeight", 0.0, "Underburden Height" );
+    m_underburdenHeight_OBSOLETE.xmlCapability()->setIOWritable( false );
 
     CAF_PDM_InitField( &m_autoCheckStateBasedOnCurveData, "AutoCheckStateBasedOnCurveData", false, "Hide Track if No Curve Data" );
-
-    CAF_PDM_InitField( &m_overburdenHeight, "OverburdenHeight", 0.0, "Overburden Height" );
-    m_overburdenHeight.uiCapability()->setUiHidden( true );
-    CAF_PDM_InitField( &m_underburdenHeight, "UnderburdenHeight", 0.0, "Underburden Height" );
-    m_underburdenHeight.uiCapability()->setUiHidden( true );
 
     CAF_PDM_InitFieldNoDefault( &m_resultDefinition, "ResultDefinition", "Result Definition" );
     m_resultDefinition.uiCapability()->setUiTreeChildrenHidden( true );
@@ -414,9 +412,9 @@ void RimWellLogTrack::calculatePropertyValueZoomRange()
         minValue = 0;
         maxValue = 0;
     }
-    else if ( m_minorTickIntervalPropertyAxis() != 0.0 )
+    else if ( m_propertyAxisSettings->minorTickInterval() != 0.0 )
     {
-        std::tie( minValue, maxValue ) = adjustXRange( minValue, maxValue, m_minorTickIntervalPropertyAxis() );
+        std::tie( minValue, maxValue ) = adjustXRange( minValue, maxValue, m_propertyAxisSettings->minorTickInterval() );
     }
     else
     {
@@ -458,7 +456,7 @@ void RimWellLogTrack::calculateDepthZoomRange()
         }
     }
 
-    if ( m_showWellPathAttributes || m_showWellPathCompletions )
+    if ( m_wellPathAttributeSettings->showWellPathAttributes() || m_wellPathAttributeSettings->showWellPathCompletions() )
     {
         for ( const std::unique_ptr<RiuWellPathComponentPlotItem>& plotObject : m_wellPathAttributePlotObjects )
         {
@@ -495,17 +493,18 @@ void RimWellLogTrack::updatePropertyValueZoom()
 
     calculatePropertyValueZoomRange();
 
-    if ( m_isAutoScalePropertyValuesEnabled )
+    if ( m_propertyAxisSettings->isAutoScaleEnabled() )
     {
-        m_visiblePropertyValueRangeMin = m_availablePropertyValueRangeMin;
-        m_visiblePropertyValueRangeMax = m_availablePropertyValueRangeMax;
+        double rangeMin = m_availablePropertyValueRangeMin;
+        double rangeMax = m_availablePropertyValueRangeMax;
 
-        if ( !visibleStackedCurves().empty() && !m_isPropertyLogarithmicScaleEnabled )
+        if ( !visibleStackedCurves().empty() && !m_propertyAxisSettings->isLogarithmicScaleEnabled() )
         {
             // Try to ensure we include the base line whether the values are negative or positive.
-            m_visiblePropertyValueRangeMin = std::min( m_visiblePropertyValueRangeMin(), 0.0 );
-            m_visiblePropertyValueRangeMax = std::max( m_visiblePropertyValueRangeMax(), 0.0 );
+            rangeMin = std::min( rangeMin, 0.0 );
+            rangeMax = std::max( rangeMax, 0.0 );
         }
+        m_propertyAxisSettings->setVisibleRange( rangeMin, rangeMax );
         computeAndSetPropertyValueRangeMinForLogarithmicScale();
         updateEditors();
     }
@@ -516,12 +515,12 @@ void RimWellLogTrack::updatePropertyValueZoom()
     // Set an extended range here to allow for some label space.
     double componentRangeMax = 2.0 / ( static_cast<double>( colSpan() ) );
     double componentRangeMin = -0.25;
-    if ( m_showWellPathComponentsBothSides )
+    if ( m_wellPathAttributeSettings->showBothSides() )
     {
         componentRangeMin = -1.5;
         componentRangeMax *= 2.0;
     }
-    if ( m_showWellPathComponentLabels )
+    if ( m_wellPathAttributeSettings->showComponentLabels() )
     {
         componentRangeMax *= 1.5;
     }
@@ -590,173 +589,9 @@ void RimWellLogTrack::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
     {
         updateParentLayout();
     }
-    else if ( changedField == &m_explicitTickIntervalsPropertyValueAxis )
-    {
-        if ( m_plotWidget )
-        {
-            m_majorTickIntervalPropertyAxis = m_plotWidget->majorTickInterval( valueAxis() );
-            m_minorTickIntervalPropertyAxis = m_plotWidget->minorTickInterval( valueAxis() );
-        }
-        m_majorTickIntervalPropertyAxis.uiCapability()->setUiHidden( !m_explicitTickIntervalsPropertyValueAxis() );
-        m_minorTickIntervalPropertyAxis.uiCapability()->setUiHidden( !m_explicitTickIntervalsPropertyValueAxis() );
-        if ( !m_explicitTickIntervalsPropertyValueAxis() )
-        {
-            updatePropertyValueAxisAndGridTickIntervals();
-        }
-    }
-    else if ( changedField == &m_isPropertyAxisEnabled )
-    {
-        updatePropertyValueAxisAndGridTickIntervals();
-        updateParentLayout();
-    }
-    else if ( changedField == &m_propertyValueAxisGridVisibility || changedField == &m_majorTickIntervalPropertyAxis ||
-              changedField == &m_minorTickIntervalPropertyAxis || changedField == &m_propertyAxisMinAndMaxTicksOnly ||
-              changedField == &m_invertPropertyValueAxis )
-    {
-        updatePropertyValueAxisAndGridTickIntervals();
-    }
-    else if ( changedField == &m_visiblePropertyValueRangeMin || changedField == &m_visiblePropertyValueRangeMax )
-    {
-        bool emptyRange = isEmptyVisiblePropertyRange();
-        m_explicitTickIntervalsPropertyValueAxis.uiCapability()->setUiReadOnly( emptyRange );
-        m_propertyValueAxisGridVisibility.uiCapability()->setUiReadOnly( emptyRange );
+    // Region annotation field changes are now handled by RimWellLogRegionAnnotationSettings
+    // Well path attribute field changes are now handled by RimWellLogWellPathAttributeSettings
 
-        m_isAutoScalePropertyValuesEnabled = false;
-
-        updatePropertyValueZoom();
-        m_plotWidget->scheduleReplot();
-
-        updateEditors();
-    }
-    else if ( changedField == &m_isAutoScalePropertyValuesEnabled )
-    {
-        if ( m_isAutoScalePropertyValuesEnabled() )
-        {
-            updatePropertyValueZoom();
-            m_plotWidget->scheduleReplot();
-        }
-    }
-    else if ( changedField == &m_isPropertyLogarithmicScaleEnabled )
-    {
-        updateAxisScaleEngine();
-        if ( m_isPropertyLogarithmicScaleEnabled() )
-        {
-            m_explicitTickIntervalsPropertyValueAxis = false;
-        }
-        m_explicitTickIntervalsPropertyValueAxis.uiCapability()->setUiHidden( m_isPropertyLogarithmicScaleEnabled() );
-
-        updatePropertyValueZoom();
-        loadDataAndUpdate();
-    }
-    else if ( changedField == &m_regionAnnotationType || changedField == &m_regionAnnotationDisplay || changedField == &m_formationSource ||
-              changedField == &m_colorShadingTransparency || changedField == &m_colorShadingLegend )
-    {
-        if ( changedField == &m_formationSource && m_formationSource == FormationSource::WELL_PICK_FILTER )
-        {
-            std::vector<RimWellPath*> wellPaths;
-            RimTools::wellPathWithFormations( &wellPaths );
-            for ( RimWellPath* wellPath : wellPaths )
-            {
-                if ( wellPath == m_formationWellPathForSourceCase )
-                {
-                    m_formationWellPathForSourceWellPath = m_formationWellPathForSourceCase();
-                    break;
-                }
-            }
-        }
-
-        loadDataAndUpdate();
-        updateParentLayout();
-        updateConnectedEditors();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_showRegionLabels || changedField == &m_regionLabelFontSize )
-    {
-        loadDataAndUpdate();
-    }
-    else if ( changedField == &m_formationCase )
-    {
-        QList<caf::PdmOptionItemInfo> options;
-        RimWellLogTrack::simWellOptionItems( &options, m_formationCase );
-
-        if ( options.isEmpty() || m_formationCase == nullptr )
-        {
-            m_formationSimWellName = QString( "None" );
-        }
-
-        loadDataAndUpdate();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_formationWellPathForSourceCase )
-    {
-        loadDataAndUpdate();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_formationSimWellName )
-    {
-        loadDataAndUpdate();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_formationTrajectoryType )
-    {
-        if ( m_formationTrajectoryType == WELL_PATH )
-        {
-            RimProject* proj                 = RimProject::current();
-            m_formationWellPathForSourceCase = proj->wellPathFromSimWellName( m_formationSimWellName );
-        }
-        else
-        {
-            if ( m_formationWellPathForSourceCase )
-            {
-                m_formationSimWellName = m_formationWellPathForSourceCase->associatedSimulationWellName();
-            }
-        }
-
-        loadDataAndUpdate();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_formationBranchIndex || changedField == &m_formationBranchDetection )
-    {
-        m_formationBranchIndex =
-            RiaSimWellBranchTools::clampBranchIndex( m_formationSimWellName, m_formationBranchIndex, m_formationBranchDetection );
-
-        loadDataAndUpdate();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_formationWellPathForSourceWellPath )
-    {
-        loadDataAndUpdate();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_formationLevel )
-    {
-        loadDataAndUpdate();
-    }
-    else if ( changedField == &m_showformationFluids )
-    {
-        loadDataAndUpdate();
-    }
-    else if ( changedField == &m_showWellPathAttributes || changedField == &m_showWellPathCompletions ||
-              changedField == &m_showWellPathComponentsBothSides || changedField == &m_showWellPathComponentLabels ||
-              changedField == &m_wellPathAttributesInLegend || changedField == &m_wellPathCompletionsInLegend )
-    {
-        updateWellPathAttributesOnPlot();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
-    else if ( changedField == &m_wellPathComponentSource )
-    {
-        updateWellPathAttributesCollection();
-        updateWellPathAttributesOnPlot();
-        updateParentLayout();
-        RiuPlotMainWindowTools::refreshToolbars();
-    }
     else if ( changedField == &m_autoCheckStateBasedOnCurveData )
     {
         updateCheckStateBasedOnCurveData();
@@ -809,7 +644,7 @@ void RimWellLogTrack::curveStackingChanged( const caf::SignalEmitter* emitter, b
 {
     updateStackedCurveData();
 
-    m_isAutoScalePropertyValuesEnabled = true;
+    m_propertyAxisSettings->setAutoScaleEnabled( true );
     updatePropertyValueZoom();
     m_plotWidget->scheduleReplot();
 }
@@ -832,11 +667,11 @@ void RimWellLogTrack::updatePropertyValueAxisAndGridTickIntervals()
     {
         m_plotWidget->setAxisLabelsAndTicksEnabled( valueAxis(), true, true );
 
-        auto rangeBoundaryA = m_visiblePropertyValueRangeMin();
-        auto rangeBoundaryB = m_visiblePropertyValueRangeMax();
-        if ( m_invertPropertyValueAxis() ) std::swap( rangeBoundaryA, rangeBoundaryB );
+        auto rangeBoundaryA = m_propertyAxisSettings->visibleRangeMin();
+        auto rangeBoundaryB = m_propertyAxisSettings->visibleRangeMax();
+        if ( m_propertyAxisSettings->isAxisInverted() ) std::swap( rangeBoundaryA, rangeBoundaryB );
 
-        if ( m_propertyAxisMinAndMaxTicksOnly )
+        if ( m_propertyAxisSettings->isMinAndMaxTicksOnly() )
         {
             auto roundToDigits = []( double value, int numberOfDigits, bool useFloor )
             {
@@ -881,11 +716,11 @@ void RimWellLogTrack::updatePropertyValueAxisAndGridTickIntervals()
                 m_plotWidget->qwtPlot()->setAxisScaleDiv( QwtAxis::YLeft, div );
             }
         }
-        else if ( m_explicitTickIntervalsPropertyValueAxis )
+        else if ( m_propertyAxisSettings->isExplicitTickIntervals() )
         {
             m_plotWidget->setMajorAndMinorTickIntervals( valueAxis(),
-                                                         m_majorTickIntervalPropertyAxis(),
-                                                         m_minorTickIntervalPropertyAxis(),
+                                                         m_propertyAxisSettings->majorTickInterval(),
+                                                         m_propertyAxisSettings->minorTickInterval(),
                                                          rangeBoundaryA,
                                                          rangeBoundaryB );
         }
@@ -898,8 +733,8 @@ void RimWellLogTrack::updatePropertyValueAxisAndGridTickIntervals()
         }
 
         m_plotWidget->enableGridLines( valueAxis(),
-                                       m_propertyValueAxisGridVisibility() & RimWellLogPlot::AXIS_GRID_MAJOR,
-                                       m_propertyValueAxisGridVisibility() & RimWellLogPlot::AXIS_GRID_MINOR );
+                                       m_propertyAxisSettings->gridVisibility() & RimWellLogPlot::AXIS_GRID_MAJOR,
+                                       m_propertyAxisSettings->gridVisibility() & RimWellLogPlot::AXIS_GRID_MINOR );
     }
 
     RimDepthTrackPlot* wellLogPlot = firstAncestorOrThisOfType<RimDepthTrackPlot>();
@@ -910,7 +745,7 @@ void RimWellLogTrack::updatePropertyValueAxisAndGridTickIntervals()
                                        wellLogPlot->depthAxisGridLinesEnabled() & RimWellLogPlot::AXIS_GRID_MINOR );
     }
 
-    m_plotWidget->enableAxisNumberLabels( valueAxis(), m_isPropertyAxisEnabled() );
+    m_plotWidget->enableAxisNumberLabels( valueAxis(), m_propertyAxisSettings->isEnabled() );
 
     m_plotWidget->scheduleReplot();
 }
@@ -1083,10 +918,9 @@ void RimWellLogTrack::updateAxisRangesFromPlotWidget()
     auto [xIntervalMin, xIntervalMax]         = m_plotWidget->axisRange( valueAxis() );
     auto [depthIntervalMin, depthIntervalMax] = m_plotWidget->axisRange( depthAxis() );
 
-    m_visiblePropertyValueRangeMin = xIntervalMin;
-    m_visiblePropertyValueRangeMax = xIntervalMax;
-    m_visibleDepthRangeMin         = depthIntervalMin;
-    m_visibleDepthRangeMax         = depthIntervalMax;
+    m_propertyAxisSettings->setVisibleRange( xIntervalMin, xIntervalMax );
+    m_visibleDepthRangeMin = depthIntervalMin;
+    m_visibleDepthRangeMax = depthIntervalMax;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1112,63 +946,11 @@ QList<caf::PdmOptionItemInfo> RimWellLogTrack::calculateValueOptions( const caf:
 {
     QList<caf::PdmOptionItemInfo> options;
 
-    if ( fieldNeedingOptions == &m_formationWellPathForSourceCase )
-    {
-        RimTools::wellPathOptionItems( &options );
-    }
-    else if ( fieldNeedingOptions == &m_formationWellPathForSourceWellPath )
-    {
-        RimTools::wellPathWithFormationsOptionItems( &options );
-    }
-    else if ( fieldNeedingOptions == &m_formationCase )
-    {
-        RimTools::caseOptionItems( &options );
-    }
-    else if ( fieldNeedingOptions == &m_formationSimWellName )
-    {
-        RimWellLogTrack::simWellOptionItems( &options, m_formationCase );
-    }
-    else if ( fieldNeedingOptions == &m_formationBranchIndex )
-    {
-        auto simulationWellBranches = RiaSimWellBranchTools::simulationWellBranches( m_formationSimWellName(), m_formationBranchDetection );
-        options                     = RiaSimWellBranchTools::valueOptionsForBranchIndexField( simulationWellBranches );
-    }
-    else if ( fieldNeedingOptions == &m_formationLevel )
-    {
-        if ( m_formationWellPathForSourceWellPath )
-        {
-            const RigWellPathFormations* formations = m_formationWellPathForSourceWellPath->formationsGeometry();
-            if ( formations )
-            {
-                using FormationLevelEnum = caf::AppEnum<RigWellPathFormations::FormationLevel>;
+    // Formation field options are now handled by RimWellLogFormationSettings
+    // Region annotation field options are now handled by RimWellLogRegionAnnotationSettings
+    // Well path attribute field options are now handled by RimWellLogWellPathAttributeSettings
 
-                options.push_back(
-                    caf::PdmOptionItemInfo( FormationLevelEnum::uiText( RigWellPathFormations::NONE ), RigWellPathFormations::NONE ) );
-
-                options.push_back(
-                    caf::PdmOptionItemInfo( FormationLevelEnum::uiText( RigWellPathFormations::ALL ), RigWellPathFormations::ALL ) );
-
-                for ( const RigWellPathFormations::FormationLevel& level : formations->formationsLevelsPresent() )
-                {
-                    size_t index = FormationLevelEnum::index( level );
-                    if ( index >= FormationLevelEnum::size() ) continue;
-
-                    options.push_back(
-                        caf::PdmOptionItemInfo( FormationLevelEnum::uiTextFromIndex( index ), FormationLevelEnum::fromIndex( index ) ) );
-                }
-            }
-        }
-    }
-    else if ( fieldNeedingOptions == &m_wellPathComponentSource )
-    {
-        RimTools::wellPathOptionItems( &options );
-        options.push_front( caf::PdmOptionItemInfo( "None", nullptr ) );
-    }
-    else if ( fieldNeedingOptions == &m_colorShadingLegend )
-    {
-        RimTools::colorLegendOptionItems( &options );
-    }
-    else if ( fieldNeedingOptions == &m_ensembleWellLogCurveSet )
+    if ( fieldNeedingOptions == &m_ensembleWellLogCurveSet )
     {
     }
 
@@ -1258,8 +1040,8 @@ void RimWellLogTrack::availableDepthRange( double* minimumDepth, double* maximum
 void RimWellLogTrack::visiblePropertyValueRange( double* minX, double* maxX )
 {
     CAF_ASSERT( minX && maxX );
-    *minX = m_visiblePropertyValueRangeMin;
-    *maxX = m_visiblePropertyValueRangeMax;
+    *minX = m_propertyAxisSettings->visibleRangeMin();
+    *maxX = m_propertyAxisSettings->visibleRangeMax();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1277,8 +1059,8 @@ void RimWellLogTrack::visibleDepthRange( double* minDepth, double* maxDepth )
 //--------------------------------------------------------------------------------------------------
 bool RimWellLogTrack::isEmptyVisiblePropertyRange() const
 {
-    return std::abs( m_visiblePropertyValueRangeMax() - m_visiblePropertyValueRangeMin ) <
-           1.0e-6 * std::max( 1.0, std::max( m_visiblePropertyValueRangeMax(), m_visiblePropertyValueRangeMin() ) );
+    return std::abs( m_propertyAxisSettings->visibleRangeMax() - m_propertyAxisSettings->visibleRangeMin() ) <
+           1.0e-6 * std::max( 1.0, std::max( m_propertyAxisSettings->visibleRangeMax(), m_propertyAxisSettings->visibleRangeMin() ) );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1414,8 +1196,8 @@ void RimWellLogTrack::onLoadDataAndUpdate()
         m_curves[cIdx]->loadDataAndUpdate( false );
     }
 
-    if ( m_regionAnnotationType == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS ||
-         m_regionAnnotationType == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
+    if ( m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS ||
+         m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
     {
         m_resultDefinition->loadDataAndUpdate();
         setFormationFieldsUiReadOnly( false );
@@ -1424,9 +1206,7 @@ void RimWellLogTrack::onLoadDataAndUpdate()
     {
         setFormationFieldsUiReadOnly( true );
     }
-    bool noAnnotations = m_regionAnnotationType() == RiaDefines::RegionAnnotationType::NO_ANNOTATIONS;
-    m_regionAnnotationDisplay.uiCapability()->setUiReadOnly( noAnnotations );
-    m_showRegionLabels.uiCapability()->setUiReadOnly( noAnnotations );
+    // UI read-only state for region annotation fields is managed by RimWellLogRegionAnnotationSettings
 
     if ( m_plotWidget )
     {
@@ -1440,13 +1220,6 @@ void RimWellLogTrack::onLoadDataAndUpdate()
     }
 
     updatePropertyValueAxisAndGridTickIntervals();
-    m_majorTickIntervalPropertyAxis.uiCapability()->setUiHidden( !m_explicitTickIntervalsPropertyValueAxis() );
-    m_minorTickIntervalPropertyAxis.uiCapability()->setUiHidden( !m_explicitTickIntervalsPropertyValueAxis() );
-
-    bool emptyRange = isEmptyVisiblePropertyRange();
-    m_explicitTickIntervalsPropertyValueAxis.uiCapability()->setUiReadOnly( emptyRange );
-    m_propertyValueAxisGridVisibility.uiCapability()->setUiReadOnly( emptyRange );
-
     updateDepthZoom();
 
     updateLegend();
@@ -1457,15 +1230,15 @@ void RimWellLogTrack::onLoadDataAndUpdate()
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAndUpdateWellPathFormationNamesData( RimCase* rimCase, RimWellPath* wellPath )
 {
-    m_formationCase                  = rimCase;
-    m_formationTrajectoryType        = RimWellLogTrack::WELL_PATH;
-    m_formationWellPathForSourceCase = wellPath;
-    m_formationSimWellName           = "";
-    m_formationBranchIndex           = -1;
+    m_formationSettings->setFormationCase( rimCase );
+    m_formationSettings->setTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::WELL_PATH );
+    m_formationSettings->setWellPathForSourceCase( wellPath );
+    m_formationSettings->setSimWellName( "" );
+    m_formationSettings->setBranchIndex( -1 );
 
     updateConnectedEditors();
 
-    if ( m_regionAnnotationType != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )
+    if ( m_regionAnnotationSettings->annotationType() != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )
     {
         updateRegionAnnotationsOnPlot();
     }
@@ -1479,8 +1252,8 @@ void RimWellLogTrack::setAndUpdateSimWellFormationNamesAndBranchData( RimCase*  
                                                                       int            branchIndex,
                                                                       bool           useBranchDetection )
 {
-    m_formationBranchIndex     = branchIndex;
-    m_formationBranchDetection = useBranchDetection;
+    m_formationSettings->setBranchIndex( branchIndex );
+    m_formationSettings->setBranchDetection( useBranchDetection );
 
     setAndUpdateSimWellFormationNamesData( rimCase, simWellName );
 }
@@ -1490,14 +1263,14 @@ void RimWellLogTrack::setAndUpdateSimWellFormationNamesAndBranchData( RimCase*  
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAndUpdateSimWellFormationNamesData( RimCase* rimCase, const QString& simWellName )
 {
-    m_formationCase                  = rimCase;
-    m_formationTrajectoryType        = RimWellLogTrack::SIMULATION_WELL;
-    m_formationWellPathForSourceCase = nullptr;
-    m_formationSimWellName           = simWellName;
+    m_formationSettings->setFormationCase( rimCase );
+    m_formationSettings->setTrajectoryType( RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL );
+    m_formationSettings->setWellPathForSourceCase( nullptr );
+    m_formationSettings->setSimWellName( simWellName );
 
     updateConnectedEditors();
 
-    if ( m_regionAnnotationType != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )
+    if ( m_regionAnnotationSettings->annotationType() != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )
     {
         updateRegionAnnotationsOnPlot();
     }
@@ -1524,7 +1297,7 @@ void RimWellLogTrack::setAutoScaleYEnabled( bool enabled )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAutoScalePropertyValuesEnabled( bool enabled )
 {
-    m_isAutoScalePropertyValuesEnabled = enabled;
+    m_propertyAxisSettings->setAutoScaleEnabled( enabled );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1546,16 +1319,16 @@ void RimWellLogTrack::setAutoScalePropertyValuesIfNecessary()
 {
     // Avoid resetting if visible range has set to empty by user
     bool emptyRange = isEmptyVisiblePropertyRange();
-    if ( !m_isAutoScalePropertyValuesEnabled && emptyRange ) return;
+    if ( !m_propertyAxisSettings->isAutoScaleEnabled() && emptyRange ) return;
 
     const double eps = 1.0e-8;
     calculatePropertyValueZoomRange();
 
-    double maxRange = std::max( m_visiblePropertyValueRangeMax - m_visiblePropertyValueRangeMin,
+    double maxRange = std::max( m_propertyAxisSettings->visibleRangeMax() - m_propertyAxisSettings->visibleRangeMin(),
                                 m_availablePropertyValueRangeMax - m_availablePropertyValueRangeMin );
 
-    double maxLow  = std::max( m_visiblePropertyValueRangeMin(), m_availablePropertyValueRangeMin );
-    double minHigh = std::min( m_visiblePropertyValueRangeMax(), m_availablePropertyValueRangeMax );
+    double maxLow  = std::max( m_propertyAxisSettings->visibleRangeMin(), m_availablePropertyValueRangeMin );
+    double minHigh = std::min( m_propertyAxisSettings->visibleRangeMax(), m_availablePropertyValueRangeMax );
     double overlap = minHigh - maxLow;
 
     if ( maxRange < eps || overlap < eps * maxRange )
@@ -1592,7 +1365,7 @@ QString RimWellLogTrack::depthAxisTitle() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setFormationWellPath( RimWellPath* wellPath )
 {
-    m_formationWellPathForSourceCase = wellPath;
+    m_formationSettings->setWellPathForSourceCase( wellPath );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1600,7 +1373,7 @@ void RimWellLogTrack::setFormationWellPath( RimWellPath* wellPath )
 //--------------------------------------------------------------------------------------------------
 RimWellPath* RimWellLogTrack::formationWellPath() const
 {
-    return m_formationWellPathForSourceCase;
+    return m_formationSettings->wellPathForSourceCase();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1608,7 +1381,7 @@ RimWellPath* RimWellLogTrack::formationWellPath() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setFormationSimWellName( const QString& simWellName )
 {
-    m_formationSimWellName = simWellName;
+    m_formationSettings->setSimWellName( simWellName );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1616,7 +1389,7 @@ void RimWellLogTrack::setFormationSimWellName( const QString& simWellName )
 //--------------------------------------------------------------------------------------------------
 QString RimWellLogTrack::formationSimWellName() const
 {
-    return m_formationSimWellName;
+    return m_formationSettings->simWellName();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1624,7 +1397,7 @@ QString RimWellLogTrack::formationSimWellName() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setFormationBranchDetection( bool branchDetection )
 {
-    m_formationBranchDetection = branchDetection;
+    m_formationSettings->setBranchDetection( branchDetection );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1632,7 +1405,7 @@ void RimWellLogTrack::setFormationBranchDetection( bool branchDetection )
 //--------------------------------------------------------------------------------------------------
 bool RimWellLogTrack::formationBranchDetection() const
 {
-    return m_formationBranchDetection();
+    return m_formationSettings->branchDetection();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1640,7 +1413,7 @@ bool RimWellLogTrack::formationBranchDetection() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setFormationBranchIndex( int branchIndex )
 {
-    m_formationBranchIndex = branchIndex;
+    m_formationSettings->setBranchIndex( branchIndex );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1648,7 +1421,7 @@ void RimWellLogTrack::setFormationBranchIndex( int branchIndex )
 //--------------------------------------------------------------------------------------------------
 int RimWellLogTrack::formationBranchIndex() const
 {
-    return m_formationBranchIndex;
+    return m_formationSettings->branchIndex();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1656,7 +1429,7 @@ int RimWellLogTrack::formationBranchIndex() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setFormationCase( RimCase* rimCase )
 {
-    m_formationCase = rimCase;
+    m_formationSettings->setFormationCase( rimCase );
     m_resultDefinition->setEclipseCase( dynamic_cast<RimEclipseCase*>( rimCase ) );
     m_resultDefinition->setPorosityModel( RiaDefines::PorosityModelType::MATRIX_MODEL );
 }
@@ -1675,23 +1448,23 @@ void RimWellLogTrack::setRegionPropertyResultType( RiaDefines::ResultCatType res
 //--------------------------------------------------------------------------------------------------
 RimCase* RimWellLogTrack::formationNamesCase() const
 {
-    return m_formationCase();
+    return m_formationSettings->formationCase();
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimWellLogTrack::setFormationTrajectoryType( TrajectoryType trajectoryType )
+void RimWellLogTrack::setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType trajectoryType )
 {
-    m_formationTrajectoryType = trajectoryType;
+    m_formationSettings->setTrajectoryType( trajectoryType );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimWellLogTrack::TrajectoryType RimWellLogTrack::formationTrajectoryType() const
+RiaDefines::WellLogTrackTrajectoryType RimWellLogTrack::formationTrajectoryType() const
 {
-    return m_formationTrajectoryType();
+    return m_formationSettings->trajectoryType();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1775,8 +1548,7 @@ void RimWellLogTrack::updateEditors()
 void RimWellLogTrack::setVisiblePropertyValueRange( double minValue, double maxValue )
 {
     setAutoScalePropertyValuesEnabled( false );
-    m_visiblePropertyValueRangeMin = minValue;
-    m_visiblePropertyValueRangeMax = maxValue;
+    m_propertyAxisSettings->setVisibleRange( minValue, maxValue );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1803,9 +1575,7 @@ void RimWellLogTrack::updatePlotWidgetFromAxisRanges()
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setTickIntervals( double majorTickInterval, double minorTickInterval )
 {
-    m_explicitTickIntervalsPropertyValueAxis = true;
-    m_majorTickIntervalPropertyAxis          = majorTickInterval;
-    m_minorTickIntervalPropertyAxis          = minorTickInterval;
+    m_propertyAxisSettings->setTickIntervals( majorTickInterval, minorTickInterval );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1813,7 +1583,7 @@ void RimWellLogTrack::setTickIntervals( double majorTickInterval, double minorTi
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setMinAndMaxTicksOnly( bool enable )
 {
-    m_propertyAxisMinAndMaxTicksOnly = enable;
+    m_propertyAxisSettings->setMinAndMaxTicksOnly( enable );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1821,7 +1591,7 @@ void RimWellLogTrack::setMinAndMaxTicksOnly( bool enable )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setPropertyValueAxisGridVisibility( RimWellLogPlot::AxisGridVisibility gridLines )
 {
-    m_propertyValueAxisGridVisibility = gridLines;
+    m_propertyAxisSettings->setGridVisibility( gridLines );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1829,7 +1599,7 @@ void RimWellLogTrack::setPropertyValueAxisGridVisibility( RimWellLogPlot::AxisGr
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setColorShadingLegend( RimColorLegend* colorLegend )
 {
-    m_colorShadingLegend = colorLegend;
+    m_regionAnnotationSettings->setColorShadingLegend( colorLegend );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1837,7 +1607,7 @@ void RimWellLogTrack::setColorShadingLegend( RimColorLegend* colorLegend )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAnnotationType( RiaDefines::RegionAnnotationType annotationType )
 {
-    m_regionAnnotationType = annotationType;
+    m_regionAnnotationSettings->setAnnotationType( annotationType );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1845,7 +1615,7 @@ void RimWellLogTrack::setAnnotationType( RiaDefines::RegionAnnotationType annota
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAnnotationDisplay( RiaDefines::RegionDisplay annotationDisplay )
 {
-    m_regionAnnotationDisplay = annotationDisplay;
+    m_regionAnnotationSettings->setAnnotationDisplay( annotationDisplay );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1853,7 +1623,7 @@ void RimWellLogTrack::setAnnotationDisplay( RiaDefines::RegionDisplay annotation
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAnnotationTransparency( int percent )
 {
-    m_colorShadingTransparency = percent;
+    m_regionAnnotationSettings->setColorShadingTransparency( percent );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1861,7 +1631,7 @@ void RimWellLogTrack::setAnnotationTransparency( int percent )
 //--------------------------------------------------------------------------------------------------
 RiaDefines::RegionAnnotationType RimWellLogTrack::annotationType() const
 {
-    return m_regionAnnotationType();
+    return m_regionAnnotationSettings->annotationType();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1869,7 +1639,7 @@ RiaDefines::RegionAnnotationType RimWellLogTrack::annotationType() const
 //--------------------------------------------------------------------------------------------------
 RiaDefines::RegionDisplay RimWellLogTrack::annotationDisplay() const
 {
-    return m_regionAnnotationDisplay();
+    return m_regionAnnotationSettings->annotationDisplay();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1877,7 +1647,7 @@ RiaDefines::RegionDisplay RimWellLogTrack::annotationDisplay() const
 //--------------------------------------------------------------------------------------------------
 bool RimWellLogTrack::showFormations() const
 {
-    return m_regionAnnotationType() == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS;
+    return m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1885,7 +1655,7 @@ bool RimWellLogTrack::showFormations() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setShowRegionLabels( bool on )
 {
-    m_showRegionLabels = on;
+    m_regionAnnotationSettings->setShowRegionLabels( on );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1893,7 +1663,7 @@ void RimWellLogTrack::setShowRegionLabels( bool on )
 //--------------------------------------------------------------------------------------------------
 bool RimWellLogTrack::showWellPathAttributes() const
 {
-    return m_showWellPathAttributes;
+    return m_wellPathAttributeSettings->showWellPathAttributes();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1901,7 +1671,7 @@ bool RimWellLogTrack::showWellPathAttributes() const
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setShowWellPathAttributes( bool on )
 {
-    m_showWellPathAttributes = on;
+    m_wellPathAttributeSettings->setShowWellPathAttributes( on );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1909,7 +1679,7 @@ void RimWellLogTrack::setShowWellPathAttributes( bool on )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setShowWellPathAttributesInLegend( bool on )
 {
-    m_wellPathAttributesInLegend = on;
+    m_wellPathAttributeSettings->setShowAttributesInLegend( on );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1917,7 +1687,7 @@ void RimWellLogTrack::setShowWellPathAttributesInLegend( bool on )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setShowWellPathCompletionsInLegend( bool on )
 {
-    m_wellPathCompletionsInLegend = on;
+    m_wellPathAttributeSettings->setShowCompletionsInLegend( on );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1925,7 +1695,7 @@ void RimWellLogTrack::setShowWellPathCompletionsInLegend( bool on )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setShowBothSidesOfWell( bool on )
 {
-    m_showWellPathComponentsBothSides = on;
+    m_wellPathAttributeSettings->setShowBothSides( on );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1933,7 +1703,7 @@ void RimWellLogTrack::setShowBothSidesOfWell( bool on )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setWellPathAttributesSource( RimWellPath* wellPath )
 {
-    m_wellPathComponentSource = wellPath;
+    m_wellPathAttributeSettings->setWellPathComponentSource( wellPath );
     updateWellPathAttributesCollection();
 }
 
@@ -1942,7 +1712,7 @@ void RimWellLogTrack::setWellPathAttributesSource( RimWellPath* wellPath )
 //--------------------------------------------------------------------------------------------------
 RimWellPath* RimWellLogTrack::wellPathAttributeSource() const
 {
-    return m_wellPathComponentSource;
+    return m_wellPathAttributeSettings->wellPathComponentSource();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2016,78 +1786,20 @@ void RimWellLogTrack::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
     caf::PdmUiGroup* annotationGroup = uiOrdering.addNewGroup( "Regions/Annotations" );
     annotationGroup->setCollapsedByDefault();
 
-    annotationGroup->add( &m_regionAnnotationType );
-    annotationGroup->add( &m_regionAnnotationDisplay );
-    annotationGroup->add( &m_showRegionLabels );
-    if ( m_regionAnnotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
-        annotationGroup->add( &m_regionLabelFontSize );
+    // Region annotation settings UI ordering
+    m_regionAnnotationSettings->uiOrdering( uiConfigName, *annotationGroup );
 
-    if ( m_regionAnnotationDisplay() & RiaDefines::COLOR_SHADING || m_regionAnnotationDisplay() & RiaDefines::COLORED_LINES )
-    {
-        annotationGroup->add( &m_colorShadingLegend );
-        if ( m_regionAnnotationDisplay() & RiaDefines::COLOR_SHADING )
-        {
-            annotationGroup->add( &m_colorShadingTransparency );
-        }
-    }
+    // Formation settings UI ordering
+    m_formationSettings->uiOrdering( uiConfigName, *annotationGroup, m_formationsForCaseWithSimWellOnly );
 
-    if ( !m_formationsForCaseWithSimWellOnly )
-    {
-        annotationGroup->add( &m_formationSource );
-    }
-    else
-    {
-        m_formationSource = FormationSource::CASE;
-    }
-
-    if ( m_formationSource() == FormationSource::CASE )
-    {
-        annotationGroup->add( &m_formationCase );
-
-        if ( !m_formationsForCaseWithSimWellOnly )
-        {
-            annotationGroup->add( &m_formationTrajectoryType );
-
-            if ( m_formationTrajectoryType() == WELL_PATH )
-            {
-                annotationGroup->add( &m_formationWellPathForSourceCase );
-            }
-        }
-
-        if ( m_formationsForCaseWithSimWellOnly || m_formationTrajectoryType() == SIMULATION_WELL )
-        {
-            annotationGroup->add( &m_formationSimWellName );
-
-            RiaSimWellBranchTools::appendSimWellBranchFieldsIfRequiredFromSimWellName( annotationGroup,
-                                                                                       m_formationSimWellName,
-                                                                                       m_formationBranchDetection,
-                                                                                       m_formationBranchIndex );
-        }
-    }
-    else if ( m_formationSource() == FormationSource::WELL_PICK_FILTER )
-    {
-        annotationGroup->add( &m_formationWellPathForSourceWellPath );
-        if ( m_formationWellPathForSourceWellPath() )
-        {
-            annotationGroup->add( &m_formationLevel );
-            annotationGroup->add( &m_showformationFluids );
-        }
-    }
-
-    if ( m_regionAnnotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
+    if ( m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
     {
         m_resultDefinition->uiOrdering( uiConfigName, *annotationGroup );
     }
 
     caf::PdmUiGroup* componentGroup = uiOrdering.addNewGroup( "Well Path Components" );
-    componentGroup->add( &m_showWellPathAttributes );
-    componentGroup->add( &m_showWellPathCompletions );
-    componentGroup->add( &m_wellPathAttributesInLegend );
-    componentGroup->add( &m_wellPathCompletionsInLegend );
-    componentGroup->add( &m_showWellPathComponentsBothSides );
-    componentGroup->add( &m_showWellPathComponentLabels );
-
-    componentGroup->add( &m_wellPathComponentSource );
+    componentGroup->setCollapsedByDefault();
+    m_wellPathAttributeSettings->uiOrdering( uiConfigName, *componentGroup );
 
     uiOrdering.add( &m_ensembleWellLogCurveSet );
 
@@ -2101,15 +1813,66 @@ void RimWellLogTrack::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::initAfterRead()
 {
-    if ( m_regionAnnotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
+    if ( m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
     {
-        RimEclipseCase* eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationCase.value() );
+        RimEclipseCase* eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationSettings->formationCase() );
         m_resultDefinition->setEclipseCase( dynamic_cast<RimEclipseCase*>( eclipseCase ) );
     }
 
-    if ( m_propertyValueAxisGridVisibility() == RimWellLogPlot::AXIS_GRID_MINOR )
+    // Migrate property axis settings from obsolete fields (pre-2025.12.0)
+    if ( RimProject::current()->isProjectFileVersionEqualOrOlderThan( "2025.12.0" ) )
     {
-        m_propertyValueAxisGridVisibility = RimWellLogPlot::AXIS_GRID_MAJOR_AND_MINOR;
+        m_propertyAxisSettings->setEnabled( m_isPropertyAxisEnabled_OBSOLETE() );
+        m_propertyAxisSettings->setVisibleRange( m_visiblePropertyValueRangeMin_OBSOLETE(), m_visiblePropertyValueRangeMax_OBSOLETE() );
+        m_propertyAxisSettings->setAutoScaleEnabled( m_isAutoScalePropertyValuesEnabled_OBSOLETE() );
+        m_propertyAxisSettings->setLogarithmicScaleEnabled( m_isPropertyLogarithmicScaleEnabled_OBSOLETE() );
+        m_propertyAxisSettings->setAxisInverted( m_invertPropertyValueAxis_OBSOLETE() );
+
+        auto gridVisibility = m_propertyValueAxisGridVisibility_OBSOLETE();
+        if ( gridVisibility == RimWellLogPlot::AXIS_GRID_MINOR )
+        {
+            gridVisibility = RimWellLogPlot::AXIS_GRID_MAJOR_AND_MINOR;
+        }
+        m_propertyAxisSettings->setGridVisibility( gridVisibility );
+
+        m_propertyAxisSettings->setMinAndMaxTicksOnly( m_propertyAxisMinAndMaxTicksOnly_OBSOLETE() );
+        m_propertyAxisSettings->setExplicitTickIntervals( m_explicitTickIntervalsPropertyValueAxis_OBSOLETE() );
+        if ( m_explicitTickIntervalsPropertyValueAxis_OBSOLETE() )
+        {
+            m_propertyAxisSettings->setTickIntervals( m_majorTickIntervalPropertyAxis_OBSOLETE(), m_minorTickIntervalPropertyAxis_OBSOLETE() );
+        }
+
+        // Migrate formation settings from obsolete fields
+        m_formationSettings->setFormationSource( m_formationSource_OBSOLETE() );
+        m_formationSettings->setFormationCase( m_formationCase_OBSOLETE() );
+        m_formationSettings->setTrajectoryType( m_formationTrajectoryType_OBSOLETE() );
+        m_formationSettings->setWellPathForSourceCase( m_formationWellPathForSourceCase_OBSOLETE() );
+        m_formationSettings->setWellPathForSourceWellPath( m_formationWellPathForSourceWellPath_OBSOLETE() );
+        m_formationSettings->setSimWellName( m_formationSimWellName_OBSOLETE() );
+        m_formationSettings->setBranchIndex( m_formationBranchIndex_OBSOLETE() );
+        m_formationSettings->setBranchDetection( m_formationBranchDetection_OBSOLETE() );
+        m_formationSettings->setFormationLevel( m_formationLevel_OBSOLETE() );
+        m_formationSettings->setShowFormationFluids( m_showformationFluids_OBSOLETE() );
+
+        // Migrate region annotation settings from obsolete fields
+        m_regionAnnotationSettings->setAnnotationType( m_regionAnnotationType_OBSOLETE() );
+        m_regionAnnotationSettings->setAnnotationDisplay( m_regionAnnotationDisplay_OBSOLETE() );
+        m_regionAnnotationSettings->setColorShadingLegend( m_colorShadingLegend_OBSOLETE() );
+        m_regionAnnotationSettings->setColorShadingTransparency( m_colorShadingTransparency_OBSOLETE() );
+        m_regionAnnotationSettings->setShowRegionLabels( m_showRegionLabels_OBSOLETE() );
+        m_regionAnnotationSettings->setRegionLabelFontSize( m_regionLabelFontSize_OBSOLETE() );
+
+        // Migrate well path attribute settings from obsolete fields
+        m_wellPathAttributeSettings->setShowWellPathAttributes( m_showWellPathAttributes_OBSOLETE() );
+        m_wellPathAttributeSettings->setShowWellPathCompletions( m_showWellPathCompletions_OBSOLETE() );
+        m_wellPathAttributeSettings->setShowBothSides( m_showWellPathComponentsBothSides_OBSOLETE() );
+        m_wellPathAttributeSettings->setShowComponentLabels( m_showWellPathComponentLabels_OBSOLETE() );
+        m_wellPathAttributeSettings->setShowAttributesInLegend( m_wellPathAttributesInLegend_OBSOLETE() );
+        m_wellPathAttributeSettings->setShowCompletionsInLegend( m_wellPathCompletionsInLegend_OBSOLETE() );
+        m_wellPathAttributeSettings->setWellPathComponentSource( m_wellPathComponentSource_OBSOLETE() );
+        m_wellPathAttributeSettings->setWellPathAttributeCollection( m_wellPathAttributeCollection_OBSOLETE() );
+        m_wellPathAttributeSettings->setOverburdenHeight( m_overburdenHeight_OBSOLETE() );
+        m_wellPathAttributeSettings->setUnderburdenHeight( m_underburdenHeight_OBSOLETE() );
     }
 
     for ( auto curve : m_curves )
@@ -2123,15 +1886,7 @@ void RimWellLogTrack::initAfterRead()
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_colorShadingTransparency )
-    {
-        auto sliderAttrib = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute );
-        if ( sliderAttrib )
-        {
-            sliderAttrib->m_minimum = 0;
-            sliderAttrib->m_maximum = 100;
-        }
-    }
+    // Editor attributes are now handled by the individual settings objects
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2164,7 +1919,7 @@ void RimWellLogTrack::updateAxisScaleEngine()
         {
             m_plotWidget->setAxisInverted( RiuPlotAxis::defaultLeft(), true );
 
-            if ( m_isPropertyLogarithmicScaleEnabled )
+            if ( m_propertyAxisSettings->isLogarithmicScaleEnabled() )
             {
                 m_plotWidget->qwtPlot()->setAxisScaleEngine( QwtAxis::XTop, new QwtLogScaleEngine );
 
@@ -2183,7 +1938,7 @@ void RimWellLogTrack::updateAxisScaleEngine()
         {
             m_plotWidget->setAxisInverted( RiuPlotAxis::defaultLeft(), false );
 
-            if ( m_isPropertyLogarithmicScaleEnabled )
+            if ( m_propertyAxisSettings->isLogarithmicScaleEnabled() )
             {
                 m_plotWidget->qwtPlot()->setAxisScaleEngine( QwtAxis::YLeft, new QwtLogScaleEngine );
 
@@ -2261,14 +2016,14 @@ std::pair<double, double> RimWellLogTrack::extendMinMaxRange( double minValue, d
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::updateWellPathAttributesCollection()
 {
-    m_wellPathAttributeCollection = nullptr;
-    if ( m_wellPathComponentSource )
+    m_wellPathAttributeSettings->setWellPathAttributeCollection( nullptr );
+    if ( m_wellPathAttributeSettings->wellPathComponentSource() )
     {
         std::vector<RimWellPathAttributeCollection*> attributeCollection =
-            m_wellPathComponentSource->descendantsIncludingThisOfType<RimWellPathAttributeCollection>();
+            m_wellPathAttributeSettings->wellPathComponentSource()->descendantsIncludingThisOfType<RimWellPathAttributeCollection>();
         if ( !attributeCollection.empty() )
         {
-            m_wellPathAttributeCollection = attributeCollection.front();
+            m_wellPathAttributeSettings->setWellPathAttributeCollection( attributeCollection.front() );
         }
     }
 }
@@ -2377,7 +2132,7 @@ void RimWellLogTrack::connectCurveSignals( RimWellLogCurve* curve )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::computeAndSetPropertyValueRangeMinForLogarithmicScale()
 {
-    if ( m_isAutoScalePropertyValuesEnabled && m_isPropertyLogarithmicScaleEnabled )
+    if ( m_propertyAxisSettings->isAutoScaleEnabled() && m_propertyAxisSettings->isLogarithmicScaleEnabled() )
     {
         double pos = HUGE_VAL;
         double neg = -HUGE_VAL;
@@ -2392,7 +2147,7 @@ void RimWellLogTrack::computeAndSetPropertyValueRangeMinForLogarithmicScale()
 
         if ( pos != HUGE_VAL )
         {
-            m_visiblePropertyValueRangeMin = pos;
+            m_propertyAxisSettings->setVisibleRange( pos, m_propertyAxisSettings->visibleRangeMax() );
         }
     }
 }
@@ -2402,7 +2157,7 @@ void RimWellLogTrack::computeAndSetPropertyValueRangeMinForLogarithmicScale()
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setLogarithmicScale( bool enable )
 {
-    m_isPropertyLogarithmicScaleEnabled = enable;
+    m_propertyAxisSettings->setLogarithmicScaleEnabled( enable );
 
     updateAxisScaleEngine();
     computeAndSetPropertyValueRangeMinForLogarithmicScale();
@@ -2413,7 +2168,7 @@ void RimWellLogTrack::setLogarithmicScale( bool enable )
 //--------------------------------------------------------------------------------------------------
 bool RimWellLogTrack::isLogarithmicScale() const
 {
-    return m_isPropertyLogarithmicScaleEnabled;
+    return m_propertyAxisSettings->isLogarithmicScaleEnabled();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2474,21 +2229,12 @@ void RimWellLogTrack::uiOrderingForRftPltFormations( caf::PdmUiOrdering& uiOrder
 {
     caf::PdmUiGroup* formationGroup = uiOrdering.addNewGroup( "Zonation/Formation Names" );
     formationGroup->setCollapsedByDefault();
-    formationGroup->add( &m_regionAnnotationType );
-    formationGroup->add( &m_regionAnnotationDisplay );
-    formationGroup->add( &m_formationSource );
-    if ( m_formationSource == FormationSource::CASE )
-    {
-        formationGroup->add( &m_formationCase );
-    }
-    if ( m_formationSource == FormationSource::WELL_PICK_FILTER )
-    {
-        if ( m_formationWellPathForSourceWellPath() && m_formationWellPathForSourceWellPath()->hasFormations() )
-        {
-            formationGroup->add( &m_formationLevel );
-            formationGroup->add( &m_showformationFluids );
-        }
-    }
+
+    // Region annotation settings UI ordering
+    m_regionAnnotationSettings->uiOrdering( "", *formationGroup );
+
+    // Delegate to formation settings for formation-related fields
+    m_formationSettings->uiOrdering( "", *formationGroup, m_formationsForCaseWithSimWellOnly );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2496,20 +2242,7 @@ void RimWellLogTrack::uiOrderingForRftPltFormations( caf::PdmUiOrdering& uiOrder
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::uiOrderingForPropertyAxisSettings( caf::PdmUiOrdering& uiOrdering )
 {
-    caf::PdmUiGroup* gridGroup = uiOrdering.addNewGroup( "Property Axis Settings" );
-    gridGroup->add( &m_isPropertyAxisEnabled );
-    gridGroup->add( &m_isPropertyLogarithmicScaleEnabled );
-    gridGroup->add( &m_visiblePropertyValueRangeMin );
-    gridGroup->add( &m_visiblePropertyValueRangeMax );
-    gridGroup->add( &m_invertPropertyValueAxis );
-    gridGroup->add( &m_propertyValueAxisGridVisibility );
-    gridGroup->add( &m_propertyAxisMinAndMaxTicksOnly );
-
-    // TODO Revisit if these settings are required
-    // See issue https://github.com/OPM/ResInsight/issues/4367
-    //     gridGroup->add( &m_explicitTickIntervals );
-    //     gridGroup->add( &m_majorTickInterval );
-    //     gridGroup->add( &m_minorTickInterval );
+    m_propertyAxisSettings->uiOrdering( "", uiOrdering );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2517,7 +2250,7 @@ void RimWellLogTrack::uiOrderingForPropertyAxisSettings( caf::PdmUiOrdering& uiO
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::enablePropertyAxis( bool enable )
 {
-    m_isPropertyAxisEnabled = enable;
+    m_propertyAxisSettings->setEnabled( enable );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2525,7 +2258,7 @@ void RimWellLogTrack::enablePropertyAxis( bool enable )
 //--------------------------------------------------------------------------------------------------
 bool RimWellLogTrack::isPropertyAxisEnabled() const
 {
-    return m_isPropertyAxisEnabled();
+    return m_propertyAxisSettings->isEnabled();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2774,7 +2507,13 @@ void RimWellLogTrack::updateStackedCurveData()
             }
 
             RigWellLogCurveData tempCurveData;
-            tempCurveData.setValuesAndDepths( allStackedValues, allDepthValues, depthType, 0.0, displayUnit, false, m_isPropertyLogarithmicScaleEnabled );
+            tempCurveData.setValuesAndDepths( allStackedValues,
+                                              allDepthValues,
+                                              depthType,
+                                              0.0,
+                                              displayUnit,
+                                              false,
+                                              m_propertyAxisSettings->isLogarithmicScaleEnabled() );
 
             auto plotDepthValues          = tempCurveData.depths( depthType );
             auto polyLineStartStopIndices = tempCurveData.polylineStartStopIndices();
@@ -2805,18 +2544,9 @@ void RimWellLogTrack::updateStackedCurveData()
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setFormationFieldsUiReadOnly( bool readOnly /*= true*/ )
 {
-    m_formationSource.uiCapability()->setUiReadOnly( readOnly );
-    m_formationTrajectoryType.uiCapability()->setUiReadOnly( readOnly );
-    m_formationSimWellName.uiCapability()->setUiReadOnly( readOnly );
-    m_formationCase.uiCapability()->setUiReadOnly( readOnly );
-    m_formationWellPathForSourceCase.uiCapability()->setUiReadOnly( readOnly );
-    m_formationWellPathForSourceWellPath.uiCapability()->setUiReadOnly( readOnly );
-    m_formationBranchDetection.uiCapability()->setUiReadOnly( readOnly );
-    m_formationBranchIndex.uiCapability()->setUiReadOnly( readOnly );
-    m_formationLevel.uiCapability()->setUiReadOnly( readOnly );
-    m_showformationFluids.uiCapability()->setUiReadOnly( readOnly );
-    m_colorShadingTransparency.uiCapability()->setUiReadOnly( readOnly );
-    m_colorShadingLegend.uiCapability()->setUiReadOnly( readOnly );
+    // Formation fields are now managed by RimWellLogFormationSettings
+    // Region annotation fields are managed by RimWellLogRegionAnnotationSettings
+    // The settings objects handle their own UI read-only state
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2826,18 +2556,18 @@ void RimWellLogTrack::updateRegionAnnotationsOnPlot()
 {
     removeRegionAnnotations();
 
-    if ( m_regionAnnotationType == RiaDefines::RegionAnnotationType::NO_ANNOTATIONS ) return;
+    if ( m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::NO_ANNOTATIONS ) return;
 
     if ( m_annotationTool == nullptr )
     {
         m_annotationTool = std::make_unique<RiuPlotAnnotationTool>();
     }
 
-    if ( m_regionAnnotationType == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS )
+    if ( m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::FORMATION_ANNOTATIONS )
     {
         updateFormationNamesOnPlot();
     }
-    else if ( m_regionAnnotationType == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
+    else if ( m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
     {
         updateResultPropertyNamesOnPlot();
     }
@@ -2859,9 +2589,9 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
 
     auto orientation = plot->depthOrientation();
 
-    if ( m_formationSource() == FormationSource::WELL_PICK_FILTER )
+    if ( m_formationSettings->formationSource() == RiaDefines::WellLogTrackFormationSource::WELL_PICK_FILTER )
     {
-        if ( m_formationWellPathForSourceWellPath == nullptr ) return;
+        if ( m_formationSettings->wellPathForSourceWellPath() == nullptr ) return;
 
         if ( plot->depthType() != RiaDefines::DepthTypeEnum::MEASURED_DEPTH &&
              plot->depthType() != RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH &&
@@ -2872,21 +2602,22 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
 
         std::vector<double> yValues;
 
-        const RigWellPathFormations* formations = m_formationWellPathForSourceWellPath->formationsGeometry();
+        const RigWellPathFormations* formations = m_formationSettings->wellPathForSourceWellPath()->formationsGeometry();
         if ( !formations ) return;
 
         std::vector<QString> formationNamesToPlot;
-        formations->depthAndFormationNamesUpToLevel( m_formationLevel(),
+        auto                 formationLevel = static_cast<RigWellPathFormations::FormationLevel>( m_formationSettings->formationLevel() );
+        formations->depthAndFormationNamesUpToLevel( formationLevel,
                                                      &formationNamesToPlot,
                                                      &yValues,
-                                                     m_showformationFluids(),
+                                                     m_formationSettings->showFormationFluids(),
                                                      plot->depthType() );
 
         if ( plot->depthType() == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
         {
             for ( double& depthValue : yValues )
             {
-                depthValue += m_formationWellPathForSourceWellPath->wellPathGeometry()->rkbDiff();
+                depthValue += m_formationSettings->wellPathForSourceWellPath()->wellPathGeometry()->rkbDiff();
             }
         }
 
@@ -2905,23 +2636,24 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
         RigEclipseWellLogExtractor* eclWellLogExtractor     = nullptr;
         RigGeoMechWellLogExtractor* geoMechWellLogExtractor = nullptr;
 
-        if ( m_formationTrajectoryType == SIMULATION_WELL )
+        if ( m_formationSettings->trajectoryType() == RiaDefines::WellLogTrackTrajectoryType::SIMULATION_WELL )
         {
             eclWellLogExtractor = RimWellLogTrack::createSimWellExtractor( wellLogCollection,
-                                                                           m_formationCase,
-                                                                           m_formationSimWellName,
-                                                                           m_formationBranchIndex,
-                                                                           m_formationBranchDetection );
+                                                                           m_formationSettings->formationCase(),
+                                                                           m_formationSettings->simWellName(),
+                                                                           m_formationSettings->branchIndex(),
+                                                                           m_formationSettings->branchDetection() );
         }
         else
         {
-            eclWellLogExtractor = RiaExtractionTools::findOrCreateWellLogExtractor( m_formationWellPathForSourceCase,
-                                                                                    dynamic_cast<RimEclipseCase*>( m_formationCase() ) );
+            eclWellLogExtractor =
+                RiaExtractionTools::findOrCreateWellLogExtractor( m_formationSettings->wellPathForSourceCase(),
+                                                                  dynamic_cast<RimEclipseCase*>( m_formationSettings->formationCase() ) );
         }
 
         if ( eclWellLogExtractor )
         {
-            RimEclipseCase*             eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationCase() );
+            RimEclipseCase*             eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationSettings->formationCase() );
             cvf::ref<RigResultAccessor> resultAccessor =
                 RigResultAccessorFactory::createFromResultAddress( eclipseCase->eclipseCaseData(),
                                                                    0,
@@ -2937,8 +2669,9 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
         }
         else
         {
-            geoMechWellLogExtractor = RiaExtractionTools::findOrCreateWellLogExtractor( m_formationWellPathForSourceCase,
-                                                                                        dynamic_cast<RimGeoMechCase*>( m_formationCase() ) );
+            geoMechWellLogExtractor =
+                RiaExtractionTools::findOrCreateWellLogExtractor( m_formationSettings->wellPathForSourceCase(),
+                                                                  dynamic_cast<RimGeoMechCase*>( m_formationSettings->formationCase() ) );
             if ( !geoMechWellLogExtractor ) return;
 
             std::string activeFormationNamesResultName = RiaResultNames::activeFormationNamesResultName().toStdString();
@@ -2962,29 +2695,30 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
                                                   { "Sea Level", "" },
                                                   orientation,
                                                   convertedYValues,
-                                                  m_regionAnnotationDisplay(),
+                                                  m_regionAnnotationSettings->annotationDisplay(),
                                                   waterAndRockColors,
-                                                  ( ( 100 - m_colorShadingTransparency ) * 255 ) / 100,
-                                                  m_showRegionLabels(),
+                                                  ( ( 100 - m_regionAnnotationSettings->colorShadingTransparency() ) * 255 ) / 100,
+                                                  m_regionAnnotationSettings->showRegionLabels(),
                                                   RiaDefines::TrackSpan::LEFT_COLUMN,
                                                   { Qt::SolidPattern, Qt::Dense6Pattern } );
         }
 
-        if ( m_formationSource == FormationSource::CASE && m_plotWidget )
+        if ( m_formationSettings->formationSource() == RiaDefines::WellLogTrackFormationSource::CASE && m_plotWidget )
         {
-            if ( ( m_formationSimWellName == QString( "None" ) && m_formationWellPathForSourceCase == nullptr ) || m_formationCase == nullptr )
+            if ( ( m_formationSettings->simWellName() == QString( "None" ) && m_formationSettings->wellPathForSourceCase() == nullptr ) ||
+                 m_formationSettings->formationCase() == nullptr )
                 return;
 
-            std::vector<QString> formationNamesVector = RimWellLogTrack::formationNamesVector( m_formationCase );
+            std::vector<QString> formationNamesVector = RimWellLogTrack::formationNamesVector( m_formationSettings->formationCase() );
 
-            if ( m_overburdenHeight > 0.0 )
+            if ( m_wellPathAttributeSettings->overburdenHeight() > 0.0 )
             {
-                addOverburden( formationNamesVector, curveData, m_overburdenHeight );
+                addOverburden( formationNamesVector, curveData, m_wellPathAttributeSettings->overburdenHeight() );
             }
 
-            if ( m_underburdenHeight > 0.0 )
+            if ( m_wellPathAttributeSettings->underburdenHeight() > 0.0 )
             {
-                addUnderburden( formationNamesVector, curveData, m_underburdenHeight );
+                addUnderburden( formationNamesVector, curveData, m_wellPathAttributeSettings->underburdenHeight() );
             }
 
             std::vector<std::pair<double, double>> yValues;
@@ -2995,15 +2729,15 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
             std::vector<std::pair<double, double>> convertedYValues =
                 RiaWellLogUnitTools<double>::convertDepths( yValues, fromDepthUnit, toDepthUnit );
 
-            caf::ColorTable colorTable( m_colorShadingLegend->colorArray() );
+            caf::ColorTable colorTable( m_regionAnnotationSettings->colorShadingLegend()->colorArray() );
             m_annotationTool->attachNamedRegions( m_plotWidget->qwtPlot(),
                                                   formationNamesToPlot,
                                                   orientation,
                                                   convertedYValues,
-                                                  m_regionAnnotationDisplay(),
+                                                  m_regionAnnotationSettings->annotationDisplay(),
                                                   colorTable,
-                                                  ( ( 100 - m_colorShadingTransparency ) * 255 ) / 100,
-                                                  m_showRegionLabels() );
+                                                  ( ( 100 - m_regionAnnotationSettings->colorShadingTransparency() ) * 255 ) / 100,
+                                                  m_regionAnnotationSettings->showRegionLabels() );
         }
     }
 }
@@ -3021,7 +2755,8 @@ void RimWellLogTrack::updateResultPropertyNamesOnPlot()
     auto orientation = plot->depthOrientation();
 
     RigEclipseWellLogExtractor* eclWellLogExtractor =
-        RiaExtractionTools::findOrCreateWellLogExtractor( m_formationWellPathForSourceCase, dynamic_cast<RimEclipseCase*>( m_formationCase() ) );
+        RiaExtractionTools::findOrCreateWellLogExtractor( m_formationSettings->wellPathForSourceCase(),
+                                                          dynamic_cast<RimEclipseCase*>( m_formationSettings->formationCase() ) );
 
     if ( !eclWellLogExtractor )
     {
@@ -3029,7 +2764,7 @@ void RimWellLogTrack::updateResultPropertyNamesOnPlot()
         return;
     }
 
-    RimEclipseCase* eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationCase() );
+    RimEclipseCase* eclipseCase = dynamic_cast<RimEclipseCase*>( m_formationSettings->formationCase() );
 
     m_resultDefinition->loadResult();
 
@@ -3051,35 +2786,36 @@ void RimWellLogTrack::updateResultPropertyNamesOnPlot()
 
     // Attach water and rock base formations
 
-    if ( m_formationSource == FormationSource::CASE )
+    if ( m_formationSettings->formationSource() == RiaDefines::WellLogTrackFormationSource::CASE )
     {
-        if ( ( m_formationSimWellName == QString( "None" ) && m_formationWellPathForSourceCase == nullptr ) || m_formationCase == nullptr )
+        if ( ( m_formationSettings->simWellName() == QString( "None" ) && m_formationSettings->wellPathForSourceCase() == nullptr ) ||
+             m_formationSettings->formationCase() == nullptr )
             return;
 
         std::vector<cvf::Color3ub> colors;
 
         // Find the largest category number.
         int maxCategoryValue = std::numeric_limits<int>::min();
-        for ( RimColorLegendItem* legendItem : m_colorShadingLegend()->colorLegendItems() )
+        for ( RimColorLegendItem* legendItem : m_regionAnnotationSettings->colorShadingLegend()->colorLegendItems() )
         {
             maxCategoryValue = std::max( maxCategoryValue, legendItem->categoryValue() );
         }
 
         // Insert each name at index matching the category number.
         std::vector<QString> namesVector( maxCategoryValue + 1 );
-        for ( RimColorLegendItem* legendItem : m_colorShadingLegend()->colorLegendItems() )
+        for ( RimColorLegendItem* legendItem : m_regionAnnotationSettings->colorShadingLegend()->colorLegendItems() )
         {
             namesVector[legendItem->categoryValue()] = legendItem->categoryName();
         }
 
-        if ( m_overburdenHeight > 0.0 )
+        if ( m_wellPathAttributeSettings->overburdenHeight() > 0.0 )
         {
-            addOverburden( namesVector, curveData, m_overburdenHeight );
+            addOverburden( namesVector, curveData, m_wellPathAttributeSettings->overburdenHeight() );
         }
 
-        if ( m_underburdenHeight > 0.0 )
+        if ( m_wellPathAttributeSettings->underburdenHeight() > 0.0 )
         {
-            addUnderburden( namesVector, curveData, m_underburdenHeight );
+            addUnderburden( namesVector, curveData, m_wellPathAttributeSettings->underburdenHeight() );
         }
 
         std::vector<QString>                   namesToPlot;
@@ -3095,7 +2831,7 @@ void RimWellLogTrack::updateResultPropertyNamesOnPlot()
         for ( QString nameToPlot : namesToPlot )
         {
             bool isFound = false;
-            for ( RimColorLegendItem* legendItem : m_colorShadingLegend()->colorLegendItems() )
+            for ( RimColorLegendItem* legendItem : m_regionAnnotationSettings->colorShadingLegend()->colorLegendItems() )
             {
                 if ( legendItem->categoryName() == nameToPlot )
                 {
@@ -3118,16 +2854,17 @@ void RimWellLogTrack::updateResultPropertyNamesOnPlot()
 
         caf::ColorTable colorTable( colors );
 
-        int fontSize = caf::FontTools::absolutePointSize( RiaPreferences::current()->defaultPlotFontSize(), m_regionLabelFontSize() );
+        int fontSize = caf::FontTools::absolutePointSize( RiaPreferences::current()->defaultPlotFontSize(),
+                                                          m_regionAnnotationSettings->regionLabelFontSize() );
 
         m_annotationTool->attachNamedRegions( m_plotWidget->qwtPlot(),
                                               namesToPlot,
                                               orientation,
                                               convertedYValues,
-                                              m_regionAnnotationDisplay(),
+                                              m_regionAnnotationSettings->annotationDisplay(),
                                               colorTable,
-                                              ( ( 100 - m_colorShadingTransparency ) * 255 ) / 100,
-                                              m_showRegionLabels(),
+                                              ( ( 100 - m_regionAnnotationSettings->colorShadingTransparency() ) * 255 ) / 100,
+                                              m_regionAnnotationSettings->showRegionLabels(),
                                               RiaDefines::TrackSpan::FULL_WIDTH,
                                               {},
                                               fontSize );
@@ -3176,7 +2913,7 @@ void RimWellLogTrack::updateCurveDataRegionsOnPlot()
             std::vector<double> ucsSourceRegions     = geoMechWellLogExtractor->ucsSourceRegions( stepIdx, frameIdx );
 
             {
-                caf::ColorTable colorTable( m_colorShadingLegend->colorArray() );
+                caf::ColorTable colorTable( m_regionAnnotationSettings->colorShadingLegend()->colorArray() );
 
                 std::vector<QString> sourceNames =
                     RigWbsParameter::PP_Reservoir().allSourceUiLabels( "\n", wbsPlot->userDefinedValue( RigWbsParameter::PP_NonReservoir() ) );
@@ -3194,14 +2931,14 @@ void RimWellLogTrack::updateCurveDataRegionsOnPlot()
                                                       sourceNamesToPlot,
                                                       orientation,
                                                       convertedYValues,
-                                                      m_regionAnnotationDisplay(),
+                                                      m_regionAnnotationSettings->annotationDisplay(),
                                                       colorTable,
-                                                      ( ( ( 100 - m_colorShadingTransparency ) * 255 ) / 100 ) / 3,
-                                                      m_showRegionLabels(),
+                                                      ( ( ( 100 - m_regionAnnotationSettings->colorShadingTransparency() ) * 255 ) / 100 ) / 3,
+                                                      m_regionAnnotationSettings->showRegionLabels(),
                                                       RiaDefines::TrackSpan::LEFT_COLUMN );
             }
             {
-                caf::ColorTable colorTable( m_colorShadingLegend->colorArray() );
+                caf::ColorTable colorTable( m_regionAnnotationSettings->colorShadingLegend()->colorArray() );
 
                 std::vector<QString> sourceNames =
                     RigWbsParameter::poissonRatio().allSourceUiLabels( "\n", wbsPlot->userDefinedValue( RigWbsParameter::poissonRatio() ) );
@@ -3219,14 +2956,14 @@ void RimWellLogTrack::updateCurveDataRegionsOnPlot()
                                                       sourceNamesToPlot,
                                                       orientation,
                                                       convertedYValues,
-                                                      m_regionAnnotationDisplay(),
+                                                      m_regionAnnotationSettings->annotationDisplay(),
                                                       colorTable,
-                                                      ( ( ( 100 - m_colorShadingTransparency ) * 255 ) / 100 ) / 3,
-                                                      m_showRegionLabels(),
+                                                      ( ( ( 100 - m_regionAnnotationSettings->colorShadingTransparency() ) * 255 ) / 100 ) / 3,
+                                                      m_regionAnnotationSettings->showRegionLabels(),
                                                       RiaDefines::TrackSpan::CENTRE_COLUMN );
             }
             {
-                caf::ColorTable colorTable( m_colorShadingLegend->colorArray() );
+                caf::ColorTable colorTable( m_regionAnnotationSettings->colorShadingLegend()->colorArray() );
 
                 std::vector<QString> sourceNames =
                     RigWbsParameter::UCS().allSourceUiLabels( "\n", wbsPlot->userDefinedValue( RigWbsParameter::UCS() ) );
@@ -3245,10 +2982,10 @@ void RimWellLogTrack::updateCurveDataRegionsOnPlot()
                                                       sourceNamesToPlot,
                                                       orientation,
                                                       convertedYValues,
-                                                      m_regionAnnotationDisplay(),
+                                                      m_regionAnnotationSettings->annotationDisplay(),
                                                       colorTable,
-                                                      ( ( ( 100 - m_colorShadingTransparency ) * 255 ) / 100 ) / 3,
-                                                      m_showRegionLabels(),
+                                                      ( ( ( 100 - m_regionAnnotationSettings->colorShadingTransparency() ) * 255 ) / 100 ) / 3,
+                                                      m_regionAnnotationSettings->showRegionLabels(),
                                                       RiaDefines::TrackSpan::RIGHT_COLUMN );
             }
         }
@@ -3266,16 +3003,17 @@ void RimWellLogTrack::updateWellPathAttributesOnPlot()
     {
         std::vector<const RimWellPathComponentInterface*> allWellPathComponents;
 
-        if ( wellPathAttributeSource()->wellPathGeometry() && ( m_showWellPathAttributes || m_showWellPathCompletions ) )
+        if ( wellPathAttributeSource()->wellPathGeometry() &&
+             ( m_wellPathAttributeSettings->showWellPathAttributes() || m_wellPathAttributeSettings->showWellPathCompletions() ) )
         {
             m_wellPathAttributePlotObjects.push_back( std::make_unique<RiuWellPathComponentPlotItem>( wellPathAttributeSource() ) );
         }
 
-        if ( m_showWellPathAttributes )
+        if ( m_wellPathAttributeSettings->showWellPathAttributes() )
         {
-            if ( m_wellPathAttributeCollection )
+            if ( m_wellPathAttributeSettings->wellPathAttributeCollection() )
             {
-                std::vector<RimWellPathAttribute*> attributes = m_wellPathAttributeCollection->attributes();
+                std::vector<RimWellPathAttribute*> attributes = m_wellPathAttributeSettings->wellPathAttributeCollection()->attributes();
                 for ( const RimWellPathAttribute* attribute : attributes )
                 {
                     if ( attribute->isEnabled() )
@@ -3285,7 +3023,7 @@ void RimWellLogTrack::updateWellPathAttributesOnPlot()
                 }
             }
         }
-        if ( m_showWellPathCompletions )
+        if ( m_wellPathAttributeSettings->showWellPathCompletions() )
         {
             const RimWellPathCompletions*                     completionsCollection = wellPathAttributeSource()->completions();
             std::vector<const RimWellPathComponentInterface*> allCompletions        = completionsCollection->allCompletions();
@@ -3328,7 +3066,8 @@ void RimWellLogTrack::updateWellPathAttributesOnPlot()
 
             std::unique_ptr<RiuWellPathComponentPlotItem> plotItem( new RiuWellPathComponentPlotItem( wellPathAttributeSource(), component ) );
             QString legendTitle        = plotItem->legendTitle();
-            bool    contributeToLegend = m_wellPathCompletionsInLegend() && !completionsAssignedToLegend.count( legendTitle );
+            bool    contributeToLegend = m_wellPathAttributeSettings->showCompletionsInLegend() &&
+                                      !completionsAssignedToLegend.count( legendTitle );
             plotItem->setContributeToLegend( contributeToLegend );
             m_wellPathAttributePlotObjects.push_back( std::move( plotItem ) );
             completionsAssignedToLegend.insert( legendTitle );
@@ -3342,7 +3081,7 @@ void RimWellLogTrack::updateWellPathAttributesOnPlot()
         {
             attributePlotObject->setDepthType( depthType );
             attributePlotObject->setDepthOrientation( depthOrientation );
-            attributePlotObject->setShowLabel( m_showWellPathComponentLabels() );
+            attributePlotObject->setShowLabel( m_wellPathAttributeSettings->showComponentLabels() );
             attributePlotObject->loadDataAndUpdate( false );
             attributePlotObject->setParentPlotNoReplot( m_plotWidget->qwtPlot() );
         }
@@ -3386,7 +3125,7 @@ void RimWellLogTrack::onChildDeleted( caf::PdmChildArrayFieldHandle* childArray,
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setOverburdenHeight( double overburdenHeight )
 {
-    m_overburdenHeight = overburdenHeight;
+    m_wellPathAttributeSettings->setOverburdenHeight( overburdenHeight );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -3394,7 +3133,7 @@ void RimWellLogTrack::setOverburdenHeight( double overburdenHeight )
 //--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setUnderburdenHeight( double underburdenHeight )
 {
-    m_underburdenHeight = underburdenHeight;
+    m_wellPathAttributeSettings->setUnderburdenHeight( underburdenHeight );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -1197,13 +1197,7 @@ void RimWellLogTrack::onLoadDataAndUpdate()
          m_regionAnnotationSettings->annotationType() == RiaDefines::RegionAnnotationType::RESULT_PROPERTY_ANNOTATIONS )
     {
         m_resultDefinition->loadDataAndUpdate();
-        setFormationFieldsUiReadOnly( false );
     }
-    else
-    {
-        setFormationFieldsUiReadOnly( true );
-    }
-    // UI read-only state for region annotation fields is managed by RimWellLogRegionAnnotationSettings
 
     if ( m_plotWidget )
     {
@@ -2526,16 +2520,6 @@ void RimWellLogTrack::updateStackedCurveData()
             zPos -= 1.0;
         }
     }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimWellLogTrack::setFormationFieldsUiReadOnly( bool readOnly /*= true*/ )
-{
-    // Formation fields are now managed by RimWellLogFormationSettings
-    // Region annotation fields are managed by RimWellLogRegionAnnotationSettings
-    // The settings objects handle their own UI read-only state
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "RiaWellLogTrackDefines.h"
 #include "RimWellLogPlot.h"
 
 #include "RiaPlotDefines.h"
@@ -30,6 +31,7 @@
 #include "RiuPlotAxis.h"
 
 #include "cafPdmChildArrayField.h"
+#include "cafPdmChildField.h"
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 #include "cafPdmPtrField.h"
@@ -58,6 +60,10 @@ class RigWellLogExtractor;
 class RimEclipseResultDefinition;
 class RimColorLegend;
 class RimEnsembleWellLogCurveSet;
+class RimWellLogPropertyAxisSettings;
+class RimWellLogFormationSettings;
+class RimWellLogRegionAnnotationSettings;
+class RimWellLogWellPathAttributeSettings;
 class RiuPlotAnnotationTool;
 
 struct CurveSamplingPointData
@@ -78,17 +84,6 @@ class RimWellLogTrack : public RimPlot
     CAF_PDM_HEADER_INIT;
 
 public:
-    enum TrajectoryType
-    {
-        WELL_PATH,
-        SIMULATION_WELL
-    };
-    enum FormationSource
-    {
-        CASE,
-        WELL_PICK_FILTER
-    };
-
     using RegionAnnotationTypeEnum    = caf::AppEnum<RiaDefines::RegionAnnotationType>;
     using RegionAnnotationDisplayEnum = caf::AppEnum<RiaDefines::RegionDisplay>;
 
@@ -116,19 +111,19 @@ public:
     void    setPropertyValueAxisTitle( const QString& text );
     QString depthAxisTitle() const;
 
-    void           setFormationWellPath( RimWellPath* wellPath );
-    RimWellPath*   formationWellPath() const;
-    void           setFormationSimWellName( const QString& simWellName );
-    QString        formationSimWellName() const;
-    void           setFormationBranchDetection( bool branchDetection );
-    bool           formationBranchDetection() const;
-    void           setFormationBranchIndex( int branchIndex );
-    int            formationBranchIndex() const;
-    void           setFormationCase( RimCase* rimCase );
-    RimCase*       formationNamesCase() const;
-    void           setFormationTrajectoryType( TrajectoryType trajectoryType );
-    TrajectoryType formationTrajectoryType() const;
-    void           setRegionPropertyResultType( RiaDefines::ResultCatType resultCatType, const QString& resultVariable );
+    void                                   setFormationWellPath( RimWellPath* wellPath );
+    RimWellPath*                           formationWellPath() const;
+    void                                   setFormationSimWellName( const QString& simWellName );
+    QString                                formationSimWellName() const;
+    void                                   setFormationBranchDetection( bool branchDetection );
+    bool                                   formationBranchDetection() const;
+    void                                   setFormationBranchIndex( int branchIndex );
+    int                                    formationBranchIndex() const;
+    void                                   setFormationCase( RimCase* rimCase );
+    RimCase*                               formationNamesCase() const;
+    void                                   setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType trajectoryType );
+    RiaDefines::WellLogTrackTrajectoryType formationTrajectoryType() const;
+    void setRegionPropertyResultType( RiaDefines::ResultCatType resultCatType, const QString& resultVariable );
 
     void detachAllCurves() override;
     void reattachAllCurves() override;
@@ -315,18 +310,30 @@ private:
     caf::PdmField<QString>                    m_description;
     caf::PdmChildArrayField<RimWellLogCurve*> m_curves;
 
-    // Property value axis
-    caf::PdmField<bool>                         m_isPropertyAxisEnabled;
-    caf::PdmField<double>                       m_visiblePropertyValueRangeMin;
-    caf::PdmField<double>                       m_visiblePropertyValueRangeMax;
-    caf::PdmField<bool>                         m_isAutoScalePropertyValuesEnabled;
-    caf::PdmField<bool>                         m_isPropertyLogarithmicScaleEnabled;
-    caf::PdmField<bool>                         m_invertPropertyValueAxis;
-    caf::PdmField<RimWellLogPlot::AxisGridEnum> m_propertyValueAxisGridVisibility;
-    caf::PdmField<bool>                         m_propertyAxisMinAndMaxTicksOnly;
-    caf::PdmField<bool>                         m_explicitTickIntervalsPropertyValueAxis;
-    caf::PdmField<double>                       m_majorTickIntervalPropertyAxis;
-    caf::PdmField<double>                       m_minorTickIntervalPropertyAxis;
+    // Property value axis settings
+    caf::PdmChildField<RimWellLogPropertyAxisSettings*> m_propertyAxisSettings;
+
+    // Formation settings
+    caf::PdmChildField<RimWellLogFormationSettings*> m_formationSettings;
+
+    // Region annotation settings
+    caf::PdmChildField<RimWellLogRegionAnnotationSettings*> m_regionAnnotationSettings;
+
+    // Well path attribute settings
+    caf::PdmChildField<RimWellLogWellPathAttributeSettings*> m_wellPathAttributeSettings;
+
+    // OBSOLETE: Property value axis fields (migrated to RimWellLogPropertyAxisSettings)
+    caf::PdmField<bool>                         m_isPropertyAxisEnabled_OBSOLETE;
+    caf::PdmField<double>                       m_visiblePropertyValueRangeMin_OBSOLETE;
+    caf::PdmField<double>                       m_visiblePropertyValueRangeMax_OBSOLETE;
+    caf::PdmField<bool>                         m_isAutoScalePropertyValuesEnabled_OBSOLETE;
+    caf::PdmField<bool>                         m_isPropertyLogarithmicScaleEnabled_OBSOLETE;
+    caf::PdmField<bool>                         m_invertPropertyValueAxis_OBSOLETE;
+    caf::PdmField<RimWellLogPlot::AxisGridEnum> m_propertyValueAxisGridVisibility_OBSOLETE;
+    caf::PdmField<bool>                         m_propertyAxisMinAndMaxTicksOnly_OBSOLETE;
+    caf::PdmField<bool>                         m_explicitTickIntervalsPropertyValueAxis_OBSOLETE;
+    caf::PdmField<double>                       m_majorTickIntervalPropertyAxis_OBSOLETE;
+    caf::PdmField<double>                       m_minorTickIntervalPropertyAxis_OBSOLETE;
 
     // Depth axis
     caf::PdmField<double> m_visibleDepthRangeMin;
@@ -334,34 +341,40 @@ private:
 
     RimFontSizeField m_axisFontSize;
 
-    caf::PdmField<RegionAnnotationTypeEnum>                            m_regionAnnotationType;
-    caf::PdmField<RegionAnnotationDisplayEnum>                         m_regionAnnotationDisplay;
-    caf::PdmPtrField<RimColorLegend*>                                  m_colorShadingLegend;
-    caf::PdmField<int>                                                 m_colorShadingTransparency;
-    caf::PdmField<bool>                                                m_showRegionLabels;
-    RimFontSizeField                                                   m_regionLabelFontSize;
-    caf::PdmField<caf::AppEnum<FormationSource>>                       m_formationSource;
-    caf::PdmPtrField<RimCase*>                                         m_formationCase;
-    caf::PdmField<caf::AppEnum<TrajectoryType>>                        m_formationTrajectoryType;
-    caf::PdmPtrField<RimWellPath*>                                     m_formationWellPathForSourceCase;
-    caf::PdmPtrField<RimWellPath*>                                     m_formationWellPathForSourceWellPath;
-    caf::PdmField<QString>                                             m_formationSimWellName;
-    caf::PdmField<int>                                                 m_formationBranchIndex;
-    caf::PdmField<caf::AppEnum<RigWellPathFormations::FormationLevel>> m_formationLevel;
-    caf::PdmField<bool>                                                m_showformationFluids;
-    caf::PdmField<bool>                                                m_formationBranchDetection;
-    caf::PdmField<bool>                                                m_showWellPathAttributes;
-    caf::PdmField<bool>                                                m_showWellPathCompletions;
-    caf::PdmField<bool>                                                m_showWellPathComponentsBothSides;
-    caf::PdmField<bool>                                                m_showWellPathComponentLabels;
-    caf::PdmField<bool>                                                m_wellPathAttributesInLegend;
-    caf::PdmField<bool>                                                m_wellPathCompletionsInLegend;
-    caf::PdmPtrField<RimWellPath*>                                     m_wellPathComponentSource;
-    caf::PdmPtrField<RimWellPathAttributeCollection*>                  m_wellPathAttributeCollection;
-    caf::PdmChildField<RimEclipseResultDefinition*>                    m_resultDefinition;
-    caf::PdmField<double>                                              m_overburdenHeight;
-    caf::PdmField<double>                                              m_underburdenHeight;
-    caf::PdmChildField<RimEnsembleWellLogCurveSet*>                    m_ensembleWellLogCurveSet;
+    // OBSOLETE: Region annotation fields (migrated to RimWellLogRegionAnnotationSettings)
+    caf::PdmField<RegionAnnotationTypeEnum>    m_regionAnnotationType_OBSOLETE;
+    caf::PdmField<RegionAnnotationDisplayEnum> m_regionAnnotationDisplay_OBSOLETE;
+    caf::PdmPtrField<RimColorLegend*>          m_colorShadingLegend_OBSOLETE;
+    caf::PdmField<int>                         m_colorShadingTransparency_OBSOLETE;
+    caf::PdmField<bool>                        m_showRegionLabels_OBSOLETE;
+    RimFontSizeField                           m_regionLabelFontSize_OBSOLETE;
+
+    // OBSOLETE: Formation fields (migrated to RimWellLogFormationSettings)
+    caf::PdmField<caf::AppEnum<RiaDefines::WellLogTrackFormationSource>> m_formationSource_OBSOLETE;
+    caf::PdmPtrField<RimCase*>                                           m_formationCase_OBSOLETE;
+    caf::PdmField<caf::AppEnum<RiaDefines::WellLogTrackTrajectoryType>>  m_formationTrajectoryType_OBSOLETE;
+    caf::PdmPtrField<RimWellPath*>                                       m_formationWellPathForSourceCase_OBSOLETE;
+    caf::PdmPtrField<RimWellPath*>                                       m_formationWellPathForSourceWellPath_OBSOLETE;
+    caf::PdmField<QString>                                               m_formationSimWellName_OBSOLETE;
+    caf::PdmField<int>                                                   m_formationBranchIndex_OBSOLETE;
+    caf::PdmField<caf::AppEnum<RiaDefines::WellLogTrackFormationLevel>>  m_formationLevel_OBSOLETE;
+    caf::PdmField<bool>                                                  m_showformationFluids_OBSOLETE;
+    caf::PdmField<bool>                                                  m_formationBranchDetection_OBSOLETE;
+
+    // OBSOLETE: Well path attribute fields (migrated to RimWellLogWellPathAttributeSettings)
+    caf::PdmField<bool>                               m_showWellPathAttributes_OBSOLETE;
+    caf::PdmField<bool>                               m_showWellPathCompletions_OBSOLETE;
+    caf::PdmField<bool>                               m_showWellPathComponentsBothSides_OBSOLETE;
+    caf::PdmField<bool>                               m_showWellPathComponentLabels_OBSOLETE;
+    caf::PdmField<bool>                               m_wellPathAttributesInLegend_OBSOLETE;
+    caf::PdmField<bool>                               m_wellPathCompletionsInLegend_OBSOLETE;
+    caf::PdmPtrField<RimWellPath*>                    m_wellPathComponentSource_OBSOLETE;
+    caf::PdmPtrField<RimWellPathAttributeCollection*> m_wellPathAttributeCollection_OBSOLETE;
+    caf::PdmField<double>                             m_overburdenHeight_OBSOLETE;
+    caf::PdmField<double>                             m_underburdenHeight_OBSOLETE;
+
+    caf::PdmChildField<RimEclipseResultDefinition*> m_resultDefinition;
+    caf::PdmChildField<RimEnsembleWellLogCurveSet*> m_ensembleWellLogCurveSet;
 
     caf::PdmField<bool> m_autoCheckStateBasedOnCurveData;
 

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
@@ -120,7 +120,7 @@ public:
     void                                   setFormationBranchIndex( int branchIndex );
     int                                    formationBranchIndex() const;
     void                                   setFormationCase( RimCase* rimCase );
-    RimCase*                               formationNamesCase() const;
+    RimCase*                               formationCase() const;
     void                                   setFormationTrajectoryType( RiaDefines::WellLogTrackTrajectoryType trajectoryType );
     RiaDefines::WellLogTrackTrajectoryType formationTrajectoryType() const;
     void setRegionPropertyResultType( RiaDefines::ResultCatType resultCatType, const QString& resultVariable );
@@ -265,7 +265,6 @@ private:
 
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void initAfterRead() override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
     caf::PdmFieldHandle* userDescriptionField() override;
 
@@ -300,7 +299,7 @@ private:
     void handleWheelEvent( QWheelEvent* event ) override;
     void doUpdateLayout() override;
 
-    std::vector<std::pair<double, double>> waterAndRockRegions( RiaDefines::DepthTypeEnum         depthType,
+    std::vector<std::pair<double, double>> waterAndRockRegions( RiaDefines::DepthType             depthType,
                                                                 const RigGeoMechWellLogExtractor* extractor ) const;
 
     void connectCurveSignals( RimWellLogCurve* curve );

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
@@ -278,8 +278,6 @@ private:
                                                                int                       branchIndex,
                                                                bool                      useBranchDetection );
 
-    void setFormationFieldsUiReadOnly( bool readOnly = true );
-
     void updateRegionAnnotationsOnPlot();
     void updateFormationNamesOnPlot();
     void updateResultPropertyNamesOnPlot();

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.cpp
@@ -1,0 +1,262 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimWellLogWellPathAttributeSettings.h"
+
+#include "RimTools.h"
+#include "RimWellLogTrack.h"
+#include "RimWellPath.h"
+#include "RimWellPathAttributeCollection.h"
+
+#include "cafPdmUiOrdering.h"
+
+CAF_PDM_SOURCE_INIT( RimWellLogWellPathAttributeSettings, "RimWellLogWellPathAttributeSettings" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogWellPathAttributeSettings::RimWellLogWellPathAttributeSettings()
+{
+    CAF_PDM_InitObject( "Well Path Attribute Settings" );
+
+    CAF_PDM_InitField( &m_showWellPathAttributes, "ShowWellPathAttributes", false, "Show Well Attributes" );
+    CAF_PDM_InitField( &m_wellPathAttributesInLegend, "WellPathAttributesInLegend", true, "Attributes in Legend" );
+    CAF_PDM_InitField( &m_showWellPathCompletions, "ShowWellPathCompletions", true, "Show Well Completions" );
+    CAF_PDM_InitField( &m_wellPathCompletionsInLegend, "WellPathCompletionsInLegend", true, "Completions in Legend" );
+    CAF_PDM_InitField( &m_showWellPathComponentsBothSides, "ShowWellPathAttrBothSides", true, "Show Both Sides" );
+    CAF_PDM_InitField( &m_showWellPathComponentLabels, "ShowWellPathAttrLabels", false, "Show Labels" );
+    CAF_PDM_InitFieldNoDefault( &m_wellPathComponentSource, "AttributesWellPathSource", "Well Path" );
+    CAF_PDM_InitFieldNoDefault( &m_wellPathAttributeCollection, "AttributesCollection", "Well Attributes" );
+
+    CAF_PDM_InitField( &m_overburdenHeight, "OverburdenHeight", 0.0, "Overburden Height" );
+    m_overburdenHeight.uiCapability()->setUiHidden( true );
+    CAF_PDM_InitField( &m_underburdenHeight, "UnderburdenHeight", 0.0, "Underburden Height" );
+    m_underburdenHeight.uiCapability()->setUiHidden( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellLogWellPathAttributeSettings::~RimWellLogWellPathAttributeSettings()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogWellPathAttributeSettings::showWellPathAttributes() const
+{
+    return m_showWellPathAttributes();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setShowWellPathAttributes( bool show )
+{
+    m_showWellPathAttributes = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogWellPathAttributeSettings::showWellPathCompletions() const
+{
+    return m_showWellPathCompletions();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setShowWellPathCompletions( bool show )
+{
+    m_showWellPathCompletions = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogWellPathAttributeSettings::showBothSides() const
+{
+    return m_showWellPathComponentsBothSides();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setShowBothSides( bool show )
+{
+    m_showWellPathComponentsBothSides = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogWellPathAttributeSettings::showComponentLabels() const
+{
+    return m_showWellPathComponentLabels();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setShowComponentLabels( bool show )
+{
+    m_showWellPathComponentLabels = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogWellPathAttributeSettings::showAttributesInLegend() const
+{
+    return m_wellPathAttributesInLegend();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setShowAttributesInLegend( bool show )
+{
+    m_wellPathAttributesInLegend = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimWellLogWellPathAttributeSettings::showCompletionsInLegend() const
+{
+    return m_wellPathCompletionsInLegend();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setShowCompletionsInLegend( bool show )
+{
+    m_wellPathCompletionsInLegend = show;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPath* RimWellLogWellPathAttributeSettings::wellPathComponentSource() const
+{
+    return m_wellPathComponentSource();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setWellPathComponentSource( RimWellPath* wellPath )
+{
+    m_wellPathComponentSource = wellPath;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPathAttributeCollection* RimWellLogWellPathAttributeSettings::wellPathAttributeCollection() const
+{
+    return m_wellPathAttributeCollection();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setWellPathAttributeCollection( RimWellPathAttributeCollection* collection )
+{
+    m_wellPathAttributeCollection = collection;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimWellLogWellPathAttributeSettings::overburdenHeight() const
+{
+    return m_overburdenHeight();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setOverburdenHeight( double height )
+{
+    m_overburdenHeight = height;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimWellLogWellPathAttributeSettings::underburdenHeight() const
+{
+    return m_underburdenHeight();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::setUnderburdenHeight( double height )
+{
+    m_underburdenHeight = height;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    uiOrdering.add( &m_showWellPathAttributes );
+    uiOrdering.add( &m_showWellPathCompletions );
+    uiOrdering.add( &m_wellPathAttributesInLegend );
+    uiOrdering.add( &m_wellPathCompletionsInLegend );
+    uiOrdering.add( &m_showWellPathComponentsBothSides );
+    uiOrdering.add( &m_showWellPathComponentLabels );
+    uiOrdering.add( &m_wellPathComponentSource );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellLogWellPathAttributeSettings::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
+                                                            const QVariant&            oldValue,
+                                                            const QVariant&            newValue )
+{
+    auto track = firstAncestorOrThisOfType<RimWellLogTrack>();
+    if ( track )
+    {
+        track->loadDataAndUpdate();
+        track->updateConnectedEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RimWellLogWellPathAttributeSettings::calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions )
+{
+    QList<caf::PdmOptionItemInfo> options;
+
+    if ( fieldNeedingOptions == &m_wellPathComponentSource )
+    {
+        RimTools::wellPathOptionItems( &options );
+        options.push_front( caf::PdmOptionItemInfo( "None", nullptr ) );
+    }
+
+    return options;
+}

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.cpp
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025-     Equinor ASA
+//  Copyright (C) 2026-     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogWellPathAttributeSettings.h
@@ -1,0 +1,94 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2025-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+#include "cafPdmPtrField.h"
+
+class RimWellPath;
+class RimWellPathAttributeCollection;
+
+//==================================================================================================
+///
+/// Settings class for well path attribute/completion display in well log tracks
+///
+//==================================================================================================
+class RimWellLogWellPathAttributeSettings : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RimWellLogWellPathAttributeSettings();
+    ~RimWellLogWellPathAttributeSettings() override;
+
+    // Show attributes/completions
+    bool showWellPathAttributes() const;
+    void setShowWellPathAttributes( bool show );
+
+    bool showWellPathCompletions() const;
+    void setShowWellPathCompletions( bool show );
+
+    // Display options
+    bool showBothSides() const;
+    void setShowBothSides( bool show );
+
+    bool showComponentLabels() const;
+    void setShowComponentLabels( bool show );
+
+    // Legend options
+    bool showAttributesInLegend() const;
+    void setShowAttributesInLegend( bool show );
+
+    bool showCompletionsInLegend() const;
+    void setShowCompletionsInLegend( bool show );
+
+    // Well path source
+    RimWellPath* wellPathComponentSource() const;
+    void         setWellPathComponentSource( RimWellPath* wellPath );
+
+    RimWellPathAttributeCollection* wellPathAttributeCollection() const;
+    void                            setWellPathAttributeCollection( RimWellPathAttributeCollection* collection );
+
+    // Overburden/underburden
+    double overburdenHeight() const;
+    void   setOverburdenHeight( double height );
+
+    double underburdenHeight() const;
+    void   setUnderburdenHeight( double height );
+
+    // UI ordering
+    void uiOrdering( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering );
+
+protected:
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
+
+private:
+    caf::PdmField<bool>                               m_showWellPathAttributes;
+    caf::PdmField<bool>                               m_showWellPathCompletions;
+    caf::PdmField<bool>                               m_showWellPathComponentsBothSides;
+    caf::PdmField<bool>                               m_showWellPathComponentLabels;
+    caf::PdmField<bool>                               m_wellPathAttributesInLegend;
+    caf::PdmField<bool>                               m_wellPathCompletionsInLegend;
+    caf::PdmPtrField<RimWellPath*>                    m_wellPathComponentSource;
+    caf::PdmPtrField<RimWellPathAttributeCollection*> m_wellPathAttributeCollection;
+    caf::PdmField<double>                             m_overburdenHeight;
+    caf::PdmField<double>                             m_underburdenHeight;
+};

--- a/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementCurve.cpp
@@ -126,7 +126,7 @@ void RimWellMeasurementCurve::onLoadDataAndUpdate( bool updateParentPlot )
                 bool useLogarithmicScale = false;
                 setPropertyValuesAndDepths( values,
                                             measuredDepthValues,
-                                            RiaDefines::DepthTypeEnum::MEASURED_DEPTH,
+                                            RiaDefines::DepthType::MEASURED_DEPTH,
                                             0.0,
                                             RiaDefines::DepthUnitType::UNIT_METER,
                                             false,
@@ -150,7 +150,7 @@ void RimWellMeasurementCurve::onLoadDataAndUpdate( bool updateParentPlot )
             displayUnit = wellLogPlot->depthUnit();
         }
 
-        RiaDefines::DepthTypeEnum depthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+        RiaDefines::DepthType depthType = RiaDefines::DepthType::MEASURED_DEPTH;
         if ( wellLogPlot && curveData()->availableDepthTypes().count( wellLogPlot->depthType() ) )
         {
             depthType = wellLogPlot->depthType();

--- a/ApplicationLibCode/ReservoirDataModel/RigLasFileExporter.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigLasFileExporter.cpp
@@ -190,10 +190,7 @@ public:
 
         if ( !firstCurveData->depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ).empty() )
         {
-            lasFile->AddLog( "TVDMSL",
-                             "M",
-                             "True vertical depth in meters",
-                             firstCurveData->depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ) );
+            lasFile->AddLog( "TVDMSL", "M", "True vertical depth in meters", firstCurveData->depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ) );
 
             if ( m_exportTvdrkb && m_rkbDiff != -1.0 )
             {

--- a/ApplicationLibCode/ReservoirDataModel/RigLasFileExporter.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigLasFileExporter.cpp
@@ -177,28 +177,28 @@ public:
 
         if ( firstCurveData->depthUnit() == RiaDefines::DepthUnitType::UNIT_METER )
         {
-            lasFile->AddLog( "DEPTH", "M", "Depth in meters", firstCurveData->depths( RiaDefines::DepthTypeEnum::MEASURED_DEPTH ) );
+            lasFile->AddLog( "DEPTH", "M", "Depth in meters", firstCurveData->depths( RiaDefines::DepthType::MEASURED_DEPTH ) );
         }
         else if ( firstCurveData->depthUnit() == RiaDefines::DepthUnitType::UNIT_FEET )
         {
-            lasFile->AddLog( "DEPTH", "FT", "Depth in feet", firstCurveData->depths( RiaDefines::DepthTypeEnum::MEASURED_DEPTH ) );
+            lasFile->AddLog( "DEPTH", "FT", "Depth in feet", firstCurveData->depths( RiaDefines::DepthType::MEASURED_DEPTH ) );
         }
         else if ( firstCurveData->depthUnit() == RiaDefines::DepthUnitType::UNIT_NONE )
         {
-            lasFile->AddLog( "DEPTH", "", "Depth in Connection number", firstCurveData->depths( RiaDefines::DepthTypeEnum::MEASURED_DEPTH ) );
+            lasFile->AddLog( "DEPTH", "", "Depth in Connection number", firstCurveData->depths( RiaDefines::DepthType::MEASURED_DEPTH ) );
         }
 
-        if ( !firstCurveData->depths( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH ).empty() )
+        if ( !firstCurveData->depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ).empty() )
         {
             lasFile->AddLog( "TVDMSL",
                              "M",
                              "True vertical depth in meters",
-                             firstCurveData->depths( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH ) );
+                             firstCurveData->depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ) );
 
             if ( m_exportTvdrkb && m_rkbDiff != -1.0 )
             {
                 // Export True Vertical Depth Rotary Kelly Bushing - TVDRKB
-                std::vector<double> tvdrkbValues = firstCurveData->depths( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH );
+                std::vector<double> tvdrkbValues = firstCurveData->depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH );
                 for ( auto& value : tvdrkbValues )
                 {
                     value += m_rkbDiff;
@@ -222,7 +222,7 @@ public:
 
         double minDepth = 0.0;
         double maxDepth = 0.0;
-        firstCurveData->calculateDepthRange( RiaDefines::DepthTypeEnum::MEASURED_DEPTH, firstCurveData->depthUnit(), &minDepth, &maxDepth );
+        firstCurveData->calculateDepthRange( RiaDefines::DepthType::MEASURED_DEPTH, firstCurveData->depthUnit(), &minDepth, &maxDepth );
 
         lasFile->setStartDepth( minDepth );
         lasFile->setStopDepth( maxDepth );

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.cpp
@@ -71,7 +71,7 @@ void RigWellLogCurveData::setDepthUnit( RiaDefines::DepthUnitType depthUnit )
 //--------------------------------------------------------------------------------------------------
 void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>& xValues,
                                               const std::vector<double>& depths,
-                                              RiaDefines::DepthTypeEnum  depthType,
+                                              RiaDefines::DepthType  depthType,
                                               double                     rkbDiff,
                                               RiaDefines::DepthUnitType  depthUnit,
                                               bool                       isExtractionCurve,
@@ -96,7 +96,7 @@ void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>& xValues
 ///
 //--------------------------------------------------------------------------------------------------
 void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>&                                      xValues,
-                                              const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& depths,
+                                              const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
                                               double                                                          rkbDiff,
                                               RiaDefines::DepthUnitType                                       depthUnit,
                                               bool                                                            isExtractionCurve,
@@ -143,7 +143,7 @@ std::vector<double> RigWellLogCurveData::propertyValues( const QString& units ) 
 {
     std::vector<double> convertedValues;
     if ( units != m_propertyValueUnitString &&
-         RiaWellLogUnitTools<double>::convertValues( depths( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB ),
+         RiaWellLogUnitTools<double>::convertValues( depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB ),
                                                      m_propertyValues,
                                                      &convertedValues,
                                                      m_propertyValueUnitString,
@@ -165,7 +165,7 @@ QString RigWellLogCurveData::propertyValueUnit() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthTypeEnum depthType ) const
+std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthType depthType ) const
 {
     auto it = m_depths.find( depthType );
     if ( it != m_depths.end() )
@@ -173,19 +173,19 @@ std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthTypeEnum depth
         return it->second;
     }
 
-    if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB && m_depths.count( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH ) )
+    if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB && m_depths.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ) )
     {
-        std::vector<double> tvds = depths( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH );
+        std::vector<double> tvds = depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH );
         for ( double& tvdValue : tvds )
         {
             tvdValue += m_rkbDiff;
         }
         return tvds;
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH &&
-              m_depths.count( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB ) )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH &&
+              m_depths.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB ) )
     {
-        std::vector<double> tvds = depths( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB );
+        std::vector<double> tvds = depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB );
         for ( double& tvdValue : tvds )
         {
             tvdValue -= m_rkbDiff;
@@ -199,7 +199,7 @@ std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthTypeEnum depth
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthTypeEnum depthType, RiaDefines::DepthUnitType destinationDepthUnit ) const
+std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthType depthType, RiaDefines::DepthUnitType destinationDepthUnit ) const
 {
     return depthsForDepthUnit( depths( depthType ), m_depthUnit, destinationDepthUnit );
 }
@@ -207,9 +207,9 @@ std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthTypeEnum depth
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::set<RiaDefines::DepthTypeEnum> RigWellLogCurveData::availableDepthTypes() const
+std::set<RiaDefines::DepthType> RigWellLogCurveData::availableDepthTypes() const
 {
-    std::set<RiaDefines::DepthTypeEnum> depthTypes;
+    std::set<RiaDefines::DepthType> depthTypes;
 
     for ( auto depthValuePair : m_depths )
     {
@@ -218,15 +218,15 @@ std::set<RiaDefines::DepthTypeEnum> RigWellLogCurveData::availableDepthTypes() c
 
     if ( m_rkbDiff != 0.0 )
     {
-        if ( depthTypes.count( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH ) &&
-             !depthTypes.count( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB ) )
+        if ( depthTypes.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ) &&
+             !depthTypes.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB ) )
         {
-            depthTypes.insert( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB );
+            depthTypes.insert( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB );
         }
-        else if ( depthTypes.count( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB ) &&
-                  !depthTypes.count( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH ) )
+        else if ( depthTypes.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB ) &&
+                  !depthTypes.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ) )
         {
-            depthTypes.insert( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH );
+            depthTypes.insert( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH );
         }
     }
 
@@ -247,7 +247,7 @@ std::vector<double> RigWellLogCurveData::propertyValuesByIntervals() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RigWellLogCurveData::depthValuesByIntervals( RiaDefines::DepthTypeEnum depthType,
+std::vector<double> RigWellLogCurveData::depthValuesByIntervals( RiaDefines::DepthType depthType,
                                                                  RiaDefines::DepthUnitType destinationDepthUnit ) const
 {
     const std::vector<double> depthValues = RigWellLogCurveData::depthsForDepthUnit( depths( depthType ), m_depthUnit, destinationDepthUnit );
@@ -278,8 +278,8 @@ cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( 
     bool                isTVDAvailable = false;
     std::vector<double> tvDepths;
 
-    auto mdIt  = m_depths.find( RiaDefines::DepthTypeEnum::MEASURED_DEPTH );
-    auto tvdIt = m_depths.find( RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH );
+    auto mdIt  = m_depths.find( RiaDefines::DepthType::MEASURED_DEPTH );
+    auto tvdIt = m_depths.find( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH );
 
     if ( tvdIt != m_depths.end() && !tvdIt->second.empty() ) isTVDAvailable = true;
 
@@ -328,15 +328,15 @@ cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( 
 
     if ( isTVDAvailable )
     {
-        std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths =
-            { { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, tvDepths }, { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, measuredDepths } };
+        std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths =
+            { { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvDepths }, { RiaDefines::DepthType::MEASURED_DEPTH, measuredDepths } };
         reSampledData->setValuesAndDepths( xValues, resampledDepths, m_rkbDiff, m_depthUnit, true, m_useLogarithmicScale );
     }
     else
     {
         reSampledData->setValuesAndDepths( xValues,
                                            measuredDepths,
-                                           RiaDefines::DepthTypeEnum::MEASURED_DEPTH,
+                                           RiaDefines::DepthType::MEASURED_DEPTH,
                                            0.0,
                                            m_depthUnit,
                                            m_isExtractionCurve,
@@ -354,12 +354,12 @@ cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( 
 //--------------------------------------------------------------------------------------------------
 void RigWellLogCurveData::createAndAddInterpolatedSegmentValueAndDepths(
     std::vector<double>&                                            resampledValues,
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>>&       resampledDepths,
-    RiaDefines::DepthTypeEnum                                       resamplingDepthType,
+    std::map<RiaDefines::DepthType, std::vector<double>>&       resampledDepths,
+    RiaDefines::DepthType                                       resamplingDepthType,
     double                                                          targetDepthValue,
     size_t                                                          firstIndex,
     size_t                                                          secondIndex,
-    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+    const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
     const std::vector<double>&                                      propertyValues,
     double                                                          eps )
 {
@@ -417,10 +417,10 @@ bool isRightOf( double x1, double x2, bool reverseOrder, double eps )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::pair<std::vector<double>, std::map<RiaDefines::DepthTypeEnum, std::vector<double>>>
-    RigWellLogCurveData::createResampledValuesAndDepths( RiaDefines::DepthTypeEnum  resamplingDepthType,
+std::pair<std::vector<double>, std::map<RiaDefines::DepthType, std::vector<double>>>
+    RigWellLogCurveData::createResampledValuesAndDepths( RiaDefines::DepthType  resamplingDepthType,
                                                          const std::vector<double>& targetDepths,
-                                                         const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+                                                         const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
                                                          const std::vector<double>&                                      propertyValues )
 {
     const double eps = 1.0e-8;
@@ -429,10 +429,10 @@ std::pair<std::vector<double>, std::map<RiaDefines::DepthTypeEnum, std::vector<d
     if ( depthIt == originalDepths.end() || depthIt->second.empty() ) return {};
     const auto& depthValues = depthIt->second;
 
-    bool reverseOrder = resamplingDepthType == RiaDefines::DepthTypeEnum::CONNECTION_NUMBER;
+    bool reverseOrder = resamplingDepthType == RiaDefines::DepthType::CONNECTION_NUMBER;
 
     std::vector<double>                                      resampledValues;
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths;
+    std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths;
 
     size_t segmentSearchStartIdx = 0;
     for ( const auto& targetDepth : targetDepths )
@@ -521,7 +521,7 @@ std::pair<std::vector<double>, std::map<RiaDefines::DepthTypeEnum, std::vector<d
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( RiaDefines::DepthTypeEnum  resamplingDepthType,
+cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( RiaDefines::DepthType  resamplingDepthType,
                                                                                 const std::vector<double>& depths ) const
 {
     const auto [xValues, resampledDepths] = createResampledValuesAndDepths( resamplingDepthType, depths, m_depths, m_propertyValues );
@@ -541,7 +541,7 @@ void RigWellLogCurveData::calculateIntervalsOfContinousValidValues()
 
     m_intervalsOfContinousValidValues.clear();
 
-    if ( !m_isExtractionCurve || !m_depths.count( RiaDefines::DepthTypeEnum::MEASURED_DEPTH ) )
+    if ( !m_isExtractionCurve || !m_depths.count( RiaDefines::DepthType::MEASURED_DEPTH ) )
     {
         m_intervalsOfContinousValidValues = intervalsOfValidValues;
     }
@@ -551,7 +551,7 @@ void RigWellLogCurveData::calculateIntervalsOfContinousValidValues()
         for ( size_t intIdx = 0; intIdx < intervalsCount; intIdx++ )
         {
             std::vector<std::pair<size_t, size_t>> depthValuesIntervals;
-            splitIntervalAtEmptySpace( m_depths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH],
+            splitIntervalAtEmptySpace( m_depths[RiaDefines::DepthType::MEASURED_DEPTH],
                                        intervalsOfValidValues[intIdx].first,
                                        intervalsOfValidValues[intIdx].second,
                                        &depthValuesIntervals );
@@ -629,7 +629,7 @@ void RigWellLogCurveData::splitIntervalAtEmptySpace( const std::vector<double>& 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RigWellLogCurveData::calculateDepthRange( RiaDefines::DepthTypeEnum depthType,
+bool RigWellLogCurveData::calculateDepthRange( RiaDefines::DepthType depthType,
                                                RiaDefines::DepthUnitType depthUnit,
                                                double*                   minimumDepth,
                                                double*                   maximumDepth ) const

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.cpp
@@ -71,7 +71,7 @@ void RigWellLogCurveData::setDepthUnit( RiaDefines::DepthUnitType depthUnit )
 //--------------------------------------------------------------------------------------------------
 void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>& xValues,
                                               const std::vector<double>& depths,
-                                              RiaDefines::DepthType  depthType,
+                                              RiaDefines::DepthType      depthType,
                                               double                     rkbDiff,
                                               RiaDefines::DepthUnitType  depthUnit,
                                               bool                       isExtractionCurve,
@@ -95,12 +95,12 @@ void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>& xValues
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>&                                      xValues,
+void RigWellLogCurveData::setValuesAndDepths( const std::vector<double>&                                  xValues,
                                               const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
-                                              double                                                          rkbDiff,
-                                              RiaDefines::DepthUnitType                                       depthUnit,
-                                              bool                                                            isExtractionCurve,
-                                              bool                                                            useLogarithmicScale )
+                                              double                                                      rkbDiff,
+                                              RiaDefines::DepthUnitType                                   depthUnit,
+                                              bool                                                        isExtractionCurve,
+                                              bool                                                        useLogarithmicScale )
 {
     for ( auto it = depths.begin(); it != depths.end(); ++it )
     {
@@ -182,8 +182,7 @@ std::vector<double> RigWellLogCurveData::depths( RiaDefines::DepthType depthType
         }
         return tvds;
     }
-    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH &&
-              m_depths.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB ) )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH && m_depths.count( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB ) )
     {
         std::vector<double> tvds = depths( RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB );
         for ( double& tvdValue : tvds )
@@ -247,7 +246,7 @@ std::vector<double> RigWellLogCurveData::propertyValuesByIntervals() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<double> RigWellLogCurveData::depthValuesByIntervals( RiaDefines::DepthType depthType,
+std::vector<double> RigWellLogCurveData::depthValuesByIntervals( RiaDefines::DepthType     depthType,
                                                                  RiaDefines::DepthUnitType destinationDepthUnit ) const
 {
     const std::vector<double> depthValues = RigWellLogCurveData::depthsForDepthUnit( depths( depthType ), m_depthUnit, destinationDepthUnit );
@@ -328,8 +327,8 @@ cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( 
 
     if ( isTVDAvailable )
     {
-        std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths =
-            { { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvDepths }, { RiaDefines::DepthType::MEASURED_DEPTH, measuredDepths } };
+        std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths = { { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, tvDepths },
+                                                                                 { RiaDefines::DepthType::MEASURED_DEPTH, measuredDepths } };
         reSampledData->setValuesAndDepths( xValues, resampledDepths, m_rkbDiff, m_depthUnit, true, m_useLogarithmicScale );
     }
     else
@@ -352,16 +351,15 @@ cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( 
 /// resampledDepths vector for the resampling type. The depth values for remaining depth types
 /// are created by linear interpolation between first and second depth value of the resampling type.
 //--------------------------------------------------------------------------------------------------
-void RigWellLogCurveData::createAndAddInterpolatedSegmentValueAndDepths(
-    std::vector<double>&                                            resampledValues,
-    std::map<RiaDefines::DepthType, std::vector<double>>&       resampledDepths,
-    RiaDefines::DepthType                                       resamplingDepthType,
-    double                                                          targetDepthValue,
-    size_t                                                          firstIndex,
-    size_t                                                          secondIndex,
-    const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
-    const std::vector<double>&                                      propertyValues,
-    double                                                          eps )
+void RigWellLogCurveData::createAndAddInterpolatedSegmentValueAndDepths( std::vector<double>& resampledValues,
+                                                                         std::map<RiaDefines::DepthType, std::vector<double>>& resampledDepths,
+                                                                         RiaDefines::DepthType resamplingDepthType,
+                                                                         double                targetDepthValue,
+                                                                         size_t                firstIndex,
+                                                                         size_t                secondIndex,
+                                                                         const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
+                                                                         const std::vector<double>& propertyValues,
+                                                                         double                     eps )
 {
     if ( !originalDepths.contains( resamplingDepthType ) ) return;
 
@@ -418,10 +416,10 @@ bool isRightOf( double x1, double x2, bool reverseOrder, double eps )
 ///
 //--------------------------------------------------------------------------------------------------
 std::pair<std::vector<double>, std::map<RiaDefines::DepthType, std::vector<double>>>
-    RigWellLogCurveData::createResampledValuesAndDepths( RiaDefines::DepthType  resamplingDepthType,
-                                                         const std::vector<double>& targetDepths,
+    RigWellLogCurveData::createResampledValuesAndDepths( RiaDefines::DepthType                                       resamplingDepthType,
+                                                         const std::vector<double>&                                  targetDepths,
                                                          const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
-                                                         const std::vector<double>&                                      propertyValues )
+                                                         const std::vector<double>&                                  propertyValues )
 {
     const double eps = 1.0e-8;
 
@@ -431,7 +429,7 @@ std::pair<std::vector<double>, std::map<RiaDefines::DepthType, std::vector<doubl
 
     bool reverseOrder = resamplingDepthType == RiaDefines::DepthType::CONNECTION_NUMBER;
 
-    std::vector<double>                                      resampledValues;
+    std::vector<double>                                  resampledValues;
     std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths;
 
     size_t segmentSearchStartIdx = 0;
@@ -521,7 +519,7 @@ std::pair<std::vector<double>, std::map<RiaDefines::DepthType, std::vector<doubl
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( RiaDefines::DepthType  resamplingDepthType,
+cvf::ref<RigWellLogCurveData> RigWellLogCurveData::calculateResampledCurveData( RiaDefines::DepthType      resamplingDepthType,
                                                                                 const std::vector<double>& depths ) const
 {
     const auto [xValues, resampledDepths] = createResampledValuesAndDepths( resamplingDepthType, depths, m_depths, m_propertyValues );
@@ -629,7 +627,7 @@ void RigWellLogCurveData::splitIntervalAtEmptySpace( const std::vector<double>& 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RigWellLogCurveData::calculateDepthRange( RiaDefines::DepthType depthType,
+bool RigWellLogCurveData::calculateDepthRange( RiaDefines::DepthType     depthType,
                                                RiaDefines::DepthUnitType depthUnit,
                                                double*                   minimumDepth,
                                                double*                   maximumDepth ) const

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.h
@@ -47,14 +47,14 @@ public:
 
     void setValuesAndDepths( const std::vector<double>& propertyValues,
                              const std::vector<double>& depths,
-                             RiaDefines::DepthTypeEnum  depthType,
+                             RiaDefines::DepthType  depthType,
                              double                     rkbDiff,
                              RiaDefines::DepthUnitType  depthUnit,
                              bool                       isExtractionCurve,
                              bool                       useLogarithmicScale );
 
     void setValuesAndDepths( const std::vector<double>&                                      propertyValues,
-                             const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& depths,
+                             const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
                              double                                                          rkbDiff,
                              RiaDefines::DepthUnitType                                       depthUnit,
                              bool                                                            isExtractionCurve,
@@ -66,39 +66,39 @@ public:
     std::vector<double> propertyValues( const QString& units ) const;
     QString             propertyValueUnit() const;
 
-    std::vector<double> depths( RiaDefines::DepthTypeEnum depthType ) const;
-    std::vector<double> depths( RiaDefines::DepthTypeEnum depthType, RiaDefines::DepthUnitType destinationDepthUnit ) const;
+    std::vector<double> depths( RiaDefines::DepthType depthType ) const;
+    std::vector<double> depths( RiaDefines::DepthType depthType, RiaDefines::DepthUnitType destinationDepthUnit ) const;
 
-    std::set<RiaDefines::DepthTypeEnum> availableDepthTypes() const;
+    std::set<RiaDefines::DepthType> availableDepthTypes() const;
 
-    bool calculateDepthRange( RiaDefines::DepthTypeEnum depthType, RiaDefines::DepthUnitType depthUnit, double* minMD, double* maxMD ) const;
+    bool calculateDepthRange( RiaDefines::DepthType depthType, RiaDefines::DepthUnitType depthUnit, double* minMD, double* maxMD ) const;
 
     RiaDefines::DepthUnitType depthUnit() const;
 
     std::vector<double> propertyValuesByIntervals() const;
-    std::vector<double> depthValuesByIntervals( RiaDefines::DepthTypeEnum depthType, RiaDefines::DepthUnitType destinationDepthUnit ) const;
+    std::vector<double> depthValuesByIntervals( RiaDefines::DepthType depthType, RiaDefines::DepthUnitType destinationDepthUnit ) const;
     std::vector<std::pair<size_t, size_t>> polylineStartStopIndices() const;
 
     cvf::ref<RigWellLogCurveData> calculateResampledCurveData( double newMeasuredDepthStepSize ) const;
-    cvf::ref<RigWellLogCurveData> calculateResampledCurveData( RiaDefines::DepthTypeEnum  resamplingDepthType,
+    cvf::ref<RigWellLogCurveData> calculateResampledCurveData( RiaDefines::DepthType  resamplingDepthType,
                                                                const std::vector<double>& depths ) const;
 
     // Made static due to unit testing
     static void createAndAddInterpolatedSegmentValueAndDepths( std::vector<double>&                                      resampledValues,
-                                                               std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& resampledDepths,
-                                                               RiaDefines::DepthTypeEnum resamplingDepthType,
+                                                               std::map<RiaDefines::DepthType, std::vector<double>>& resampledDepths,
+                                                               RiaDefines::DepthType resamplingDepthType,
                                                                double                    targetDepthValue,
                                                                size_t                    firstIndex,
                                                                size_t                    secondIndex,
-                                                               const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+                                                               const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
                                                                const std::vector<double>& propertyValues,
                                                                double                     eps );
 
     // Made static due to unit testing
-    static std::pair<std::vector<double>, std::map<RiaDefines::DepthTypeEnum, std::vector<double>>>
-        createResampledValuesAndDepths( RiaDefines::DepthTypeEnum                                       resamplingDepthType,
+    static std::pair<std::vector<double>, std::map<RiaDefines::DepthType, std::vector<double>>>
+        createResampledValuesAndDepths( RiaDefines::DepthType                                       resamplingDepthType,
                                         const std::vector<double>&                                      targetDepths,
-                                        const std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& originalDepths,
+                                        const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
                                         const std::vector<double>&                                      propertyValues );
 
 private:
@@ -115,7 +115,7 @@ private:
 
 private:
     std::vector<double>                                      m_propertyValues;
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> m_depths;
+    std::map<RiaDefines::DepthType, std::vector<double>> m_depths;
     bool                                                     m_isExtractionCurve;
     double                                                   m_rkbDiff;
     bool                                                     m_useLogarithmicScale;

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellLogCurveData.h
@@ -47,18 +47,18 @@ public:
 
     void setValuesAndDepths( const std::vector<double>& propertyValues,
                              const std::vector<double>& depths,
-                             RiaDefines::DepthType  depthType,
+                             RiaDefines::DepthType      depthType,
                              double                     rkbDiff,
                              RiaDefines::DepthUnitType  depthUnit,
                              bool                       isExtractionCurve,
                              bool                       useLogarithmicScale );
 
-    void setValuesAndDepths( const std::vector<double>&                                      propertyValues,
+    void setValuesAndDepths( const std::vector<double>&                                  propertyValues,
                              const std::map<RiaDefines::DepthType, std::vector<double>>& depths,
-                             double                                                          rkbDiff,
-                             RiaDefines::DepthUnitType                                       depthUnit,
-                             bool                                                            isExtractionCurve,
-                             bool                                                            useLogarithmicScale );
+                             double                                                      rkbDiff,
+                             RiaDefines::DepthUnitType                                   depthUnit,
+                             bool                                                        isExtractionCurve,
+                             bool                                                        useLogarithmicScale );
 
     void setPropertyValueUnit( const QString& propertyValueUnitString );
 
@@ -80,26 +80,26 @@ public:
     std::vector<std::pair<size_t, size_t>> polylineStartStopIndices() const;
 
     cvf::ref<RigWellLogCurveData> calculateResampledCurveData( double newMeasuredDepthStepSize ) const;
-    cvf::ref<RigWellLogCurveData> calculateResampledCurveData( RiaDefines::DepthType  resamplingDepthType,
+    cvf::ref<RigWellLogCurveData> calculateResampledCurveData( RiaDefines::DepthType      resamplingDepthType,
                                                                const std::vector<double>& depths ) const;
 
     // Made static due to unit testing
-    static void createAndAddInterpolatedSegmentValueAndDepths( std::vector<double>&                                      resampledValues,
+    static void createAndAddInterpolatedSegmentValueAndDepths( std::vector<double>&                                  resampledValues,
                                                                std::map<RiaDefines::DepthType, std::vector<double>>& resampledDepths,
-                                                               RiaDefines::DepthType resamplingDepthType,
-                                                               double                    targetDepthValue,
-                                                               size_t                    firstIndex,
-                                                               size_t                    secondIndex,
+                                                               RiaDefines::DepthType                                 resamplingDepthType,
+                                                               double                                                targetDepthValue,
+                                                               size_t                                                firstIndex,
+                                                               size_t                                                secondIndex,
                                                                const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
-                                                               const std::vector<double>& propertyValues,
-                                                               double                     eps );
+                                                               const std::vector<double>&                                  propertyValues,
+                                                               double                                                      eps );
 
     // Made static due to unit testing
     static std::pair<std::vector<double>, std::map<RiaDefines::DepthType, std::vector<double>>>
         createResampledValuesAndDepths( RiaDefines::DepthType                                       resamplingDepthType,
-                                        const std::vector<double>&                                      targetDepths,
+                                        const std::vector<double>&                                  targetDepths,
                                         const std::map<RiaDefines::DepthType, std::vector<double>>& originalDepths,
-                                        const std::vector<double>&                                      propertyValues );
+                                        const std::vector<double>&                                  propertyValues );
 
 private:
     void calculateIntervalsOfContinousValidValues();
@@ -114,11 +114,11 @@ private:
                                            std::vector<std::pair<size_t, size_t>>* intervals );
 
 private:
-    std::vector<double>                                      m_propertyValues;
+    std::vector<double>                                  m_propertyValues;
     std::map<RiaDefines::DepthType, std::vector<double>> m_depths;
-    bool                                                     m_isExtractionCurve;
-    double                                                   m_rkbDiff;
-    bool                                                     m_useLogarithmicScale;
+    bool                                                 m_isExtractionCurve;
+    double                                               m_rkbDiff;
+    bool                                                 m_useLogarithmicScale;
 
     std::vector<std::pair<size_t, size_t>> m_intervalsOfContinousValidValues;
 

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.cpp
@@ -47,9 +47,9 @@ RigWellPathFormations::RigWellPathFormations( const std::vector<RigWellPathForma
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*         names,
-                                                                            std::vector<double>*          measuredDepths,
-                                                                            RimWellLogPlot::DepthTypeEnum depthType ) const
+void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*     names,
+                                                                            std::vector<double>*      measuredDepths,
+                                                                            RiaDefines::DepthTypeEnum depthType ) const
 {
     std::map<double, bool, DepthComp> tempMakeVectorUniqueOnMeasuredDepth;
 
@@ -97,49 +97,6 @@ void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std:
             }
         }
     }
-
-    /*
-    for (const std::pair<RigWellPathFormation, FormationLevel>& formation : m_formations)
-    {
-        if (!tempMakeVectorUniqueOnMeasuredDepth.count(formation.first.mdTop))
-        {
-            double depth;
-            if (depthType == RiaDefines::MEASURED_DEPTH)
-            {
-                depth = formation.first.mdTop;
-            }
-            else if (depthType == RiaDefines::TRUE_VERTICAL_DEPTH)
-            {
-                depth = formation.first.tvdTop;
-            }
-            else return;
-
-            measuredDepths->push_back(depth);
-            names->push_back(formation.first.formationName + " Top");
-            tempMakeVectorUniqueOnMeasuredDepth[depth] = true;
-        }
-    }
-
-    for (const std::pair<RigWellPathFormation, FormationLevel>& formation : m_formations)
-    {
-        double depth;
-        if (depthType == RiaDefines::MEASURED_DEPTH)
-        {
-            depth = formation.first.mdBase;
-        }
-        else if (depthType == RiaDefines::TRUE_VERTICAL_DEPTH)
-        {
-            depth = formation.first.tvdBase;
-        }
-        else return;
-
-        if (!tempMakeVectorUniqueOnMeasuredDepth.count(formation.first.mdBase))
-        {
-            measuredDepths->push_back(depth);
-            names->push_back(formation.first.formationName + " Base");
-            tempMakeVectorUniqueOnMeasuredDepth[depth] = true;
-        }
-    }*/
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -149,7 +106,7 @@ void RigWellPathFormations::evaluateFormationsForOnePosition( const std::vector<
                                                               const FormationLevel&                      maxLevel,
                                                               const PickPosition&                        position,
                                                               std::map<double, LevelAndName, DepthComp>* uniqueListMaker,
-                                                              RimWellLogPlot::DepthTypeEnum              depthType ) const
+                                                              RiaDefines::DepthTypeEnum                  depthType ) const
 {
     QString postFix;
 
@@ -207,7 +164,7 @@ void RigWellPathFormations::evaluateFormations( const std::vector<std::pair<RigW
                                                 const FormationLevel&                                               maxLevel,
                                                 std::vector<QString>*                                               names,
                                                 std::vector<double>*                                                depths,
-                                                RimWellLogPlot::DepthTypeEnum                                       depthType ) const
+                                                RiaDefines::DepthTypeEnum                                           depthType ) const
 {
     std::map<double, LevelAndName, DepthComp> tempMakeVectorUniqueOnDepth;
 
@@ -227,7 +184,7 @@ void RigWellPathFormations::evaluateFormations( const std::vector<std::pair<RigW
 void RigWellPathFormations::evaluateFluids( const std::vector<RigWellPathFormation>& fluidFormations,
                                             std::vector<QString>*                    names,
                                             std::vector<double>*                     depths,
-                                            RimWellLogPlot::DepthTypeEnum            depthType ) const
+                                            RiaDefines::DepthTypeEnum                depthType ) const
 {
     std::map<double, QString, DepthComp> uniqueListMaker;
 
@@ -275,11 +232,11 @@ void RigWellPathFormations::evaluateFluids( const std::vector<RigWellPathFormati
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellPathFormations::depthAndFormationNamesUpToLevel( FormationLevel                level,
-                                                             std::vector<QString>*         names,
-                                                             std::vector<double>*          depths,
-                                                             bool                          includeFluids,
-                                                             RimWellLogPlot::DepthTypeEnum depthType ) const
+void RigWellPathFormations::depthAndFormationNamesUpToLevel( FormationLevel            level,
+                                                             std::vector<QString>*     names,
+                                                             std::vector<double>*      depths,
+                                                             bool                      includeFluids,
+                                                             RiaDefines::DepthTypeEnum depthType ) const
 {
     names->clear();
     depths->clear();
@@ -289,11 +246,11 @@ void RigWellPathFormations::depthAndFormationNamesUpToLevel( FormationLevel     
         evaluateFluids( m_fluids, names, depths, depthType );
     }
 
-    if ( level == RigWellPathFormations::NONE )
+    if ( level == FormationLevel::NONE )
     {
         return;
     }
-    else if ( level == RigWellPathFormations::ALL )
+    else if ( level == FormationLevel::ALL )
     {
         depthAndFormationNamesWithoutDuplicatesOnDepth( names, depths, depthType );
     }
@@ -369,7 +326,7 @@ RigWellPathFormations::FormationLevel RigWellPathFormations::detectLevel( QStrin
     }
     if ( isGroupName )
     {
-        return RigWellPathFormations::GROUP;
+        return FormationLevel::GROUP;
     }
 
     QStringList formationNameSplitted = formationName.split( " " );
@@ -389,7 +346,7 @@ RigWellPathFormations::FormationLevel RigWellPathFormations::detectLevel( QStrin
     }
     if ( levelDesctiptorCandidates.empty() )
     {
-        return RigWellPathFormations::LEVEL0;
+        return FormationLevel::LEVEL0;
     }
 
     if ( levelDesctiptorCandidates.size() > 1 )
@@ -405,7 +362,7 @@ RigWellPathFormations::FormationLevel RigWellPathFormations::detectLevel( QStrin
             }
         }
     }
-    if ( levelDesctiptorCandidates.size() != 1 ) return RigWellPathFormations::UNKNOWN;
+    if ( levelDesctiptorCandidates.size() != 1 ) return FormationLevel::UNKNOWN;
 
     QString levelDescriptor = levelDesctiptorCandidates[0];
 
@@ -420,27 +377,27 @@ RigWellPathFormations::FormationLevel RigWellPathFormations::detectLevel( QStrin
     switch ( dotCount )
     {
         case 0:
-            return RigWellPathFormations::LEVEL1;
+            return FormationLevel::LEVEL1;
         case 1:
-            return RigWellPathFormations::LEVEL2;
+            return FormationLevel::LEVEL2;
         case 2:
-            return RigWellPathFormations::LEVEL3;
+            return FormationLevel::LEVEL3;
         case 3:
-            return RigWellPathFormations::LEVEL4;
+            return FormationLevel::LEVEL4;
         case 4:
-            return RigWellPathFormations::LEVEL5;
+            return FormationLevel::LEVEL5;
         case 5:
-            return RigWellPathFormations::LEVEL6;
+            return FormationLevel::LEVEL6;
         case 6:
-            return RigWellPathFormations::LEVEL7;
+            return FormationLevel::LEVEL7;
         case 7:
-            return RigWellPathFormations::LEVEL8;
+            return FormationLevel::LEVEL8;
         case 8:
-            return RigWellPathFormations::LEVEL9;
+            return FormationLevel::LEVEL9;
         case 9:
-            return RigWellPathFormations::LEVEL10;
+            return FormationLevel::LEVEL10;
         default:
             break;
     }
-    return RigWellPathFormations::UNKNOWN;
+    return FormationLevel::UNKNOWN;
 }

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.cpp
@@ -47,8 +47,8 @@ RigWellPathFormations::RigWellPathFormations( const std::vector<RigWellPathForma
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*     names,
-                                                                            std::vector<double>*      measuredDepths,
+void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>* names,
+                                                                            std::vector<double>*  measuredDepths,
                                                                             RiaDefines::DepthType depthType ) const
 {
     std::map<double, bool, DepthComp> tempMakeVectorUniqueOnMeasuredDepth;
@@ -106,7 +106,7 @@ void RigWellPathFormations::evaluateFormationsForOnePosition( const std::vector<
                                                               const FormationLevel&                      maxLevel,
                                                               const PickPosition&                        position,
                                                               std::map<double, LevelAndName, DepthComp>* uniqueListMaker,
-                                                              RiaDefines::DepthType                  depthType ) const
+                                                              RiaDefines::DepthType                      depthType ) const
 {
     QString postFix;
 
@@ -164,7 +164,7 @@ void RigWellPathFormations::evaluateFormations( const std::vector<std::pair<RigW
                                                 const FormationLevel&                                               maxLevel,
                                                 std::vector<QString>*                                               names,
                                                 std::vector<double>*                                                depths,
-                                                RiaDefines::DepthType                                           depthType ) const
+                                                RiaDefines::DepthType                                               depthType ) const
 {
     std::map<double, LevelAndName, DepthComp> tempMakeVectorUniqueOnDepth;
 
@@ -184,7 +184,7 @@ void RigWellPathFormations::evaluateFormations( const std::vector<std::pair<RigW
 void RigWellPathFormations::evaluateFluids( const std::vector<RigWellPathFormation>& fluidFormations,
                                             std::vector<QString>*                    names,
                                             std::vector<double>*                     depths,
-                                            RiaDefines::DepthType                depthType ) const
+                                            RiaDefines::DepthType                    depthType ) const
 {
     std::map<double, QString, DepthComp> uniqueListMaker;
 
@@ -232,10 +232,10 @@ void RigWellPathFormations::evaluateFluids( const std::vector<RigWellPathFormati
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigWellPathFormations::depthAndFormationNamesUpToLevel( FormationLevel            level,
-                                                             std::vector<QString>*     names,
-                                                             std::vector<double>*      depths,
-                                                             bool                      includeFluids,
+void RigWellPathFormations::depthAndFormationNamesUpToLevel( FormationLevel        level,
+                                                             std::vector<QString>* names,
+                                                             std::vector<double>*  depths,
+                                                             bool                  includeFluids,
                                                              RiaDefines::DepthType depthType ) const
 {
     names->clear();

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.cpp
@@ -49,11 +49,11 @@ RigWellPathFormations::RigWellPathFormations( const std::vector<RigWellPathForma
 //--------------------------------------------------------------------------------------------------
 void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*     names,
                                                                             std::vector<double>*      measuredDepths,
-                                                                            RiaDefines::DepthTypeEnum depthType ) const
+                                                                            RiaDefines::DepthType depthType ) const
 {
     std::map<double, bool, DepthComp> tempMakeVectorUniqueOnMeasuredDepth;
 
-    if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH )
     {
         for ( const std::pair<RigWellPathFormation, FormationLevel>& formation : m_formations )
         {
@@ -75,7 +75,7 @@ void RigWellPathFormations::depthAndFormationNamesWithoutDuplicatesOnDepth( std:
             }
         }
     }
-    else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+    else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
     {
         for ( const std::pair<RigWellPathFormation, FormationLevel>& formation : m_formations )
         {
@@ -106,7 +106,7 @@ void RigWellPathFormations::evaluateFormationsForOnePosition( const std::vector<
                                                               const FormationLevel&                      maxLevel,
                                                               const PickPosition&                        position,
                                                               std::map<double, LevelAndName, DepthComp>* uniqueListMaker,
-                                                              RiaDefines::DepthTypeEnum                  depthType ) const
+                                                              RiaDefines::DepthType                  depthType ) const
 {
     QString postFix;
 
@@ -123,7 +123,7 @@ void RigWellPathFormations::evaluateFormationsForOnePosition( const std::vector<
     {
         double depth;
 
-        if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+        if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH )
         {
             if ( position == TOP )
             {
@@ -134,7 +134,7 @@ void RigWellPathFormations::evaluateFormationsForOnePosition( const std::vector<
                 depth = formation.first.mdBase;
             }
         }
-        else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+        else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
         {
             if ( position == TOP )
             {
@@ -164,7 +164,7 @@ void RigWellPathFormations::evaluateFormations( const std::vector<std::pair<RigW
                                                 const FormationLevel&                                               maxLevel,
                                                 std::vector<QString>*                                               names,
                                                 std::vector<double>*                                                depths,
-                                                RiaDefines::DepthTypeEnum                                           depthType ) const
+                                                RiaDefines::DepthType                                           depthType ) const
 {
     std::map<double, LevelAndName, DepthComp> tempMakeVectorUniqueOnDepth;
 
@@ -184,18 +184,18 @@ void RigWellPathFormations::evaluateFormations( const std::vector<std::pair<RigW
 void RigWellPathFormations::evaluateFluids( const std::vector<RigWellPathFormation>& fluidFormations,
                                             std::vector<QString>*                    names,
                                             std::vector<double>*                     depths,
-                                            RiaDefines::DepthTypeEnum                depthType ) const
+                                            RiaDefines::DepthType                depthType ) const
 {
     std::map<double, QString, DepthComp> uniqueListMaker;
 
     for ( const RigWellPathFormation& formation : fluidFormations )
     {
         double depthBase;
-        if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+        if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH )
         {
             depthBase = formation.mdBase;
         }
-        else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+        else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
         {
             depthBase = formation.tvdBase;
         }
@@ -208,11 +208,11 @@ void RigWellPathFormations::evaluateFluids( const std::vector<RigWellPathFormati
     for ( const RigWellPathFormation& formation : fluidFormations )
     {
         double depthTop;
-        if ( depthType == RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+        if ( depthType == RiaDefines::DepthType::MEASURED_DEPTH )
         {
             depthTop = formation.mdTop;
         }
-        else if ( depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+        else if ( depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
         {
             depthTop = formation.tvdTop;
         }
@@ -236,7 +236,7 @@ void RigWellPathFormations::depthAndFormationNamesUpToLevel( FormationLevel     
                                                              std::vector<QString>*     names,
                                                              std::vector<double>*      depths,
                                                              bool                      includeFluids,
-                                                             RiaDefines::DepthTypeEnum depthType ) const
+                                                             RiaDefines::DepthType depthType ) const
 {
     names->clear();
     depths->clear();

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.h
@@ -18,10 +18,11 @@
 
 #pragma once
 
+#include "RiaDefines.h"
+#include "RiaWellLogTrackDefines.h"
+
 #include "cvfMath.h"
 #include "cvfObject.h"
-
-#include "RimWellLogPlot.h"
 
 #include <map>
 #include <utility>
@@ -44,33 +45,16 @@ struct RigWellPathFormation
 class RigWellPathFormations : public cvf::Object
 {
 public:
-    enum FormationLevel
-    {
-        GROUP,
-        LEVEL0,
-        LEVEL1,
-        LEVEL2,
-        LEVEL3,
-        LEVEL4,
-        LEVEL5,
-        LEVEL6,
-        LEVEL7,
-        LEVEL8,
-        LEVEL9,
-        LEVEL10,
-        ALL,
-        UNKNOWN,
-        NONE
-    };
+    using FormationLevel = RiaDefines::WellLogTrackFormationLevel;
 
 public:
     RigWellPathFormations( const std::vector<RigWellPathFormation>& formations, const QString& filePath, const QString& key );
 
-    void depthAndFormationNamesUpToLevel( FormationLevel                level,
-                                          std::vector<QString>*         names,
-                                          std::vector<double>*          depths,
-                                          bool                          includeFluids,
-                                          RimWellLogPlot::DepthTypeEnum depthType ) const;
+    void depthAndFormationNamesUpToLevel( FormationLevel            level,
+                                          std::vector<QString>*     names,
+                                          std::vector<double>*      depths,
+                                          bool                      includeFluids,
+                                          RiaDefines::DepthTypeEnum depthType ) const;
 
     std::vector<FormationLevel> formationsLevelsPresent() const;
 
@@ -95,14 +79,14 @@ private:
     struct LevelAndName
     {
         LevelAndName() = default;
-        LevelAndName( RigWellPathFormations::FormationLevel level, QString name )
+        LevelAndName( FormationLevel level, QString name )
             : level( level )
             , name( name )
         {
         }
 
-        RigWellPathFormations::FormationLevel level;
-        QString                               name;
+        FormationLevel level;
+        QString        name;
     };
 
     enum PickPosition
@@ -116,22 +100,22 @@ private:
                              const FormationLevel&                                               maxLevel,
                              std::vector<QString>*                                               names,
                              std::vector<double>*                                                depths,
-                             RimWellLogPlot::DepthTypeEnum                                       depthType ) const;
+                             RiaDefines::DepthTypeEnum                                           depthType ) const;
 
     void evaluateFluids( const std::vector<RigWellPathFormation>& fluidFormations,
                          std::vector<QString>*                    names,
                          std::vector<double>*                     depths,
-                         RimWellLogPlot::DepthTypeEnum            depthType ) const;
+                         RiaDefines::DepthTypeEnum                depthType ) const;
 
     void evaluateFormationsForOnePosition( const std::vector<std::pair<RigWellPathFormation, FormationLevel>>& formations,
                                            const FormationLevel&                                               maxLevel,
                                            const PickPosition&                                                 position,
                                            std::map<double, LevelAndName, DepthComp>*                          uniqueListMaker,
-                                           RimWellLogPlot::DepthTypeEnum                                       depthType ) const;
+                                           RiaDefines::DepthTypeEnum                                           depthType ) const;
 
-    void depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*         names,
-                                                         std::vector<double>*          measuredDepths,
-                                                         RimWellLogPlot::DepthTypeEnum depthType ) const;
+    void depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*     names,
+                                                         std::vector<double>*      measuredDepths,
+                                                         RiaDefines::DepthTypeEnum depthType ) const;
 
     bool           isFluid( QString formationName );
     FormationLevel detectLevel( QString formationName );

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.h
@@ -50,10 +50,10 @@ public:
 public:
     RigWellPathFormations( const std::vector<RigWellPathFormation>& formations, const QString& filePath, const QString& key );
 
-    void depthAndFormationNamesUpToLevel( FormationLevel            level,
-                                          std::vector<QString>*     names,
-                                          std::vector<double>*      depths,
-                                          bool                      includeFluids,
+    void depthAndFormationNamesUpToLevel( FormationLevel        level,
+                                          std::vector<QString>* names,
+                                          std::vector<double>*  depths,
+                                          bool                  includeFluids,
                                           RiaDefines::DepthType depthType ) const;
 
     std::vector<FormationLevel> formationsLevelsPresent() const;
@@ -100,21 +100,21 @@ private:
                              const FormationLevel&                                               maxLevel,
                              std::vector<QString>*                                               names,
                              std::vector<double>*                                                depths,
-                             RiaDefines::DepthType                                           depthType ) const;
+                             RiaDefines::DepthType                                               depthType ) const;
 
     void evaluateFluids( const std::vector<RigWellPathFormation>& fluidFormations,
                          std::vector<QString>*                    names,
                          std::vector<double>*                     depths,
-                         RiaDefines::DepthType                depthType ) const;
+                         RiaDefines::DepthType                    depthType ) const;
 
     void evaluateFormationsForOnePosition( const std::vector<std::pair<RigWellPathFormation, FormationLevel>>& formations,
                                            const FormationLevel&                                               maxLevel,
                                            const PickPosition&                                                 position,
                                            std::map<double, LevelAndName, DepthComp>*                          uniqueListMaker,
-                                           RiaDefines::DepthType                                           depthType ) const;
+                                           RiaDefines::DepthType                                               depthType ) const;
 
-    void depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*     names,
-                                                         std::vector<double>*      measuredDepths,
+    void depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>* names,
+                                                         std::vector<double>*  measuredDepths,
                                                          RiaDefines::DepthType depthType ) const;
 
     bool           isFluid( QString formationName );

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathFormations.h
@@ -54,7 +54,7 @@ public:
                                           std::vector<QString>*     names,
                                           std::vector<double>*      depths,
                                           bool                      includeFluids,
-                                          RiaDefines::DepthTypeEnum depthType ) const;
+                                          RiaDefines::DepthType depthType ) const;
 
     std::vector<FormationLevel> formationsLevelsPresent() const;
 
@@ -100,22 +100,22 @@ private:
                              const FormationLevel&                                               maxLevel,
                              std::vector<QString>*                                               names,
                              std::vector<double>*                                                depths,
-                             RiaDefines::DepthTypeEnum                                           depthType ) const;
+                             RiaDefines::DepthType                                           depthType ) const;
 
     void evaluateFluids( const std::vector<RigWellPathFormation>& fluidFormations,
                          std::vector<QString>*                    names,
                          std::vector<double>*                     depths,
-                         RiaDefines::DepthTypeEnum                depthType ) const;
+                         RiaDefines::DepthType                depthType ) const;
 
     void evaluateFormationsForOnePosition( const std::vector<std::pair<RigWellPathFormation, FormationLevel>>& formations,
                                            const FormationLevel&                                               maxLevel,
                                            const PickPosition&                                                 position,
                                            std::map<double, LevelAndName, DepthComp>*                          uniqueListMaker,
-                                           RiaDefines::DepthTypeEnum                                           depthType ) const;
+                                           RiaDefines::DepthType                                           depthType ) const;
 
     void depthAndFormationNamesWithoutDuplicatesOnDepth( std::vector<QString>*     names,
                                                          std::vector<double>*      measuredDepths,
-                                                         RiaDefines::DepthTypeEnum depthType ) const;
+                                                         RiaDefines::DepthType depthType ) const;
 
     bool           isFluid( QString formationName );
     FormationLevel detectLevel( QString formationName );

--- a/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
@@ -34,17 +34,17 @@
 TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_first )
 {
     // Input data
-    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
-        { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, { 0.0, 20.0, 40.0 } },
-          { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, { 0.0, 30.0, 60.0 } },
-          { RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, { 0.0, 40.0, 80.0 } } };
+    const std::map<RiaDefines::DepthType, std::vector<double>> originalDepths =
+        { { RiaDefines::DepthType::MEASURED_DEPTH, { 0.0, 20.0, 40.0 } },
+          { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, { 0.0, 30.0, 60.0 } },
+          { RiaDefines::DepthType::PSEUDO_LENGTH, { 0.0, 40.0, 80.0 } } };
     const std::vector<double> propertyValues = { 0.0, 100.0, 150.0 };
     const double              eps            = 1e-6;
 
     // Output data
-    const auto                                               resamplingDepthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    const auto                                               resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
     std::vector<double>                                      resampledValues;
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths;
+    std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths;
 
     // Target data (resampling with MEASURED_DEPTH)
     const double targetDepthValue = 10.0; // Halfway between index 0 and 1 for MEASURED_DEPTH in originalDepths
@@ -68,14 +68,14 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_first )
 
     ASSERT_EQ( resampledDepths.size(), size_t( 3 ) );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH].size(), size_t( 1 ) );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][0], 10.0 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH].size(), size_t( 1 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][0], 10.0 );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), size_t( 1 ) );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH].size(), size_t( 1 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][0], 15.0 );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), size_t( 1 ) );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 20.0 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH].size(), size_t( 1 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][0], 20.0 );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -84,17 +84,17 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_first )
 TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second )
 {
     // Input data
-    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
-        { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, { 0.0, 20.0, 40.0 } },
-          { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, { 0.0, 30.0, 60.0 } },
-          { RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, { 0.0, 40.0, 80.0 } } };
+    const std::map<RiaDefines::DepthType, std::vector<double>> originalDepths =
+        { { RiaDefines::DepthType::MEASURED_DEPTH, { 0.0, 20.0, 40.0 } },
+          { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, { 0.0, 30.0, 60.0 } },
+          { RiaDefines::DepthType::PSEUDO_LENGTH, { 0.0, 40.0, 80.0 } } };
     const std::vector<double> propertyValues = { 0.0, 100.0, 150.0 };
     const double              eps            = 1e-6;
 
     // Output data
-    const auto                                               resamplingDepthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    const auto                                               resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
     std::vector<double>                                      resampledValues;
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>> resampledDepths;
+    std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths;
 
     // Target data (resampling with MEASURED_DEPTH)
     const double firstTargetDepthValue  = 10.0; // Halfway between first and second index for MEASURED_DEPTH in originalDepths
@@ -132,17 +132,17 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second 
 
     ASSERT_EQ( resampledDepths.size(), size_t( 3 ) );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH].size(), size_t( 2 ) );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][0], 10.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][1], 30.0 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH].size(), size_t( 2 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][0], 10.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][1], 30.0 );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), size_t( 2 ) );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 15.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][1], 45.0 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH].size(), size_t( 2 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][0], 15.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][1], 45.0 );
 
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), size_t( 2 ) );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 20.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][1], 60.0 );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH].size(), size_t( 2 ) );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][0], 20.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][1], 60.0 );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -151,12 +151,12 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second 
 TEST( RigWellLogCurveData, CreateResampledValuesAndDepthsTest )
 {
     // Input data
-    RiaDefines::DepthTypeEnum                                      resamplingDepthType = RiaDefines::DepthTypeEnum::MEASURED_DEPTH;
+    RiaDefines::DepthType                                      resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
     const std::vector<double>                                      targetDepths        = { 0.0, 5.0, 10.0, 15.0 };
-    const std::map<RiaDefines::DepthTypeEnum, std::vector<double>> originalDepths =
-        { { RiaDefines::DepthTypeEnum::MEASURED_DEPTH, { 0.0, 10.0, 20.0 } },
-          { RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH, { 0.0, 20.0, 40.0 } },
-          { RiaDefines::DepthTypeEnum::PSEUDO_LENGTH, { 0.0, 30.0, 60.0 } } };
+    const std::map<RiaDefines::DepthType, std::vector<double>> originalDepths =
+        { { RiaDefines::DepthType::MEASURED_DEPTH, { 0.0, 10.0, 20.0 } },
+          { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, { 0.0, 20.0, 40.0 } },
+          { RiaDefines::DepthType::PSEUDO_LENGTH, { 0.0, 30.0, 60.0 } } };
     const std::vector<double> propertyValues = { 0.0, 100.0, 200.0 };
 
     // Call the function under test
@@ -164,13 +164,13 @@ TEST( RigWellLogCurveData, CreateResampledValuesAndDepthsTest )
 
     // Check the results
     std::vector<double>&                                      resampledPropertyValues = result.first;
-    std::map<RiaDefines::DepthTypeEnum, std::vector<double>>& resampledDepths         = result.second;
+    std::map<RiaDefines::DepthType, std::vector<double>>& resampledDepths         = result.second;
     const auto                                                expectedSize            = targetDepths.size();
 
     ASSERT_EQ( resampledDepths.size(), originalDepths.size() );
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH].size(), expectedSize );
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH].size(), expectedSize );
-    ASSERT_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH].size(), expectedSize );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH].size(), expectedSize );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH].size(), expectedSize );
+    ASSERT_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH].size(), expectedSize );
 
     ASSERT_EQ( resampledPropertyValues.size(), expectedSize );
 
@@ -180,18 +180,18 @@ TEST( RigWellLogCurveData, CreateResampledValuesAndDepthsTest )
     ASSERT_DOUBLE_EQ( resampledPropertyValues[2], 100.0 );
     ASSERT_DOUBLE_EQ( resampledPropertyValues[3], 150.0 );
 
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][0], 0.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][1], 5.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][2], 10.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::MEASURED_DEPTH][3], 15.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][1], 5.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][2], 10.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH][3], 15.0 );
 
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][0], 0.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][1], 10.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][2], 20.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH][3], 30.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][1], 10.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][2], 20.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::TRUE_VERTICAL_DEPTH][3], 30.0 );
 
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][0], 0.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][1], 15.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][2], 30.0 );
-    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthTypeEnum::PSEUDO_LENGTH][3], 45.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][0], 0.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][1], 15.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][2], 30.0 );
+    ASSERT_DOUBLE_EQ( resampledDepths[RiaDefines::DepthType::PSEUDO_LENGTH][3], 45.0 );
 }

--- a/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogCurveData-Test.cpp
@@ -42,8 +42,8 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_first )
     const double              eps            = 1e-6;
 
     // Output data
-    const auto                                               resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
-    std::vector<double>                                      resampledValues;
+    const auto                                           resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
+    std::vector<double>                                  resampledValues;
     std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths;
 
     // Target data (resampling with MEASURED_DEPTH)
@@ -92,8 +92,8 @@ TEST( RigWellLogCurveData, createAndAddInterpolatedSegmentValueAndDepths_second 
     const double              eps            = 1e-6;
 
     // Output data
-    const auto                                               resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
-    std::vector<double>                                      resampledValues;
+    const auto                                           resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
+    std::vector<double>                                  resampledValues;
     std::map<RiaDefines::DepthType, std::vector<double>> resampledDepths;
 
     // Target data (resampling with MEASURED_DEPTH)
@@ -152,7 +152,7 @@ TEST( RigWellLogCurveData, CreateResampledValuesAndDepthsTest )
 {
     // Input data
     RiaDefines::DepthType                                      resamplingDepthType = RiaDefines::DepthType::MEASURED_DEPTH;
-    const std::vector<double>                                      targetDepths        = { 0.0, 5.0, 10.0, 15.0 };
+    const std::vector<double>                                  targetDepths        = { 0.0, 5.0, 10.0, 15.0 };
     const std::map<RiaDefines::DepthType, std::vector<double>> originalDepths =
         { { RiaDefines::DepthType::MEASURED_DEPTH, { 0.0, 10.0, 20.0 } },
           { RiaDefines::DepthType::TRUE_VERTICAL_DEPTH, { 0.0, 20.0, 40.0 } },
@@ -163,9 +163,9 @@ TEST( RigWellLogCurveData, CreateResampledValuesAndDepthsTest )
     auto result = RigWellLogCurveData::createResampledValuesAndDepths( resamplingDepthType, targetDepths, originalDepths, propertyValues );
 
     // Check the results
-    std::vector<double>&                                      resampledPropertyValues = result.first;
+    std::vector<double>&                                  resampledPropertyValues = result.first;
     std::map<RiaDefines::DepthType, std::vector<double>>& resampledDepths         = result.second;
-    const auto                                                expectedSize            = targetDepths.size();
+    const auto                                            expectedSize            = targetDepths.size();
 
     ASSERT_EQ( resampledDepths.size(), originalDepths.size() );
     ASSERT_EQ( resampledDepths[RiaDefines::DepthType::MEASURED_DEPTH].size(), expectedSize );

--- a/ApplicationLibCode/UserInterface/RiuWellPathComponentPlotItem.cpp
+++ b/ApplicationLibCode/UserInterface/RiuWellPathComponentPlotItem.cpp
@@ -45,7 +45,7 @@ RiuWellPathComponentPlotItem::RiuWellPathComponentPlotItem( const RimWellPath* w
     : m_wellPath( wellPath )
     , m_componentType( RiaDefines::WellPathComponentType::WELL_PATH )
     , m_columnOffset( 0.0 )
-    , m_depthType( RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    , m_depthType( RiaDefines::DepthType::MEASURED_DEPTH )
     , m_depthOrientation( RiaDefines::Orientation::VERTICAL )
     , m_maxColumnOffset( 0.0 )
     , m_showLabel( false )
@@ -63,7 +63,7 @@ RiuWellPathComponentPlotItem::RiuWellPathComponentPlotItem( const RimWellPath* w
 RiuWellPathComponentPlotItem::RiuWellPathComponentPlotItem( const RimWellPath* wellPath, const RimWellPathComponentInterface* component )
     : m_wellPath( wellPath )
     , m_columnOffset( 0.0 )
-    , m_depthType( RiaDefines::DepthTypeEnum::MEASURED_DEPTH )
+    , m_depthType( RiaDefines::DepthType::MEASURED_DEPTH )
     , m_maxColumnOffset( 0.0 )
     , m_showLabel( false )
 {
@@ -298,7 +298,7 @@ std::pair<double, double> RiuWellPathComponentPlotItem::depthsOfDepthType() cons
     double startDepth = m_startMD;
     double endDepth   = m_endMD;
 
-    if ( m_depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH || m_depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+    if ( m_depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH || m_depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
     {
         endDepth       = -m_wellPath->wellPathGeometry()->interpolatedPointAlongWellPath( m_endMD ).z();
         double rkbDiff = m_wellPath->wellPathGeometry()->rkbDiff();
@@ -310,11 +310,11 @@ std::pair<double, double> RiuWellPathComponentPlotItem::depthsOfDepthType() cons
         if ( m_componentType == RiaDefines::WellPathComponentType::WELL_PATH )
         {
             startDepth = 0.0;
-            if ( m_depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH )
+            if ( m_depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH )
             {
                 startDepth -= rkbDiff;
             }
-            else if ( m_depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+            else if ( m_depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
             {
                 endDepth += m_wellPath->wellPathGeometry()->rkbDiff();
             }
@@ -322,7 +322,7 @@ std::pair<double, double> RiuWellPathComponentPlotItem::depthsOfDepthType() cons
         else
         {
             startDepth = -m_wellPath->wellPathGeometry()->interpolatedPointAlongWellPath( m_startMD ).z();
-            if ( m_depthType == RiaDefines::DepthTypeEnum::TRUE_VERTICAL_DEPTH_RKB )
+            if ( m_depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH_RKB )
             {
                 startDepth += m_wellPath->wellPathGeometry()->rkbDiff();
                 endDepth += m_wellPath->wellPathGeometry()->rkbDiff();


### PR DESCRIPTION
Major refactoring of RimWellLogTrack to delegate property axis, formation, region annotation, and well path attribute settings to dedicated settings classes. Introduces RimWellLogPropertyAxisSettings, RimWellLogFormationSettings, RimWellLogRegionAnnotationSettings, and RimWellLogWellPathAttributeSettings, each encapsulating related fields, UI logic, and option handling. Old fields are retained for migration and backward compatibility. Updates enums and signatures for consistency.
