### PR TITLE
#13715 Plot Editor: Make summary data available for all ensemble realizations

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
@@ -1073,8 +1073,11 @@ std::set<RifEclipseSummaryAddress>
 
         if ( currCase )
         {
-            RifSummaryReaderInterface* reader = currCase->summaryReader();
-            if ( reader ) allAddresses = reader->allResultAddresses();
+            if ( RifSummaryReaderInterface* reader = currCase->summaryReader() )
+            {
+                reader->createAddressesIfRequired();
+                allAddresses = reader->allResultAddresses();
+            }
         }
         else if ( currEnsemble )
         {


### PR DESCRIPTION
## Summary
- In the Plot Editor dialog, summary data was only available for the first (representative) realization of an ensemble
- For ensemble member cases used as individual sources, `createAddressesIfRequired()` was never called, so `allResultAddresses()` returned an empty set for all non-representative realizations
- Added `createAddressesIfRequired()` call before `allResultAddresses()` in `RiuSummaryVectorSelectionUi::findPossibleSummaryAddresses()` to lazily populate addresses on demand

Fixes #13715