### PR TITLE
RicHelpAboutFeature: Display active gRPC port in About dialog

### DIFF
--- a/ApplicationExeCode/RiaGrpcGuiApplication.cpp
+++ b/ApplicationExeCode/RiaGrpcGuiApplication.cpp
@@ -91,6 +91,15 @@ void RiaGrpcGuiApplication::doIdleProcessing()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::optional<int> RiaGrpcGuiApplication::activeGrpcPortNumber() const
+{
+    if ( m_grpcServer && m_grpcServer->isRunning() ) return m_grpcServer->portNumber();
+    return std::nullopt;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RiaGrpcGuiApplication::onGuiPreferencesChanged()
 {
     bool isGrpcRunning     = m_grpcServer != nullptr && m_grpcServer->isRunning();

--- a/ApplicationExeCode/RiaGrpcGuiApplication.h
+++ b/ApplicationExeCode/RiaGrpcGuiApplication.h
@@ -23,6 +23,8 @@
 #include <QPointer>
 #include <QTimer>
 
+#include <optional>
+
 class QProcessEnvironment;
 
 class RiaGrpcGuiApplication : public RiaGuiApplication, public RiaGrpcApplicationInterface
@@ -34,6 +36,7 @@ public:
     ~RiaGrpcGuiApplication() override;
 
     QProcessEnvironment pythonProcessEnvironment() const override;
+    std::optional<int>  activeGrpcPortNumber() const override;
 
 private:
     void onGuiPreferencesChanged() override;

--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -1341,6 +1341,14 @@ QProcessEnvironment RiaApplication::pythonProcessEnvironment() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::optional<int> RiaApplication::activeGrpcPortNumber() const
+{
+    return std::nullopt;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RiaApplication::launchProcess( const QString& program, const QStringList& arguments, const QProcessEnvironment& processEnvironment )
 {
     if ( m_workerProcess == nullptr )

--- a/ApplicationLibCode/Application/RiaApplication.h
+++ b/ApplicationLibCode/Application/RiaApplication.h
@@ -164,6 +164,7 @@ public:
 
     QString                     pythonPath() const;
     virtual QProcessEnvironment pythonProcessEnvironment() const;
+    virtual std::optional<int>  activeGrpcPortNumber() const;
 
     bool launchProcess( const QString& program, const QStringList& arguments, const QProcessEnvironment& processEnvironment );
     bool launchProcessForMultipleCases( const QString&             program,

--- a/ApplicationLibCode/Commands/ApplicationCommands/RicHelpFeatures.cpp
+++ b/ApplicationLibCode/Commands/ApplicationCommands/RicHelpFeatures.cpp
@@ -172,6 +172,13 @@ void RicHelpAboutFeature::onActionTriggered( bool isChecked )
         dlg.addVersionEntry( " ", QString( "  Runtime version: " ) + pythonRuntimeVersion );
     }
 
+    if ( auto grpcPort = RiaApplication::instance()->activeGrpcPortNumber() )
+    {
+        dlg.addVersionEntry( " ", "" );
+        dlg.addVersionEntry( " ", "gRPC Server" );
+        dlg.addVersionEntry( " ", QString( "  Port: %1" ).arg( *grpcPort ) );
+    }
+
     dlg.addVersionEntry( " ", "" );
     QString buildDate = RESINSIGHT_BUILD_DATE;
     dlg.addVersionEntry( "", QString( "Build date: " ) + buildDate );


### PR DESCRIPTION
Retrieve the active gRPC port number from the application instance and display it within the version information section of the About dialog.
