### PR TITLE
Remove dependency from Rig libraries to Rim

### DIFF
--- a/ApplicationLibCode/Application/Tools/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Application/Tools/CMakeLists_files.cmake
@@ -29,7 +29,6 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaCurveDataTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaWellLogCurveMerger.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaTimeHistoryCurveResampler.h
-    ${CMAKE_CURRENT_LIST_DIR}/RiaStatisticsTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaOffshoreSphericalCoords.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedMeanCalculator.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaMedianCalculator.h
@@ -92,7 +91,6 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaCurveDataTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWellLogCurveMerger.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaTimeHistoryCurveResampler.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/RiaStatisticsTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedGeometricMeanCalculator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedHarmonicMeanCalculator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaOptionItemFactory.cpp

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicMswValveAccumulators.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicMswValveAccumulators.cpp
@@ -17,7 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 #include "RicMswValveAccumulators.h"
 
-#include "RiaStatisticsTools.h"
+#include "RigStatisticsTools.h"
 
 #include "RicMswCompletions.h"
 
@@ -126,7 +126,7 @@ bool RicMswAICDAccumulator::accumulateValveParameters( const RimWellPathValve* w
                 std::array<double, AICD_NUM_PARAMS> values = params->doubleValues();
                 for ( size_t i = 0; i < (size_t)AICD_NUM_PARAMS; ++i )
                 {
-                    if ( RiaStatisticsTools::isValidNumber( values[i] ) )
+                    if ( RigStatisticsTools::isValidNumber( values[i] ) )
                     {
                         m_meanCalculators[i].addValueAndWeight( values[i], overlapLength );
                     }
@@ -244,7 +244,7 @@ bool RicMswSICDAccumulator::accumulateValveParameters( const RimWellPathValve* w
                 std::array<double, SICD_NUM_PARAMS> values = params->doubleValues();
                 for ( size_t i = 0; i < (size_t)SICD_NUM_PARAMS; ++i )
                 {
-                    if ( RiaStatisticsTools::isValidNumber( values[i] ) )
+                    if ( RigStatisticsTools::isValidNumber( values[i] ) )
                     {
                         m_meanCalculators[i].addValueAndWeight( values[i], overlapLength );
                     }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp
@@ -23,8 +23,8 @@
 #include "RiaFractureDefines.h"
 #include "RiaLogging.h"
 #include "RiaPreferencesSystem.h"
-#include "RiaStatisticsTools.h"
 #include "RiaWeightedMeanCalculator.h"
+#include "RigStatisticsTools.h"
 
 #include "ExportCommands/RicExportLgrFeature.h"
 #include "RicExportCompletionDataSettingsUi.h"
@@ -422,7 +422,7 @@ RigCompletionData RicWellPathExportCompletionDataFeatureImpl::combineEclipseCell
     RiaWeightedMeanCalculator<double> skinFactorCalculator;
 
     auto isValidTransmissibility = []( double transmissibility )
-    { return RiaStatisticsTools::isValidNumber<double>( transmissibility ) && transmissibility >= 0.0; };
+    { return RigStatisticsTools::isValidNumber<double>( transmissibility ) && transmissibility >= 0.0; };
 
     auto startMD          = completions[0].startMD();
     auto endMD            = completions[0].endMD();

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/CMakeLists.txt
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/CMakeLists.txt
@@ -117,3 +117,7 @@ target_link_libraries(
                              CommonCode ResultStatisticsCache
 )
 target_link_libraries(RigGeoMechDataModel PRIVATE ResInsightCommonSettings)
+target_include_directories(
+  RigGeoMechDataModel
+  PRIVATE "$<TARGET_PROPERTY:ApplicationLibCode,INTERFACE_INCLUDE_DIRECTORIES>"
+)

--- a/ApplicationLibCode/GeoMech/GeoMechFileInterface/CMakeLists.txt
+++ b/ApplicationLibCode/GeoMech/GeoMechFileInterface/CMakeLists.txt
@@ -24,3 +24,7 @@ target_link_libraries(
   RifGeoMechFileInterface PUBLIC RigGeoMechDataModel LibCore
 )
 target_link_libraries(RifGeoMechFileInterface PRIVATE ResInsightCommonSettings)
+target_include_directories(
+  RifGeoMechFileInterface
+  PRIVATE "$<TARGET_PROPERTY:ApplicationLibCode,INTERFACE_INCLUDE_DIRECTORIES>"
+)

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
@@ -20,7 +20,7 @@
 
 #include "RiaLogging.h"
 #include "RiaPreferencesGrid.h"
-#include "RiaStatisticsTools.h"
+#include "RigStatisticsTools.h"
 
 #include "RicNewStatisticsContourMapViewFeature.h"
 
@@ -469,16 +469,16 @@ void RimStatisticsContourMap::doStatisticsCalculation( std::map<size_t, std::vec
 
             RigStatisticsMath::calculateStatisticsCurves( samples, &p10, &p50, &p90, &mean, RigStatisticsMath::PercentileStyle::SWITCHED );
 
-            if ( RiaStatisticsTools::isValidNumber( p10 ) ) p10Results[i] = p10;
-            if ( RiaStatisticsTools::isValidNumber( p50 ) ) p50Results[i] = p50;
-            if ( RiaStatisticsTools::isValidNumber( p90 ) ) p90Results[i] = p90;
-            if ( RiaStatisticsTools::isValidNumber( mean ) ) meanResults[i] = mean;
+            if ( RigStatisticsTools::isValidNumber( p10 ) ) p10Results[i] = p10;
+            if ( RigStatisticsTools::isValidNumber( p50 ) ) p50Results[i] = p50;
+            if ( RigStatisticsTools::isValidNumber( p90 ) ) p90Results[i] = p90;
+            if ( RigStatisticsTools::isValidNumber( mean ) ) meanResults[i] = mean;
 
-            double minValue = RiaStatisticsTools::minimumValue( samples );
-            if ( RiaStatisticsTools::isValidNumber( minValue ) && minValue < std::numeric_limits<double>::max() ) minResults[i] = minValue;
+            double minValue = RigStatisticsTools::minimumValue( samples );
+            if ( RigStatisticsTools::isValidNumber( minValue ) && minValue < std::numeric_limits<double>::max() ) minResults[i] = minValue;
 
-            double maxValue = RiaStatisticsTools::maximumValue( samples );
-            if ( RiaStatisticsTools::isValidNumber( maxValue ) && maxValue > -std::numeric_limits<double>::max() ) maxResults[i] = maxValue;
+            double maxValue = RigStatisticsTools::maximumValue( samples );
+            if ( RigStatisticsTools::isValidNumber( maxValue ) && maxValue > -std::numeric_limits<double>::max() ) maxResults[i] = maxValue;
         }
 
         m_timeResults[timeStep][StatisticsType::P10]  = p10Results;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
@@ -21,7 +21,7 @@
 #include "RiaColorTools.h"
 #include "RiaPreferences.h"
 #include "RiaQDateTimeTools.h"
-#include "RiaStatisticsTools.h"
+#include "RigStatisticsTools.h"
 #include "Summary/RiaSummaryCurveDefinition.h"
 
 #include "RifCsvDataTableFormatter.h"
@@ -560,7 +560,7 @@ void RimCorrelationMatrixPlot::createMatrix()
 
                     if ( parameterValues.empty() ) continue;
 
-                    correlation = RiaStatisticsTools::pearsonCorrelation( parameterValues, caseValuesAtTimestep );
+                    correlation = RigStatisticsTools::pearsonCorrelation( parameterValues, caseValuesAtTimestep );
 
                     bool validResult = RiaCurveDataTools::isValidValue( correlation, false );
                     if ( validResult )

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
@@ -22,9 +22,9 @@
 #include "RiaFieldHandleTools.h"
 #include "RiaFilePathTools.h"
 #include "RiaLogging.h"
-#include "RiaStatisticsTools.h"
 #include "RiaStdStringTools.h"
 #include "RiaTextStringTools.h"
+#include "RigStatisticsTools.h"
 #include "Summary/Ensemble/RimSummaryEnsembleParameterCollection.h"
 #include "Summary/RiaSummaryAddressAnalyzer.h"
 #include "Summary/RiaSummaryTools.h"
@@ -576,7 +576,7 @@ std::vector<std::pair<RigEnsembleParameter, double>>
     for ( auto parameterValuesPair : parameterValues )
     {
         double correlation = 0.0;
-        double pearson     = RiaStatisticsTools::pearsonCorrelation( parameterValuesPair.second, caseValuesAtTimestep );
+        double pearson     = RigStatisticsTools::pearsonCorrelation( parameterValuesPair.second, caseValuesAtTimestep );
         if ( pearson != std::numeric_limits<double>::infinity() ) correlation = pearson;
         correlationResults.push_back( std::make_pair( parameterValuesPair.first, correlation ) );
     }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryRegressionAnalysisCurve.cpp
@@ -21,8 +21,8 @@
 #include "RiaLogging.h"
 #include "RiaQDateTimeTools.h"
 #include "RiaRegressionTextTools.h"
-#include "RiaStatisticsTools.h"
 #include "RiaTimeTTools.h"
+#include "RigStatisticsTools.h"
 
 #include "RimEnsembleCurveSet.h"
 #include "RimEnsembleCurveSetCollection.h"
@@ -210,7 +210,7 @@ void RimSummaryRegressionAnalysisCurve::onLoadDataAndUpdate( bool updateParentPl
     {
         for ( size_t i = 0; i < xValues.size(); i++ )
         {
-            if ( xValues[i] < m_valueRangeX().first || xValues[i] > m_valueRangeX().second || !RiaStatisticsTools::isValidNumber( xValues[i] ) )
+            if ( xValues[i] < m_valueRangeX().first || xValues[i] > m_valueRangeX().second || !RigStatisticsTools::isValidNumber( xValues[i] ) )
             {
                 indicesToRemove.push_back( i );
             }
@@ -218,7 +218,7 @@ void RimSummaryRegressionAnalysisCurve::onLoadDataAndUpdate( bool updateParentPl
 
         for ( size_t i = 0; i < yValues.size(); i++ )
         {
-            if ( yValues[i] < m_valueRangeY().first || yValues[i] > m_valueRangeY().second || !RiaStatisticsTools::isValidNumber( yValues[i] ) )
+            if ( yValues[i] < m_valueRangeY().first || yValues[i] > m_valueRangeY().second || !RigStatisticsTools::isValidNumber( yValues[i] ) )
             {
                 indicesToRemove.push_back( i );
             }

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogRftCurve.cpp
@@ -27,8 +27,8 @@
 #include "RiaResultNames.h"
 #include "RiaRftDefines.h"
 #include "RiaSimWellBranchTools.h"
-#include "RiaStatisticsTools.h"
 #include "RiaTextStringTools.h"
+#include "RigStatisticsTools.h"
 #include "Summary/RiaSummaryTools.h"
 
 #include "RifEclipseRftAddress.h"
@@ -670,7 +670,7 @@ void RimWellLogRftCurve::onLoadDataAndUpdate( bool updateParentPlot )
         {
             for ( const auto& v : values )
             {
-                if ( RiaStatisticsTools::isValidNumber<double>( v ) ) return true;
+                if ( RigStatisticsTools::isValidNumber<double>( v ) ) return true;
             }
             return false;
         };

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.cpp
@@ -18,8 +18,8 @@
 
 #include "RigContourMapProjection.h"
 
-#include "RiaStatisticsTools.h"
 #include "RiaWeightedMeanCalculator.h"
+#include "RigStatisticsTools.h"
 
 #include "RigContourMapCalculator.h"
 #include "RigContourMapGrid.h"
@@ -231,7 +231,7 @@ double RigContourMapProjection::calculateValueInMapCell( unsigned int           
 //--------------------------------------------------------------------------------------------------
 double RigContourMapProjection::maxValue( const std::vector<double>& aggregatedResults )
 {
-    double maxV = RiaStatisticsTools::maximumValue( aggregatedResults );
+    double maxV = RigStatisticsTools::maximumValue( aggregatedResults );
     return maxV != -std::numeric_limits<double>::max() ? maxV : -std::numeric_limits<double>::infinity();
 }
 
@@ -240,7 +240,7 @@ double RigContourMapProjection::maxValue( const std::vector<double>& aggregatedR
 //--------------------------------------------------------------------------------------------------
 double RigContourMapProjection::minValue( const std::vector<double>& aggregatedResults )
 {
-    double minV = RiaStatisticsTools::minimumValue( aggregatedResults );
+    double minV = RigStatisticsTools::minimumValue( aggregatedResults );
     return minV != std::numeric_limits<double>::max() ? minV : std::numeric_limits<double>::infinity();
 }
 

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellTargetMapping.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellTargetMapping.cpp
@@ -1084,16 +1084,16 @@ void RigWellTargetMapping::computeStatisticsAndCreateVectors( RimEclipseCase&   
         double p10, p50, p90, mean;
         RigStatisticsMath::calculateStatisticsCurves( samples, &p10, &p50, &p90, &mean, RigStatisticsMath::PercentileStyle::SWITCHED );
 
-        if ( RiaStatisticsTools::isValidNumber( p10 ) ) p10Results[i] = p10;
-        if ( RiaStatisticsTools::isValidNumber( p50 ) ) p50Results[i] = p50;
-        if ( RiaStatisticsTools::isValidNumber( p90 ) ) p90Results[i] = p90;
-        if ( RiaStatisticsTools::isValidNumber( mean ) ) meanResults[i] = mean;
+        if ( RigStatisticsTools::isValidNumber( p10 ) ) p10Results[i] = p10;
+        if ( RigStatisticsTools::isValidNumber( p50 ) ) p50Results[i] = p50;
+        if ( RigStatisticsTools::isValidNumber( p90 ) ) p90Results[i] = p90;
+        if ( RigStatisticsTools::isValidNumber( mean ) ) meanResults[i] = mean;
 
-        double minValue = RiaStatisticsTools::minimumValue( samples );
-        if ( RiaStatisticsTools::isValidNumber( minValue ) && minValue < std::numeric_limits<double>::max() ) minResults[i] = minValue;
+        double minValue = RigStatisticsTools::minimumValue( samples );
+        if ( RigStatisticsTools::isValidNumber( minValue ) && minValue < std::numeric_limits<double>::max() ) minResults[i] = minValue;
 
-        double maxValue = RiaStatisticsTools::maximumValue( samples );
-        if ( RiaStatisticsTools::isValidNumber( maxValue ) && maxValue > -std::numeric_limits<double>::max() ) maxResults[i] = maxValue;
+        double maxValue = RigStatisticsTools::maximumValue( samples );
+        if ( RigStatisticsTools::isValidNumber( maxValue ) && maxValue > -std::numeric_limits<double>::max() ) maxResults[i] = maxValue;
     }
 
     createResultVectorIfDefined( targetCase, resultName + "_P10", p10Results );

--- a/ApplicationLibCode/ResultStatisticsCache/CMakeLists.txt
+++ b/ApplicationLibCode/ResultStatisticsCache/CMakeLists.txt
@@ -2,11 +2,16 @@ project(ResultStatisticsCache)
 
 add_library(
   ${PROJECT_NAME}
-  RigStatisticsCalculator.h RigStatisticsCalculator.cpp
-  RigStatisticsDataCache.h RigStatisticsDataCache.cpp RigStatisticsMath.h
+  RigStatisticsCalculator.h
+  RigStatisticsCalculator.cpp
+  RigStatisticsDataCache.h
+  RigStatisticsDataCache.cpp
+  RigStatisticsMath.h
   RigStatisticsMath.cpp
+  RigStatisticsTools.h
+  RigStatisticsTools.cpp
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(${PROJECT_NAME} LibCore ApplicationLibCode)
+target_link_libraries(${PROJECT_NAME} LibCore)

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
@@ -88,7 +88,7 @@ void RigStatisticsMath::calculateBasicStatistics( const std::vector<double>& val
     for ( size_t i = 0; i < values.size(); i++ )
     {
         double val = values[i];
-        if ( RiaStatisticsTools::isInvalidNumber<double>( val ) ) continue;
+        if ( RigStatisticsTools::isInvalidNumber<double>( val ) ) continue;
 
         validValueCount++;
 
@@ -207,7 +207,7 @@ std::expected<std::vector<double>, std::string> RigStatisticsMath::calculatePerc
 
     sortedValues.erase( std::remove_if( sortedValues.begin(),
                                         sortedValues.end(),
-                                        []( double x ) { return !RiaStatisticsTools::isValidNumber( x ); } ),
+                                        []( double x ) { return !RigStatisticsTools::isValidNumber( x ); } ),
                         sortedValues.end() );
 
     if ( sortedValues.empty() )
@@ -298,7 +298,7 @@ std::expected<std::vector<double>, std::string>
 
     for ( size_t i = 0; i < inputValues.size(); ++i )
     {
-        if ( RiaStatisticsTools::isValidNumber<double>( inputValues[i] ) )
+        if ( RigStatisticsTools::isValidNumber<double>( inputValues[i] ) )
         {
             sortedValues.push_back( inputValues[i] );
         }
@@ -372,7 +372,7 @@ std::expected<std::vector<double>, std::string>
 
     for ( size_t i = 0; i < inputValues.size(); ++i )
     {
-        if ( RiaStatisticsTools::isValidNumber<double>( inputValues[i] ) )
+        if ( RigStatisticsTools::isValidNumber<double>( inputValues[i] ) )
         {
             sortedValues.push_back( inputValues[i] );
         }
@@ -423,7 +423,7 @@ double RigStatisticsMath::calculateMean( const std::vector<double>& values )
     std::vector<double> validValues = values;
     validValues.erase( std::remove_if( validValues.begin(),
                                        validValues.end(),
-                                       []( double x ) { return !RiaStatisticsTools::isValidNumber( x ); } ),
+                                       []( double x ) { return !RigStatisticsTools::isValidNumber( x ); } ),
                        validValues.end() );
 
     if ( !validValues.empty() )
@@ -466,7 +466,7 @@ RigHistogramCalculator::RigHistogramCalculator( double min, double max, size_t n
 //--------------------------------------------------------------------------------------------------
 void RigHistogramCalculator::addValue( double value )
 {
-    if ( RiaStatisticsTools::isInvalidNumber<double>( value ) ) return;
+    if ( RigStatisticsTools::isInvalidNumber<double>( value ) ) return;
 
     size_t index = 0;
 

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.h
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.h
@@ -17,7 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include "RiaStatisticsTools.h"
+#include "RigStatisticsTools.h"
 
 #include <cmath>
 #include <cstddef>
@@ -113,7 +113,7 @@ public:
 
     void addValue( double value )
     {
-        if ( RiaStatisticsTools::isValidNumber<double>( value ) )
+        if ( RigStatisticsTools::isValidNumber<double>( value ) )
         {
             if ( value < min )
             {
@@ -192,7 +192,7 @@ public:
 
     void addValue( double value )
     {
-        if ( RiaStatisticsTools::isValidNumber<double>( value ) )
+        if ( RigStatisticsTools::isValidNumber<double>( value ) )
         {
             if ( value < pos && value > 0 )
             {
@@ -237,7 +237,7 @@ public:
 
     void addValue( double value )
     {
-        if ( RiaStatisticsTools::isValidNumber<double>( value ) )
+        if ( RigStatisticsTools::isValidNumber<double>( value ) )
         {
             valueSum += value;
             ++sampleCount;
@@ -271,7 +271,7 @@ public:
 
     void addValue( double value )
     {
-        if ( RiaStatisticsTools::isValidNumber<double>( value ) )
+        if ( RigStatisticsTools::isValidNumber<double>( value ) )
         {
             uniqueValues.insert( static_cast<int>( value ) );
         }

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsTools.cpp
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsTools.cpp
@@ -18,14 +18,14 @@
 //
 /////////////////////////////////////////////////////////////////////////////////
 
-#include "RiaStatisticsTools.h"
+#include "RigStatisticsTools.h"
 
 #include "RigStatisticsMath.h"
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-double RiaStatisticsTools::pearsonCorrelation( const std::vector<double>& xValues, const std::vector<double>& yValues )
+double RigStatisticsTools::pearsonCorrelation( const std::vector<double>& xValues, const std::vector<double>& yValues )
 {
     const double eps    = 1.0e-8;
     double       rangeX = 0.0, rangeY = 0.0;

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsTools.h
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsTools.h
@@ -29,7 +29,7 @@
 //
 //
 //==================================================================================================
-class RiaStatisticsTools
+class RigStatisticsTools
 {
 public:
     template <class NumberType>
@@ -50,7 +50,7 @@ public:
         NumberType minValue = std::numeric_limits<NumberType>::max();
         for ( NumberType value : values )
         {
-            if ( RiaStatisticsTools::isValidNumber<NumberType>( value ) )
+            if ( RigStatisticsTools::isValidNumber<NumberType>( value ) )
             {
                 minValue = std::min( minValue, value );
             }
@@ -65,7 +65,7 @@ public:
         NumberType maxValue = -std::numeric_limits<NumberType>::max();
         for ( NumberType value : values )
         {
-            if ( RiaStatisticsTools::isValidNumber<NumberType>( value ) )
+            if ( RigStatisticsTools::isValidNumber<NumberType>( value ) )
             {
                 maxValue = std::max( maxValue, value );
             }

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -80,7 +80,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RifColorLegendData-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifRoffReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifElasticPropertiesReader-Test.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/RiaStatisticsTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigStatisticsTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifStimPlanXmlReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifThermalFractureReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellPathGeometryExporter-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigStatisticsTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigStatisticsTools-Test.cpp
@@ -18,13 +18,13 @@
 
 #include "gtest/gtest.h"
 
-#include "RiaStatisticsTools.h"
+#include "RigStatisticsTools.h"
 
 #include <QDebug>
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RiaStatisticsTools, NoCorrelation )
+TEST( RigStatisticsTools, NoCorrelation )
 {
     const int           N = 1000;
     std::vector<double> a, b;
@@ -38,14 +38,14 @@ TEST( RiaStatisticsTools, NoCorrelation )
     {
         b.push_back( (double)std::rand() );
     }
-    double correlation = RiaStatisticsTools::pearsonCorrelation( a, b );
+    double correlation = RigStatisticsTools::pearsonCorrelation( a, b );
     EXPECT_LE( correlation, 0.25 );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RiaStatisticsTools, FullCorrelation )
+TEST( RigStatisticsTools, FullCorrelation )
 {
     const int           N = 1000;
     std::vector<double> a, b;
@@ -59,14 +59,14 @@ TEST( RiaStatisticsTools, FullCorrelation )
     {
         b.push_back( i * 2.0 + 1.0 );
     }
-    double correlation = RiaStatisticsTools::pearsonCorrelation( a, b );
+    double correlation = RigStatisticsTools::pearsonCorrelation( a, b );
     EXPECT_NEAR( correlation, 1.0, 1.0e-2 );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RiaStatisticsTools, NegativeCorrelation )
+TEST( RigStatisticsTools, NegativeCorrelation )
 {
     const int           N = 1000;
     std::vector<double> a, b;
@@ -80,14 +80,14 @@ TEST( RiaStatisticsTools, NegativeCorrelation )
     {
         b.push_back( i * -2.0 + 1.0 );
     }
-    double correlation = RiaStatisticsTools::pearsonCorrelation( a, b );
+    double correlation = RigStatisticsTools::pearsonCorrelation( a, b );
     EXPECT_NEAR( correlation, -1.0, 1.0e-2 );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RiaStatisticsTools, MinValue )
+TEST( RigStatisticsTools, MinValue )
 {
     const int           N = 1000;
     std::vector<double> a;
@@ -95,14 +95,14 @@ TEST( RiaStatisticsTools, MinValue )
     {
         a.push_back( static_cast<double>( i ) );
     }
-    double minValue = RiaStatisticsTools::minimumValue( a );
+    double minValue = RigStatisticsTools::minimumValue( a );
     EXPECT_EQ( minValue, 10.0 );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-TEST( RiaStatisticsTools, MaxValue )
+TEST( RigStatisticsTools, MaxValue )
 {
     const int           N = 1000;
     std::vector<double> a;
@@ -110,6 +110,6 @@ TEST( RiaStatisticsTools, MaxValue )
     {
         a.push_back( static_cast<double>( i ) );
     }
-    double maxValue = RiaStatisticsTools::maximumValue( a );
+    double maxValue = RigStatisticsTools::maximumValue( a );
     EXPECT_EQ( maxValue, 999.0 );
 }


### PR DESCRIPTION
`ResultStatisticsCache` was depending on `ApplicationLibCode` because of the class `RiaStatisticsTools`. Move and rename this class into `ResultStatisticsCache` and remove dependency.

Fix other missing compile errors due to missing includes in other libraries. 