### PR TITLE
Adds support for reservoir grid ensembles

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -86,6 +86,7 @@
 #include "RimOsduWellPathDataLoader.h"
 #include "RimPlotWindow.h"
 #include "RimProject.h"
+#include "RimReservoirGridEnsemble.h"
 #include "RimScriptCollection.h"
 #include "RimSeismicData.h"
 #include "RimSeismicDataCollection.h"
@@ -819,6 +820,22 @@ bool RiaApplication::loadProject( const QString& projectFileName, ProjectLoadAct
             for ( auto gridCaseEnsemble : gridCaseEnsembles )
             {
                 auto views = gridCaseEnsemble->viewCollection()->views();
+                for ( auto view : views )
+                {
+                    view->loadDataAndUpdate();
+                }
+            }
+        }
+
+        // Load all reservoir grid ensemble views
+        {
+            auto reservoirGridEnsembles = m_project->activeOilField()->analysisModels()->reservoirGridEnsembles.childrenByType();
+
+            for ( auto gridEnsemble : reservoirGridEnsembles )
+            {
+                gridEnsemble->loadDataAndUpdate();
+
+                auto views = gridEnsemble->allViews();
                 for ( auto view : views )
                 {
                     view->loadDataAndUpdate();

--- a/ApplicationLibCode/CommandFileInterface/RicfComputeCaseGroupStatistics.cpp
+++ b/ApplicationLibCode/CommandFileInterface/RicfComputeCaseGroupStatistics.cpp
@@ -55,7 +55,7 @@ caf::PdmScriptResponse RicfComputeCaseGroupStatistics::execute()
     {
         for ( RimIdenticalGridCaseGroup* group : RimProject::current()->activeOilField()->analysisModels()->caseGroups )
         {
-            for ( RimEclipseCase* c : group->statisticsCaseCollection->reservoirs )
+            for ( RimEclipseCase* c : group->statisticsCaseCollection()->reservoirs )
             {
                 caseIds.push_back( c->caseId() );
             }
@@ -67,7 +67,7 @@ caf::PdmScriptResponse RicfComputeCaseGroupStatistics::execute()
         bool foundCase = false;
         for ( RimIdenticalGridCaseGroup* group : RimProject::current()->activeOilField()->analysisModels()->caseGroups )
         {
-            for ( RimEclipseCase* c : group->statisticsCaseCollection->reservoirs )
+            for ( RimEclipseCase* c : group->statisticsCaseCollection()->reservoirs )
             {
                 if ( c->caseId() == caseId )
                 {

--- a/ApplicationLibCode/Commands/EclipseCommands/RicComputeStatisticsFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicComputeStatisticsFeature.cpp
@@ -23,7 +23,7 @@
 #include "RimEclipseCase.h"
 #include "RimEclipseStatisticsCase.h"
 #include "RimEclipseStatisticsCaseCollection.h"
-#include "RimIdenticalGridCaseGroup.h"
+#include "RimReservoirGridEnsembleBase.h"
 
 #include "cafCmdFeatureManager.h"
 #include "cafSelectionManager.h"
@@ -43,10 +43,8 @@ bool RicComputeStatisticsFeature::isCommandEnabled() const
         RimEclipseStatisticsCase* statisticsCase = selection[0];
         if ( statisticsCase )
         {
-            RimIdenticalGridCaseGroup* gridCaseGroup = statisticsCase->firstAncestorOrThisOfType<RimIdenticalGridCaseGroup>();
-
-            RimCaseCollection* caseCollection = gridCaseGroup ? gridCaseGroup->caseCollection() : nullptr;
-            return caseCollection ? !caseCollection->reservoirs.empty() : false;
+            auto* ensembleBase = statisticsCase->gridEnsembleBase();
+            return ensembleBase ? !ensembleBase->sourceCases().empty() : false;
         }
     }
 

--- a/ApplicationLibCode/Commands/EclipseCommands/RicNewStatisticsCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicNewStatisticsCaseFeature.cpp
@@ -24,6 +24,7 @@
 #include "RimEclipseStatisticsCaseCollection.h"
 #include "RimIdenticalGridCaseGroup.h"
 #include "RimProject.h"
+#include "RimReservoirGridEnsembleBase.h"
 
 #include "Riu3DMainWindowTools.h"
 
@@ -93,30 +94,26 @@ caf::PdmUiItem* RicNewStatisticsCaseFeature::selectedValidUIItem()
 //--------------------------------------------------------------------------------------------------
 RimEclipseStatisticsCase* RicNewStatisticsCaseFeature::addStatisticalCalculation( caf::PdmUiItem* uiItem )
 {
-    RimIdenticalGridCaseGroup* caseGroup = nullptr;
+    RimCaseCollection* caseCollection = nullptr;
 
-    if ( dynamic_cast<RimEclipseStatisticsCase*>( uiItem ) )
+    if ( auto* statCase = dynamic_cast<RimEclipseStatisticsCase*>( uiItem ) )
     {
-        RimEclipseStatisticsCase* currentObject = dynamic_cast<RimEclipseStatisticsCase*>( uiItem );
-        caseGroup                               = currentObject->parentStatisticsCaseCollection()->parentCaseGroup();
+        caseCollection = statCase->parentStatisticsCaseCollection();
     }
-    else if ( dynamic_cast<RimCaseCollection*>( uiItem ) )
+    else if ( auto* caseColl = dynamic_cast<RimCaseCollection*>( uiItem ) )
     {
-        RimCaseCollection* statColl = dynamic_cast<RimCaseCollection*>( uiItem );
-        caseGroup                   = statColl->parentCaseGroup();
+        caseCollection = caseColl;
     }
 
-    if ( caseGroup )
-    {
-        RimProject*               proj          = RimProject::current();
-        RimEclipseStatisticsCase* createdObject = caseGroup->createAndAppendStatisticsCase();
-        proj->assignCaseIdToCase( createdObject );
+    if ( !caseCollection ) return nullptr;
 
-        caseGroup->updateConnectedEditors();
-        return createdObject;
-    }
-    else
-    {
-        return nullptr;
-    }
+    auto* ensembleBase = caseCollection->parentGridEnsembleBase();
+    if ( !ensembleBase ) return nullptr;
+
+    auto* createdObject = ensembleBase->createAndAppendStatisticsCase();
+    RimProject::current()->assignCaseIdToCase( createdObject );
+
+    caseCollection->parentField()->ownerObject()->uiCapability()->updateConnectedEditors();
+
+    return createdObject;
 }

--- a/ApplicationLibCode/Commands/EnsembleFileSetCommands/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/EnsembleFileSetCommands/CMakeLists_files.cmake
@@ -1,11 +1,13 @@
 set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicImportEnsembleFileSetFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicCreateEnsembleFromFileSetFeature.h
+    ${CMAKE_CURRENT_LIST_DIR}/RicCreateReservoirGridEnsembleFromFileSetFeature.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicImportEnsembleFileSetFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicCreateEnsembleFromFileSetFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicCreateReservoirGridEnsembleFromFileSetFeature.cpp
 )
 
 list(APPEND COMMAND_CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/Commands/EnsembleFileSetCommands/RicCreateReservoirGridEnsembleFromFileSetFeature.cpp
+++ b/ApplicationLibCode/Commands/EnsembleFileSetCommands/RicCreateReservoirGridEnsembleFromFileSetFeature.cpp
@@ -1,0 +1,127 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicCreateReservoirGridEnsembleFromFileSetFeature.h"
+
+#include "RiaLogging.h"
+
+#include "EnsembleFileSet/RimEnsembleFileSet.h"
+#include "RimEclipseCaseCollection.h"
+#include "RimEclipseView.h"
+#include "RimOilField.h"
+#include "RimProject.h"
+#include "RimReservoirGridEnsemble.h"
+
+#include "Riu3DMainWindowTools.h"
+
+#include "cafProgressInfo.h"
+#include "cafSelectionManagerTools.h"
+
+#include <QAction>
+#include <QFileInfo>
+
+CAF_CMD_SOURCE_INIT( RicCreateReservoirGridEnsembleFromFileSetFeature, "RicCreateReservoirGridEnsembleFromFileSetFeature" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RicCreateReservoirGridEnsembleFromFileSetFeature::isCommandEnabled() const
+{
+    return !caf::selectedObjectsByType<RimEnsembleFileSet*>().empty();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicCreateReservoirGridEnsembleFromFileSetFeature::onActionTriggered( bool isChecked )
+{
+    std::vector<RimEnsembleFileSet*> selectedFileSets = caf::selectedObjectsByType<RimEnsembleFileSet*>();
+
+    if ( selectedFileSets.empty() ) return;
+
+    RimProject*               project         = RimProject::current();
+    RimEclipseCaseCollection* eclipseCaseColl = project->activeOilField()->analysisModels();
+
+    for ( RimEnsembleFileSet* fileSet : selectedFileSets )
+    {
+        // Get grid file paths from the file set
+        QStringList gridFiles = fileSet->createPaths( ".EGRID" );
+        if ( gridFiles.empty() )
+        {
+            gridFiles = fileSet->createPaths( ".GRID" );
+        }
+
+        // Filter out non-existing files
+        QStringList existingGridFiles;
+        for ( const QString& filePath : gridFiles )
+        {
+            if ( QFileInfo::exists( filePath ) )
+            {
+                existingGridFiles.append( filePath );
+            }
+            else
+            {
+                RiaLogging::warning( QString( "Grid file does not exist: %1" ).arg( filePath ) );
+            }
+        }
+        gridFiles = existingGridFiles;
+
+        if ( gridFiles.empty() )
+        {
+            RiaLogging::warning( QString( "No existing grid files found for ensemble '%1'" ).arg( fileSet->name() ) );
+            continue;
+        }
+
+        // Always create RimReservoirGridEnsemble
+        RiaLogging::info(
+            QString( "Creating Reservoir Grid Ensemble for '%1' with %2 grid files." ).arg( fileSet->name() ).arg( gridFiles.size() ) );
+
+        RimReservoirGridEnsemble* gridEnsemble = new RimReservoirGridEnsemble();
+        gridEnsemble->setEnsembleFileSet( fileSet );
+        gridEnsemble->createGridCasesFromEnsembleFileSet();
+
+        project->assignIdToCaseGroup( gridEnsemble );
+        eclipseCaseColl->reservoirGridEnsembles.push_back( gridEnsemble );
+
+        gridEnsemble->loadDataAndUpdate();
+
+        // Create view for first case if available
+        auto allCases = gridEnsemble->cases();
+        if ( !allCases.empty() )
+        {
+            RimEclipseView* view = gridEnsemble->addViewForCase( allCases[0] );
+            if ( view )
+            {
+                view->loadDataAndUpdate();
+            }
+        }
+
+        Riu3DMainWindowTools::selectAsCurrentItem( gridEnsemble );
+    }
+
+    eclipseCaseColl->updateAllRequiredEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicCreateReservoirGridEnsembleFromFileSetFeature::setupActionLook( QAction* actionToSetup )
+{
+    actionToSetup->setIcon( QIcon( ":/GridCaseGroup16x16.png" ) );
+    actionToSetup->setText( "Create Reservoir Grid Ensemble" );
+}

--- a/ApplicationLibCode/Commands/EnsembleFileSetCommands/RicCreateReservoirGridEnsembleFromFileSetFeature.h
+++ b/ApplicationLibCode/Commands/EnsembleFileSetCommands/RicCreateReservoirGridEnsembleFromFileSetFeature.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2011-2012 Statoil ASA, Ceetron AS
+//  Copyright (C) 2026     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -18,33 +18,17 @@
 
 #pragma once
 
-#include "cafPdmChildArrayField.h"
-#include "cafPdmField.h"
-#include "cafPdmObject.h"
-
-class RimEclipseCase;
-class RimReservoirGridEnsembleBase;
-class RimIdenticalGridCaseGroup;
-class RimReservoirGridEnsemble;
-class RimCase;
+#include "cafCmdFeature.h"
 
 //==================================================================================================
-//
-//
-//
+///
 //==================================================================================================
-class RimCaseCollection : public caf::PdmObject
+class RicCreateReservoirGridEnsembleFromFileSetFeature : public caf::CmdFeature
 {
-    CAF_PDM_HEADER_INIT;
+    CAF_CMD_HEADER_INIT;
 
-public:
-    RimCaseCollection();
-
-    std::vector<RimCase*> cases() const;
-
-    caf::PdmChildArrayField<RimEclipseCase*> reservoirs;
-
-    RimIdenticalGridCaseGroup*    parentCaseGroup();
-    RimReservoirGridEnsemble*     parentGridEnsemble();
-    RimReservoirGridEnsembleBase* parentGridEnsembleBase();
+protected:
+    bool isCommandEnabled() const override;
+    void onActionTriggered( bool isChecked ) override;
+    void setupActionLook( QAction* actionToSetup ) override;
 };

--- a/ApplicationLibCode/Commands/RicCloseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCloseCaseFeature.cpp
@@ -31,6 +31,7 @@
 #include "RimMainPlotCollection.h"
 #include "RimOilField.h"
 #include "RimProject.h"
+#include "RimReservoirGridEnsemble.h"
 #include "RimSummaryCaseMainCollection.h"
 #include "RimWellLogPlotCollection.h"
 
@@ -147,10 +148,16 @@ void RicCloseCaseFeature::deleteEclipseCase( RimEclipseCase* eclipseCase )
         if ( RimIdenticalGridCaseGroup::isStatisticsCaseCollection( caseCollection ) )
         {
             RimIdenticalGridCaseGroup* caseGroup = caseCollection->parentCaseGroup();
-            CVF_ASSERT( caseGroup );
-
-            caseGroup->statisticsCaseCollection()->reservoirs.removeChild( eclipseCase );
-            caseGroup->updateConnectedEditors();
+            if ( caseGroup )
+            {
+                caseGroup->statisticsCaseCollection()->reservoirs.removeChild( eclipseCase );
+                caseGroup->updateConnectedEditors();
+            }
+            else if ( RimReservoirGridEnsemble* ensemble = caseCollection->parentGridEnsemble() )
+            {
+                caseCollection->reservoirs.removeChild( eclipseCase );
+                ensemble->updateConnectedEditors();
+            }
         }
         else
         {

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -75,6 +75,31 @@ RifReaderOpmCommon::~RifReaderOpmCommon()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RifReaderOpmCommon::GridDimensions RifReaderOpmCommon::readGridDimensions( const QString& gridFileName )
+{
+    GridDimensions result;
+
+    try
+    {
+        Opm::EclIO::EGrid opmGrid( gridFileName.toStdString() );
+
+        const auto& dims       = opmGrid.dimension();
+        result.i               = dims[0];
+        result.j               = dims[1];
+        result.k               = dims[2];
+        result.activeCellCount = opmGrid.activeCells();
+    }
+    catch ( std::exception& e )
+    {
+        RiaLogging::debug( QString( "Failed to read grid dimensions from %1: %2" ).arg( gridFileName ).arg( e.what() ) );
+    }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RifReaderOpmCommon::open( const QString& fileName, RigEclipseCaseData* eclipseCaseData )
 {
     caf::ProgressInfo progress( 100, "Reading Grid" );

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.h
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.h
@@ -53,6 +53,14 @@ class ProgressInfo;
 class RifReaderOpmCommon : public RifReaderInterface
 {
 public:
+    struct GridDimensions
+    {
+        size_t i               = 0;
+        size_t j               = 0;
+        size_t k               = 0;
+        size_t activeCellCount = 0;
+    };
+
     RifReaderOpmCommon();
     ~RifReaderOpmCommon() override;
 
@@ -63,6 +71,8 @@ public:
 
     std::vector<QDateTime>          timeStepsOnFile( QString gridFileName );
     std::set<RiaDefines::PhaseType> availablePhases() const override;
+
+    static GridDimensions readGridDimensions( const QString& gridFileName );
 
 protected:
     virtual bool importGrid( RigMainGrid* mainGrid, RigEclipseCaseData* caseData );

--- a/ApplicationLibCode/ProjectDataModel/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/CMakeLists_files.cmake
@@ -129,6 +129,8 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimRegularGridCase.h
     ${CMAKE_CURRENT_LIST_DIR}/RimGeometrySelectionItem.h
     ${CMAKE_CURRENT_LIST_DIR}/RimCornerPointCase.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimReservoirGridEnsemble.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimReservoirGridEnsembleBase.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -256,6 +258,8 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimRegularGridCase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimGeometrySelectionItem.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimCornerPointCase.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimReservoirGridEnsemble.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimReservoirGridEnsembleBase.cpp
 )
 
 list(APPEND CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSet.cpp
@@ -336,6 +336,7 @@ void RimEnsembleFileSet::fieldChangedByUi( const caf::PdmFieldHandle* changedFie
 void RimEnsembleFileSet::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
 {
     menuBuilder << "RicCreateEnsembleFromFileSetFeature";
+    menuBuilder << "RicCreateReservoirGridEnsembleFromFileSetFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp
@@ -25,7 +25,10 @@
 #include "EnsembleFileSet/RimEnsembleFileSet.h"
 #include "EnsembleFileSet/RimEnsembleFileSetCollection.h"
 #include "RiaEnsembleNameTools.h"
+#include "RimEclipseCaseCollection.h"
+#include "RimOilField.h"
 #include "RimProject.h"
+#include "RimReservoirGridEnsemble.h"
 #include "RimSummaryCaseMainCollection.h"
 
 namespace RimEnsembleFileSetTools
@@ -80,6 +83,33 @@ std::vector<RimEnsembleFileSet*> createEnsembleFileSets( const QStringList& file
     collection->updateAllRequiredEditors();
 
     return fileSets;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimReservoirGridEnsemble*> createGridEnsemblesFromFileSets( const std::vector<RimEnsembleFileSet*> fileSets )
+{
+    RimProject*               project         = RimProject::current();
+    RimEclipseCaseCollection* eclipseCaseColl = project->activeOilField()->analysisModels();
+    if ( !eclipseCaseColl ) return {};
+
+    std::vector<RimReservoirGridEnsemble*> ensembles;
+    for ( auto fileSet : fileSets )
+    {
+        auto ensemble = new RimReservoirGridEnsemble();
+        ensemble->setEnsembleFileSet( fileSet );
+
+        project->assignIdToCaseGroup( ensemble );
+        eclipseCaseColl->reservoirGridEnsembles.push_back( ensemble );
+
+        ensemble->loadDataAndUpdate();
+        ensembles.push_back( ensemble );
+    }
+
+    eclipseCaseColl->updateAllRequiredEditors();
+
+    return ensembles;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.h
+++ b/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.h
@@ -28,11 +28,14 @@
 
 class RimSummaryEnsemble;
 class RimEnsembleFileSet;
+class RimReservoirGridEnsemble;
 
 namespace RimEnsembleFileSetTools
 {
 std::vector<RimSummaryEnsemble*> createSummaryEnsemblesFromFileSets( const std::vector<RimEnsembleFileSet*> fileSets );
 std::vector<RimEnsembleFileSet*> createEnsembleFileSets( const QStringList& fileNames, RiaDefines::EnsembleGroupingMode groupingMode );
+
+std::vector<RimReservoirGridEnsemble*> createGridEnsemblesFromFileSets( const std::vector<RimEnsembleFileSet*> fileSets );
 
 RimEnsembleFileSet* createEnsembleFileSetFromOpm( const QString& pathPattern, const QString& name );
 

--- a/ApplicationLibCode/ProjectDataModel/RimCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCaseCollection.cpp
@@ -22,6 +22,7 @@
 
 #include "RimEclipseCase.h"
 #include "RimIdenticalGridCaseGroup.h"
+#include "RimReservoirGridEnsemble.h"
 
 CAF_PDM_SOURCE_INIT( RimCaseCollection, "RimCaseCollection" );
 
@@ -61,15 +62,21 @@ RimIdenticalGridCaseGroup* RimCaseCollection::parentCaseGroup()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimEclipseCase* RimCaseCollection::findByDescription( const QString& caseDescription ) const
+RimReservoirGridEnsemble* RimCaseCollection::parentGridEnsemble()
 {
-    for ( size_t i = 0; i < reservoirs.size(); i++ )
-    {
-        if ( caseDescription == reservoirs[i]->caseUserDescription() )
-        {
-            return reservoirs[i];
-        }
-    }
+    return dynamic_cast<RimReservoirGridEnsemble*>( parentField()->ownerObject() );
+}
 
-    return nullptr;
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimReservoirGridEnsembleBase* RimCaseCollection::parentGridEnsembleBase()
+{
+    auto* owner = parentField()->ownerObject();
+
+    if ( auto* caseGroup = dynamic_cast<RimIdenticalGridCaseGroup*>( owner ) )
+    {
+        return caseGroup;
+    }
+    return dynamic_cast<RimReservoirGridEnsemble*>( owner );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
@@ -32,6 +32,7 @@
 #include "RimEclipseStatisticsCase.h"
 #include "RimIdenticalGridCaseGroup.h"
 #include "RimProject.h"
+#include "RimReservoirGridEnsemble.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
 
@@ -48,6 +49,8 @@ RimEclipseCaseCollection::RimEclipseCaseCollection()
     CAF_PDM_InitFieldNoDefault( &caseGroups, "CaseGroups", "" );
 
     CAF_PDM_InitFieldNoDefault( &caseEnsembles, "CaseEnsembles", "" );
+
+    CAF_PDM_InitFieldNoDefault( &reservoirGridEnsembles, "ReservoirGridEnsembles", "" );
 
     m_gridCollection = new RigGridManager;
 }
@@ -70,6 +73,7 @@ void RimEclipseCaseCollection::close()
     cases.deleteChildren();
     caseGroups.deleteChildren();
     caseEnsembles.deleteChildren();
+    reservoirGridEnsembles.deleteChildren();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -174,7 +178,7 @@ void RimEclipseCaseCollection::recomputeStatisticsForAllCaseGroups()
     for ( size_t caseGrpIdx = 0; caseGrpIdx < numCaseGroups; ++caseGrpIdx )
     {
         RimIdenticalGridCaseGroup* caseGroup                = caseGroups[caseGrpIdx];
-        RimCaseCollection*         statisticsCaseCollection = caseGroup->statisticsCaseCollection;
+        RimCaseCollection*         statisticsCaseCollection = caseGroup->statisticsCaseCollection();
         const size_t               numStatisticsCases       = statisticsCaseCollection->reservoirs.size();
         for ( size_t caseIdx = 0; caseIdx < numStatisticsCases; caseIdx++ )
         {

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.h
@@ -34,6 +34,7 @@ class RimEclipseCase;
 class RimIdenticalGridCaseGroup;
 class RimWellPathCollection;
 class RimEclipseCaseEnsemble;
+class RimReservoirGridEnsemble;
 
 //==================================================================================================
 ///
@@ -50,6 +51,7 @@ public:
     caf::PdmChildArrayField<RimEclipseCase*>            cases;
     caf::PdmChildArrayField<RimIdenticalGridCaseGroup*> caseGroups;
     caf::PdmChildArrayField<RimEclipseCaseEnsemble*>    caseEnsembles;
+    caf::PdmChildArrayField<RimReservoirGridEnsemble*>  reservoirGridEnsembles;
 
     void close();
 

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseEnsemble.cpp
@@ -108,16 +108,6 @@ bool RimEclipseCaseEnsemble::contains( RimEclipseCase* reservoir ) const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimEclipseCase* RimEclipseCaseEnsemble::findByDescription( const QString& caseDescription ) const
-{
-    if ( !m_caseCollection ) return nullptr;
-
-    return m_caseCollection->findByDescription( caseDescription );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 RimEclipseCase* RimEclipseCaseEnsemble::findByFileName( const QString& gridFileName ) const
 {
     for ( RimEclipseCase* rimReservoir : cases() )

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseEnsemble.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseEnsemble.h
@@ -51,7 +51,6 @@ public:
     void removeCase( RimEclipseCase* reservoir );
     bool contains( RimEclipseCase* reservoir ) const;
 
-    RimEclipseCase* findByDescription( const QString& description ) const;
     RimEclipseCase* findByFileName( const QString& gridFileName ) const;
 
     std::vector<RimEclipseCase*> cases() const;

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCase.cpp
@@ -36,10 +36,10 @@
 #include "RimEclipseStatisticsCaseEvaluator.h"
 #include "RimEclipseView.h"
 #include "RimGridCalculationCollection.h"
-#include "RimIdenticalGridCaseGroup.h"
 #include "RimIntersectionCollection.h"
 #include "RimProject.h"
 #include "RimReservoirCellResultsStorage.h"
+#include "RimReservoirGridEnsembleBase.h"
 #include "RimSimWellInViewCollection.h"
 
 #include "RiuMainWindow.h"
@@ -126,7 +126,10 @@ RimEclipseStatisticsCase::RimEclipseStatisticsCase()
     CAF_PDM_InitScriptableField( &m_midPercentile, "MidPercentile", 50.0, "Mid" );
     CAF_PDM_InitScriptableField( &m_highPercentile, "HighPercentile", 90.0, "High" );
 
-    CAF_PDM_InitScriptableField( &m_wellDataSourceCase, "WellDataSourceCase", RiaResultNames::undefinedResultName(), "Well Data Source Case" );
+    CAF_PDM_InitScriptableFieldNoDefault( &m_wellDataSourceCase, "WellDataSourceCasePtr", "Well Data Source Case" );
+
+    CAF_PDM_InitFieldNoDefault( &obsoleteField_wellDataSourceCase, "WellDataSourceCase", "Well Data Source Case" );
+    obsoleteField_wellDataSourceCase.xmlCapability()->setIOWritable( false );
 
     CAF_PDM_InitScriptableField( &m_useZeroAsInactiveCellValue, "UseZeroAsInactiveCellValue", false, "Use Zero as Inactive Cell Value" );
 
@@ -150,6 +153,31 @@ RimEclipseStatisticsCase::~RimEclipseStatisticsCase()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimEclipseStatisticsCase::initAfterRead()
+{
+    RimEclipseCase::initAfterRead();
+
+    if ( !obsoleteField_wellDataSourceCase().isEmpty() && obsoleteField_wellDataSourceCase() != RiaResultNames::undefinedResultName() )
+    {
+        auto* owner = gridEnsembleBase();
+        if ( owner )
+        {
+            for ( auto* sourceCase : owner->sourceCases() )
+            {
+                if ( sourceCase->caseUserDescription() == obsoleteField_wellDataSourceCase() )
+                {
+                    m_wellDataSourceCase = sourceCase;
+                    break;
+                }
+            }
+        }
+        obsoleteField_wellDataSourceCase = "";
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimEclipseStatisticsCase::setMainGrid( RigMainGrid* mainGrid )
 {
     CVF_ASSERT( mainGrid );
@@ -165,23 +193,23 @@ bool RimEclipseStatisticsCase::openEclipseGridFile()
 {
     if ( eclipseCaseData() ) return true;
 
+    auto* ensembleBase = gridEnsembleBase();
+    if ( !ensembleBase ) return false;
+
+    RigMainGrid* mainGrid = ensembleBase->mainGrid();
+    if ( !mainGrid ) return false;
+
     cvf::ref<RigEclipseCaseData> eclipseCase = new RigEclipseCaseData( this );
-
-    CVF_ASSERT( parentStatisticsCaseCollection() );
-
-    RimIdenticalGridCaseGroup* gridCaseGroup = parentStatisticsCaseCollection()->parentCaseGroup();
-    CVF_ASSERT( gridCaseGroup );
-
-    RigMainGrid* mainGrid = gridCaseGroup->mainGrid();
-
     eclipseCase->setMainGrid( mainGrid );
 
     eclipseCase->setActiveCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL,
-                                    gridCaseGroup->unionOfActiveCells( RiaDefines::PorosityModelType::MATRIX_MODEL ) );
+                                    ensembleBase->unionOfActiveCells( RiaDefines::PorosityModelType::MATRIX_MODEL ) );
     eclipseCase->setActiveCellInfo( RiaDefines::PorosityModelType::FRACTURE_MODEL,
-                                    gridCaseGroup->unionOfActiveCells( RiaDefines::PorosityModelType::FRACTURE_MODEL ) );
+                                    ensembleBase->unionOfActiveCells( RiaDefines::PorosityModelType::FRACTURE_MODEL ) );
 
     setReservoirData( eclipseCase.p() );
+
+    computeCachedData();
 
     loadSimulationWellDataFromSourceCase();
 
@@ -256,10 +284,12 @@ void RimEclipseStatisticsCase::setSourceProperties( RiaDefines::ResultCatType pr
 //--------------------------------------------------------------------------------------------------
 void RimEclipseStatisticsCase::selectAllTimeSteps()
 {
-    RimIdenticalGridCaseGroup* idgcg = caseGroup();
-    if ( idgcg && idgcg->mainCase() )
+    auto* ensembleBase = gridEnsembleBase();
+    if ( !ensembleBase ) return;
+
+    if ( RimEclipseCase* mainCase = ensembleBase->mainCase() )
     {
-        int timeStepCount = idgcg->mainCase()->timeStepStrings().size();
+        int timeStepCount = mainCase->timeStepStrings().size();
 
         if ( timeStepCount > 0 )
         {
@@ -274,9 +304,9 @@ void RimEclipseStatisticsCase::selectAllTimeSteps()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimEclipseStatisticsCase::setWellDataSourceCase( const QString& reservoirDescription )
+void RimEclipseStatisticsCase::setWellDataSourceCase( RimEclipseCase* sourceCase )
 {
-    m_wellDataSourceCase = reservoirDescription;
+    m_wellDataSourceCase = sourceCase;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -289,9 +319,10 @@ void RimEclipseStatisticsCase::computeStatistics()
         openEclipseGridFile();
     }
 
-    RimIdenticalGridCaseGroup* gridCaseGroup = caseGroup();
-    CVF_ASSERT( gridCaseGroup );
-    gridCaseGroup->computeUnionOfActiveCells();
+    auto* ensembleBase = gridEnsembleBase();
+    if ( !ensembleBase ) return;
+
+    ensembleBase->computeUnionOfActiveCells();
 
     std::vector<RimEclipseCase*> sourceCases = getSourceCases();
 
@@ -415,8 +446,14 @@ void RimEclipseStatisticsCase::computeStatistics()
                                                                                 calculationName ) );
     }
 
-    bool clearGridCalculationMemory = m_dataSourceForStatistics() == DataSourceType::GRID_CALCULATION;
-    RimEclipseStatisticsCaseEvaluator stat( sourceCases, timeStepIndices, statisticsConfig, resultCase, gridCaseGroup, clearGridCalculationMemory );
+    bool                              clearGridCalculationMemory = m_dataSourceForStatistics() == DataSourceType::GRID_CALCULATION;
+    RimEclipseStatisticsCaseEvaluator stat( sourceCases,
+                                            timeStepIndices,
+                                            statisticsConfig,
+                                            resultCase,
+                                            ensembleBase->unionOfActiveCells( RiaDefines::PorosityModelType::MATRIX_MODEL ),
+                                            ensembleBase->unionOfActiveCells( RiaDefines::PorosityModelType::FRACTURE_MODEL ),
+                                            clearGridCalculationMemory );
 
     if ( m_useZeroAsInactiveCellValue )
     {
@@ -441,36 +478,21 @@ void RimEclipseStatisticsCase::scheduleACTIVEGeometryRegenOnReservoirViews()
 //--------------------------------------------------------------------------------------------------
 std::vector<RimEclipseCase*> RimEclipseStatisticsCase::getSourceCases() const
 {
-    std::vector<RimEclipseCase*> sourceCases;
+    auto* ensembleBase = gridEnsembleBase();
+    if ( !ensembleBase ) return {};
 
-    RimIdenticalGridCaseGroup* gridCaseGroup = caseGroup();
-    if ( gridCaseGroup )
-    {
-        size_t caseCount = gridCaseGroup->caseCollection->reservoirs.size();
-        for ( size_t i = 0; i < caseCount; i++ )
-        {
-            CVF_ASSERT( gridCaseGroup->caseCollection );
-            CVF_ASSERT( gridCaseGroup->caseCollection->reservoirs[i] );
-
-            RimEclipseCase* sourceCase = gridCaseGroup->caseCollection->reservoirs[i];
-            sourceCases.push_back( sourceCase );
-        }
-    }
-
-    return sourceCases;
+    return ensembleBase->sourceCases();
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimIdenticalGridCaseGroup* RimEclipseStatisticsCase::caseGroup() const
+RimReservoirGridEnsembleBase* RimEclipseStatisticsCase::gridEnsembleBase() const
 {
-    RimCaseCollection* parentCollection = parentStatisticsCaseCollection();
-    if ( parentCollection )
+    if ( RimCaseCollection* parentCollection = parentStatisticsCaseCollection() )
     {
-        return parentCollection->parentCaseGroup();
+        return parentCollection->parentGridEnsembleBase();
     }
-
     return nullptr;
 }
 
@@ -578,8 +600,11 @@ QList<caf::PdmOptionItemInfo> RimEclipseStatisticsCase::toOptionList( const QStr
 //--------------------------------------------------------------------------------------------------
 QList<caf::PdmOptionItemInfo> RimEclipseStatisticsCase::calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions )
 {
-    RimIdenticalGridCaseGroup* idgcg = caseGroup();
-    if ( !( caseGroup() && caseGroup()->mainCase() && caseGroup()->mainCase()->eclipseCaseData() ) )
+    auto* ensembleBase = gridEnsembleBase();
+    if ( !ensembleBase ) return {};
+
+    RimEclipseCase* mainCase = ensembleBase->mainCase();
+    if ( !( mainCase && mainCase->eclipseCaseData() ) )
     {
         return {};
     }
@@ -618,13 +643,13 @@ QList<caf::PdmOptionItemInfo> RimEclipseStatisticsCase::calculateValueOptions( c
         return options;
     }
 
-    RigEclipseCaseData* caseData = idgcg->mainCase()->eclipseCaseData();
+    RigEclipseCaseData* caseData = mainCase->eclipseCaseData();
 
     if ( &m_selectedTimeSteps == fieldNeedingOptions )
     {
         QList<caf::PdmOptionItemInfo> options;
 
-        const auto timeStepStrings = idgcg->mainCase()->timeStepStrings();
+        const auto timeStepStrings = mainCase->timeStepStrings();
 
         int index = 0;
         for ( const auto& text : timeStepStrings )
@@ -700,15 +725,15 @@ QList<caf::PdmOptionItemInfo> RimEclipseStatisticsCase::calculateValueOptions( c
 
     else if ( &m_wellDataSourceCase == fieldNeedingOptions )
     {
-        QStringList sourceCaseNames;
-        sourceCaseNames += RiaResultNames::undefinedResultName();
+        QList<caf::PdmOptionItemInfo> options;
+        options.push_back( caf::PdmOptionItemInfo( RiaResultNames::undefinedResultName(), nullptr ) );
 
-        for ( size_t i = 0; i < caseGroup()->caseCollection()->reservoirs().size(); i++ )
+        for ( auto* sourceCase : ensembleBase->sourceCases() )
         {
-            sourceCaseNames += caseGroup()->caseCollection()->reservoirs()[i]->caseUserDescription();
+            options.push_back( caf::PdmOptionItemInfo( sourceCase->caseUserDescription(), sourceCase ) );
         }
 
-        return toOptionList( sourceCaseNames );
+        return options;
     }
 
     return RimEclipseCase::calculateValueOptions( fieldNeedingOptions );
@@ -759,8 +784,7 @@ void RimEclipseStatisticsCase::fieldChangedByUi( const caf::PdmFieldHandle* chan
 //--------------------------------------------------------------------------------------------------
 void RimEclipseStatisticsCase::loadSimulationWellDataFromSourceCase()
 {
-    // Find or load well data for given case
-    RimEclipseCase* sourceResultCase = caseGroup()->caseCollection()->findByDescription( m_wellDataSourceCase );
+    RimEclipseCase* sourceResultCase = m_wellDataSourceCase();
     if ( sourceResultCase )
     {
         sourceResultCase->openEclipseGridFile();
@@ -1006,13 +1030,16 @@ void RimEclipseStatisticsCase::computeStatisticsAndUpdateViews()
 //--------------------------------------------------------------------------------------------------
 void RimEclipseStatisticsCase::populateResultSelection()
 {
-    RimIdenticalGridCaseGroup* idgcg = caseGroup();
-    if ( !( caseGroup() && caseGroup()->mainCase() && caseGroup()->mainCase()->eclipseCaseData() ) )
+    auto* ensembleBase = gridEnsembleBase();
+    if ( !ensembleBase ) return;
+
+    RimEclipseCase* mainCase = ensembleBase->mainCase();
+    if ( !( mainCase && mainCase->eclipseCaseData() ) )
     {
         return;
     }
 
-    RigEclipseCaseData* caseData = idgcg->mainCase()->eclipseCaseData();
+    RigEclipseCaseData* caseData = mainCase->eclipseCaseData();
 
     if ( m_selectedDynamicProperties().empty() )
     {

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCase.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCase.h
@@ -28,10 +28,12 @@
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 
+class RigActiveCellInfo;
 class RigMainGrid;
 class RigSimWellData;
 class RimEclipseResultDefinition;
 class RimEclipseStatisticsCaseCollection;
+class RimReservoirGridEnsembleBase;
 class RimIdenticalGridCaseGroup;
 class RimGridCalculation;
 
@@ -80,12 +82,13 @@ public:
     void setSourceProperties( RiaDefines::ResultCatType propertyType, const std::vector<QString>& propertyNames );
     void selectAllTimeSteps();
 
-    void setWellDataSourceCase( const QString& reservoirDescription );
+    void setWellDataSourceCase( RimEclipseCase* sourceCase );
+
+    RimReservoirGridEnsembleBase* gridEnsembleBase() const;
 
 private:
     void scheduleACTIVEGeometryRegenOnReservoirViews();
 
-    RimIdenticalGridCaseGroup*   caseGroup() const;
     std::vector<RimEclipseCase*> getSourceCases() const;
 
     void populateResultSelection();
@@ -99,6 +102,7 @@ private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
 
     void loadSimulationWellDataFromSourceCase();
+    void initAfterRead() override;
 
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
     void initializeSelectedTimeSteps();
@@ -134,9 +138,12 @@ private:
     caf::PdmField<double>                           m_midPercentile;
     caf::PdmField<double>                           m_highPercentile;
 
-    caf::PdmField<QString> m_wellDataSourceCase;
+    caf::PdmPtrField<RimEclipseCase*> m_wellDataSourceCase;
 
     caf::PdmField<bool> m_useZeroAsInactiveCellValue;
+
+    // Obsolete
+    caf::PdmField<QString> obsoleteField_wellDataSourceCase;
 
     bool m_populateSelectionAfterLoadingGrid;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
@@ -22,6 +22,7 @@
 
 #include "RiaLogging.h"
 
+#include "RigActiveCellInfo.h"
 #include "RigCaseCellResultsData.h"
 #include "RigEclipseCaseData.h"
 #include "RigEclipseResultInfo.h"
@@ -32,12 +33,9 @@
 #include "RigStatisticsMath.h"
 
 #include "RimEclipseView.h"
-#include "RimIdenticalGridCaseGroup.h"
 #include "RimReservoirCellResultsStorage.h"
 
 #include "cafProgressInfo.h"
-
-#include <QDebug>
 
 #include <algorithm>
 
@@ -210,6 +208,10 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
                     visibility = filterView->currentTotalCellVisibility();
                 }
 
+                auto destinationActiveCellInfo = m_destinationCase->activeCellInfo( poroModel );
+                auto unionActiveCells          = ( poroModel == RiaDefines::PorosityModelType::MATRIX_MODEL ) ? m_unionOfMatrixActiveCells
+                                                                                                              : m_unionOfFractureActiveCells;
+
                 // Loop over the cells in the grid, get the case values, and calculate the cell statistics
 #pragma omp parallel for schedule( dynamic ) firstprivate( statParams, values )
                 for ( int cellIdx = 0; cellIdx < cellCount; cellIdx++ )
@@ -218,7 +220,7 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
 
                     if ( visibility.notNull() && !visibility->val( reservoirCellIndex ) ) continue;
 
-                    if ( m_destinationCase->activeCellInfo( poroModel )->isActive( reservoirCellIndex ) )
+                    if ( destinationActiveCellInfo->isActive( reservoirCellIndex ) )
                     {
                         // Extract the cell values from each of the cases and assemble them into one vector
 
@@ -230,7 +232,7 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
                             // Replace huge_val with zero in the statistical computation for the following case
                             if ( m_useZeroAsInactiveCellValue || resultName.toUpper() == "ACTNUM" )
                             {
-                                if ( m_identicalGridCaseGroup->unionOfActiveCells( poroModel )->isActive( reservoirCellIndex ) && val == HUGE_VAL )
+                                if ( unionActiveCells && unionActiveCells->isActive( reservoirCellIndex ) && val == HUGE_VAL )
                                 {
                                     val = 0.0;
                                 }
@@ -404,14 +406,16 @@ RimEclipseStatisticsCaseEvaluator::RimEclipseStatisticsCaseEvaluator( const std:
                                                                       const std::vector<int>&             timeStepIndices,
                                                                       const RimStatisticsConfig&          statisticsConfig,
                                                                       RigEclipseCaseData*                 destinationCase,
-                                                                      RimIdenticalGridCaseGroup*          identicalGridCaseGroup,
+                                                                      RigActiveCellInfo*                  unionOfMatrixActiveCells,
+                                                                      RigActiveCellInfo*                  unionOfFractureActiveCells,
                                                                       bool                                clearGridCalculationMemory )
     : m_sourceCases( sourceCases )
     , m_statisticsConfig( statisticsConfig )
     , m_destinationCase( destinationCase )
     , m_reservoirCellCount( 0 )
     , m_timeStepIndices( timeStepIndices )
-    , m_identicalGridCaseGroup( identicalGridCaseGroup )
+    , m_unionOfMatrixActiveCells( unionOfMatrixActiveCells )
+    , m_unionOfFractureActiveCells( unionOfFractureActiveCells )
     , m_useZeroAsInactiveCellValue( false )
     , m_clearGridCalculationMemory( clearGridCalculationMemory )
 {

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.h
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <vector>
 
+class RigActiveCellInfo;
 class RimEclipseCase;
 class RigEclipseCaseData;
 class RigCaseCellResultsData;
@@ -57,7 +58,8 @@ public:
                                        const std::vector<int>&             timeStepIndices,
                                        const RimStatisticsConfig&          statisticsConfig,
                                        RigEclipseCaseData*                 destinationCase,
-                                       RimIdenticalGridCaseGroup*          identicalGridCaseGroup,
+                                       RigActiveCellInfo*                  unionOfMatrixActiveCells,
+                                       RigActiveCellInfo*                  unionOfFractureActiveCells,
                                        bool                                clearGridCalculationMemory );
 
     struct ResSpec
@@ -108,10 +110,11 @@ private:
     std::vector<RimEclipseCase*> m_sourceCases;
     std::vector<int>             m_timeStepIndices;
 
-    size_t                     m_reservoirCellCount;
-    RimStatisticsConfig        m_statisticsConfig;
-    RigEclipseCaseData*        m_destinationCase;
-    RimIdenticalGridCaseGroup* m_identicalGridCaseGroup;
-    bool                       m_useZeroAsInactiveCellValue;
-    bool                       m_clearGridCalculationMemory;
+    size_t              m_reservoirCellCount;
+    RimStatisticsConfig m_statisticsConfig;
+    RigEclipseCaseData* m_destinationCase;
+    RigActiveCellInfo*  m_unionOfMatrixActiveCells;
+    RigActiveCellInfo*  m_unionOfFractureActiveCells;
+    bool                m_useZeroAsInactiveCellValue;
+    bool                m_clearGridCalculationMemory;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -1626,13 +1626,17 @@ void RimEclipseView::updateLegendRangesTextAndVisibility( RimRegularLegendConfig
         nativeOrOverrideViewer()->addColorLegendToBottomLeftCorner( legendConfig->titledOverlayFrame(), isUsingOverrideViewer() );
     }
 
-    size_t maxTimeStepCount = eclResultDef->currentGridCellResults()->maxTimeStepCount();
-    if ( eclResultDef->isTernarySaturationSelected() && maxTimeStepCount > 1 )
+    if ( RigCaseCellResultsData* cellResultsData = eclResultDef->currentGridCellResults() )
     {
-        if ( ternaryLegendConfig->showLegend() && ternaryLegendConfig->titledOverlayFrame() )
+        size_t maxTimeStepCount = cellResultsData->maxTimeStepCount();
+        if ( eclResultDef->isTernarySaturationSelected() && maxTimeStepCount > 1 )
         {
-            ternaryLegendConfig->setTitle( legendHeading );
-            nativeOrOverrideViewer()->addColorLegendToBottomLeftCorner( ternaryLegendConfig->titledOverlayFrame(), isUsingOverrideViewer() );
+            if ( ternaryLegendConfig->showLegend() && ternaryLegendConfig->titledOverlayFrame() )
+            {
+                ternaryLegendConfig->setTitle( legendHeading );
+                nativeOrOverrideViewer()->addColorLegendToBottomLeftCorner( ternaryLegendConfig->titledOverlayFrame(),
+                                                                            isUsingOverrideViewer() );
+            }
         }
     }
 }
@@ -1655,6 +1659,14 @@ void RimEclipseView::setEclipseCase( RimEclipseCase* reservoir )
 RimEclipseCase* RimEclipseView::eclipseCase() const
 {
     return m_eclipseCase;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEclipseView::setEclipseCaseProvider( std::function<std::vector<RimEclipseCase*>()> provider )
+{
+    m_eclipseCaseProvider = provider;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2088,7 +2100,18 @@ QList<caf::PdmOptionItemInfo> RimEclipseView::calculateValueOptions( const caf::
     {
         QList<caf::PdmOptionItemInfo> options;
 
-        for ( auto eclCase : RimEclipseCaseTools::allEclipseGridCases() )
+        // Use callback if provided, otherwise use global case list
+        std::vector<RimEclipseCase*> availableCases;
+        if ( m_eclipseCaseProvider )
+        {
+            availableCases = m_eclipseCaseProvider();
+        }
+        else
+        {
+            availableCases = RimEclipseCaseTools::allEclipseGridCases();
+        }
+
+        for ( auto eclCase : availableCases )
         {
             options.push_back( caf::PdmOptionItemInfo( eclCase->caseUserDescription(), eclCase, false, eclCase->uiIconProvider() ) );
         }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
@@ -36,6 +36,8 @@
 #include "cafPdmFieldCvfColor.h"
 #include "cafPdmFieldCvfMat4d.h"
 
+#include <functional>
+
 class RigActiveCellInfo;
 class RigCaseCellResultsData;
 class RigGridBase;
@@ -129,6 +131,8 @@ public:
     void            setEclipseCase( RimEclipseCase* reservoir );
     RimEclipseCase* eclipseCase() const;
     RimCase*        ownerCase() const override;
+
+    void setEclipseCaseProvider( std::function<std::vector<RimEclipseCase*>()> provider );
 
     RigMainGrid* mainGrid() const;
 
@@ -269,4 +273,7 @@ private:
 
     caf::PdmChildField<RimMultipleEclipseResults*> m_additionalResultsForResultInfo;
     caf::PdmChildArrayField<RimCameraPosition*>    m_cameraPositions;
+
+    // Callback for providing available Eclipse cases (used by view collections to filter cases)
+    std::function<std::vector<RimEclipseCase*>()> m_eclipseCaseProvider;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.cpp
@@ -93,6 +93,9 @@ RimEclipseView* RimEclipseViewCollection::addView( RimEclipseCase* eclipseCase )
 
     view->setEclipseCase( eclipseCase );
 
+    // Configure case provider callback
+    applyCallbackToView( view );
+
     auto prefs = RiaPreferences::current();
     view->faultCollection()->setActive( prefs->enableFaultsByDefault() );
 
@@ -125,6 +128,9 @@ RimEclipseView* RimEclipseViewCollection::addView( RimEclipseCase* eclipseCase )
 //--------------------------------------------------------------------------------------------------
 void RimEclipseViewCollection::addView( RimEclipseView* view )
 {
+    // Configure case provider callback
+    applyCallbackToView( view );
+
     m_views.push_back( view );
     updateConnectedEditors();
 }
@@ -136,4 +142,38 @@ void RimEclipseViewCollection::removeView( RimEclipseView* view )
 {
     m_views.removeChild( view );
     updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEclipseViewCollection::setEclipseCaseProvider( std::function<std::vector<RimEclipseCase*>()> provider )
+{
+    // Store the callback for future views
+    if ( provider )
+    {
+        m_eclipseCaseProvider = provider;
+    }
+    else
+    {
+        m_eclipseCaseProvider = nullptr;
+    }
+
+    // Apply the callback to all existing views in the collection
+    for ( auto view : m_views )
+    {
+        applyCallbackToView( view );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEclipseViewCollection::applyCallbackToView( RimEclipseView* view )
+{
+    if ( m_eclipseCaseProvider )
+    {
+        // Use the stored custom callback
+        view->setEclipseCaseProvider( m_eclipseCaseProvider );
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.h
@@ -24,6 +24,8 @@
 
 #include <QString>
 
+#include <functional>
+
 class RimEclipseView;
 class RimEclipseCase;
 
@@ -44,9 +46,14 @@ public:
 
     std::vector<RimEclipseView*> views() const;
 
+    void setEclipseCaseProvider( std::function<std::vector<RimEclipseCase*>()> provider = nullptr );
+
 private:
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
 
+    void applyCallbackToView( RimEclipseView* view );
+
 private:
-    caf::PdmChildArrayField<RimEclipseView*> m_views;
+    caf::PdmChildArrayField<RimEclipseView*>      m_views;
+    std::function<std::vector<RimEclipseCase*>()> m_eclipseCaseProvider;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
@@ -63,7 +63,7 @@ RimIdenticalGridCaseGroup::RimIdenticalGridCaseGroup()
     groupId.uiCapability()->setUiReadOnly( true );
     groupId.capability<caf::PdmAbstractFieldScriptingCapability>()->setIOWriteable( false );
 
-    CAF_PDM_InitFieldNoDefault( &statisticsCaseCollection, "StatisticsCaseCollection", "statisticsCaseCollection ChildArrayField" );
+    CAF_PDM_InitFieldNoDefault( &m_statisticsCaseCollection, "StatisticsCaseCollection", "statisticsCaseCollection ChildArrayField" );
 
     CAF_PDM_InitFieldNoDefault( &caseCollection, "CaseCollection", "Source Cases ChildArrayField" );
 
@@ -71,9 +71,9 @@ RimIdenticalGridCaseGroup::RimIdenticalGridCaseGroup()
     caseCollection->uiCapability()->setUiName( "Source Cases" );
     caseCollection->uiCapability()->setUiIconFromResourceString( ":/Cases16x16.png" );
 
-    statisticsCaseCollection = new RimCaseCollection;
-    statisticsCaseCollection->uiCapability()->setUiName( "Derived Statistics" );
-    statisticsCaseCollection->uiCapability()->setUiIconFromResourceString( ":/Histograms16x16.png" );
+    m_statisticsCaseCollection = new RimCaseCollection;
+    m_statisticsCaseCollection->uiCapability()->setUiName( "Derived Statistics" );
+    m_statisticsCaseCollection->uiCapability()->setUiIconFromResourceString( ":/Histograms16x16.png" );
 
     m_mainGrid = nullptr;
 
@@ -93,8 +93,8 @@ RimIdenticalGridCaseGroup::~RimIdenticalGridCaseGroup()
     delete caseCollection;
     caseCollection = nullptr;
 
-    delete statisticsCaseCollection;
-    statisticsCaseCollection = nullptr;
+    delete m_statisticsCaseCollection;
+    m_statisticsCaseCollection = nullptr;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -344,19 +344,35 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimEclipseStatisticsCase* RimIdenticalGridCaseGroup::createAndAppendStatisticsCase()
+RimEclipseStatisticsCase* RimIdenticalGridCaseGroup::createAndAppendEmptyStatisticsCase()
 {
-    bool selectDefaultResults = true;
-    return createStatisticsCase( selectDefaultResults );
+    auto* statsColl = statisticsCaseCollection();
+    if ( !statsColl ) return nullptr;
+
+    RimEclipseStatisticsCase* newStatisticsCase = new RimEclipseStatisticsCase;
+
+    newStatisticsCase->setCaseUserDescription( QString( "Statistics " ) + QString::number( statsColl->reservoirs.size() + 1 ) );
+    statsColl->reservoirs.push_back( newStatisticsCase );
+
+    auto cases = sourceCases();
+    if ( !cases.empty() )
+    {
+        newStatisticsCase->setWellDataSourceCase( cases.front() );
+    }
+
+    newStatisticsCase->openEclipseGridFile();
+    newStatisticsCase->computeActiveCellsBoundingBox();
+    newStatisticsCase->selectAllTimeSteps();
+
+    return newStatisticsCase;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimEclipseStatisticsCase* RimIdenticalGridCaseGroup::createAndAppendEmptyStatisticsCase()
+RimCaseCollection* RimIdenticalGridCaseGroup::statisticsCaseCollection() const
 {
-    bool selectDefaultResults = false;
-    return createStatisticsCase( selectDefaultResults );
+    return m_statisticsCaseCollection;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -364,9 +380,9 @@ RimEclipseStatisticsCase* RimIdenticalGridCaseGroup::createAndAppendEmptyStatist
 //--------------------------------------------------------------------------------------------------
 void RimIdenticalGridCaseGroup::updateMainGridAndActiveCellsForStatisticsCases()
 {
-    for ( size_t i = 0; i < statisticsCaseCollection->reservoirs().size(); i++ )
+    for ( size_t i = 0; i < m_statisticsCaseCollection->reservoirs().size(); i++ )
     {
-        RimEclipseCase* rimStaticsCase = statisticsCaseCollection->reservoirs[i];
+        RimEclipseCase* rimStaticsCase = m_statisticsCaseCollection->reservoirs[i];
 
         if ( rimStaticsCase->eclipseCaseData() )
         {
@@ -385,9 +401,9 @@ void RimIdenticalGridCaseGroup::updateMainGridAndActiveCellsForStatisticsCases()
 //--------------------------------------------------------------------------------------------------
 void RimIdenticalGridCaseGroup::clearStatisticsResults()
 {
-    for ( size_t i = 0; i < statisticsCaseCollection->reservoirs().size(); i++ )
+    for ( size_t i = 0; i < m_statisticsCaseCollection->reservoirs().size(); i++ )
     {
-        RimEclipseCase* rimStaticsCase = statisticsCaseCollection->reservoirs[i];
+        RimEclipseCase* rimStaticsCase = m_statisticsCaseCollection->reservoirs[i];
         if ( !rimStaticsCase ) continue;
 
         if ( rimStaticsCase->results( RiaDefines::PorosityModelType::MATRIX_MODEL ) )
@@ -417,32 +433,6 @@ void RimIdenticalGridCaseGroup::clearActiveCellUnions()
 {
     m_unionOfMatrixActiveCells->clear();
     m_unionOfFractureActiveCells->clear();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RimEclipseStatisticsCase* RimIdenticalGridCaseGroup::createStatisticsCase( bool selectDefaultResults )
-{
-    RimEclipseStatisticsCase* newStatisticsCase = new RimEclipseStatisticsCase;
-
-    newStatisticsCase->setCaseUserDescription( QString( "Statistics " ) + QString::number( statisticsCaseCollection()->reservoirs.size() + 1 ) );
-    statisticsCaseCollection()->reservoirs.push_back( newStatisticsCase );
-
-    if ( selectDefaultResults ) newStatisticsCase->populateResultSelectionAfterLoadingGrid();
-
-    auto reservoirs = caseCollection->reservoirs().childrenByType();
-    if ( !reservoirs.empty() )
-    {
-        auto caseDescription = reservoirs.front()->caseUserDescription();
-        newStatisticsCase->setWellDataSourceCase( caseDescription );
-    }
-
-    newStatisticsCase->openEclipseGridFile();
-    newStatisticsCase->computeActiveCellsBoundingBox();
-    newStatisticsCase->selectAllTimeSteps();
-
-    return newStatisticsCase;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -509,4 +499,12 @@ RimEclipseCase* RimIdenticalGridCaseGroup::mainCase()
     {
         return nullptr;
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimEclipseCase*> RimIdenticalGridCaseGroup::sourceCases() const
+{
+    return caseCollection->reservoirs.childrenByType();
 }

--- a/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.h
+++ b/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "RiaPorosityModel.h"
+#include "RimReservoirGridEnsembleBase.h"
 
 #include "cafPdmChildField.h"
 #include "cafPdmField.h"
@@ -40,7 +41,7 @@ class RimEclipseStatisticsCase;
 //
 //
 //==================================================================================================
-class RimIdenticalGridCaseGroup : public caf::PdmObject
+class RimIdenticalGridCaseGroup : public caf::PdmObject, public RimReservoirGridEnsembleBase
 {
     CAF_PDM_HEADER_INIT;
 
@@ -51,23 +52,24 @@ public:
     caf::PdmField<QString>                 name;
     caf::PdmField<int>                     groupId;
     caf::PdmChildField<RimCaseCollection*> caseCollection;
-    caf::PdmChildField<RimCaseCollection*> statisticsCaseCollection;
 
     void addCase( RimEclipseCase* reservoir );
     void removeCase( RimEclipseCase* reservoir );
 
     bool contains( RimEclipseCase* reservoir ) const;
 
-    RimEclipseStatisticsCase* createAndAppendStatisticsCase();
     RimEclipseStatisticsCase* createAndAppendEmptyStatisticsCase();
 
-    RimEclipseCase* mainCase();
-    void            loadMainCaseAndActiveCellInfo();
+    RimEclipseCase*    mainCase() override;
+    RimCaseCollection* statisticsCaseCollection() const override;
+    void               loadMainCaseAndActiveCellInfo();
 
-    RigMainGrid* mainGrid();
+    RigMainGrid* mainGrid() override;
 
-    RigActiveCellInfo* unionOfActiveCells( RiaDefines::PorosityModelType porosityType );
-    void               computeUnionOfActiveCells();
+    std::vector<RimEclipseCase*> sourceCases() const override;
+
+    RigActiveCellInfo* unionOfActiveCells( RiaDefines::PorosityModelType porosityType ) override;
+    void               computeUnionOfActiveCells() override;
 
     static bool isStatisticsCaseCollection( RimCaseCollection* rimCaseCollection );
 
@@ -79,9 +81,9 @@ private:
     void clearStatisticsResults();
     void clearActiveCellUnions();
 
-    RimEclipseStatisticsCase* createStatisticsCase( bool selectDefaultResults );
-
 private:
+    caf::PdmChildField<RimCaseCollection*> m_statisticsCaseCollection;
+
     RigMainGrid* m_mainGrid;
 
     cvf::ref<RigActiveCellInfo> m_unionOfMatrixActiveCells;

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -75,6 +75,7 @@
 #include "RimPlotWindow.h"
 #include "RimPltPlotCollection.h"
 #include "RimPolylinesFromFileAnnotation.h"
+#include "RimReservoirGridEnsemble.h"
 #include "RimRftPlotCollection.h"
 #include "RimSaturationPressurePlotCollection.h"
 #include "RimScriptCollection.h"
@@ -713,6 +714,30 @@ void RimProject::assignIdToCaseGroup( RimIdenticalGridCaseGroup* caseGroup )
         }
 
         caseGroup->groupId = m_nextValidCaseGroupId++;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimProject::assignIdToCaseGroup( RimReservoirGridEnsemble* gridEnsemble )
+{
+    if ( gridEnsemble )
+    {
+        std::vector<RimIdenticalGridCaseGroup*> identicalCaseGroups = descendantsIncludingThisOfType<RimIdenticalGridCaseGroup>();
+        std::vector<RimReservoirGridEnsemble*>  gridEnsembles       = descendantsIncludingThisOfType<RimReservoirGridEnsemble>();
+
+        for ( RimIdenticalGridCaseGroup* existingCaseGroup : identicalCaseGroups )
+        {
+            m_nextValidCaseGroupId = std::max( m_nextValidCaseGroupId, existingCaseGroup->groupId() + 1 );
+        }
+
+        for ( RimReservoirGridEnsemble* existingEnsemble : gridEnsembles )
+        {
+            m_nextValidCaseGroupId = std::max( m_nextValidCaseGroupId, existingEnsemble->groupId() + 1 );
+        }
+
+        gridEnsemble->setGroupId( m_nextValidCaseGroupId++ );
     }
 }
 
@@ -1507,6 +1532,7 @@ void RimProject::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, Q
         {
             if ( oilField->analysisModels() ) uiTreeOrdering.add( oilField->analysisModels() );
         }
+        uiTreeOrdering.add( &m_ensembleFileSetCollection );
     }
     else
     {

--- a/ApplicationLibCode/ProjectDataModel/RimProject.h
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.h
@@ -46,6 +46,7 @@ class RimEclipseCase;
 class RimGeoMechCase;
 class RimIdenticalGridCaseGroup;
 class RimMainPlotCollection;
+class RimReservoirGridEnsemble;
 class RimMeasurement;
 class RimAdvancedSnapshotExportDefinition;
 class RimObservedSummaryData;
@@ -125,6 +126,7 @@ public:
 
     void assignCaseIdToCase( RimCase* reservoirCase );
     void assignIdToCaseGroup( RimIdenticalGridCaseGroup* caseGroup );
+    void assignIdToCaseGroup( RimReservoirGridEnsemble* gridEnsemble );
     void assignViewIdToView( Rim3dView* view );
     void assignPlotIdToPlotWindow( RimPlotWindow* plotWindow );
     void assignCaseIdToSummaryCase( RimSummaryCase* summaryCase );

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -1,0 +1,865 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimReservoirGridEnsemble.h"
+
+#include "RiaLogging.h"
+#include "RiaResultNames.h"
+
+#include "RifReaderOpmCommon.h"
+#include "RigActiveCellInfo.h"
+#include "RigEclipseCaseData.h"
+#include "RigGridBase.h"
+#include "RigGridManager.h"
+#include "RigMainGrid.h"
+
+#include "ContourMap/RimStatisticsContourMap.h"
+#include "ContourMap/RimStatisticsContourMapView.h"
+#include "EnsembleFileSet/RimEnsembleFileSet.h"
+#include "RimCaseCollection.h"
+#include "RimEclipseCase.h"
+#include "RimEclipseCellColors.h"
+#include "RimEclipseResultCase.h"
+#include "RimEclipseStatisticsCase.h"
+#include "RimEclipseView.h"
+#include "RimEclipseViewCollection.h"
+#include "RimProject.h"
+#include "RimWellTargetMapping.h"
+
+#include "cafCmdFeatureMenuBuilder.h"
+#include "cafPdmFieldScriptingCapability.h"
+#include "cafPdmObjectScriptingCapability.h"
+#include "cafProgressInfo.h"
+
+#include "RigCaseCellResultsData.h"
+
+CAF_PDM_SOURCE_INIT( RimReservoirGridEnsemble, "RimReservoirGridEnsemble" );
+
+namespace caf
+{
+template <>
+void caf::AppEnum<RimReservoirGridEnsemble::GridModeType>::setUp()
+{
+    addItem( RimReservoirGridEnsemble::GridModeType::AUTO_DETECT, "AutoDetect", "Auto Detect" );
+    addItem( RimReservoirGridEnsemble::GridModeType::SHARED_GRID, "SharedGrid", "Shared Grid" );
+    addItem( RimReservoirGridEnsemble::GridModeType::INDIVIDUAL_GRIDS, "IndividualGrids", "Individual Grids" );
+    setDefault( RimReservoirGridEnsemble::GridModeType::AUTO_DETECT );
+}
+} // namespace caf
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimReservoirGridEnsemble::RimReservoirGridEnsemble()
+    : m_mainGrid( nullptr )
+{
+    CAF_PDM_InitScriptableObjectWithNameAndComment( "Reservoir Grid Ensemble",
+                                                    ":/GridCaseGroup16x16.png",
+                                                    "",
+                                                    "",
+                                                    "ReservoirGridEnsemble",
+                                                    "Grid Ensemble from File Set" );
+
+    CAF_PDM_InitScriptableField( &m_groupId, "GroupId", -1, "Ensemble ID" );
+    m_groupId.uiCapability()->setUiReadOnly( true );
+    m_groupId.capability<caf::PdmAbstractFieldScriptingCapability>()->setIOWriteable( false );
+
+    CAF_PDM_InitFieldNoDefault( &m_ensembleFileSet, "EnsembleFileSet", "Ensemble File Set" );
+    m_ensembleFileSet.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitField( &m_gridMode, "GridMode", GridModeType::AUTO_DETECT, "Grid Mode" );
+
+    CAF_PDM_InitFieldNoDefault( &m_caseCollection, "CaseCollection", "Source Cases" );
+    m_caseCollection = new RimCaseCollection;
+    m_caseCollection->uiCapability()->setUiName( "Realizations" );
+    m_caseCollection->uiCapability()->setUiIconFromResourceString( ":/Cases16x16.png" );
+    m_caseCollection.xmlCapability()->disableIO();
+
+    CAF_PDM_InitFieldNoDefault( &m_statisticsCaseCollection, "StatisticsCaseCollection", "Statistics Cases" );
+    m_statisticsCaseCollection = new RimCaseCollection;
+    m_statisticsCaseCollection->uiCapability()->setUiName( "Derived Statistics" );
+    m_statisticsCaseCollection->uiCapability()->setUiIconFromResourceString( ":/Histograms16x16.png" );
+
+    CAF_PDM_InitFieldNoDefault( &m_viewCollection, "ViewCollection", "Views" );
+    m_viewCollection = new RimEclipseViewCollection;
+    m_viewCollection->setEclipseCaseProvider( [this]() { return this->cases(); } );
+
+    CAF_PDM_InitFieldNoDefault( &m_wellTargetMappings, "WellTargetMappings", "Well Target Mappings" );
+    CAF_PDM_InitFieldNoDefault( &m_statisticsContourMaps, "StatisticsContourMaps", "Statistics Contour Maps" );
+
+    m_unionOfMatrixActiveCells   = new RigActiveCellInfo;
+    m_unionOfFractureActiveCells = new RigActiveCellInfo;
+
+    setDeletable( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+int RimReservoirGridEnsemble::groupId() const
+{
+    return m_groupId;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::setGroupId( int id )
+{
+    m_groupId = id;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::setEnsembleFileSet( RimEnsembleFileSet* ensembleFileSet )
+{
+    if ( m_ensembleFileSet )
+    {
+        m_ensembleFileSet->fileSetChanged.disconnect( this );
+        m_ensembleFileSet->nameChanged.disconnect( this );
+    }
+
+    m_ensembleFileSet = ensembleFileSet;
+
+    if ( m_ensembleFileSet )
+    {
+        m_ensembleFileSet->fileSetChanged.connect( this, &RimReservoirGridEnsemble::onFileSetChanged );
+        m_ensembleFileSet->nameChanged.connect( this,
+                                                [this]( const caf::SignalEmitter* )
+                                                {
+                                                    if ( m_ensembleFileSet ) setName( m_ensembleFileSet->name() );
+                                                } );
+        setName( m_ensembleFileSet->name() );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEnsembleFileSet* RimReservoirGridEnsemble::ensembleFileSet() const
+{
+    return m_ensembleFileSet;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::addCase( RimEclipseCase* reservoir )
+{
+    CVF_ASSERT( reservoir );
+
+    if ( !m_mainGrid && reservoir->eclipseCaseData() )
+    {
+        m_mainGrid = reservoir->eclipseCaseData()->mainGrid();
+    }
+    else if ( hasSharedGrid() && reservoir->eclipseCaseData() )
+    {
+        // Share the main grid for identical grids
+        reservoir->eclipseCaseData()->setMainGrid( m_mainGrid );
+    }
+
+    m_caseCollection()->reservoirs().push_back( reservoir );
+
+    clearActiveCellUnions();
+    clearStatisticsResults();
+    updateMainGridAndActiveCellsForStatisticsCases();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::removeCase( RimEclipseCase* reservoir )
+{
+    if ( m_caseCollection()->reservoirs().count( reservoir ) == 0 ) return;
+
+    m_caseCollection()->reservoirs().removeChild( reservoir );
+
+    if ( m_caseCollection()->reservoirs().empty() )
+    {
+        m_mainGrid = nullptr;
+    }
+
+    clearActiveCellUnions();
+    clearStatisticsResults();
+    updateMainGridAndActiveCellsForStatisticsCases();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimReservoirGridEnsemble::contains( RimEclipseCase* reservoir ) const
+{
+    CVF_ASSERT( reservoir );
+
+    for ( RimEclipseCase* rimReservoir : cases() )
+    {
+        if ( reservoir->gridFileName() == rimReservoir->gridFileName() ) return true;
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimEclipseCase*> RimReservoirGridEnsemble::cases() const
+{
+    if ( !m_caseCollection ) return {};
+
+    return m_caseCollection->reservoirs.childrenByType();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseCase* RimReservoirGridEnsemble::mainCase()
+{
+    if ( !m_caseCollection()->reservoirs().empty() )
+    {
+        return m_caseCollection()->reservoirs()[0];
+    }
+    return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimEclipseCase*> RimReservoirGridEnsemble::sourceCases() const
+{
+    return cases();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseCase* RimReservoirGridEnsemble::findByFileName( const QString& gridFileName ) const
+{
+    for ( RimEclipseCase* rimReservoir : cases() )
+    {
+        if ( gridFileName == rimReservoir->gridFileName() ) return rimReservoir;
+    }
+
+    return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimReservoirGridEnsemble::hasSharedGrid() const
+{
+    return m_gridMode.v() == GridModeType::SHARED_GRID;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimReservoirGridEnsemble::isGridDataLoaded() const
+{
+    return m_mainGrid != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimReservoirGridEnsemble::GridModeType RimReservoirGridEnsemble::effectiveGridMode() const
+{
+    return m_gridMode.v();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::setGridMode( GridModeType mode )
+{
+    m_gridMode = mode;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RigMainGrid* RimReservoirGridEnsemble::mainGrid()
+{
+    // Trigger deferred loading if needed
+    if ( !m_mainGrid && !cases().empty() )
+    {
+        const_cast<RimReservoirGridEnsemble*>( this )->loadGridDataFromFiles();
+    }
+
+    return m_mainGrid;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::setupSharedGrid()
+{
+    if ( !hasSharedGrid() ) return;
+
+    auto allCases = cases();
+    if ( allCases.empty() ) return;
+
+    // Use the first case's grid as the shared grid
+    RimEclipseCase* firstCase = allCases[0];
+    if ( !firstCase || !firstCase->eclipseCaseData() ) return;
+
+    m_mainGrid = firstCase->eclipseCaseData()->mainGrid();
+
+    // Set the shared grid on all other cases
+    for ( size_t i = 1; i < allCases.size(); i++ )
+    {
+        if ( allCases[i] && allCases[i]->eclipseCaseData() )
+        {
+            allCases[i]->eclipseCaseData()->setMainGrid( m_mainGrid );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RigActiveCellInfo* RimReservoirGridEnsemble::unionOfActiveCells( RiaDefines::PorosityModelType porosityType )
+{
+    if ( porosityType == RiaDefines::PorosityModelType::MATRIX_MODEL )
+    {
+        return m_unionOfMatrixActiveCells.p();
+    }
+    else
+    {
+        return m_unionOfFractureActiveCells.p();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::computeUnionOfActiveCells()
+{
+    if ( !hasSharedGrid() ) return;
+
+    if ( m_unionOfMatrixActiveCells->reservoirActiveCellCount() > 0 )
+    {
+        return;
+    }
+
+    if ( m_caseCollection->reservoirs.empty() || !m_mainGrid )
+    {
+        clearActiveCellUnions();
+        return;
+    }
+
+    m_unionOfMatrixActiveCells->setReservoirCellCount( m_mainGrid->totalCellCount() );
+    m_unionOfFractureActiveCells->setReservoirCellCount( m_mainGrid->totalCellCount() );
+    m_unionOfMatrixActiveCells->setGridCount( m_mainGrid->gridCount() );
+    m_unionOfFractureActiveCells->setGridCount( m_mainGrid->gridCount() );
+
+    size_t globalActiveMatrixIndex   = 0;
+    size_t globalActiveFractureIndex = 0;
+
+    for ( size_t gridIdx = 0; gridIdx < m_mainGrid->gridCount(); gridIdx++ )
+    {
+        RigGridBase* grid = m_mainGrid->gridByIndex( gridIdx );
+
+        std::vector<char> activeM( grid->cellCount(), 0 );
+        std::vector<char> activeF( grid->cellCount(), 0 );
+
+        for ( size_t gridLocalCellIndex = 0; gridLocalCellIndex < grid->cellCount(); gridLocalCellIndex++ )
+        {
+            for ( size_t caseIdx = 0; caseIdx < m_caseCollection->reservoirs.size(); caseIdx++ )
+            {
+                size_t reservoirCellIndex = grid->reservoirCellIndex( gridLocalCellIndex );
+
+                if ( activeM[gridLocalCellIndex] == 0 )
+                {
+                    if ( m_caseCollection->reservoirs[caseIdx]
+                             ->eclipseCaseData()
+                             ->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL )
+                             ->isActive( reservoirCellIndex ) )
+                    {
+                        activeM[gridLocalCellIndex] = 1;
+                    }
+                }
+
+                if ( activeF[gridLocalCellIndex] == 0 )
+                {
+                    if ( m_caseCollection->reservoirs[caseIdx]
+                             ->eclipseCaseData()
+                             ->activeCellInfo( RiaDefines::PorosityModelType::FRACTURE_MODEL )
+                             ->isActive( reservoirCellIndex ) )
+                    {
+                        activeF[gridLocalCellIndex] = 1;
+                    }
+                }
+            }
+        }
+
+        size_t activeMatrixIndex   = 0;
+        size_t activeFractureIndex = 0;
+
+        for ( size_t gridLocalCellIndex = 0; gridLocalCellIndex < grid->cellCount(); gridLocalCellIndex++ )
+        {
+            size_t reservoirCellIndex = grid->reservoirCellIndex( gridLocalCellIndex );
+
+            if ( activeM[gridLocalCellIndex] != 0 )
+            {
+                m_unionOfMatrixActiveCells->setCellResultIndex( reservoirCellIndex, globalActiveMatrixIndex++ );
+                activeMatrixIndex++;
+            }
+
+            if ( activeF[gridLocalCellIndex] != 0 )
+            {
+                m_unionOfFractureActiveCells->setCellResultIndex( reservoirCellIndex, globalActiveFractureIndex++ );
+                activeFractureIndex++;
+            }
+        }
+
+        m_unionOfMatrixActiveCells->setGridActiveCellCounts( gridIdx, activeMatrixIndex );
+        m_unionOfFractureActiveCells->setGridActiveCellCounts( gridIdx, activeFractureIndex );
+    }
+
+    m_unionOfMatrixActiveCells->computeDerivedData();
+    m_unionOfFractureActiveCells->computeDerivedData();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimCaseCollection* RimReservoirGridEnsemble::statisticsCaseCollection() const
+{
+    return m_statisticsCaseCollection;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseStatisticsCase* RimReservoirGridEnsemble::createAndAppendStatisticsCase()
+{
+    if ( !hasSharedGrid() )
+    {
+        RiaLogging::warning( QString( "Cannot create statistics case for ensemble '%1': grids are not identical." ).arg( name() ) );
+        return nullptr;
+    }
+
+    return RimReservoirGridEnsembleBase::createAndAppendStatisticsCase();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::addView( RimEclipseView* view )
+{
+    m_viewCollection->addView( view );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseView* RimReservoirGridEnsemble::addViewForCase( RimEclipseCase* eclipseCase )
+{
+    return m_viewCollection->addView( eclipseCase );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimEclipseView*> RimReservoirGridEnsemble::allViews() const
+{
+    std::vector<RimEclipseView*> views;
+
+    for ( auto view : m_viewCollection->views() )
+    {
+        views.push_back( view );
+    }
+
+    for ( auto statCase : m_statisticsCaseCollection->reservoirs() )
+    {
+        for ( auto view : statCase->reservoirViews() )
+        {
+            views.push_back( view );
+        }
+    }
+
+    for ( auto cmap : m_statisticsContourMaps )
+    {
+        for ( auto view : cmap->views() )
+        {
+            views.push_back( view );
+        }
+    }
+
+    return views;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::set<RimEclipseCase*> RimReservoirGridEnsemble::casesInViews() const
+{
+    if ( !m_caseCollection ) return {};
+    if ( !m_viewCollection || m_viewCollection->isEmpty() ) return {};
+
+    std::set<RimEclipseCase*> retCases;
+
+    for ( auto view : m_viewCollection->views() )
+    {
+        if ( view->eclipseCase() != nullptr ) retCases.insert( view->eclipseCase() );
+    }
+
+    return retCases;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::addWellTargetMapping( RimWellTargetMapping* wellTargetMapping )
+{
+    m_wellTargetMappings.push_back( wellTargetMapping );
+    wellTargetMapping->updateResultDefinition();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimWellTargetMapping*> RimReservoirGridEnsemble::wellTargetMappings() const
+{
+    return m_wellTargetMappings.childrenByType();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::addStatisticsContourMap( RimStatisticsContourMap* statisticsContourMap )
+{
+    m_statisticsContourMaps.push_back( statisticsContourMap );
+    statisticsContourMap->setName( QString( "Ensemble Contour Map #%1" ).arg( m_statisticsContourMaps.size() ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::loadDataAndUpdate()
+{
+    if ( !isGridDataLoaded() )
+    {
+        loadGridDataFromFiles();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::createGridCasesFromEnsembleFileSet()
+{
+    if ( !m_ensembleFileSet ) return;
+
+    // Clear existing cases and statistics
+    m_caseCollection->reservoirs.deleteChildren();
+    m_statisticsCaseCollection->reservoirs.deleteChildren();
+    m_mainGrid = nullptr;
+    clearActiveCellUnions();
+
+    // Create case objects without loading grids
+    createCaseObjectsFromEnsembleFileSet();
+
+    updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicNewViewForGridEnsembleFeature";
+    menuBuilder << "RicNewStatisticsContourMapFeature";
+
+    if ( hasSharedGrid() )
+    {
+        menuBuilder << "RicNewStatisticsCaseFeature";
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    uiOrdering.add( nameField() );
+    uiOrdering.add( &m_groupId );
+    uiOrdering.add( &m_ensembleFileSet );
+    uiOrdering.add( &m_gridMode );
+
+    uiOrdering.skipRemainingFields();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::initAfterRead()
+{
+    if ( m_ensembleFileSet )
+    {
+        m_ensembleFileSet->fileSetChanged.connect( this, &RimReservoirGridEnsemble::onFileSetChanged );
+        m_ensembleFileSet->nameChanged.connect( this,
+                                                [this]( const caf::SignalEmitter* )
+                                                {
+                                                    if ( m_ensembleFileSet ) setName( m_ensembleFileSet->name() );
+                                                } );
+
+        // Create case objects WITHOUT loading grid data (deferred loading)
+        if ( m_caseCollection && m_caseCollection->reservoirs().empty() )
+        {
+            createCaseObjectsFromEnsembleFileSet();
+        }
+
+        // NB! This code must be run AFTER the grid case objects are created.
+        for ( auto view : m_viewCollection->views() )
+        {
+            if ( view )
+            {
+                // Resolve the grid case reference for the view after grids are loaded
+                view->resolveReferencesRecursively();
+
+                // Propagate the eclipse case to child objects to ensure all references are updated. setEclipseCase() calls
+                // propagateEclipseCaseToChildObjects() internally, but we need to call it here to ensure propagation after loading and
+                // reference resolution.
+                auto eclipseCase = view->eclipseCase();
+                view->setEclipseCase( eclipseCase );
+            }
+        }
+    }
+
+    // Set the case provider for views in the view collection
+    if ( m_viewCollection )
+    {
+        m_viewCollection->setEclipseCaseProvider( [this]() { return this->cases(); } );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::onFileSetChanged( const caf::SignalEmitter* emitter )
+{
+    createGridCasesFromEnsembleFileSet();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::clearActiveCellUnions()
+{
+    m_unionOfMatrixActiveCells->clear();
+    m_unionOfFractureActiveCells->clear();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::clearStatisticsResults()
+{
+    for ( size_t i = 0; i < m_statisticsCaseCollection->reservoirs().size(); i++ )
+    {
+        RimEclipseCase* rimStaticsCase = m_statisticsCaseCollection->reservoirs[i];
+        if ( !rimStaticsCase ) continue;
+
+        if ( rimStaticsCase->results( RiaDefines::PorosityModelType::MATRIX_MODEL ) )
+        {
+            rimStaticsCase->results( RiaDefines::PorosityModelType::MATRIX_MODEL )->clearAllResults();
+        }
+        if ( rimStaticsCase->results( RiaDefines::PorosityModelType::FRACTURE_MODEL ) )
+        {
+            rimStaticsCase->results( RiaDefines::PorosityModelType::FRACTURE_MODEL )->clearAllResults();
+        }
+
+        auto views = rimStaticsCase->reservoirViews();
+        for ( size_t j = 0; j < views.size(); j++ )
+        {
+            RimEclipseView* rimReservoirView = views[j];
+            rimReservoirView->cellResult()->setResultVariable( RiaResultNames::undefinedResultName() );
+            rimReservoirView->loadDataAndUpdate();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::updateMainGridAndActiveCellsForStatisticsCases()
+{
+    for ( size_t i = 0; i < m_statisticsCaseCollection->reservoirs().size(); i++ )
+    {
+        RimEclipseCase* rimStaticsCase = m_statisticsCaseCollection->reservoirs[i];
+
+        if ( rimStaticsCase->eclipseCaseData() )
+        {
+            rimStaticsCase->eclipseCaseData()->setMainGrid( mainGrid() );
+
+            if ( i == 0 )
+            {
+                rimStaticsCase->computeActiveCellsBoundingBox();
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::createCaseObjectsFromEnsembleFileSet()
+{
+    if ( !m_ensembleFileSet ) return;
+
+    // Get grid file paths from the file set
+    QStringList gridFiles = m_ensembleFileSet->createPaths( ".EGRID" );
+    if ( gridFiles.empty() )
+    {
+        // Try .GRID extension
+        gridFiles = m_ensembleFileSet->createPaths( ".GRID" );
+    }
+
+    if ( gridFiles.empty() )
+    {
+        RiaLogging::warning( QString( "No grid files found for ensemble '%1'" ).arg( name() ) );
+        return;
+    }
+
+    // Create case objects without loading grids
+    for ( const QString& gridFile : gridFiles )
+    {
+        RimEclipseResultCase* resultCase = new RimEclipseResultCase();
+        resultCase->setGridFileName( gridFile );
+        // DO NOT call openEclipseGridFile() here - deferred loading
+
+        RimProject::current()->assignCaseIdToCase( resultCase );
+        m_caseCollection->reservoirs().push_back( resultCase );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::loadGridDataFromFiles()
+{
+    // Guard: Only load once
+    if ( m_mainGrid != nullptr ) return;
+
+    auto allCases = cases();
+    if ( allCases.empty() ) return;
+
+    // Determine effective grid mode
+    GridModeType effectiveMode = m_gridMode.v();
+
+    if ( effectiveMode == GridModeType::AUTO_DETECT )
+    {
+        // Run dimension detection
+        bool identical = detectGridDimensionEquality();
+        effectiveMode  = identical ? GridModeType::SHARED_GRID : GridModeType::INDIVIDUAL_GRIDS;
+        m_gridMode     = effectiveMode; // Update to detected mode
+    }
+
+    // Load grids based on effective mode
+    if ( effectiveMode == GridModeType::SHARED_GRID )
+    {
+        loadGridsInSharedMode();
+    }
+    else
+    {
+        // TODO: Probably not needed load grids here, they are loaded on demand in individual mode
+        // loadGridsInIndividualMode();
+    }
+
+    updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimReservoirGridEnsemble::detectGridDimensionEquality()
+{
+    auto allCases = cases();
+    if ( allCases.size() < 2 ) return true;
+
+    RifReaderOpmCommon::GridDimensions firstDim;
+
+    for ( int i = 0; i < static_cast<int>( allCases.size() ); i++ )
+    {
+        auto dim = RifReaderOpmCommon::readGridDimensions( allCases[i]->gridFileName() );
+
+        if ( i == 0 )
+        {
+            firstDim = dim;
+        }
+        else if ( dim.i != firstDim.i || dim.j != firstDim.j || dim.k != firstDim.k )
+        {
+            return false; // Different dimensions
+        }
+    }
+
+    return true; // All dimensions identical
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::loadGridsInSharedMode()
+{
+    auto allCases = cases();
+
+    RiaLogging::info( QString( "Grid ensemble '%1': Loading grid in shared mode for %2 cases." ).arg( name() ).arg( allCases.size() ) );
+
+    // Load first case fully
+    RimEclipseCase* firstCase = allCases[0];
+    if ( firstCase->openEclipseGridFile() )
+    {
+        m_mainGrid = firstCase->eclipseCaseData()->mainGrid();
+
+        // Load remaining cases and share grid
+        for ( size_t i = 1; i < allCases.size(); i++ )
+        {
+            RimEclipseCase* eclipseCase = allCases[i];
+            if ( auto resultCase = dynamic_cast<RimEclipseResultCase*>( eclipseCase ) )
+            {
+                resultCase->openAndReadActiveCellData( firstCase->eclipseCaseData() );
+            }
+            eclipseCase->eclipseCaseData()->setMainGrid( m_mainGrid );
+        }
+
+        computeUnionOfActiveCells();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::loadGridsInIndividualMode()
+{
+    auto allCases = cases();
+
+    RiaLogging::info( QString( "Grid ensemble '%1': Loading grids in individual mode for %2 cases." ).arg( name() ).arg( allCases.size() ) );
+
+    for ( auto eclipseCase : allCases )
+    {
+        eclipseCase->openEclipseGridFile();
+    }
+
+    // Store first grid as reference
+    if ( !allCases.empty() && allCases[0]->eclipseCaseData() )
+    {
+        m_mainGrid = allCases[0]->eclipseCaseData()->mainGrid();
+    }
+}

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.h
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.h
@@ -1,0 +1,163 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RiaPorosityModel.h"
+#include "RimNamedObject.h"
+#include "RimReservoirGridEnsembleBase.h"
+
+#include "cafAppEnum.h"
+#include "cafPdmChildArrayField.h"
+#include "cafPdmChildField.h"
+#include "cafPdmField.h"
+#include "cafPdmPtrField.h"
+
+#include "cvfObject.h"
+
+#include <set>
+
+class RigActiveCellInfo;
+class RigMainGrid;
+class RimCaseCollection;
+class RimEclipseCase;
+class RimEclipseStatisticsCase;
+class RimEclipseView;
+class RimEclipseViewCollection;
+class RimEnsembleFileSet;
+class RimStatisticsContourMap;
+class RimWellTargetMapping;
+
+//==================================================================================================
+///
+/// RimReservoirGridEnsemble - Grid ensemble created from an RimEnsembleFileSet
+///
+/// This class creates and manages grid cases from an ensemble file set pattern. It detects
+/// whether all grids have identical geometry and enables shared grid operations (statistics,
+/// shared main grid) when they do.
+///
+//==================================================================================================
+class RimReservoirGridEnsemble : public RimNamedObject, public RimReservoirGridEnsembleBase
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    enum class GridModeType
+    {
+        AUTO_DETECT,
+        SHARED_GRID,
+        INDIVIDUAL_GRIDS
+    };
+
+    RimReservoirGridEnsemble();
+
+    // Ensemble file set connection
+    void                setEnsembleFileSet( RimEnsembleFileSet* ensembleFileSet );
+    RimEnsembleFileSet* ensembleFileSet() const;
+
+    // Group ID
+    int  groupId() const;
+    void setGroupId( int id );
+
+    // Case management
+    void                         addCase( RimEclipseCase* reservoir );
+    void                         removeCase( RimEclipseCase* reservoir );
+    bool                         contains( RimEclipseCase* reservoir ) const;
+    std::vector<RimEclipseCase*> cases() const;
+    RimEclipseCase*              mainCase() override;
+    std::vector<RimEclipseCase*> sourceCases() const override;
+    RimEclipseCase*              findByFileName( const QString& gridFileName ) const;
+
+    // Grid detection and shared grid
+    RigMainGrid* mainGrid() override;
+    void         setupSharedGrid();
+
+    // Deferred loading control
+    void loadGridDataFromFiles();
+    bool isGridDataLoaded() const;
+    void setGridMode( GridModeType mode );
+
+    // Helper methods
+    bool         hasSharedGrid() const;
+    GridModeType effectiveGridMode() const;
+
+    // Active cells
+    RigActiveCellInfo* unionOfActiveCells( RiaDefines::PorosityModelType porosityType ) override;
+    void               computeUnionOfActiveCells() override;
+
+    // Statistics
+    RimCaseCollection*        statisticsCaseCollection() const override;
+    RimEclipseStatisticsCase* createAndAppendStatisticsCase() override;
+
+    // Views
+    void                         addView( RimEclipseView* view );
+    RimEclipseView*              addViewForCase( RimEclipseCase* eclipseCase );
+    std::vector<RimEclipseView*> allViews() const;
+    std::set<RimEclipseCase*>    casesInViews() const;
+
+    // Well target mapping
+    void                               addWellTargetMapping( RimWellTargetMapping* wellTargetMapping );
+    std::vector<RimWellTargetMapping*> wellTargetMappings() const;
+
+    // Statistics contour maps
+    void addStatisticsContourMap( RimStatisticsContourMap* statisticsContourMap );
+
+    // Load and initialization
+    void loadDataAndUpdate();
+    void createGridCasesFromEnsembleFileSet();
+
+protected:
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+    void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+    void initAfterRead() override;
+
+private:
+    void onFileSetChanged( const caf::SignalEmitter* emitter );
+    void clearActiveCellUnions();
+    void clearStatisticsResults();
+    void updateMainGridAndActiveCellsForStatisticsCases();
+
+    void createCaseObjectsFromEnsembleFileSet();
+    bool detectGridDimensionEquality();
+    void loadGridsInSharedMode();
+    void loadGridsInIndividualMode();
+
+private:
+    // File set reference
+    caf::PdmPtrField<RimEnsembleFileSet*> m_ensembleFileSet;
+
+    // Ensemble id
+    caf::PdmField<int> m_groupId;
+
+    // Cases
+    caf::PdmChildField<RimCaseCollection*> m_caseCollection;
+    caf::PdmChildField<RimCaseCollection*> m_statisticsCaseCollection;
+
+    // Grid mode
+    caf::PdmField<caf::AppEnum<GridModeType>> m_gridMode;
+
+    // Views and mappings
+    caf::PdmChildField<RimEclipseViewCollection*>     m_viewCollection;
+    caf::PdmChildArrayField<RimWellTargetMapping*>    m_wellTargetMappings;
+    caf::PdmChildArrayField<RimStatisticsContourMap*> m_statisticsContourMaps;
+
+    // Shared grid data (for identical grids)
+    RigMainGrid*                m_mainGrid;
+    cvf::ref<RigActiveCellInfo> m_unionOfMatrixActiveCells;
+    cvf::ref<RigActiveCellInfo> m_unionOfFractureActiveCells;
+};

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsembleBase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsembleBase.cpp
@@ -1,0 +1,50 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimReservoirGridEnsembleBase.h"
+
+#include "RimCaseCollection.h"
+#include "RimEclipseStatisticsCase.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseStatisticsCase* RimReservoirGridEnsembleBase::createAndAppendStatisticsCase()
+{
+    auto* statsColl = statisticsCaseCollection();
+    if ( !statsColl ) return nullptr;
+
+    RimEclipseStatisticsCase* newStatisticsCase = new RimEclipseStatisticsCase;
+
+    newStatisticsCase->setCaseUserDescription( QString( "Statistics " ) + QString::number( statsColl->reservoirs.size() + 1 ) );
+    statsColl->reservoirs.push_back( newStatisticsCase );
+
+    newStatisticsCase->populateResultSelectionAfterLoadingGrid();
+
+    auto cases = sourceCases();
+    if ( !cases.empty() )
+    {
+        newStatisticsCase->setWellDataSourceCase( cases.front() );
+    }
+
+    newStatisticsCase->openEclipseGridFile();
+    newStatisticsCase->computeActiveCellsBoundingBox();
+    newStatisticsCase->selectAllTimeSteps();
+
+    return newStatisticsCase;
+}

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsembleBase.h
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsembleBase.h
@@ -1,0 +1,44 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RiaPorosityModel.h"
+
+#include <vector>
+
+class RigActiveCellInfo;
+class RigMainGrid;
+class RimCaseCollection;
+class RimEclipseCase;
+class RimEclipseStatisticsCase;
+
+class RimReservoirGridEnsembleBase
+{
+public:
+    virtual ~RimReservoirGridEnsembleBase() = default;
+
+    virtual RigMainGrid*                 mainGrid()                                                       = 0;
+    virtual RimEclipseCase*              mainCase()                                                       = 0;
+    virtual std::vector<RimEclipseCase*> sourceCases() const                                              = 0;
+    virtual RigActiveCellInfo*           unionOfActiveCells( RiaDefines::PorosityModelType porosityType ) = 0;
+    virtual void                         computeUnionOfActiveCells()                                      = 0;
+    virtual RimCaseCollection*           statisticsCaseCollection() const                                 = 0;
+
+    virtual RimEclipseStatisticsCase* createAndAppendStatisticsCase();
+};

--- a/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
@@ -42,6 +42,7 @@
 #include "RimEclipseResultDefinition.h"
 #include "RimEclipseView.h"
 #include "RimRegularGridCase.h"
+#include "RimReservoirGridEnsemble.h"
 #include "RimTools.h"
 
 #include "cafPdmUiDoubleSliderEditor.h"
@@ -458,7 +459,8 @@ void RimWellTargetMapping::defineUiOrdering( QString uiConfigName, caf::PdmUiOrd
 
     resultGroup->add( &m_volumesType );
 
-    auto hasEnsembleParent = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>() != nullptr;
+    auto hasEnsembleParent = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>() != nullptr ||
+                             firstAncestorOrThisOfType<RimReservoirGridEnsemble>() != nullptr;
     if ( !hasEnsembleParent ) uiOrdering.add( &m_filterView );
 
     caf::PdmUiGroup* minimumCellValuesGroup = uiOrdering.addNewGroup( "Minimum Cell Values" );
@@ -515,7 +517,8 @@ std::vector<double> RimWellTargetMapping::getVisibilityFilter() const
     std::vector<double> filter = {};
 
     // Visibility filter is only valid in the single case setting
-    auto hasEnsembleParent = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>() != nullptr;
+    auto hasEnsembleParent = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>() != nullptr ||
+                             firstAncestorOrThisOfType<RimReservoirGridEnsemble>() != nullptr;
     if ( !hasEnsembleParent )
     {
         auto fc = firstCase();
@@ -548,10 +551,12 @@ std::vector<double> RimWellTargetMapping::getVisibilityFilter() const
 RimEclipseCase* RimWellTargetMapping::firstCase() const
 {
     auto ensemble = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>();
-    if ( ensemble && !ensemble->cases().empty() )
-        return ensemble->cases()[0];
-    else
-        return firstAncestorOrThisOfType<RimEclipseCase>();
+    if ( ensemble && !ensemble->cases().empty() ) return ensemble->cases()[0];
+
+    auto reservoirGridEnsemble = firstAncestorOrThisOfType<RimReservoirGridEnsemble>();
+    if ( reservoirGridEnsemble && !reservoirGridEnsemble->cases().empty() ) return reservoirGridEnsemble->cases()[0];
+
+    return firstAncestorOrThisOfType<RimEclipseCase>();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -637,10 +642,21 @@ void RimWellTargetMapping::resetMinimumCellValuesToDefault()
 //--------------------------------------------------------------------------------------------------
 void RimWellTargetMapping::onGenerateButtonClicked()
 {
-    auto hasEnsembleParent = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>() != nullptr;
-    if ( hasEnsembleParent )
+    auto hasEclipseCaseEnsembleParent = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>() != nullptr;
+    auto hasGridEnsembleParent        = firstAncestorOrThisOfType<RimReservoirGridEnsemble>() != nullptr;
+    if ( hasEclipseCaseEnsembleParent )
     {
         generateEnsembleStatistics();
+    }
+    else if ( hasGridEnsembleParent )
+    {
+        // For RimReservoirGridEnsemble, generate for first case
+        // Full ensemble statistics support can be added later
+        if ( auto eclipseCase = firstCase() )
+        {
+            bool setTimeStepInView = true;
+            generateCandidates( eclipseCase, setTimeStepInView );
+        }
     }
     else if ( auto eclipseCase = firstCase() )
     {

--- a/ApplicationLibCode/UserInterface/RiuDockWidgetTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuDockWidgetTools.cpp
@@ -393,7 +393,7 @@ QIcon RiuDockWidgetTools::dockIcon( const QString dockWidgetName )
     else if ( dockWidgetName == mainWindowProjectTreeName() )
         return QIcon( ":/standard.svg" );
     else if ( dockWidgetName == mainWindowDataSourceTreeName() )
-        return QIcon( ":/Calculator.svg" );
+        return QIcon( ":/data-sources.svg" );
     else if ( dockWidgetName == mainWindowScriptsTreeName() )
         return QIcon( ":/scripts.svg" );
     else if ( dockWidgetName == mainPlotWindowName() )

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -749,14 +749,14 @@ void RiuMainWindow::createToolBars()
 void RiuMainWindow::createDockPanels()
 {
     const int                  nTreeViews        = 3;
-    const std::vector<QString> treeViewTitles    = { "Project Tree", "Calculator Data ", "Scripts/Jobs" };
+    const std::vector<QString> treeViewTitles    = { "Project Tree", "Data Sources", "Scripts/Jobs" };
     const std::vector<QString> treeViewConfigs   = { "MainWindow.ProjectTree", "MainWindow.DataSources", "MainWindow.Scripts" };
     const std::vector<QString> treeViewDockNames = { RiuDockWidgetTools::mainWindowProjectTreeName(),
                                                      RiuDockWidgetTools::mainWindowDataSourceTreeName(),
                                                      RiuDockWidgetTools::mainWindowScriptsTreeName() };
 
     const std::vector<ads::DockWidgetArea> defaultDockWidgetArea{ ads::DockWidgetArea::LeftDockWidgetArea,
-                                                                  ads::DockWidgetArea::LeftDockWidgetArea,
+                                                                  ads::DockWidgetArea::RightDockWidgetArea,
                                                                   ads::DockWidgetArea::LeftDockWidgetArea };
 
     createTreeViews( nTreeViews );


### PR DESCRIPTION
First PR related to #13432

This PR creates the infrastructure for grid case ensembles. Several UI operations requires more work.

Existing functionality for Grid Case Group and Grid Ensemble is currently unchanged, candidates for removal when the Reservoir Grid Ensemble concept is completed.

Adds functionality to manage and visualize reservoir grid ensembles:
- Introduces a new object type `RimReservoirGridEnsemble` for managing multiple grid realizations.
- Implements file set association for grid ensemble creation.
- Adds grid mode selection to allow handling shared or individual grids.
- Supports shared grid statistics for identical grids.
- Adds a new command to create reservoir grid ensembles from file sets.
- Renames "Calculator Data" to "Data Sources".