### PR TITLE
RiuRecentFileActionProvider: Normalize path separator to avoid duplicates

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp
@@ -24,6 +24,7 @@
 #include "RiaStringListSerializer.h"
 
 #include <QAction>
+#include <QDir>
 #include <QFileInfo>
 
 //--------------------------------------------------------------------------------------------------
@@ -49,7 +50,7 @@ RiuRecentFileActionProvider::~RiuRecentFileActionProvider()
 void RiuRecentFileActionProvider::addFileName( const QString& fileName )
 {
     RiaStringListSerializer stringListSerializer( registryKey() );
-    stringListSerializer.addString( fileName, m_maxActionCount );
+    stringListSerializer.addString( QDir::fromNativeSeparators( fileName ), m_maxActionCount );
 
     updateActions();
 }
@@ -60,7 +61,7 @@ void RiuRecentFileActionProvider::addFileName( const QString& fileName )
 void RiuRecentFileActionProvider::removeFileName( const QString& fileName )
 {
     RiaStringListSerializer stringListSerializer( registryKey() );
-    stringListSerializer.removeString( fileName );
+    stringListSerializer.removeString( QDir::fromNativeSeparators( fileName ) );
 
     updateActions();
 }


### PR DESCRIPTION
Use QDir::fromNativeSeparators before storing or removing file names to
ensure paths with mixed separators are treated as the same entry.
