### PR TITLE
Auto-update MSW segments on UI changes (opt-in)

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.cpp
@@ -27,6 +27,7 @@
 #include "RimFishbones.h"
 #include "RimProject.h"
 #include "RimWellPath.h"
+#include "RimWellPathCollection.h"
 
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
@@ -381,10 +382,26 @@ void RimFishbonesCollection::computeStartAndEndLocation()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimFishbonesCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimFishbonesCollection::onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
     RimProject* proj = RimProject::current();
     proj->reloadCompletionTypeResultsInAllViews();
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 
     updateConnectedEditors();
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFishbonesCollection.h
@@ -65,6 +65,7 @@ public:
 
 protected:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void initAfterRead() override;
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.cpp
@@ -26,6 +26,7 @@
 #include "RimNonDarcyPerforationParameters.h"
 #include "RimPerforationInterval.h"
 #include "RimProject.h"
+#include "RimWellPathCollection.h"
 
 #include "Well/RigWellPath.h"
 
@@ -189,10 +190,26 @@ void RimPerforationCollection::fieldChangedByUi( const caf::PdmFieldHandle* chan
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimPerforationCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimPerforationCollection::onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
     RimProject* proj = RimProject::current();
     proj->reloadCompletionTypeResultsInAllViews();
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 
     updateConnectedEditors();
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimPerforationCollection.h
@@ -51,6 +51,7 @@ public:
 private:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
 
     friend class RiuEditPerforationCollectionWidget;

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimValveCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimValveCollection.cpp
@@ -18,6 +18,8 @@
 
 #include "RimValveCollection.h"
 
+#include "WellPath/RimWellPathCollection.h"
+
 #include "RimProject.h"
 #include "RimValveTemplate.h"
 #include "RimValveTemplateCollection.h"
@@ -141,6 +143,17 @@ void RimValveCollection::fieldChangedByUi( const caf::PdmFieldHandle* changedFie
     else
     {
         proj->scheduleCreateDisplayModelAndRedrawAllViews();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimValveCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimValveCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimValveCollection.h
@@ -48,6 +48,7 @@ public:
 private:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
     void initAfterRead() override;
 

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.cpp
@@ -20,6 +20,7 @@
 
 #include "Rim3dView.h"
 #include "RimProject.h"
+#include "RimWellPathCollection.h"
 #include "RimWellPathFracture.h"
 
 #include "cafPdmObject.h"
@@ -139,8 +140,24 @@ void RimWellPathFractureCollection::fieldChangedByUi( const caf::PdmFieldHandle*
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimWellPathFractureCollection::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimWellPathFractureCollection::onChildDeleted( caf::PdmChildArrayFieldHandle*      childArray,
                                                     std::vector<caf::PdmObjectHandle*>& referringObjects )
 {
     RimProject::current()->scheduleCreateDisplayModelAndRedrawAllViews();
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFractureCollection.h
@@ -55,6 +55,7 @@ public:
 
 private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
 
 private:
     caf::PdmChildArrayField<RimWellPathFracture*> m_fractures;

--- a/ApplicationLibCode/ProjectDataModel/RimTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimTools.cpp
@@ -555,13 +555,7 @@ void RimTools::colorLegendOptionItems( QList<caf::PdmOptionItemInfo>* options )
 //--------------------------------------------------------------------------------------------------
 RimWellPathCollection* RimTools::wellPathCollection()
 {
-    RimProject* proj = RimProject::current();
-    if ( proj && proj->activeOilField() )
-    {
-        return proj->activeOilField()->wellPathCollection();
-    }
-
-    return nullptr;
+    return RimWellPathCollection::instance();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp
@@ -44,7 +44,6 @@
 #include "RimPerforationCollection.h"
 #include "RimProject.h"
 #include "RimStimPlanModelCollection.h"
-#include "RimTools.h"
 #include "RimValveCollection.h"
 #include "RimWellEventTimeline.h"
 #include "RimWellIASettingsCollection.h"
@@ -190,8 +189,7 @@ double RimWellPath::wellPathRadius( double characteristicCellSize ) const
 {
     double radius = characteristicCellSize * m_wellPathRadiusScaleFactor();
 
-    RimWellPathCollection* coll = RimTools::wellPathCollection();
-    if ( coll )
+    if ( auto coll = RimWellPathCollection::instance() )
     {
         radius *= coll->wellPathRadiusScaleFactor();
     }
@@ -492,6 +490,11 @@ void RimWellPath::fieldChangedByUi( const caf::PdmFieldHandle* changedField, con
     else
     {
         proj->scheduleCreateDisplayModelAndRedrawAllViews();
+
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
+        {
+            wellPathCollection->updateMswSegmentsForObject( this );
+        }
     }
 }
 
@@ -848,7 +851,7 @@ void RimWellPath::defineObjectEditorAttribute( QString uiConfigName, caf::PdmUiE
         // The nodes for well paths are created by the well path collection object. When a well path object is asked to
         // be updated in the project tree, always rebuild the tree from the well path collection object.
 
-        myAttr->objectForUpdateOfUiTree = RimTools::wellPathCollection();
+        myAttr->objectForUpdateOfUiTree = RimWellPathCollection::instance();
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
@@ -149,7 +149,8 @@ RimWellPathCollection::RimWellPathCollection()
     CAF_PDM_InitFieldNoDefault( &m_mswNameGroupingPattern, "MswWellNameGroupingPattern", "Grouping Pattern" );
 
     CAF_PDM_InitFieldNoDefault( &m_mswEclipseCase, "MswEclipseCase", "Eclipse Case" );
-    CAF_PDM_InitField( &m_mswShowBands, "MseShowBands", true, "Show Bands" );
+    CAF_PDM_InitField( &m_mswShowBands, "MswShowBands", true, "Show Bands" );
+    CAF_PDM_InitField( &m_mswAutoUpdateSegments, "MswAutoUpdateSegments", true, "Auto Update Segments" );
 
     m_wellPathImporter           = std::make_unique<RifWellPathImporter>();
     m_wellPathFormationsImporter = std::make_unique<RifWellPathFormationsImporter>();
@@ -160,6 +161,20 @@ RimWellPathCollection::RimWellPathCollection()
 //--------------------------------------------------------------------------------------------------
 RimWellPathCollection::~RimWellPathCollection()
 {
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimWellPathCollection* RimWellPathCollection::instance()
+{
+    RimProject* proj = RimProject::current();
+    if ( proj && proj->activeOilField() )
+    {
+        return proj->activeOilField()->wellPathCollection();
+    }
+
+    return nullptr;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -559,9 +574,13 @@ void RimWellPathCollection::defineUiOrdering( QString uiConfigName, caf::PdmUiOr
     }
 
     caf::PdmUiGroup* mswSegmentGroup = uiOrdering.addNewGroup( "MSW Segment Visualization" );
-    mswSegmentGroup->add( &m_mswShowBands );
     mswSegmentGroup->add( &m_mswEclipseCase );
-    mswSegmentGroup->addNewButton( "Update Segments", [this]() { updateMswSegments(); } );
+    mswSegmentGroup->add( &m_mswAutoUpdateSegments );
+    if ( !m_mswAutoUpdateSegments() )
+    {
+        mswSegmentGroup->addNewButton( "Update Segments", [this]() { updateMswSegments(); } );
+    }
+    mswSegmentGroup->add( &m_mswShowBands );
     uiOrdering.skipRemainingFields();
 }
 
@@ -594,6 +613,41 @@ void RimWellPathCollection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTree
 caf::PdmFieldHandle* RimWellPathCollection::objectToggleField()
 {
     return &isActive;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellPathCollection::updateMswSegmentsForObject( caf::PdmObject* changedObject )
+{
+    if ( !m_mswAutoUpdateSegments() ) return;
+    if ( !changedObject ) return;
+
+    auto wellPath = changedObject->firstAncestorOfType<RimWellPath>();
+    if ( !wellPath ) return;
+
+    auto topLevelWell = wellPath->topLevelWellPath();
+    if ( !topLevelWell ) return;
+
+    for ( const auto& wp : m_wellPaths )
+    {
+        if ( !wp || wp->topLevelWellPath() != topLevelWell ) continue;
+
+        auto* completions = wp->completions();
+        if ( !completions ) continue;
+
+        auto* segmentCollection = completions->mswSegmentCollection();
+        if ( !segmentCollection ) continue;
+
+        segmentCollection->clearSegments();
+    }
+
+    RimMswSegmentCollection::updateSegments( topLevelWell, m_mswEclipseCase() );
+
+    if ( RimProject* project = RimProject::current() )
+    {
+        project->scheduleCreateDisplayModelAndRedrawAllViews();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.h
@@ -83,6 +83,8 @@ public:
     RimWellPathCollection();
     ~RimWellPathCollection() override;
 
+    static RimWellPathCollection* instance();
+
     enum WellVisibilityType
     {
         FORCE_ALL_OFF,
@@ -154,6 +156,8 @@ public:
 
     void onChildAdded( caf::PdmFieldHandle* containerForNewObject ) override;
 
+    void updateMswSegmentsForObject( caf::PdmObject* changedObject );
+
     static std::pair<cvf::ref<RigWellPath>, QString>
         loadWellPathGeometryFromOsdu( RiaOsduConnector* osduConnector, const QString& wellTrajectoryId, double datumElevation );
 
@@ -202,4 +206,5 @@ private:
 
     caf::PdmPtrField<RimEclipseCase*> m_mswEclipseCase;
     caf::PdmField<bool>               m_mswShowBands;
+    caf::PdmField<bool>               m_mswAutoUpdateSegments;
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
@@ -32,6 +32,7 @@
 
 #include "RimModeledWellPath.h"
 #include "RimProject.h"
+#include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDefTools.h"
 #include "RimWellPathTarget.h"
 
@@ -552,6 +553,22 @@ void RimWellPathGeometryDef::fieldChangedByUi( const caf::PdmFieldHandle* change
     }
 
     changed.send( false );
+
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellPathGeometryDef::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
+{
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
+    {
+        wellPathCollection->updateMswSegmentsForObject( this );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.h
@@ -107,6 +107,7 @@ protected:
 
 private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName ) override;
     void initAfterRead() override;


### PR DESCRIPTION
Adds an 'Auto Update Segments' toggle (default: on) to the MSW Segment Visualization group in WellPathCollection. When enabled, MSW segments are automatically recomputed and redrawn whenever the user modifies:
- Well path geometry or targets
- Perforation intervals
- Fishbone laterals
- Fractures
- Well path fields

The update is triggered via a new updateMswSegmentsForObject() method, which resolves the top-level well from the changed object, clears existing segments for all lateral wells in that group, recomputes segments using updateSegments(), and schedules a full redraw.

When auto-update is disabled, an 'Update Segments' button is shown instead, allowing manual control.

Related to #13339

