### PR TITLE
#13717 RimReservoirGridEnsemble: Fix statistics not including all realizations

### DIFF
--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
@@ -172,7 +172,8 @@ RicImportGridAndSummaryEnsembleDialog::RicImportGridAndSummaryEnsembleDialog( QW
     m_searchButton->setFixedWidth( 75 );
 
     m_useRealizationStarCheckBox = new QCheckBox( "Use 'realization-*' in filter" );
-    m_ensembleGroupingMode       = new QComboBox();
+    m_useRealizationStarCheckBox->setChecked( true );
+    m_ensembleGroupingMode = new QComboBox();
 
     m_createGridEnsembleCheckBox    = new QCheckBox( "Create Grid Ensemble" );
     m_createSummaryEnsembleCheckBox = new QCheckBox( "Create Summary Ensemble" );
@@ -194,6 +195,7 @@ RicImportGridAndSummaryEnsembleDialog::RicImportGridAndSummaryEnsembleDialog( QW
     m_fileTreeView->setContextMenuPolicy( Qt::CustomContextMenu );
     m_fileTreeView->setVisible( false );
     m_fileTreeView->setMinimumHeight( 350 );
+    m_fileTreeView->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
 
     m_browseButton->setFixedWidth( 25 );
 
@@ -283,12 +285,14 @@ RicImportGridAndSummaryEnsembleDialog::RicImportGridAndSummaryEnsembleDialog( QW
     outputGridLayout->addWidget( m_treeFilterLineEdit, 0, 0 );
     outputGridLayout->addWidget( m_treeFilterButton, 0, 1 );
     outputGridLayout->addWidget( m_fileTreeView, 1, 0, 1, 2 );
+    outputGridLayout->setRowStretch( 0, 0 );
+    outputGridLayout->setRowStretch( 1, 1 );
     m_outputGroup->setLayout( outputGridLayout );
 
-    dialogLayout->addWidget( searchGroup );
-    dialogLayout->addWidget( importGroup );
-    dialogLayout->addWidget( m_outputGroup );
-    dialogLayout->addWidget( m_buttons );
+    dialogLayout->addWidget( searchGroup, 0 );
+    dialogLayout->addWidget( importGroup, 0 );
+    dialogLayout->addWidget( m_outputGroup, 1 );
+    dialogLayout->addWidget( m_buttons, 0 );
 
     setLayout( dialogLayout );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -932,6 +932,10 @@ void RimReservoirGridEnsemble::loadGridsInSharedMode()
             eclipseCase->eclipseCaseData()->setMainGrid( m_mainGrid );
         }
 
+        RigCaseCellResultsData::copyResultsMetaDataFromMainCase( firstCase->eclipseCaseData(),
+                                                                 RiaDefines::PorosityModelType::MATRIX_MODEL,
+                                                                 allCases );
+
         computeUnionOfActiveCells();
     }
 }

--- a/docs/agents/core.md
+++ b/docs/agents/core.md
@@ -69,11 +69,15 @@ ResInsight includes Python integration via gRPC when `RESINSIGHT_ENABLE_GRPC=ON`
 - Third-party dependencies: `ThirdParty/` with individual CMakeLists.txt files
 - Python API: `GrpcInterface/Python/`
 
-## Git Commit Conventions
+## Git
 
+### Commit Conventions
 - When creating a git commit for a feature request use the issue number at the start of the title, e.g "#12773 Python: Add API for creating valve templates"
 - When creating a commit use git conventions
 - Always run python formatting/check on changed files before commits
+
+### PR Conventions
+- Do not include a test plan in the PR description
 
 ## Making PDM Objects Scriptable for Python GRPC Interface
 


### PR DESCRIPTION
## Summary
- `RimReservoirGridEnsemble` was missing a call to `RigCaseCellResultsData::copyResultsMetaDataFromMainCase()` in `loadGridsInSharedMode()`
- Without result metadata, cases 1..N returned `UNDEFINED_SIZE_T` from `findOrLoadKnownScalarResultForTimeStep()`, causing them to be silently excluded from statistics calculations
- Fix mirrors the behavior of `RimIdenticalGridCaseGroup::loadMainCaseAndActiveCellInfo()` which has always done this correctly

Fixes #13717