### PR TITLE
cafProgressInfo: Support progress updates from non-GUI threads

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -79,6 +79,7 @@
 #include "cafPdmUiPropertyView.h"
 #include "cafPdmUiPropertyViewDialog.h"
 #include "cafPdmUiTreeView.h"
+#include "cafProgressInfo.h"
 #include "cafSelectionManager.h"
 #include "cafUtils.h"
 
@@ -106,6 +107,7 @@
 #include <QMimeData>
 #include <QSpinBox>
 #include <QStatusBar>
+#include <QThread>
 #include <QTimer>
 #include <QToolBar>
 #include <QToolButton>
@@ -383,6 +385,8 @@ void RiuMainWindow::createActions()
     m_executePaintEventPerformanceTest = new QAction( "&Paint Event Performance Test", this );
     m_sendTestTelemetryAction          = new QAction( "&Send Test Telemetry", this );
     m_sendTestTelemetryAction->setToolTip( "Send test logging and stack trace to OpenTelemetry endpoint" );
+    m_testProgressBarAction = new QAction( "Test Progress Bar", this );
+    m_testProgressBarAction->setToolTip( "Run a long task to test the progress bar widget" );
 
     connect( m_mockModelAction, SIGNAL( triggered() ), SLOT( slotMockModel() ) );
     connect( m_mockResultsModelAction, SIGNAL( triggered() ), SLOT( slotMockResultsModel() ) );
@@ -395,6 +399,7 @@ void RiuMainWindow::createActions()
     connect( m_showRegressionTestDialog, SIGNAL( triggered() ), SLOT( slotShowRegressionTestDialog() ) );
     connect( m_executePaintEventPerformanceTest, SIGNAL( triggered() ), SLOT( slotExecutePaintEventPerformanceTest() ) );
     connect( m_sendTestTelemetryAction, SIGNAL( triggered() ), SLOT( slotSendTestTelemetry() ) );
+    connect( m_testProgressBarAction, SIGNAL( triggered() ), SLOT( slotTestProgressBar() ) );
 
     // View actions
     m_viewFullScreen = new QAction( QIcon( ":/Fullscreen.png" ), "Full Screen", this );
@@ -561,6 +566,7 @@ void RiuMainWindow::createMenus()
     testMenu->addAction( m_showRegressionTestDialog );
     testMenu->addAction( m_executePaintEventPerformanceTest );
     testMenu->addAction( m_sendTestTelemetryAction );
+    testMenu->addAction( m_testProgressBarAction );
     testMenu->addAction( cmdFeatureMgr->action( "RicRunCommandFileFeature" ) );
     testMenu->addAction( cmdFeatureMgr->action( "RicExportObjectAndFieldKeywordsFeature" ) );
     testMenu->addAction( cmdFeatureMgr->action( "RicSaveProjectNoGlobalPathsFeature" ) );
@@ -2016,6 +2022,33 @@ void RiuMainWindow::slotSendTestTelemetry()
     // Intentional crash for testing crash handling / telemetry.
     std::raise( SIGSEGV );
     return;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMainWindow::slotTestProgressBar()
+{
+    const int         totalSteps   = 6;
+    const int         sleepSeconds = 2;
+    caf::ProgressInfo progress( totalSteps, "Test Progress Bar", false );
+
+    QEventLoop eventLoop;
+    QThread*   workerThread = QThread::create(
+        [&progress]()
+        {
+            for ( int i = 0; i < totalSteps; i++ )
+            {
+                progress.setProgressDescription(
+                    QString( "Step %1 of %2 - sleeping %3 seconds..." ).arg( i + 1 ).arg( totalSteps ).arg( sleepSeconds ) );
+                QThread::sleep( sleepSeconds );
+                progress.incrementProgress();
+            }
+        } );
+    connect( workerThread, &QThread::finished, &eventLoop, &QEventLoop::quit );
+    workerThread->start();
+    eventLoop.exec( QEventLoop::ExcludeUserInputEvents );
+    workerThread->deleteLater();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.h
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.h
@@ -177,6 +177,7 @@ private:
     QAction* m_showRegressionTestDialog;
     QAction* m_executePaintEventPerformanceTest;
     QAction* m_sendTestTelemetryAction;
+    QAction* m_testProgressBarAction;
 
     caf::AnimationToolBar* m_animationToolBar;
 
@@ -241,6 +242,7 @@ private slots:
     void slotShowRegressionTestDialog();
     void slotExecutePaintEventPerformanceTest();
     void slotSendTestTelemetry();
+    void slotTestProgressBar();
 
     // Mock models
     void slotMockModel();

--- a/Fwk/AppFwk/cafAnimControl/cafAnimationToolBar.cpp
+++ b/Fwk/AppFwk/cafAnimControl/cafAnimationToolBar.cpp
@@ -203,8 +203,8 @@ void AnimationToolBar::connectAnimationControl( caf::FrameAnimationControl* anim
 
     m_animRepeatFromStartAction->disconnect();
 
-    m_timestepCombo->disconnect();
-    m_frameRateSlider->disconnect();
+    disconnect( m_timestepCombo, SIGNAL( currentIndexChanged( int ) ), nullptr, nullptr );
+    disconnect( m_frameRateSlider, SIGNAL( valueChanged( int ) ), nullptr, nullptr );
 
     if ( animationControl )
     {

--- a/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
@@ -253,6 +253,15 @@ QString createMemoryLabelText()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+static bool isOnGuiThread()
+{
+    auto* app = QCoreApplication::instance();
+    return app && ( QThread::currentThread() == app->thread() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 static QProgressDialog* progressDialog()
 {
     static QPointer<QProgressDialog> progDialog;
@@ -262,8 +271,11 @@ static QProgressDialog* progressDialog()
     QWidget* parent = app != nullptr ? app->activeWindow() : nullptr;
 
     // Check if the current prog dialog (if any) has a proper parent.
-    // If not, re-create it, to make sure it is positioned in the correct main window
-    if ( !progDialog.isNull() && ( progDialog->parent() != parent ) && ( parent != nullptr ) )
+    // If not, re-create it, to make sure it is positioned in the correct main window.
+    // Only reparent when no progress operation is active - during an active operation
+    // activeWindow() may change due to processEvents(), which would create multiple overlapping dialogs.
+    if ( !progDialog.isNull() && ( progDialog->parent() != parent ) && ( parent != nullptr ) &&
+         !ProgressInfoStatic::isRunning() )
     {
         // Thread check, we can only modify the progDialog if we are in the same thread as it belongs
         if ( QThread::currentThread() == progDialog->thread() )
@@ -498,6 +510,16 @@ void ProgressInfoStatic::start( ProgressInfo&  progressInfo,
                                 bool           delayShowingProgress,
                                 bool           allowCancel )
 {
+    if ( !isOnGuiThread() )
+    {
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(),
+            [&]()
+            { ProgressInfoStatic::start( progressInfo, maxProgressValue, title, delayShowingProgress, allowCancel ); },
+            Qt::BlockingQueuedConnection );
+        return;
+    }
+
     if ( !isUpdatePossible() ) return;
 
     std::vector<size_t>& progressStack_v     = progressStack();
@@ -562,6 +584,15 @@ void ProgressInfoStatic::start( ProgressInfo&  progressInfo,
 //--------------------------------------------------------------------------------------------------
 void ProgressInfoStatic::setProgressDescription( const QString& description )
 {
+    if ( !isOnGuiThread() )
+    {
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(),
+            [description]() { ProgressInfoStatic::setProgressDescription( description ); },
+            Qt::QueuedConnection );
+        return;
+    }
+
     if ( !isUpdatePossible() ) return;
 
     descriptionStack().back() = description;
@@ -580,6 +611,15 @@ void ProgressInfoStatic::setProgressDescription( const QString& description )
 //--------------------------------------------------------------------------------------------------
 void ProgressInfoStatic::setProgress( size_t progressValue )
 {
+    if ( !isOnGuiThread() )
+    {
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(),
+            [progressValue]() { ProgressInfoStatic::setProgress( progressValue ); },
+            Qt::QueuedConnection );
+        return;
+    }
+
     if ( !isUpdatePossible() ) return;
 
     std::vector<size_t>& progressStack_v     = progressStack();
@@ -626,6 +666,12 @@ void ProgressInfoStatic::setProgress( size_t progressValue )
 //--------------------------------------------------------------------------------------------------
 void ProgressInfoStatic::incrementProgress()
 {
+    if ( !isOnGuiThread() )
+    {
+        QMetaObject::invokeMethod( QCoreApplication::instance(), []() { ProgressInfoStatic::incrementProgress(); }, Qt::QueuedConnection );
+        return;
+    }
+
     if ( !isUpdatePossible() ) return;
 
     std::vector<size_t>& progressStack_v     = progressStack();
@@ -640,6 +686,15 @@ void ProgressInfoStatic::incrementProgress()
 //--------------------------------------------------------------------------------------------------
 void ProgressInfoStatic::setNextProgressIncrement( size_t nextStepSize )
 {
+    if ( !isOnGuiThread() )
+    {
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(),
+            [nextStepSize]() { ProgressInfoStatic::setNextProgressIncrement( nextStepSize ); },
+            Qt::QueuedConnection );
+        return;
+    }
+
     if ( !isUpdatePossible() ) return;
 
     CAF_ASSERT( progressSpanStack().size() );
@@ -672,6 +727,12 @@ bool ProgressInfoStatic::isRunning()
 //--------------------------------------------------------------------------------------------------
 void ProgressInfoStatic::finished()
 {
+    if ( !isOnGuiThread() )
+    {
+        QMetaObject::invokeMethod( QCoreApplication::instance(), []() { ProgressInfoStatic::finished(); }, Qt::BlockingQueuedConnection );
+        return;
+    }
+
     if ( !isUpdatePossible() ) return;
 
     std::vector<size_t>& progressStack_v     = progressStack();
@@ -731,11 +792,7 @@ bool ProgressInfoStatic::isUpdatePossible()
 
     if ( dynamic_cast<QApplication*>( QCoreApplication::instance() ) )
     {
-        QProgressDialog* dialog = progressDialog();
-        if ( dialog )
-        {
-            return dialog->thread() == QThread::currentThread();
-        }
+        return progressDialog() != nullptr;
     }
     return false;
 }


### PR DESCRIPTION
## Summary

- Added `isOnGuiThread()` helper to detect whether the caller is on the GUI thread
- All static update methods now dispatch to the GUI thread via `QMetaObject::invokeMethod` when called from a worker thread — `start()`/`finished()` use `BlockingQueuedConnection` for stack integrity, description/progress updates use `QueuedConnection`
- Fixed multiple overlapping progress dialogs by only reparenting the dialog when no progress operation is active (`!ProgressInfoStatic::isRunning()`)
- Removed the now-redundant thread check from `ProgressInfoStatic::isUpdatePossible()`
- Added **Test Progress Bar** to File→Testing: runs a 6-step × 2 sec task on a worker thread with a `QEventLoop` keeping the GUI responsive

Closes #13722