### PR TITLE
RigActiveCellInfo: Fix debug build error in setCellResultIndex

### DIFF
--- a/ApplicationLibCode/Application/RiaMemoryCleanup.cpp
+++ b/ApplicationLibCode/Application/RiaMemoryCleanup.cpp
@@ -335,7 +335,7 @@ void RiaMemoryCleanup::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderin
                                  clearSelectedResultsFromMemory();
                                  m_resultsToDelete.uiCapability()->updateConnectedEditors();
                              } );
-    uiOrdering.addNewButton( "Show Memory Report", [this]() { RiaMemoryCleanup::showMemoryReport(); } );
+    uiOrdering.addNewButton( "Show Memory Report", []() { RiaMemoryCleanup::showMemoryReport(); } );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.cpp
@@ -90,7 +90,7 @@ size_t RigActiveCellInfo::cellResultIndex( size_t reservoirCellIndex ) const
 //--------------------------------------------------------------------------------------------------
 void RigActiveCellInfo::setCellResultIndex( ReservoirCellIndex reservoirCellIndex, ActiveCellIndex reservoirCellResultIndex )
 {
-    CVF_TIGHT_ASSERT( reservoirCellResultIndex < m_reservoirCellToActiveCell.size() );
+    CVF_TIGHT_ASSERT( reservoirCellResultIndex.value() < m_reservoirCellToActiveCell.size() );
 
     m_reservoirCellToActiveCell[reservoirCellIndex.value()] = reservoirCellResultIndex;
 }


### PR DESCRIPTION
Access the underlying value of the type-safe ActiveCellIndex in the assertion to resolve a compilation error in debug builds.
