### PR TITLE
#13713 RifReaderOpmCommon: Fix ACTNUM showing undefined when only stored in EGRID

### DIFF
--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -604,6 +604,16 @@ void RifReaderOpmCommon::transferGeometry( Opm::EclIO::EGrid&  opmMainGrid,
 //--------------------------------------------------------------------------------------------------
 bool RifReaderOpmCommon::staticResult( const QString& result, RiaDefines::PorosityModelType matrixOrFracture, std::vector<double>* values )
 {
+    // Active cell info is populated from the EGRID during grid import via transferActiveCells(), which reads ACTNUM from the OPM EGrid
+    // object. Most simulators also write it to INIT, but some do not. Derive the values directly from the active cell info to handle both
+    // cases consistently.
+    if ( result.compare( "ACTNUM", Qt::CaseInsensitive ) == 0 )
+    {
+        RigActiveCellInfo* activeCellInfo = m_eclipseCaseData->activeCellInfo( matrixOrFracture );
+        values->resize( activeCellInfo->reservoirActiveCellCount(), 1.0 );
+        return true;
+    }
+
     if ( m_initFile )
     {
         try

--- a/ResInsightVersion.cmake
+++ b/ResInsightVersion.cmake
@@ -11,7 +11,7 @@ set(RESINSIGHT_VERSION_TEXT "-dev")
 # Must be unique and increasing within one combination of major/minor/patch version 
 # The uniqueness of this text is independent of RESINSIGHT_VERSION_TEXT 
 # Format of text must be ".xx"
-set(RESINSIGHT_DEV_VERSION ".02")
+set(RESINSIGHT_DEV_VERSION ".03")
 
 set(STRPRODUCTVER ${RESINSIGHT_MAJOR_VERSION}.${RESINSIGHT_MINOR_VERSION}.${RESINSIGHT_PATCH_VERSION}${RESINSIGHT_VERSION_TEXT}${RESINSIGHT_DEV_VERSION})
 


### PR DESCRIPTION
## Summary
- `RifReaderOpmCommon::staticResult()` searched only the INIT file for `ACTNUM`, but ACTNUM lives in the EGRID file
- Models that do not duplicate ACTNUM into the INIT file returned an empty result vector, causing all cells to display as undefined
- Fix by deriving ACTNUM values directly from the active cell info, which is already populated from the EGRID during grid import via `transferActiveCells()`

Closes #13713