### PR TITLE
Mac: Pre-populate Windows menu to fix missing menu on macOS

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -153,6 +153,9 @@ RiuMainWindow::RiuMainWindow()
     createMenus();
     createToolBars();
     createDockPanels();
+    // Pre-populate the Windows menu so it is not empty on creation. On macOS, the native menu bar
+    // hides empty menus, preventing the aboutToShow signal from ever firing.
+    slotBuildWindowActions();
 
     setAcceptDrops( true );
 

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -132,6 +132,9 @@ RiuPlotMainWindow::RiuPlotMainWindow()
     createMenus();
     createToolBars();
     createDockPanels();
+    // Pre-populate the Windows menu so it is not empty on creation. On macOS, the native menu bar
+    // hides empty menus, preventing the aboutToShow signal from ever firing.
+    slotBuildWindowActions();
 
     setAcceptDrops( true );
 


### PR DESCRIPTION
On macOS, the native menu bar hides empty menus. The Windows menu was
populated lazily via aboutToShow, but since it was empty at creation
time macOS never rendered it, so the signal could never fire.

Fix by calling slotBuildWindowActions() after createDockPanels() in
both RiuMainWindow and RiuPlotMainWindow constructors.

Closes #8218

