### PR TITLE
RHEL8: Add separate vcpkg configuration and readme

### DIFF
--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -139,6 +139,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           prefix: vcpkg-g++/
 
+      - name: Use RHEL8 vcpkg configuration
+        run: cp vcpkg-configuration-rhel8.json vcpkg-configuration.json
+
       - name: Configure CMake
         env:
           CC: /opt/rh/gcc-toolset-14/root/usr/bin/gcc

--- a/vcpkg-configuration-rhel8.json
+++ b/vcpkg-configuration-rhel8.json
@@ -1,0 +1,14 @@
+{
+    "default-registry": {
+        "kind": "git",
+        "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
+        "repository": "https://github.com/microsoft/vcpkg"
+    },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg-readme.md
+++ b/vcpkg-readme.md
@@ -1,0 +1,26 @@
+# vcpkg Configuration
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `vcpkg-configuration.json` | Default registry configuration used by all builds |
+| `vcpkg-configuration-rhel8.json` | RHEL8-specific registry configuration with a separate baseline |
+
+## Changing the baseline
+
+The `baseline` field in each configuration file pins the vcpkg registry to a specific commit of [microsoft/vcpkg](https://github.com/microsoft/vcpkg). Packages available at that commit are used for dependency resolution.
+
+- Update `vcpkg-configuration.json` for the default (Ubuntu/Windows) builds.
+- Update `vcpkg-configuration-rhel8.json` independently when a different baseline is needed for RHEL8 (Rocky Linux 8) compatibility — e.g. to match older system libraries (glibc 2.28, OpenSSL 1.1).
+
+## RHEL8 CI usage
+
+The workflow `.github/workflows/rhel8-unit-tests.yml` copies `vcpkg-configuration-rhel8.json` over `vcpkg-configuration.json` before invoking cmake:
+
+```yaml
+- name: Use RHEL8 vcpkg configuration
+  run: cp vcpkg-configuration-rhel8.json vcpkg-configuration.json
+```
+
+This ensures vcpkg uses the RHEL8 baseline without affecting other CI runs.


### PR DESCRIPTION
Add vcpkg-configuration-rhel8.json with an independent baseline that
can be updated separately from the default config. The RHEL8 CI workflow
copies this file over vcpkg-configuration.json before running cmake.
Add vcpkg-readme.md documenting the configuration files and their usage.
