### PR TITLE
Auto-update MSW segments on UI changes (opt-in)

### DIFF
--- a/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
@@ -597,10 +597,6 @@ void RivWellPathPartMgr::appendMswSegmentsToModel( cvf::ModelBasicList*         
     auto segmentCollection = completions->mswSegmentCollection();
     if ( !segmentCollection || !segmentCollection->hasSegments() ) return;
 
-    // Use top-level well path's MSW settings for visibility control
-    RimWellPath* topLevelWell = m_rimWellPath->topLevelWellPath();
-    if ( !topLevelWell ) topLevelWell = m_rimWellPath;
-
     RimWellPathCollection* wellPathCollection = this->wellPathCollection();
     if ( !wellPathCollection ) return;
 

--- a/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
@@ -668,8 +668,7 @@ void RivWellPathPartMgr::appendMswSegmentsToModel( cvf::ModelBasicList*         
             cvf::ref<RivObjectSourceInfo> objectSourceInfo = new RivObjectSourceInfo( const_cast<RimMswSegment*>( segment ) );
             for ( auto part : parts )
             {
-                part->setName(
-                    QString( "MSW Segment %1 (Branch %2)" ).arg( segment->segmentNumber() ).arg( segment->branchNumber() ).toStdString() );
+                part->setName( m_rimWellPath->name().toStdString() );
                 part->setSourceInfo( objectSourceInfo.p() );
                 model->addPart( part.p() );
             }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.cpp
@@ -27,6 +27,7 @@
 #include "RimFishbones.h"
 #include "RimProject.h"
 #include "RimWellPath.h"
+#include "RimWellPathCollection.h"
 
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
@@ -381,10 +382,26 @@ void RimFishbonesCollection::computeStartAndEndLocation()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimFishbonesCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimFishbonesCollection::onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
     RimProject* proj = RimProject::current();
     proj->reloadCompletionTypeResultsInAllViews();
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 
     updateConnectedEditors();
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.h
@@ -65,6 +65,7 @@ public:
 
 protected:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void initAfterRead() override;
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegment.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegment.cpp
@@ -35,11 +35,17 @@ RimMswSegment::RimMswSegment()
     CAF_PDM_InitFieldNoDefault( &m_branchNumber, "BranchNumber", "Branch Number" );
     m_branchNumber.uiCapability()->setUiReadOnly( true );
 
-    CAF_PDM_InitFieldNoDefault( &m_startMD, "StartMD", "Start MD" );
-    m_startMD.uiCapability()->setUiReadOnly( true );
+    CAF_PDM_InitFieldNoDefault( &m_joinSegment, "JoinSegment", "Join Segment" );
+    m_joinSegment.uiCapability()->setUiReadOnly( true );
 
-    CAF_PDM_InitFieldNoDefault( &m_endMD, "EndMD", "End MD" );
-    m_endMD.uiCapability()->setUiReadOnly( true );
+    CAF_PDM_InitFieldNoDefault( &m_length, "Length", "Length" );
+    m_length.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_depth, "Depth", "Depth" );
+    m_depth.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_nextSegmentLength, "NextSegmentLength", "Next Segment Length" );
+    m_nextSegmentLength.uiCapability()->setUiReadOnly( true );
 
     CAF_PDM_InitFieldNoDefault( &m_diameter, "Diameter", "Diameter" );
     m_diameter.uiCapability()->setUiReadOnly( true );
@@ -57,13 +63,21 @@ RimMswSegment::~RimMswSegment()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimMswSegment::setSegmentData( int segmentNumber, int branchNumber, double startMD, double endMD, double diameter )
+void RimMswSegment::setSegmentData( int    segmentNumber,
+                                    int    branchNumber,
+                                    int    joinSegment,
+                                    double length,
+                                    double depth,
+                                    double nextSegmentLength,
+                                    double diameter )
 {
-    m_segmentNumber = segmentNumber;
-    m_branchNumber  = branchNumber;
-    m_startMD       = startMD;
-    m_endMD         = endMD;
-    m_diameter      = diameter;
+    m_segmentNumber     = segmentNumber;
+    m_branchNumber      = branchNumber;
+    m_joinSegment       = joinSegment;
+    m_length            = length;
+    m_depth             = depth;
+    m_nextSegmentLength = nextSegmentLength;
+    m_diameter          = diameter;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -80,6 +94,38 @@ int RimMswSegment::segmentNumber() const
 int RimMswSegment::branchNumber() const
 {
     return m_branchNumber;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+int RimMswSegment::joinSegment() const
+{
+    return m_joinSegment;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimMswSegment::length() const
+{
+    return m_length;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimMswSegment::depth() const
+{
+    return m_depth;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimMswSegment::nextSegmentLength() const
+{
+    return m_nextSegmentLength;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -140,7 +186,7 @@ cvf::Color3f RimMswSegment::defaultComponentColor() const
 //--------------------------------------------------------------------------------------------------
 double RimMswSegment::startMD() const
 {
-    return m_startMD;
+    return m_length;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -148,7 +194,7 @@ double RimMswSegment::startMD() const
 //--------------------------------------------------------------------------------------------------
 double RimMswSegment::endMD() const
 {
-    return m_endMD;
+    return m_nextSegmentLength;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -156,8 +202,8 @@ double RimMswSegment::endMD() const
 //--------------------------------------------------------------------------------------------------
 void RimMswSegment::applyOffset( double offsetMD )
 {
-    m_startMD = m_startMD + offsetMD;
-    m_endMD   = m_endMD + offsetMD;
+    // This does not make sense to apply offset to MSW segments, as they are not connected to each other and the start/end MD is only used
+    // for display purposes. So we do nothing here.
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -167,8 +213,10 @@ void RimMswSegment::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& 
 {
     uiOrdering.add( &m_segmentNumber );
     uiOrdering.add( &m_branchNumber );
-    uiOrdering.add( &m_startMD );
-    uiOrdering.add( &m_endMD );
+    uiOrdering.add( &m_length );
+    uiOrdering.add( &m_depth );
+    uiOrdering.add( &m_nextSegmentLength );
+    uiOrdering.add( &m_joinSegment );
     uiOrdering.add( &m_diameter );
 
     uiOrdering.skipRemainingFields( true );

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegment.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegment.h
@@ -37,10 +37,14 @@ public:
     RimMswSegment();
     ~RimMswSegment() override;
 
-    void setSegmentData( int segmentNumber, int branchNumber, double startMD, double endMD, double diameter );
+    void setSegmentData( int segmentNumber, int branchNumber, int joinSegment, double length, double depth, double nextSegmentLength, double diameter );
 
     int    segmentNumber() const;
     int    branchNumber() const;
+    int    joinSegment() const;
+    double length() const;
+    double depth() const;
+    double nextSegmentLength() const;
     double diameter() const;
 
     // RimWellPathComponentInterface overrides
@@ -59,7 +63,9 @@ protected:
 private:
     caf::PdmField<int>    m_segmentNumber;
     caf::PdmField<int>    m_branchNumber;
-    caf::PdmField<double> m_startMD;
-    caf::PdmField<double> m_endMD;
+    caf::PdmField<int>    m_joinSegment;
+    caf::PdmField<double> m_length;
+    caf::PdmField<double> m_depth;
+    caf::PdmField<double> m_nextSegmentLength;
     caf::PdmField<double> m_diameter;
 };

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp
@@ -104,21 +104,17 @@ void RimMswSegmentCollection::populateFromWelsegsData( std::vector<WelsegsRow> w
     // Sort segments by measured depth (length)
     std::sort( welsegsData.begin(), welsegsData.end(), []( const WelsegsRow& a, const WelsegsRow& b ) { return a.length < b.length; } );
 
-    // Create segments with computed start/end MD
+    // Assign segments data. Start/end measured depth is used for visualization in 2D plots by RimWellPathComponentInterface
     for ( size_t i = 0; i < welsegsData.size(); ++i )
     {
         const auto& row = welsegsData[i];
 
-        double startMD = row.length;
-        double endMD   = ( i + 1 < welsegsData.size() ) ? welsegsData[i + 1].length : wellTotalDepth;
-
-        // Skip if start >= end (invalid interval)
-        if ( startMD >= endMD ) continue;
+        double nextSegmentLength = ( i + 1 < welsegsData.size() ) ? welsegsData[i + 1].length : wellTotalDepth;
 
         double diameter = row.diameter.value_or( 0.1 ); // Default diameter if not specified
 
         auto* segment = new RimMswSegment();
-        segment->setSegmentData( row.segment1, row.branch, startMD, endMD, diameter );
+        segment->setSegmentData( row.segment1, row.branch, row.joinSegment, row.length, row.depth, nextSegmentLength, diameter );
         appendSegment( segment );
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp
@@ -140,10 +140,19 @@ double RimMswSegmentCollection::referenceDiameter() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimMswSegmentCollection::updateSegments( RimEclipseCase* eclipseCase )
+void RimMswSegmentCollection::updateSegments( RimWellPath* topLevelWell, RimEclipseCase* eclipseCase )
 {
-    // Clear existing segments before creating new ones
-    clearSegments();
+    if ( !topLevelWell )
+    {
+        RiaLogging::error( "Unable to update MSW segments: no top-level well path provided." );
+        return;
+    }
+
+    if ( !eclipseCase )
+    {
+        RiaLogging::error( "Unable to update MSW segments: no Eclipse case selected." );
+        return;
+    }
 
     auto scheduleRedraw = []()
     {
@@ -153,25 +162,12 @@ void RimMswSegmentCollection::updateSegments( RimEclipseCase* eclipseCase )
         }
     };
 
-    auto* wellPath = firstAncestorOrThisOfType<RimWellPath>();
-    if ( !wellPath )
-    {
-        RiaLogging::error( "Unable to update MSW segments: no well path found." );
-        scheduleRedraw();
-        return;
-    }
+    auto exportDate                             = RicWellPathExportCompletionDataFeatureImpl::exportDateForTimeStep( eclipseCase, 0 );
+    bool exportCompletionsAfterMainBoreSegments = true;
 
-    if ( !eclipseCase )
-    {
-        RiaLogging::error( "Unable to update MSW segments: no Eclipse case selected." );
-        scheduleRedraw();
-        return;
-    }
-
-    auto exportDate      = RicWellPathExportCompletionDataFeatureImpl::exportDateForTimeStep( eclipseCase, 0 );
     auto tableDataResult = RicWellPathExportMswTableData::extractSingleWellMswData( eclipseCase,
-                                                                                    wellPath,
-                                                                                    true,
+                                                                                    topLevelWell,
+                                                                                    exportCompletionsAfterMainBoreSegments,
                                                                                     RicWellPathExportMswTableData::CompletionType::ALL,
                                                                                     exportDate );
 

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.h
@@ -27,6 +27,7 @@
 
 class RimEclipseCase;
 class RimMswSegment;
+class RimWellPath;
 struct WelsegsRow;
 
 //==================================================================================================
@@ -47,7 +48,7 @@ public:
 
     double referenceDiameter() const;
 
-    void updateSegments( RimEclipseCase* eclipseCase );
+    static void updateSegments( RimWellPath* topLevelWell, RimEclipseCase* eclipseCase );
 
 private:
     void populateFromWelsegsData( std::vector<WelsegsRow> welsegsData, double wellTotalDepth );

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.cpp
@@ -26,6 +26,7 @@
 #include "RimNonDarcyPerforationParameters.h"
 #include "RimPerforationInterval.h"
 #include "RimProject.h"
+#include "RimWellPathCollection.h"
 
 #include "Well/RigWellPath.h"
 
@@ -189,10 +190,26 @@ void RimPerforationCollection::fieldChangedByUi( const caf::PdmFieldHandle* chan
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimPerforationCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimPerforationCollection::onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
     RimProject* proj = RimProject::current();
     proj->reloadCompletionTypeResultsInAllViews();
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 
     updateConnectedEditors();
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.h
@@ -51,6 +51,7 @@ public:
 private:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
 
     friend class RiuEditPerforationCollectionWidget;

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.cpp
@@ -20,6 +20,7 @@
 
 #include "Rim3dView.h"
 #include "RimProject.h"
+#include "RimWellPathCollection.h"
 #include "RimWellPathFracture.h"
 
 #include "cafPdmObject.h"
@@ -139,8 +140,24 @@ void RimWellPathFractureCollection::fieldChangedByUi( const caf::PdmFieldHandle*
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimWellPathFractureCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimWellPathFractureCollection::onChildDeleted( caf::PdmChildArrayFieldHandle*      childArray,
                                                     std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
     RimProject::current()->scheduleCreateDisplayModelAndRedrawAllViews();
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.h
@@ -55,6 +55,7 @@ public:
 
 private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
 
 private:
     caf::PdmChildArrayField<RimWellPathFracture*> m_fractures;

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp
@@ -44,7 +44,6 @@
 #include "RimPerforationCollection.h"
 #include "RimProject.h"
 #include "RimStimPlanModelCollection.h"
-#include "RimTools.h"
 #include "RimWellEventTimeline.h"
 #include "RimWellIASettingsCollection.h"
 #include "RimWellLogChannel.h"
@@ -187,7 +186,7 @@ double RimWellPath::wellPathRadius( double characteristicCellSize ) const
 {
     double radius = characteristicCellSize * m_wellPathRadiusScaleFactor();
 
-    RimWellPathCollection* coll = RimTools::wellPathCollection();
+    RimWellPathCollection* coll = RimWellPathCollection::instance();
     if ( coll )
     {
         radius *= coll->wellPathRadiusScaleFactor();
@@ -479,6 +478,11 @@ void RimWellPath::fieldChangedByUi( const caf::PdmFieldHandle* changedField, con
     else
     {
         proj->scheduleCreateDisplayModelAndRedrawAllViews();
+
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
+        {
+            wellPathCollection->updateMswSegmentsForObject( this );
+        }
     }
 }
 
@@ -832,7 +836,7 @@ void RimWellPath::defineObjectEditorAttribute( QString uiConfigName, caf::PdmUiE
         // The nodes for well paths are created by the well path collection object. When a well path object is asked to
         // be updated in the project tree, always rebuild the tree from the well path collection object.
 
-        myAttr->objectForUpdateOfUiTree = RimTools::wellPathCollection();
+        myAttr->objectForUpdateOfUiTree = RimWellPathCollection::instance();
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
@@ -601,6 +601,8 @@ caf::PdmFieldHandle* RimWellPathCollection::objectToggleField()
 //--------------------------------------------------------------------------------------------------
 void RimWellPathCollection::updateMswSegments()
 {
+    std::set<RimWellPath*> topLevelWells;
+
     for ( const auto& wellPath : m_wellPaths )
     {
         if ( !wellPath ) continue;
@@ -611,7 +613,15 @@ void RimWellPathCollection::updateMswSegments()
         auto* segmentCollection = completions->mswSegmentCollection();
         if ( !segmentCollection ) continue;
 
-        segmentCollection->updateSegments( m_mswEclipseCase() );
+        segmentCollection->clearSegments();
+
+        topLevelWells.insert( wellPath->topLevelWellPath() );
+    }
+
+    // Update segments for all top level wells, which will update the segments for all connected well paths
+    for ( RimWellPath* topLevelWell : topLevelWells )
+    {
+        RimMswSegmentCollection::updateSegments( topLevelWell, m_mswEclipseCase() );
     }
 
     if ( RimProject* project = RimProject::current() )

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
@@ -53,6 +53,7 @@
 #include "RimProject.h"
 #include "RimStimPlanModel.h"
 #include "RimStimPlanModelCollection.h"
+#include "RimTools.h"
 #include "RimWellLogLasFile.h"
 #include "RimWellMeasurementCollection.h"
 #include "RimWellPath.h"
@@ -149,7 +150,8 @@ RimWellPathCollection::RimWellPathCollection()
     CAF_PDM_InitFieldNoDefault( &m_mswNameGroupingPattern, "MswWellNameGroupingPattern", "Grouping Pattern" );
 
     CAF_PDM_InitFieldNoDefault( &m_mswEclipseCase, "MswEclipseCase", "Eclipse Case" );
-    CAF_PDM_InitField( &m_mswShowBands, "MseShowBands", true, "Show Bands" );
+    CAF_PDM_InitField( &m_mswShowBands, "MswShowBands", true, "Show Bands" );
+    CAF_PDM_InitField( &m_mswAutoUpdateSegments, "MswAutoUpdateSegments", true, "Auto Update Segments" );
 
     m_wellPathImporter           = std::make_unique<RifWellPathImporter>();
     m_wellPathFormationsImporter = std::make_unique<RifWellPathFormationsImporter>();
@@ -160,6 +162,14 @@ RimWellPathCollection::RimWellPathCollection()
 //--------------------------------------------------------------------------------------------------
 RimWellPathCollection::~RimWellPathCollection()
 {
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPathCollection* RimWellPathCollection::instance()
+{
+    return RimTools::wellPathCollection();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -561,6 +571,7 @@ void RimWellPathCollection::defineUiOrdering( QString uiConfigName, caf::PdmUiOr
     caf::PdmUiGroup* mswSegmentGroup = uiOrdering.addNewGroup( "MSW Segment Visualization" );
     mswSegmentGroup->add( &m_mswShowBands );
     mswSegmentGroup->add( &m_mswEclipseCase );
+    mswSegmentGroup->add( &m_mswAutoUpdateSegments );
     mswSegmentGroup->addNewButton( "Update Segments", [this]() { updateMswSegments(); } );
     uiOrdering.skipRemainingFields();
 }
@@ -594,6 +605,51 @@ void RimWellPathCollection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTree
 caf::PdmFieldHandle* RimWellPathCollection::objectToggleField()
 {
     return &isActive;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellPathCollection::updateMswSegmentsForWellPath( RimWellPath* wellPath )
+{
+    if ( !wellPath ) return;
+
+    RimWellPath* topLevelWell = wellPath->topLevelWellPath();
+    if ( !topLevelWell ) return;
+
+    for ( const auto& wp : m_wellPaths )
+    {
+        if ( !wp || wp->topLevelWellPath() != topLevelWell ) continue;
+
+        auto* completions = wp->completions();
+        if ( !completions ) continue;
+
+        auto* segmentCollection = completions->mswSegmentCollection();
+        if ( !segmentCollection ) continue;
+
+        segmentCollection->clearSegments();
+    }
+
+    RimMswSegmentCollection::updateSegments( topLevelWell, m_mswEclipseCase() );
+
+    if ( RimProject* project = RimProject::current() )
+    {
+        project->scheduleCreateDisplayModelAndRedrawAllViews();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellPathCollection::updateMswSegmentsForObject( caf::PdmObject* changedObject )
+{
+    if ( !m_mswAutoUpdateSegments() ) return;
+    if ( !changedObject ) return;
+
+    if ( auto wellPath = changedObject->firstAncestorOfType<RimWellPath>() )
+    {
+        updateMswSegmentsForWellPath( wellPath );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.h
@@ -83,6 +83,8 @@ public:
     RimWellPathCollection();
     ~RimWellPathCollection() override;
 
+    static RimWellPathCollection* instance();
+
     enum WellVisibilityType
     {
         FORCE_ALL_OFF,
@@ -154,6 +156,8 @@ public:
 
     void onChildAdded( caf::PdmFieldHandle* containerForNewObject ) override;
 
+    void updateMswSegmentsForObject( caf::PdmObject* changedObject );
+
     static std::pair<cvf::ref<RigWellPath>, QString>
         loadWellPathGeometryFromOsdu( RiaOsduConnector* osduConnector, const QString& wellTrajectoryId, double datumElevation );
 
@@ -172,6 +176,7 @@ private:
 
     std::vector<RimWellPath*> readAndAddWellPaths( std::vector<RimFileWellPath*>& wellPathArray );
     void                      sortWellsByName();
+    void                      updateMswSegmentsForWellPath( RimWellPath* wellPath );
 
     std::expected<std::vector<RimFileWellPath*>, QString> addWellPathsForFile( const QString& filePath );
 
@@ -202,4 +207,5 @@ private:
 
     caf::PdmPtrField<RimEclipseCase*> m_mswEclipseCase;
     caf::PdmField<bool>               m_mswShowBands;
+    caf::PdmField<bool>               m_mswAutoUpdateSegments;
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
@@ -32,6 +32,7 @@
 
 #include "RimModeledWellPath.h"
 #include "RimProject.h"
+#include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDefTools.h"
 #include "RimWellPathTarget.h"
 
@@ -552,6 +553,22 @@ void RimWellPathGeometryDef::fieldChangedByUi( const caf::PdmFieldHandle* change
     }
 
     changed.send( false );
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellPathGeometryDef::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.h
@@ -107,6 +107,7 @@ protected:
 
 private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName ) override;
     void initAfterRead() override;

--- a/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
@@ -836,13 +836,18 @@ void RiuViewerCommands::handlePickAction( int winPosX, int winPosY, Qt::Keyboard
                         resultInfoText += "\n\n";
                     }
 
-                    resultInfoText += QString( "Segment: %1\nBranch: %2\nMD: %3 - %4\nDiameter: %5" )
+                    resultInfoText += QString( "Segment     : %1\n"
+                                               "Branch      : %2\n"
+                                               "Join Segment: %3\n"
+                                               "Length      : %4\n"
+                                               "Depth       : %5\n"
+                                               "Diameter    : %6" )
                                           .arg( mswSegment->segmentNumber() )
                                           .arg( mswSegment->branchNumber() )
-                                          .arg( mswSegment->startMD() )
-                                          .arg( mswSegment->endMD() )
+                                          .arg( mswSegment->joinSegment() )
+                                          .arg( mswSegment->length() )
+                                          .arg( mswSegment->depth() )
                                           .arg( mswSegment->diameter() );
-
                     RiuMainWindow::instance()->setResultInfo( resultInfoText );
                     RiuMainWindow::instance()->selectAsCurrentItem( mswSegment, true );
                 }


### PR DESCRIPTION
Builds on https://github.com/OPM/ResInsight/pull/13625

Adds an auto-update option for MSW segments in RimWellPathCollection, enabling automatic segment updates when related well objects are modified via the UI. Introduces centralized update logic, hooks into child field changes and deletions, and updates the UI to expose the new toggle. Also refactors singleton access and fixes a field name typo.