### PR TITLE
cafProgressInfo: Prevent multiple overlapping progress dialogs

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -73,6 +73,7 @@
 #include "RiuViewer.h"
 
 #include "cafAnimationToolBar.h"
+#include "cafProgressInfo.h"
 #include "cafCmdExecCommandManager.h"
 #include "cafCmdFeatureManager.h"
 #include "cafMemoryInspector.h"
@@ -106,6 +107,7 @@
 #include <QMimeData>
 #include <QSpinBox>
 #include <QStatusBar>
+#include <QThread>
 #include <QTimer>
 #include <QToolBar>
 #include <QToolButton>
@@ -383,6 +385,8 @@ void RiuMainWindow::createActions()
     m_executePaintEventPerformanceTest = new QAction( "&Paint Event Performance Test", this );
     m_sendTestTelemetryAction          = new QAction( "&Send Test Telemetry", this );
     m_sendTestTelemetryAction->setToolTip( "Send test logging and stack trace to OpenTelemetry endpoint" );
+    m_testProgressBarAction = new QAction( "Test Progress Bar", this );
+    m_testProgressBarAction->setToolTip( "Run a long task to test the progress bar widget" );
 
     connect( m_mockModelAction, SIGNAL( triggered() ), SLOT( slotMockModel() ) );
     connect( m_mockResultsModelAction, SIGNAL( triggered() ), SLOT( slotMockResultsModel() ) );
@@ -395,6 +399,7 @@ void RiuMainWindow::createActions()
     connect( m_showRegressionTestDialog, SIGNAL( triggered() ), SLOT( slotShowRegressionTestDialog() ) );
     connect( m_executePaintEventPerformanceTest, SIGNAL( triggered() ), SLOT( slotExecutePaintEventPerformanceTest() ) );
     connect( m_sendTestTelemetryAction, SIGNAL( triggered() ), SLOT( slotSendTestTelemetry() ) );
+    connect( m_testProgressBarAction, SIGNAL( triggered() ), SLOT( slotTestProgressBar() ) );
 
     // View actions
     m_viewFullScreen = new QAction( QIcon( ":/Fullscreen.png" ), "Full Screen", this );
@@ -561,6 +566,7 @@ void RiuMainWindow::createMenus()
     testMenu->addAction( m_showRegressionTestDialog );
     testMenu->addAction( m_executePaintEventPerformanceTest );
     testMenu->addAction( m_sendTestTelemetryAction );
+    testMenu->addAction( m_testProgressBarAction );
     testMenu->addAction( cmdFeatureMgr->action( "RicRunCommandFileFeature" ) );
     testMenu->addAction( cmdFeatureMgr->action( "RicExportObjectAndFieldKeywordsFeature" ) );
     testMenu->addAction( cmdFeatureMgr->action( "RicSaveProjectNoGlobalPathsFeature" ) );
@@ -2016,6 +2022,23 @@ void RiuMainWindow::slotSendTestTelemetry()
     // Intentional crash for testing crash handling / telemetry.
     std::raise( SIGSEGV );
     return;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMainWindow::slotTestProgressBar()
+{
+    const int    totalSteps   = 6;
+    const int    sleepSeconds = 2;
+    caf::ProgressInfo progress( totalSteps, "Test Progress Bar" );
+
+    for ( int i = 0; i < totalSteps; i++ )
+    {
+        progress.setProgressDescription( QString( "Step %1 of %2 - sleeping %3 seconds..." ).arg( i + 1 ).arg( totalSteps ).arg( sleepSeconds ) );
+        QThread::sleep( sleepSeconds );
+        progress.incrementProgress();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -73,13 +73,13 @@
 #include "RiuViewer.h"
 
 #include "cafAnimationToolBar.h"
-#include "cafProgressInfo.h"
 #include "cafCmdExecCommandManager.h"
 #include "cafCmdFeatureManager.h"
 #include "cafMemoryInspector.h"
 #include "cafPdmUiPropertyView.h"
 #include "cafPdmUiPropertyViewDialog.h"
 #include "cafPdmUiTreeView.h"
+#include "cafProgressInfo.h"
 #include "cafSelectionManager.h"
 #include "cafUtils.h"
 
@@ -2029,13 +2029,14 @@ void RiuMainWindow::slotSendTestTelemetry()
 //--------------------------------------------------------------------------------------------------
 void RiuMainWindow::slotTestProgressBar()
 {
-    const int    totalSteps   = 6;
-    const int    sleepSeconds = 2;
+    const int         totalSteps   = 6;
+    const int         sleepSeconds = 2;
     caf::ProgressInfo progress( totalSteps, "Test Progress Bar" );
 
     for ( int i = 0; i < totalSteps; i++ )
     {
-        progress.setProgressDescription( QString( "Step %1 of %2 - sleeping %3 seconds..." ).arg( i + 1 ).arg( totalSteps ).arg( sleepSeconds ) );
+        progress.setProgressDescription(
+            QString( "Step %1 of %2 - sleeping %3 seconds..." ).arg( i + 1 ).arg( totalSteps ).arg( sleepSeconds ) );
         QThread::sleep( sleepSeconds );
         progress.incrementProgress();
     }

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.h
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.h
@@ -177,6 +177,7 @@ private:
     QAction* m_showRegressionTestDialog;
     QAction* m_executePaintEventPerformanceTest;
     QAction* m_sendTestTelemetryAction;
+    QAction* m_testProgressBarAction;
 
     caf::AnimationToolBar* m_animationToolBar;
 
@@ -241,6 +242,7 @@ private slots:
     void slotShowRegressionTestDialog();
     void slotExecutePaintEventPerformanceTest();
     void slotSendTestTelemetry();
+    void slotTestProgressBar();
 
     // Mock models
     void slotMockModel();

--- a/Fwk/AppFwk/cafAnimControl/cafAnimationToolBar.cpp
+++ b/Fwk/AppFwk/cafAnimControl/cafAnimationToolBar.cpp
@@ -203,8 +203,8 @@ void AnimationToolBar::connectAnimationControl( caf::FrameAnimationControl* anim
 
     m_animRepeatFromStartAction->disconnect();
 
-    m_timestepCombo->disconnect();
-    m_frameRateSlider->disconnect();
+    disconnect( m_timestepCombo, SIGNAL( currentIndexChanged( int ) ), nullptr, nullptr );
+    disconnect( m_frameRateSlider, SIGNAL( valueChanged( int ) ), nullptr, nullptr );
 
     if ( animationControl )
     {

--- a/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
@@ -262,8 +262,11 @@ static QProgressDialog* progressDialog()
     QWidget* parent = app != nullptr ? app->activeWindow() : nullptr;
 
     // Check if the current prog dialog (if any) has a proper parent.
-    // If not, re-create it, to make sure it is positioned in the correct main window
-    if ( !progDialog.isNull() && ( progDialog->parent() != parent ) && ( parent != nullptr ) )
+    // If not, re-create it, to make sure it is positioned in the correct main window.
+    // Only reparent when no progress operation is active - during an active operation
+    // activeWindow() may change due to processEvents(), which would create multiple overlapping dialogs.
+    if ( !progDialog.isNull() && ( progDialog->parent() != parent ) && ( parent != nullptr ) &&
+         !ProgressInfoStatic::isRunning() )
     {
         // Thread check, we can only modify the progDialog if we are in the same thread as it belongs
         if ( QThread::currentThread() == progDialog->thread() )


### PR DESCRIPTION
## Summary

- Fixed a bug where multiple progress dialogs appeared on top of each other during long-running operations
- Root cause: `progressDialog()` checked `app->activeWindow()` on every call, and `processEvents()` inside progress updates could change the active window mid-operation, causing the existing dialog to be deleted and a new one created
- Fix: only reparent the dialog when no progress operation is running (`!ProgressInfoStatic::isRunning()`)
- Added a **Test Progress Bar** entry to File→Testing menu (6 steps × 2 sec ≈ 12 sec) to reproduce and verify the issue

Closes #13722 