### PR TITLE
RiaRegressionTestRunner: Improve preference configuration and recent file handling

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -591,10 +591,9 @@ bool RiaApplication::loadProject( const QString& projectFileName, ProjectLoadAct
 
         // VL check regarding specific order mentioned in comment above...
 
-        m_preferences->lastUsedProjectFileName = fullPathProjectFileName;
-        if ( m_preferencesFileName.isEmpty() )
+        if ( !RiaRegressionTestRunner::instance()->isRunningRegressionTests() )
         {
-            m_preferences->writePreferencesToApplicationStore();
+            addToRecentFiles( fullPathProjectFileName );
         }
 
         if ( logTiming ) RiaLogging::logElapsedTime( taskName, startTime );
@@ -1000,7 +999,7 @@ bool RiaApplication::saveProjectAs( const QString& fileName, gsl::not_null<QStri
         return false;
     }
 
-    m_preferences->lastUsedProjectFileName = fileName;
+    addToRecentFiles( fileName );
     if ( m_preferencesFileName.isEmpty() )
     {
         m_preferences->writePreferencesToApplicationStore();

--- a/ApplicationLibCode/Application/RiaConsoleApplication.cpp
+++ b/ApplicationLibCode/Application/RiaConsoleApplication.cpp
@@ -26,6 +26,8 @@
 #include "RiaSocketServer.h"
 #include "RiaVersionInfo.h"
 
+#include "RiuRecentFileActionProvider.h"
+
 #include "RicImportGeneralDataFeature.h"
 
 #include "cvfProgramOptions.h"
@@ -212,7 +214,7 @@ RiaApplication::ApplicationStatus RiaConsoleApplication::handleArguments( gsl::n
 
     if ( progOpt->hasOption( "last" ) )
     {
-        projectFileName = preferences()->lastUsedProjectFileName;
+        projectFileName = RiuRecentFileActionProvider::lastUsedProjectFileName();
     }
 
     if ( cvf::Option o = progOpt->option( "project" ) )

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -691,7 +691,7 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( gsl::not_n
 
     if ( progOpt->hasOption( "last" ) )
     {
-        projectFileName = preferences()->lastUsedProjectFileName;
+        projectFileName = RiuRecentFileActionProvider::lastUsedProjectFileName();
     }
 
     if ( cvf::Option o = progOpt->option( "project" ) )

--- a/ApplicationLibCode/Application/RiaPreferences.cpp
+++ b/ApplicationLibCode/Application/RiaPreferences.cpp
@@ -192,9 +192,6 @@ RiaPreferences::RiaPreferences()
     CAF_PDM_InitField( &m_showGridBox, "showGridBox", true, "Show Grid Box in New Projects" );
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_showGridBox );
 
-    CAF_PDM_InitFieldNoDefault( &lastUsedProjectFileName, "lastUsedProjectFileName", "Last Used Project File" );
-    lastUsedProjectFileName.uiCapability()->setUiHidden( true );
-
     CAF_PDM_InitField( &holoLensDisableCertificateVerification,
                        "holoLensDisableCertificateVerification",
                        false,

--- a/ApplicationLibCode/Application/RiaPreferences.h
+++ b/ApplicationLibCode/Application/RiaPreferences.h
@@ -154,8 +154,6 @@ public:
     caf::PdmField<FontSizeEnum> defaultAnnotationFontSize;
     caf::PdmField<FontSizeEnum> defaultPlotFontSize;
 
-    caf::PdmField<QString> lastUsedProjectFileName;
-
     caf::PdmField<bool>    holoLensDisableCertificateVerification;
     caf::PdmField<QString> csvTextExportFieldSeparator;
 

--- a/ApplicationLibCode/Application/Tools/RiaRegressionTestRunner.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaRegressionTestRunner.cpp
@@ -198,24 +198,16 @@ void RiaRegressionTestRunner::runRegressionTest()
 
     RiaApplication* app = RiaApplication::instance();
 
-    // Load global preferences from main test folder if available
-    QString globalPrefsFile = testDir.filePath( "preferences.xml" );
-    if ( QFile::exists( globalPrefsFile ) )
-    {
-        RiaPreferences::current()->importPreferenceValuesFromFile( globalPrefsFile );
-        RiaLogging::info( "Loaded global preferences from: " + globalPrefsFile );
-    }
+    // Save original preferences once before the loop so each test can restore to a consistent state
+    QString originalPreferences = RiaPreferences::current()->writeObjectToXmlString();
 
     for ( const QFileInfo& folderFileInfo : folderList )
     {
         QDir testCaseFolder( folderFileInfo.filePath() );
 
-        // Save current preferences to string before loading test-specific preferences
-        QString savedPreferences;
-        QString testPrefsFile = findPreferencesConfigFile( testCaseFolder, testDir );
+        QString testPrefsFile = findPreferencesConfigFile( testCaseFolder );
         if ( !testPrefsFile.isEmpty() )
         {
-            savedPreferences = RiaPreferences::current()->writeObjectToXmlString();
             RiaPreferences::current()->importPreferenceValuesFromFile( testPrefsFile );
             RiaLogging::info( "Loaded test-specific preferences from: " + testPrefsFile );
         }
@@ -316,12 +308,8 @@ void RiaRegressionTestRunner::runRegressionTest()
             }
         }
 
-        // Restore preferences if test-specific preferences were loaded
-        if ( !savedPreferences.isEmpty() )
-        {
-            RiaPreferences::current()->readObjectFromXmlString( savedPreferences, caf::PdmDefaultObjectFactory::instance() );
-            RiaLogging::info( "Restored preferences after test" );
-        }
+        // Restore original preferences after each test
+        RiaPreferences::current()->readObjectFromXmlString( originalPreferences, caf::PdmDefaultObjectFactory::instance() );
 
         logInfoTextWithTimeInSeconds( timeStamp, "Completed test :" + testCaseFolder.absolutePath() );
     }
@@ -831,20 +819,21 @@ void RiaRegressionTestRunner::updateRegressionTest( const QString& testRootPath 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RiaRegressionTestRunner::findPreferencesConfigFile( const QDir& testCaseFolder, const QDir& mainFolder )
+QString RiaRegressionTestRunner::findPreferencesConfigFile( const QDir& testCaseFolder )
 {
-    // Check test case folder first (for test-specific overrides)
-    QString localConfig = testCaseFolder.filePath( "preferences.xml" );
-    if ( QFile::exists( localConfig ) )
+    // Search upward from test case folder, up to 3 levels, for preferences.xml
+    QDir searchDir = testCaseFolder;
+    for ( int level = 0; level < 3; ++level )
     {
-        return localConfig;
-    }
-
-    // Check main regression test folder (for global defaults)
-    QString globalConfig = mainFolder.filePath( "preferences.xml" );
-    if ( QFile::exists( globalConfig ) )
-    {
-        return globalConfig;
+        QString config = searchDir.filePath( "preferences.xml" );
+        if ( QFile::exists( config ) )
+        {
+            return config;
+        }
+        if ( !searchDir.cdUp() )
+        {
+            break;
+        }
     }
 
     // No config file found

--- a/ApplicationLibCode/Application/Tools/RiaRegressionTestRunner.h
+++ b/ApplicationLibCode/Application/Tools/RiaRegressionTestRunner.h
@@ -69,7 +69,7 @@ private:
     QFileInfoList  subDirectoriesForTestExecution( const QDir& directory );
 
     static void    selectObjectsInProject();
-    static QString findPreferencesConfigFile( const QDir& testCaseFolder, const QDir& mainFolder );
+    static QString findPreferencesConfigFile( const QDir& testCaseFolder );
 
 private:
     QString           m_rootPath;

--- a/ApplicationLibCode/Commands/ApplicationCommands/RicOpenLastUsedFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ApplicationCommands/RicOpenLastUsedFileFeature.cpp
@@ -19,9 +19,9 @@
 #include "RicOpenLastUsedFileFeature.h"
 
 #include "RiaGuiApplication.h"
-#include "RiaPreferences.h"
 
 #include "RiuMainWindow.h"
+#include "RiuRecentFileActionProvider.h"
 
 #include <QAction>
 
@@ -36,7 +36,7 @@ void RicOpenLastUsedFileFeature::onActionTriggered( bool isChecked )
 
     if ( !app->checkWithUserBeforeClose() ) return;
 
-    QString fileName = RiaPreferences::current()->lastUsedProjectFileName;
+    QString fileName = RiuRecentFileActionProvider::lastUsedProjectFileName();
 
     if ( app->loadProject( fileName ) )
     {

--- a/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp
@@ -76,6 +76,19 @@ QString RiuRecentFileActionProvider::registryKey()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+QString RiuRecentFileActionProvider::lastUsedProjectFileName()
+{
+    const QStringList files = RiaStringListSerializer( registryKey() ).textStrings();
+    for ( const QString& file : files )
+    {
+        if ( file.endsWith( ".rsp", Qt::CaseInsensitive ) ) return file;
+    }
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RiuRecentFileActionProvider::updateActions()
 {
     RiaStringListSerializer stringListSerializer( registryKey() );

--- a/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.h
+++ b/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.h
@@ -41,6 +41,8 @@ public:
     void                  addFileName( const QString& fileName );
     std::vector<QAction*> actions() const;
 
+    static QString lastUsedProjectFileName();
+
 private slots:
     void slotOpenRecentFile();
 


### PR DESCRIPTION
## Summary

- Search up to 3 directory levels for `preferences.xml` when running regression tests, allowing group-level and global preference files to be discovered automatically
- Save original preferences once before the test loop and restore after each test, ensuring a consistent baseline across all tests
- Remove `lastUsedProjectFileName` from `RiaPreferences`; store it via the existing `recentFileList` QSettings key using `RiuRecentFileActionProvider::lastUsedProjectFileName()` (filters for `.rsp` files)
- Skip adding regression test project files to the recently used files list