### PR TITLE
Removing unused boost system

### DIFF
--- a/ThirdParty/NRLib/CMakeLists.txt
+++ b/ThirdParty/NRLib/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(${PROJECT_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/nrlib/well
 )
 
-find_package(Boost REQUIRED filesystem system)
+find_package(Boost REQUIRED filesystem)
 
 target_link_libraries(${PROJECT_NAME} 
   Boost::filesystem

--- a/ThirdParty/custom-opm-flowdiag-app/CMakeLists.txt
+++ b/ThirdParty/custom-opm-flowdiag-app/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(custom-opm-flowdiag-app
     ${project_source_files_complete_path1} 
 )
 
-find_package(Boost REQUIRED filesystem system)
+find_package(Boost REQUIRED filesystem)
 
 target_link_libraries(custom-opm-flowdiag-app 
   resdata


### PR DESCRIPTION
Boost system has been removed from 1.89, then this PR enables support for boost >= 1.89.