### PR TITLE
Add RiaSummaryAddressCollectionTools utility module

### DIFF
--- a/ApplicationLibCode/Application/Tools/Summary/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Application/Tools/Summary/CMakeLists_files.cmake
@@ -9,6 +9,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryPlotTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryPlotBuilder.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryPlotTemplateTools.h
+    ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryAddressCollectionTools.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -22,6 +23,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryPlotTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryPlotBuilder.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryPlotTemplateTools.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryAddressCollectionTools.cpp
 )
 
 list(APPEND CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryAddressCollectionTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryAddressCollectionTools.cpp
@@ -1,0 +1,161 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RiaSummaryAddressCollectionTools.h"
+
+#include "RifEclipseSummaryAddress.h"
+#include "RifEclipseSummaryAddressDefines.h"
+
+#include "RimEnsembleCurveSet.h"
+#include "RimSummaryCurve.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::string RiaSummaryAddressCollectionTools::objectIdentifierForAddress( const RifEclipseSummaryAddress&                    address,
+                                                                          RimSummaryAddressCollection::CollectionContentType contentType )
+{
+    using Category    = RifEclipseSummaryAddressDefines::SummaryCategory;
+    using ContentType = RimSummaryAddressCollection::CollectionContentType;
+
+    if ( ( address.category() == Category::SUMMARY_WELL ) && ( contentType == ContentType::WELL ) )
+    {
+        return address.wellName();
+    }
+    else if ( ( address.category() == Category::SUMMARY_GROUP ) && ( contentType == ContentType::GROUP ) )
+    {
+        return address.groupName();
+    }
+    else if ( ( address.category() == Category::SUMMARY_NETWORK ) && ( contentType == ContentType::NETWORK ) )
+    {
+        return address.networkName();
+    }
+    else if ( ( address.category() == Category::SUMMARY_REGION ) && ( contentType == ContentType::REGION ) )
+    {
+        return std::to_string( address.regionNumber() );
+    }
+    else if ( ( address.category() == Category::SUMMARY_WELL_SEGMENT ) && ( contentType == ContentType::WELL_SEGMENT ) )
+    {
+        return std::to_string( address.wellSegmentNumber() );
+    }
+
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RiaSummaryCurveDefinition>
+    RiaSummaryAddressCollectionTools::buildCurveDefs( const std::vector<RiaSummaryCurveDefinition>&      sourceCurveDefs,
+                                                      const std::string&                                 droppedName,
+                                                      RimSummaryAddressCollection::CollectionContentType contentType,
+                                                      bool                                               appendHistoryVectors )
+{
+    std::set<RiaSummaryCurveDefinition> uniqueCurveDefs;
+
+    for ( const auto& curveDef : sourceCurveDefs )
+    {
+        auto       newCurveDef = curveDef;
+        const auto curveAdr    = newCurveDef.summaryAddressY();
+
+        std::string objectIdentifierString = objectIdentifierForAddress( curveAdr, contentType );
+
+        if ( !objectIdentifierString.empty() )
+        {
+            newCurveDef.setIdentifierText( curveAdr.category(), droppedName );
+            uniqueCurveDefs.insert( newCurveDef );
+
+            const auto& addr = curveDef.summaryAddressY();
+            if ( !addr.isHistoryVector() && appendHistoryVectors )
+            {
+                auto historyAddr = addr;
+                historyAddr.setVectorName( addr.vectorName() + RifEclipseSummaryAddressDefines::historyIdentifier() );
+
+                auto historyCurveDef = newCurveDef;
+                historyCurveDef.setSummaryAddressY( historyAddr );
+                uniqueCurveDefs.insert( historyCurveDef );
+            }
+        }
+    }
+
+    return { uniqueCurveDefs.begin(), uniqueCurveDefs.end() };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Filter out candidate curve definitions that already have a matching curve on the plot.
+/// A candidate is considered a duplicate only when both the summary address and the data source (case or ensemble)
+/// match an existing curve. This allows the same vector from a different case to pass through.
+//--------------------------------------------------------------------------------------------------
+std::vector<RiaSummaryCurveDefinition> RiaSummaryAddressCollectionTools::removeExistingCurveDefs(
+    const std::vector<RiaSummaryCurveDefinition>&                            candidateCurveDefs,
+    const std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>>&     existingSummaryCurves,
+    const std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>>& existingEnsembleCurves )
+{
+    std::vector<RiaSummaryCurveDefinition> filtered;
+
+    for ( const auto& curveDef : candidateCurveDefs )
+    {
+        const auto& addr = curveDef.summaryAddressY();
+
+        if ( curveDef.ensemble() )
+        {
+            // Skip if the plot already has an ensemble curve set with this address for the same ensemble
+            auto it = existingEnsembleCurves.find( addr );
+            if ( it != existingEnsembleCurves.end() && it->second.count( curveDef.ensemble() ) > 0 ) continue;
+        }
+        else if ( curveDef.summaryCaseY() )
+        {
+            // Skip if the plot already has a summary curve with this address for the same case
+            auto it = existingSummaryCurves.find( addr );
+            if ( it != existingSummaryCurves.end() && it->second.count( curveDef.summaryCaseY() ) > 0 ) continue;
+        }
+
+        filtered.push_back( curveDef );
+    }
+
+    return filtered;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>>
+    RiaSummaryAddressCollectionTools::buildAddressCaseMapFromCurves( const std::vector<RimSummaryCurve*>& curves )
+{
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>> result;
+    for ( auto* curve : curves )
+    {
+        if ( !curve || !curve->summaryCaseY() ) continue;
+        result[curve->summaryAddressY()].insert( curve->summaryCaseY() );
+    }
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>>
+    RiaSummaryAddressCollectionTools::buildAddressEnsembleMapFromCurveSets( const std::vector<RimEnsembleCurveSet*>& curveSets )
+{
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>> result;
+    for ( auto* curveSet : curveSets )
+    {
+        result[curveSet->summaryAddressY()].insert( curveSet->summaryEnsemble() );
+    }
+    return result;
+}

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryAddressCollectionTools.h
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryAddressCollectionTools.h
@@ -1,0 +1,61 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Summary/RiaSummaryCurveDefinition.h"
+
+#include "RimSummaryAddressCollection.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+class RifEclipseSummaryAddress;
+class RimEnsembleCurveSet;
+class RimSummaryCase;
+class RimSummaryCurve;
+class RimSummaryEnsemble;
+
+//==================================================================================================
+//
+//==================================================================================================
+namespace RiaSummaryAddressCollectionTools
+{
+
+std::vector<RiaSummaryCurveDefinition> buildCurveDefs( const std::vector<RiaSummaryCurveDefinition>&      sourceCurveDefs,
+                                                       const std::string&                                 droppedName,
+                                                       RimSummaryAddressCollection::CollectionContentType contentType,
+                                                       bool                                               appendHistoryVectors );
+
+std::vector<RiaSummaryCurveDefinition>
+    removeExistingCurveDefs( const std::vector<RiaSummaryCurveDefinition>&                            candidateCurveDefs,
+                             const std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>>&     existingSummaryCurves,
+                             const std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>>& existingEnsembleCurves );
+
+std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>> buildAddressCaseMapFromCurves( const std::vector<RimSummaryCurve*>& curves );
+
+std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>>
+    buildAddressEnsembleMapFromCurveSets( const std::vector<RimEnsembleCurveSet*>& curveSets );
+
+// Not used externally, public for testing purposes
+std::string objectIdentifierForAddress( const RifEclipseSummaryAddress&                    address,
+                                        RimSummaryAddressCollection::CollectionContentType contentType );
+
+}; // namespace RiaSummaryAddressCollectionTools

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -28,14 +28,8 @@
 #include "RiaPreferencesSummary.h"
 #include "RiaRegressionTestRunner.h"
 #include "RiaStdStringTools.h"
-#include "Summary/RiaSummaryCurveDefinition.h"
-#include "Summary/RiaSummaryDefines.h"
-#include "Summary/RiaSummaryPlotTools.h"
-#include "Summary/RiaSummaryTools.h"
 
 #include "RifEclipseSummaryAddressDefines.h"
-
-#include "SummaryPlotCommands/RicSummaryPlotEditorUi.h"
 
 #include "Annotations/RimTimeAxisAnnotationUpdater.h"
 #include "RimAsciiDataCurve.h"
@@ -58,6 +52,12 @@
 #include "RimSummaryPlotControls.h"
 #include "RimSummaryPlotNameHelper.h"
 #include "RimSummaryTimeAxisProperties.h"
+#include "Summary/RiaSummaryAddressCollectionTools.h"
+#include "Summary/RiaSummaryCurveDefinition.h"
+#include "Summary/RiaSummaryDefines.h"
+#include "Summary/RiaSummaryPlotTools.h"
+#include "Summary/RiaSummaryTools.h"
+#include "SummaryPlotCommands/RicSummaryPlotEditorUi.h"
 #include "Tools/RimPlotAxisTools.h"
 
 #include "RiuPlotAxis.h"
@@ -2260,14 +2260,14 @@ RimSummaryPlot::CurveInfo RimSummaryPlot::handleAddressCollectionDrop( RimSummar
     auto summaryCase  = RiaSummaryTools::summaryCaseById( addressCollection->caseId() );
     auto ensembleCase = RiaSummaryTools::ensembleById( addressCollection->ensembleId() );
 
-    std::vector<RiaSummaryCurveDefinition>                     sourceCurveDefs;
-    std::map<RiaSummaryCurveDefinition, std::set<std::string>> newCurveDefsWithObjectNames;
+    std::vector<RiaSummaryCurveDefinition> sourceCurveDefs;
 
     if ( summaryCase && !ensembleCase )
     {
         for ( auto& curve : summaryCurves() )
         {
-            sourceCurveDefs.push_back( curve->curveDefinition() );
+            auto srcDef = curve->curveDefinition();
+            sourceCurveDefs.emplace_back( summaryCase, srcDef.summaryAddressY(), srcDef.isEnsembleCurve() );
         }
     }
 
@@ -2280,61 +2280,19 @@ RimSummaryPlot::CurveInfo RimSummaryPlot::handleAddressCollectionDrop( RimSummar
         }
     }
 
-    for ( auto& curveDef : sourceCurveDefs )
+    auto candidateCurveDefs = RiaSummaryAddressCollectionTools::buildCurveDefs( sourceCurveDefs,
+                                                                                droppedName,
+                                                                                addressCollection->contentType(),
+                                                                                RiaPreferencesSummary::current()->appendHistoryVectors() );
+
+    auto existingSummaryCurves  = RiaSummaryAddressCollectionTools::buildAddressCaseMapFromCurves( summaryCurves() );
+    auto existingEnsembleCurves = RiaSummaryAddressCollectionTools::buildAddressEnsembleMapFromCurveSets( curveSets() );
+
+    auto newCurveDefs =
+        RiaSummaryAddressCollectionTools::removeExistingCurveDefs( candidateCurveDefs, existingSummaryCurves, existingEnsembleCurves );
+
+    for ( const auto& curveDef : newCurveDefs )
     {
-        auto       newCurveDef = curveDef;
-        const auto curveAdr    = newCurveDef.summaryAddressY();
-
-        std::string objectIdentifierString;
-        if ( ( curveAdr.category() == RifEclipseSummaryAddressDefines::SummaryCategory::SUMMARY_WELL ) &&
-             ( addressCollection->contentType() == RimSummaryAddressCollection::CollectionContentType::WELL ) )
-        {
-            objectIdentifierString = curveAdr.wellName();
-        }
-        else if ( ( curveAdr.category() == RifEclipseSummaryAddressDefines::SummaryCategory::SUMMARY_GROUP ) &&
-                  ( addressCollection->contentType() == RimSummaryAddressCollection::CollectionContentType::GROUP ) )
-        {
-            objectIdentifierString = curveAdr.groupName();
-        }
-        else if ( ( curveAdr.category() == RifEclipseSummaryAddressDefines::SummaryCategory::SUMMARY_NETWORK ) &&
-                  ( addressCollection->contentType() == RimSummaryAddressCollection::CollectionContentType::NETWORK ) )
-        {
-            objectIdentifierString = curveAdr.networkName();
-        }
-        else if ( ( curveAdr.category() == RifEclipseSummaryAddressDefines::SummaryCategory::SUMMARY_REGION ) &&
-                  ( addressCollection->contentType() == RimSummaryAddressCollection::CollectionContentType::REGION ) )
-        {
-            objectIdentifierString = std::to_string( curveAdr.regionNumber() );
-        }
-        else if ( ( curveAdr.category() == RifEclipseSummaryAddressDefines::SummaryCategory::SUMMARY_WELL_SEGMENT ) &&
-                  ( addressCollection->contentType() == RimSummaryAddressCollection::CollectionContentType::WELL_SEGMENT ) )
-        {
-            objectIdentifierString = std::to_string( curveAdr.wellSegmentNumber() );
-        }
-
-        if ( !objectIdentifierString.empty() )
-        {
-            newCurveDef.setIdentifierText( curveAdr.category(), droppedName );
-
-            newCurveDefsWithObjectNames[newCurveDef].insert( objectIdentifierString );
-            const auto& addr = curveDef.summaryAddressY();
-            if ( !addr.isHistoryVector() && RiaPreferencesSummary::current()->appendHistoryVectors() )
-            {
-                auto historyAddr = addr;
-                historyAddr.setVectorName( addr.vectorName() + RifEclipseSummaryAddressDefines::historyIdentifier() );
-
-                auto historyCurveDef = newCurveDef;
-                historyCurveDef.setSummaryAddressY( historyAddr );
-                newCurveDefsWithObjectNames[historyCurveDef].insert( objectIdentifierString );
-            }
-        }
-    }
-
-    for ( auto& [curveDef, objectNames] : newCurveDefsWithObjectNames )
-    {
-        // Skip adding new curves if the object name is already present for the curve definition
-        if ( objectNames.count( droppedName ) > 0 ) continue;
-
         if ( curveDef.ensemble() )
         {
             auto addresses = curveDef.ensemble()->ensembleSummaryAddresses();
@@ -2387,13 +2345,7 @@ RimSummaryPlot::CurveInfo RimSummaryPlot::handleSummaryAddressDrop( RimSummaryAd
 
     if ( summaryAddr->isEnsemble() )
     {
-        std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>> dataVectorMap;
-
-        for ( auto& curve : curveSets() )
-        {
-            const auto addr = curve->summaryAddressY();
-            dataVectorMap[addr].insert( curve->summaryEnsemble() );
-        }
+        auto dataVectorMap = RiaSummaryAddressCollectionTools::buildAddressEnsembleMapFromCurveSets( curveSets() );
 
         auto ensemble = RiaSummaryTools::ensembleById( summaryAddr->ensembleId() );
         if ( ensemble )
@@ -2424,13 +2376,7 @@ RimSummaryPlot::CurveInfo RimSummaryPlot::handleSummaryAddressDrop( RimSummaryAd
     }
     else
     {
-        std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>> dataVectorMap;
-
-        for ( auto& curve : summaryCurves() )
-        {
-            const auto addr = curve->summaryAddressY();
-            dataVectorMap[addr].insert( curve->summaryCaseY() );
-        }
+        auto dataVectorMap = RiaSummaryAddressCollectionTools::buildAddressCaseMapFromCurves( summaryCurves() );
 
         auto summaryCase = RiaSummaryTools::summaryCaseById( summaryAddr->caseId() );
         if ( summaryCase )

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -123,6 +123,9 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RifRmsWellPathReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaAngleUtils-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/cafVecIjk-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryAddressCollectionTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimMockSummaryCase.h
+    ${CMAKE_CURRENT_LIST_DIR}/RimMockSummaryCase-Test.cpp
 )
 
 if(RESINSIGHT_ENABLE_GRPC)

--- a/ApplicationLibCode/UnitTests/RiaSummaryAddressCollectionTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaSummaryAddressCollectionTools-Test.cpp
@@ -1,0 +1,234 @@
+#include "gtest/gtest.h"
+
+#include "Summary/RiaSummaryAddressCollectionTools.h"
+#include "Summary/RiaSummaryCurveDefinition.h"
+
+#include "RifEclipseSummaryAddress.h"
+#include "RimMockSummaryCase.h"
+
+//--------------------------------------------------------------------------------------------------
+// objectIdentifierForAddress tests
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierForWellAddress )
+{
+    auto address = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-1" );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address, RimSummaryAddressCollection::CollectionContentType::WELL );
+    EXPECT_EQ( "WELL-1", result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierForGroupAddress )
+{
+    auto address = RifEclipseSummaryAddress::groupAddress( "GOPT", "GROUP-1" );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address, RimSummaryAddressCollection::CollectionContentType::GROUP );
+    EXPECT_EQ( "GROUP-1", result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierForNetworkAddress )
+{
+    auto address = RifEclipseSummaryAddress::networkAddress( "NOPT", "NET-1" );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address, RimSummaryAddressCollection::CollectionContentType::NETWORK );
+    EXPECT_EQ( "NET-1", result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierForRegionAddress )
+{
+    auto address = RifEclipseSummaryAddress::regionAddress( "ROPT", 42 );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address, RimSummaryAddressCollection::CollectionContentType::REGION );
+    EXPECT_EQ( "42", result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierForWellSegmentAddress )
+{
+    auto address = RifEclipseSummaryAddress::wellSegmentAddress( "SOFR", "WELL-1", 7 );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address,
+                                                                      RimSummaryAddressCollection::CollectionContentType::WELL_SEGMENT );
+    EXPECT_EQ( "7", result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierMismatchReturnsEmpty )
+{
+    auto address = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-1" );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address, RimSummaryAddressCollection::CollectionContentType::GROUP );
+    EXPECT_TRUE( result.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, ObjectIdentifierFieldAddressReturnsEmpty )
+{
+    auto address = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    auto result =
+        RiaSummaryAddressCollectionTools::objectIdentifierForAddress( address, RimSummaryAddressCollection::CollectionContentType::FIELD );
+    EXPECT_TRUE( result.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// buildCurveDefs tests
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, BuildCurveDefsWithSingleSourceDef )
+{
+    auto wellAddress = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-A" );
+
+    RiaSummaryCurveDefinition              curveDef( nullptr, wellAddress, false );
+    std::vector<RiaSummaryCurveDefinition> sourceDefs = { curveDef };
+
+    auto result =
+        RiaSummaryAddressCollectionTools::buildCurveDefs( sourceDefs, "WELL-B", RimSummaryAddressCollection::CollectionContentType::WELL, false );
+
+    EXPECT_EQ( 1u, result.size() );
+    EXPECT_EQ( "WELL-B", result[0].summaryAddressY().wellName() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, BuildCurveDefsPreservesCasePointer )
+{
+    // The helper must preserve the case pointer from source curve defs. The caller
+    // (handleAddressCollectionDrop) is responsible for setting the correct case on
+    // source defs before calling this helper.
+    RimMockSummaryCase dummyCase;
+
+    auto wellAddress = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-A" );
+
+    RiaSummaryCurveDefinition              curveDef( &dummyCase, wellAddress, false );
+    std::vector<RiaSummaryCurveDefinition> sourceDefs = { curveDef };
+
+    auto result =
+        RiaSummaryAddressCollectionTools::buildCurveDefs( sourceDefs, "WELL-B", RimSummaryAddressCollection::CollectionContentType::WELL, false );
+
+    EXPECT_EQ( 1u, result.size() );
+    EXPECT_EQ( &dummyCase, result[0].summaryCaseY() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, BuildCurveDefsWithHistoryVectors )
+{
+    auto wellAddress = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-A" );
+
+    RiaSummaryCurveDefinition              curveDef( nullptr, wellAddress, false );
+    std::vector<RiaSummaryCurveDefinition> sourceDefs = { curveDef };
+
+    auto result =
+        RiaSummaryAddressCollectionTools::buildCurveDefs( sourceDefs, "WELL-B", RimSummaryAddressCollection::CollectionContentType::WELL, true );
+
+    EXPECT_EQ( 2u, result.size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, BuildCurveDefsWithEmptySourceDefs )
+{
+    std::vector<RiaSummaryCurveDefinition> sourceDefs;
+
+    auto result =
+        RiaSummaryAddressCollectionTools::buildCurveDefs( sourceDefs, "WELL-B", RimSummaryAddressCollection::CollectionContentType::WELL, false );
+
+    EXPECT_TRUE( result.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, BuildCurveDefsWithMultipleSourceDefs )
+{
+    auto wellAddress1 = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-A" );
+    auto wellAddress2 = RifEclipseSummaryAddress::wellAddress( "WWCT", "WELL-A" );
+
+    RiaSummaryCurveDefinition              curveDef1( nullptr, wellAddress1, false );
+    RiaSummaryCurveDefinition              curveDef2( nullptr, wellAddress2, false );
+    std::vector<RiaSummaryCurveDefinition> sourceDefs = { curveDef1, curveDef2 };
+
+    auto result =
+        RiaSummaryAddressCollectionTools::buildCurveDefs( sourceDefs, "WELL-B", RimSummaryAddressCollection::CollectionContentType::WELL, false );
+
+    EXPECT_EQ( 2u, result.size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// removeExistingCurveDefs tests
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, RemoveExistingCurveDefsKeepsDifferentCase )
+{
+    RimMockSummaryCase caseA;
+    RimMockSummaryCase caseB;
+
+    auto addr = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-B" );
+
+    // Candidate uses caseB
+    std::vector<RiaSummaryCurveDefinition> candidates = { RiaSummaryCurveDefinition( &caseB, addr, false ) };
+
+    // Plot already has this address from caseA
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>> existingSummary;
+    existingSummary[addr].insert( &caseA );
+
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>> existingEnsemble;
+
+    auto result = RiaSummaryAddressCollectionTools::removeExistingCurveDefs( candidates, existingSummary, existingEnsemble );
+
+    // Different case, should NOT be filtered out
+    EXPECT_EQ( 1u, result.size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, RemoveExistingCurveDefsFiltersSameCase )
+{
+    RimMockSummaryCase caseA;
+
+    auto addr = RifEclipseSummaryAddress::wellAddress( "WOPT", "WELL-B" );
+
+    // Candidate uses caseA
+    std::vector<RiaSummaryCurveDefinition> candidates = { RiaSummaryCurveDefinition( &caseA, addr, false ) };
+
+    // Plot already has this exact case+address
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>> existingSummary;
+    existingSummary[addr].insert( &caseA );
+
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>> existingEnsemble;
+
+    auto result = RiaSummaryAddressCollectionTools::removeExistingCurveDefs( candidates, existingSummary, existingEnsemble );
+
+    // Same case+address, should be filtered out
+    EXPECT_TRUE( result.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaSummaryAddressCollectionTools, RemoveExistingCurveDefsPassesThroughEmpty )
+{
+    std::vector<RiaSummaryCurveDefinition>                            candidates;
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryCase*>>     existingSummary;
+    std::map<RifEclipseSummaryAddress, std::set<RimSummaryEnsemble*>> existingEnsemble;
+
+    auto result = RiaSummaryAddressCollectionTools::removeExistingCurveDefs( candidates, existingSummary, existingEnsemble );
+
+    EXPECT_TRUE( result.empty() );
+}

--- a/ApplicationLibCode/UnitTests/RimMockSummaryCase-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimMockSummaryCase-Test.cpp
@@ -1,0 +1,327 @@
+#include "gtest/gtest.h"
+
+#include "RimMockSummaryCase.h"
+
+#include "RifEclipseSummaryAddress.h"
+#include "RigCaseRealizationParameters.h"
+
+//--------------------------------------------------------------------------------------------------
+// RimSummaryCase interface tests
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, DefaultCaseName )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_EQ( "MockCase", mockCase.caseName() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, SetCaseName )
+{
+    RimMockSummaryCase mockCase;
+    mockCase.setName( "MyCase" );
+    EXPECT_EQ( "MyCase", mockCase.caseName() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, SummaryReaderReturnsSelf )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_EQ( static_cast<RifSummaryReaderInterface*>( &mockCase ), mockCase.summaryReader() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// RifSummaryReaderInterface tests
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, ValuesForKnownAddress )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    mockCase.addVector( addr, { 0, 100, 200 }, { 1.0, 2.0, 3.0 } );
+
+    auto [ok, vals] = mockCase.values( addr );
+    EXPECT_TRUE( ok );
+    ASSERT_EQ( 3u, vals.size() );
+    EXPECT_DOUBLE_EQ( 1.0, vals[0] );
+    EXPECT_DOUBLE_EQ( 2.0, vals[1] );
+    EXPECT_DOUBLE_EQ( 3.0, vals[2] );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, ValuesForUnknownAddressReturnsFalse )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+
+    auto [ok, vals] = mockCase.values( addr );
+    EXPECT_FALSE( ok );
+    EXPECT_TRUE( vals.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, TimeStepsForKnownAddress )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::wellAddress( "WOPT", "W-1" );
+    mockCase.addVector( addr, { 10, 20, 30 }, { 5.0, 6.0, 7.0 } );
+
+    auto ts = mockCase.timeSteps( addr );
+    ASSERT_EQ( 3u, ts.size() );
+    EXPECT_EQ( 10, ts[0] );
+    EXPECT_EQ( 20, ts[1] );
+    EXPECT_EQ( 30, ts[2] );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, TimeStepsForUnknownAddressReturnsEmpty )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    EXPECT_TRUE( mockCase.timeSteps( addr ).empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, UnitNameForKnownAddress )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    mockCase.addVector( addr, { 0 }, { 1.0 }, "SM3" );
+
+    EXPECT_EQ( "SM3", mockCase.unitName( addr ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, UnitNameDefaultsToEmpty )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    mockCase.addVector( addr, { 0 }, { 1.0 } );
+
+    EXPECT_TRUE( mockCase.unitName( addr ).empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, UnitSystemIsMetric )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_EQ( RiaDefines::EclipseUnitSystem::UNITS_METRIC, mockCase.unitSystem() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, AllResultAddressesPopulatedByAddVector )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr1 = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    auto addr2 = RifEclipseSummaryAddress::wellAddress( "WOPT", "W-1" );
+
+    mockCase.addVector( addr1, { 0 }, { 1.0 } );
+    mockCase.addVector( addr2, { 0 }, { 2.0 } );
+
+    auto reader = mockCase.summaryReader();
+    EXPECT_EQ( 2u, reader->allResultAddresses().size() );
+    EXPECT_TRUE( reader->hasAddress( addr1 ) );
+    EXPECT_TRUE( reader->hasAddress( addr2 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, KeywordCountMatchesVectorCount )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_EQ( 0u, mockCase.keywordCount() );
+
+    mockCase.addVector( RifEclipseSummaryAddress::fieldAddress( "FOPT" ), { 0 }, { 1.0 } );
+    EXPECT_EQ( 1u, mockCase.keywordCount() );
+
+    mockCase.addVector( RifEclipseSummaryAddress::fieldAddress( "FGPT" ), { 0 }, { 2.0 } );
+    EXPECT_EQ( 2u, mockCase.keywordCount() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, AddVectorOverwritesExistingAddress )
+{
+    RimMockSummaryCase mockCase;
+
+    auto addr = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+    mockCase.addVector( addr, { 0 }, { 1.0 } );
+    mockCase.addVector( addr, { 0, 100 }, { 10.0, 20.0 } );
+
+    auto [ok, vals] = mockCase.values( addr );
+    EXPECT_TRUE( ok );
+    ASSERT_EQ( 2u, vals.size() );
+    EXPECT_DOUBLE_EQ( 10.0, vals[0] );
+    EXPECT_DOUBLE_EQ( 20.0, vals[1] );
+
+    EXPECT_EQ( 1u, mockCase.keywordCount() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// RimSummaryCase base class tests
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, CaseIdSetAndGet )
+{
+    RimMockSummaryCase mockCase;
+    mockCase.setCaseId( 42 );
+    EXPECT_EQ( 42, mockCase.caseId() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, SummaryHeaderFilename )
+{
+    RimMockSummaryCase mockCase;
+    mockCase.setSummaryHeaderFileName( "/tmp/test.SMSPEC" );
+    EXPECT_EQ( "/tmp/test.SMSPEC", mockCase.summaryHeaderFilename() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, IsObservedDataDefaultFalse )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_FALSE( mockCase.isObservedData() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, NativeCaseNameReturnsCaseName )
+{
+    RimMockSummaryCase mockCase;
+    mockCase.setName( "TestCase" );
+    EXPECT_EQ( "TestCase", mockCase.nativeCaseName() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, CustomCaseNameSetsDisplayName )
+{
+    RimMockSummaryCase mockCase;
+    mockCase.setCustomCaseName( "CustomName" );
+    EXPECT_EQ( "CustomName", mockCase.displayCaseName() );
+    EXPECT_EQ( RimCaseDisplayNameTools::DisplayName::CUSTOM, mockCase.displayNameType() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, DisplayNameOption )
+{
+    RimMockSummaryCase mockCase;
+    mockCase.setDisplayNameOption( RimCaseDisplayNameTools::DisplayName::FULL_CASE_NAME );
+    EXPECT_EQ( RimCaseDisplayNameTools::DisplayName::FULL_CASE_NAME, mockCase.displayNameType() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, UnitsSystemDelegatesToReader )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_EQ( RiaDefines::EclipseUnitSystem::UNITS_METRIC, mockCase.unitsSystem() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, CaseRealizationParametersDefault )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_FALSE( mockCase.hasCaseRealizationParameters() );
+    EXPECT_EQ( nullptr, mockCase.caseRealizationParameters() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, CaseRealizationParametersSetAndGet )
+{
+    RimMockSummaryCase mockCase;
+
+    auto params = std::make_shared<RigCaseRealizationParameters>();
+    mockCase.setCaseRealizationParameters( params );
+
+    EXPECT_TRUE( mockCase.hasCaseRealizationParameters() );
+    EXPECT_EQ( params, mockCase.caseRealizationParameters() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, LessThanOperatorSortsByCaseName )
+{
+    RimMockSummaryCase caseA;
+    RimMockSummaryCase caseB;
+    caseA.setName( "Alpha" );
+    caseB.setName( "Beta" );
+
+    EXPECT_TRUE( caseA < caseB );
+    EXPECT_FALSE( caseB < caseA );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, LessThanOperatorEqualNames )
+{
+    RimMockSummaryCase caseA;
+    RimMockSummaryCase caseB;
+    caseA.setName( "Same" );
+    caseB.setName( "Same" );
+
+    EXPECT_FALSE( caseA < caseB );
+    EXPECT_FALSE( caseB < caseA );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, CopyFromCopiesHeaderFilename )
+{
+    RimMockSummaryCase source;
+    source.setSummaryHeaderFileName( "/data/case.SMSPEC" );
+
+    RimMockSummaryCase target;
+    target.copyFrom( source );
+
+    EXPECT_EQ( "/data/case.SMSPEC", target.summaryHeaderFilename() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimMockSummaryCase, ShowTreeNodesDefault )
+{
+    RimMockSummaryCase mockCase;
+    EXPECT_TRUE( mockCase.showTreeNodes() );
+}

--- a/ApplicationLibCode/UnitTests/RimMockSummaryCase.h
+++ b/ApplicationLibCode/UnitTests/RimMockSummaryCase.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "RifSummaryReaderInterface.h"
+#include "RimSummaryCase.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+class RimMockSummaryCase : public RimSummaryCase, public RifSummaryReaderInterface
+{
+public:
+    void setName( const QString& name ) { m_name = name; }
+
+    void addVector( const RifEclipseSummaryAddress& address,
+                    const std::vector<time_t>&      timeSteps,
+                    const std::vector<double>&      values,
+                    const std::string&              unit = "" )
+    {
+        m_data[address] = { timeSteps, values, unit };
+        m_allResultAddresses.insert( address );
+    }
+
+    // RimSummaryCase overrides
+    void                       createSummaryReaderInterface() override {}
+    RifSummaryReaderInterface* summaryReader() override { return this; }
+    QString                    caseName() const override { return m_name; }
+
+    // RifSummaryReaderInterface overrides
+    std::vector<time_t> timeSteps( const RifEclipseSummaryAddress& resultAddress ) const override
+    {
+        auto it = m_data.find( resultAddress );
+        if ( it != m_data.end() ) return it->second.timeSteps;
+        return {};
+    }
+
+    std::pair<bool, std::vector<double>> values( const RifEclipseSummaryAddress& resultAddress ) const override
+    {
+        auto it = m_data.find( resultAddress );
+        if ( it != m_data.end() ) return { true, it->second.values };
+        return { false, {} };
+    }
+
+    std::string unitName( const RifEclipseSummaryAddress& resultAddress ) const override
+    {
+        auto it = m_data.find( resultAddress );
+        if ( it != m_data.end() ) return it->second.unit;
+        return {};
+    }
+
+    RiaDefines::EclipseUnitSystem unitSystem() const override { return RiaDefines::EclipseUnitSystem::UNITS_METRIC; }
+
+    size_t keywordCount() const override { return m_allResultAddresses.size(); }
+
+private:
+    struct VectorData
+    {
+        std::vector<time_t> timeSteps;
+        std::vector<double> values;
+        std::string         unit;
+    };
+
+    QString                                        m_name = "MockCase";
+    std::map<RifEclipseSummaryAddress, VectorData> m_data;
+};


### PR DESCRIPTION
Refactor summary address collection logic into a new utility module, `RiaSummaryAddressCollectionTools`, with functions for object identification, curve definition generation, duplicate filtering, and address-to-case/ensemble mapping. Update `RimSummaryPlot` to use these utilities, improving modularity and maintainability. Add comprehensive unit tests for the new module.

Closes #13513