### PR TITLE
Replace RimTools::wellPathCollection() with RimWellPathCollection::instance()

### DIFF
--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -85,7 +85,6 @@
 #include "RimSummaryPlot.h"
 #include "RimTextAnnotation.h"
 #include "RimTextAnnotationInView.h"
-#include "RimTools.h"
 #include "RimViewLinker.h"
 #include "RimViewLinkerCollection.h"
 #include "RimWellLogLasFile.h"
@@ -1495,7 +1494,7 @@ void RiaGuiApplication::applyGuiPreferences( const RiaPreferences*              
     {
         std::vector<RimViewWindow*> allViewWindows = project()->descendantsIncludingThisOfType<RimViewWindow>();
 
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+        RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
         bool existingViewsWithDifferentMeshLines = false;
         bool existingViewsWithCustomColors       = false;

--- a/ApplicationLibCode/Application/Tools/RiaExtractionTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaExtractionTools.cpp
@@ -25,7 +25,6 @@
 #include "RimEclipseCase.h"
 #include "RimMainPlotCollection.h"
 #include "RimSimWellInView.h"
-#include "RimTools.h"
 #include "RimWellLogPlotCollection.h"
 #include "RimWellPathCollection.h"
 
@@ -49,7 +48,7 @@ RigEclipseWellLogExtractor* RiaExtractionTools::findOrCreateWellLogExtractor( co
 {
     if ( !eclipseCase ) return nullptr;
 
-    if ( auto wellPathCollection = RimTools::wellPathCollection() )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         auto wellPath = wellPathCollection->tryFindMatchingWellPath( wellName );
         return RiaExtractionTools::findOrCreateWellLogExtractor( wellPath, eclipseCase );

--- a/ApplicationLibCode/Commands/CompletionCommands/RicFishbonesCreateHelper.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicFishbonesCreateHelper.cpp
@@ -24,7 +24,6 @@
 #include "RimFishbones.h"
 #include "RimFishbonesCollection.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 
@@ -98,7 +97,7 @@ void RicFishbonesCreateHelper::finalizeFishbonesCreation( RimFishbones* fishbone
 {
     RicNewFishbonesSubsFeature::adjustWellPathScaling( fishbonesCollection );
 
-    if ( auto wellPathCollection = RimTools::wellPathCollection() )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         wellPathCollection->uiCapability()->updateConnectedEditors();
     }

--- a/ApplicationLibCode/Commands/CompletionCommands/RicNewFishbonesSubsFeature.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicNewFishbonesSubsFeature.cpp
@@ -30,7 +30,6 @@
 #include "RimFishbones.h"
 #include "RimFishbonesCollection.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathCompletions.h"
@@ -170,7 +169,7 @@ bool RicNewFishbonesSubsFeature::isCommandEnabled() const
 void RicNewFishbonesSubsFeature::adjustWellPathScaling( RimFishbonesCollection* fishboneCollection )
 {
     CVF_ASSERT( fishboneCollection );
-    RimWellPathCollection* wellPathColl = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathColl = RimWellPathCollection::instance();
 
     if ( wellPathColl->wellPathRadiusScaleFactor > 0.05 )
     {

--- a/ApplicationLibCode/Commands/CompletionCommands/RicNewPerforationIntervalAtMeasuredDepthFeature.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicNewPerforationIntervalAtMeasuredDepthFeature.cpp
@@ -24,7 +24,6 @@
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 
@@ -57,7 +56,7 @@ void RicNewPerforationIntervalAtMeasuredDepthFeature::onActionTriggered( bool is
 
     wellPath->perforationIntervalCollection()->appendPerforation( perforationInterval );
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
     wellPathCollection->uiCapability()->updateConnectedEditors();
     wellPathCollection->scheduleRedrawAffectedViews();

--- a/ApplicationLibCode/Commands/CompletionCommands/RicNewPerforationIntervalFeature.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicNewPerforationIntervalFeature.cpp
@@ -25,7 +25,6 @@
 
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathCompletions.h"
@@ -61,7 +60,7 @@ void RicNewPerforationIntervalFeature::onActionTriggered( bool isChecked )
 
     perforationCollection->appendPerforation( perforationInterval );
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( !wellPathCollection ) return;
 
     wellPathCollection->uiCapability()->updateConnectedEditors();

--- a/ApplicationLibCode/Commands/CompletionCommands/RicNewValveAtMeasuredDepthFeature.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicNewValveAtMeasuredDepthFeature.cpp
@@ -23,7 +23,6 @@
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimValveCollection.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
@@ -79,7 +78,7 @@ void RicNewValveAtMeasuredDepthFeature::onActionTriggered( bool isChecked )
 
     if ( valve )
     {
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+        RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
         wellPathCollection->uiCapability()->updateConnectedEditors();
         wellPathCollection->scheduleRedrawAffectedViews();

--- a/ApplicationLibCode/Commands/CompletionCommands/RicNewValveFeature.cpp
+++ b/ApplicationLibCode/Commands/CompletionCommands/RicNewValveFeature.cpp
@@ -5,7 +5,6 @@
 
 #include "RimPerforationInterval.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimValveCollection.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
@@ -101,7 +100,7 @@ void RicNewValveFeature::onActionTriggered( bool isChecked )
 
     if ( valve )
     {
-        if ( auto wellPathCollection = RimTools::wellPathCollection() )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             wellPathCollection->updateConnectedEditors();
             wellPathCollection->scheduleRedrawAffectedViews();

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathFractureTextReportFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathFractureTextReportFeatureImpl.cpp
@@ -37,7 +37,6 @@
 #include "RimMeshFractureTemplate.h"
 #include "RimOilField.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathCompletions.h"
@@ -207,8 +206,7 @@ std::vector<RimWellPath*> RicWellPathFractureTextReportFeatureImpl::wellPathsWit
 {
     std::vector<RimWellPath*> wellPaths;
 
-    auto* wellPathColl = RimTools::wellPathCollection();
-    if ( wellPathColl )
+    if ( auto* wellPathColl = RimWellPathCollection::instance() )
     {
         for ( const auto& wellPath : wellPathColl->allWellPaths() )
         {

--- a/ApplicationLibCode/Commands/EclipseCommands/EclipseWell/RicCreateWellPathFromSimulationWellFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/EclipseWell/RicCreateWellPathFromSimulationWellFeature.cpp
@@ -27,7 +27,6 @@
 #include "RimProject.h"
 #include "RimSimWellInView.h"
 #include "RimSimWellInViewCollection.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDef.h"
@@ -90,7 +89,7 @@ void RicCreateWellPathFromSimulationWellFeature::onActionTriggered( bool isCheck
     RimProject* project = RimProject::current();
     if ( !project ) return;
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( !wellPathCollection ) return;
 
     std::vector<RimWellPath*> newWellPaths;

--- a/ApplicationLibCode/Commands/FractureCommands/RicNewWellPathStimPlanModelAtPosFeature.cpp
+++ b/ApplicationLibCode/Commands/FractureCommands/RicNewWellPathStimPlanModelAtPosFeature.cpp
@@ -23,7 +23,6 @@
 #include "RicNewStimPlanModelFeature.h"
 
 #include "RimEclipseView.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 
@@ -44,7 +43,7 @@ void RicNewWellPathStimPlanModelAtPosFeature::onActionTriggered( bool isChecked 
     RimWellPath* wellPath = wellPathItem->m_wellpath;
     if ( !wellPath ) return;
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( !wellPathCollection ) return;
 
     RimEclipseView* activeView  = dynamic_cast<RimEclipseView*>( RiaApplication::instance()->activeGridView() );

--- a/ApplicationLibCode/Commands/RicWellMeasurementImportTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellMeasurementImportTools.cpp
@@ -23,7 +23,6 @@
 #include "Rim3dView.h"
 #include "RimGridView.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellMeasurement.h"
 #include "RimWellMeasurementCollection.h"
 #include "RimWellMeasurementFilePath.h"
@@ -168,5 +167,5 @@ RimWellPathCollection* RicWellMeasurementImportTools::selectedWellPathCollection
         return caf::SelectionManager::instance()->selectedItemAncestorOfType<RimWellPathCollection>();
     }
 
-    return RimTools::wellPathCollection();
+    return RimWellPathCollection::instance();
 }

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellBoreStabilityPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellBoreStabilityPlotFeature.cpp
@@ -34,7 +34,6 @@
 #include "RimGeoMechCase.h"
 #include "RimGeoMechView.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellBoreStabilityPlot.h"
 #include "RimWellLogChannel.h"
 #include "RimWellLogExtractionCurve.h"
@@ -357,7 +356,7 @@ void RicNewWellBoreStabilityPlotFeature::createStabilityCurvesTrack( RimWellBore
         curve->updateCurveName();
     }
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
     const RimWellMeasurementCollection* measurementCollection = wellPathCollection->measurementCollection();
     for ( QString wbsMeasurementKind : RimWellMeasurement::measurementKindsForWellBoreStability() )

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogFileCurveFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogFileCurveFeature.cpp
@@ -23,7 +23,6 @@
 #include "RicWellLogPlotCurveFeatureImpl.h"
 #include "RicWellLogTools.h"
 
-#include "RimTools.h"
 #include "RimWellLogChannel.h"
 #include "RimWellLogLasFile.h"
 #include "RimWellLogLasFileCurve.h"
@@ -93,7 +92,7 @@ void RicNewWellLogFileCurveFeature::setupActionLook( QAction* actionToSetup )
 //--------------------------------------------------------------------------------------------------
 bool RicNewWellLogFileCurveFeature::wellLogsAvailable()
 {
-    auto wellPathCollection = RimTools::wellPathCollection();
+    auto wellPathCollection = RimWellPathCollection::instance();
     if ( wellPathCollection )
     {
         for ( auto wellPath : wellPathCollection->allWellPaths() )

--- a/ApplicationLibCode/Commands/WellLogCommands/RicNewWellMeasurementCurveFeature.cpp
+++ b/ApplicationLibCode/Commands/WellLogCommands/RicNewWellMeasurementCurveFeature.cpp
@@ -20,7 +20,6 @@
 #include "RicWellLogPlotCurveFeatureImpl.h"
 #include "RicWellLogTools.h"
 
-#include "RimTools.h"
 #include "RimWellLogTrack.h"
 #include "RimWellMeasurement.h"
 #include "RimWellMeasurementCollection.h"
@@ -54,8 +53,7 @@ void RicNewWellMeasurementCurveFeature::onActionTriggered( bool isChecked )
     {
         RimWellPath* wellPath = nullptr;
 
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-        if ( wellPathCollection )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             const RimWellMeasurementCollection* measurementCollection = wellPathCollection->measurementCollection();
 

--- a/ApplicationLibCode/Commands/WellPathCommands/RicCreateMultipleWellPathLaterals.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicCreateMultipleWellPathLaterals.cpp
@@ -24,7 +24,6 @@
 
 #include "RimModeledWellPath.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathCompletions.h"
 #include "RimWellPathGeometryDef.h"
@@ -140,8 +139,7 @@ void RicCreateMultipleWellPathLaterals::slotAppendFractures()
     auto sourceLocationOfFirstWellTarget = sourceLateral->geometryDefinition()->firstActiveTarget()->targetPointXYZ();
     auto sourceTieInMeasuredDepth        = sourceLateral->wellPathTieIn()->tieInMeasuredDepth();
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-    if ( wellPathCollection )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         for ( auto measuredDepth : m_ui->locationConfig()->locations() )
         {

--- a/ApplicationLibCode/Commands/WellPathCommands/RicCreateMultipleWellPathLateralsUi.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicCreateMultipleWellPathLateralsUi.cpp
@@ -24,7 +24,6 @@
 #include "Well/RigWellPath.h"
 
 #include "RimModeledWellPath.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathTieIn.h"
 
@@ -61,7 +60,7 @@ void RicCreateMultipleWellPathLateralsUi::setTopLevelWellPath( RimWellPath* well
 {
     m_topLevelWellPath = wellPath;
 
-    auto laterals = RimTools::wellPathCollection()->connectedWellPathLaterals( m_topLevelWellPath );
+    auto laterals = RimWellPathCollection::instance()->connectedWellPathLaterals( m_topLevelWellPath );
 
     if ( !laterals.empty() ) m_sourceLateral = dynamic_cast<RimModeledWellPath*>( laterals.front() );
 }
@@ -115,7 +114,7 @@ QList<caf::PdmOptionItemInfo> RicCreateMultipleWellPathLateralsUi::calculateValu
     {
         if ( m_topLevelWellPath )
         {
-            auto laterals = RimTools::wellPathCollection()->connectedWellPathLaterals( m_topLevelWellPath );
+            auto laterals = RimWellPathCollection::instance()->connectedWellPathLaterals( m_topLevelWellPath );
 
             for ( auto lateral : laterals )
             {

--- a/ApplicationLibCode/Commands/WellPathCommands/RicDeleteWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicDeleteWellPathFeature.cpp
@@ -18,7 +18,6 @@
 
 #include "RicDeleteWellPathFeature.h"
 
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 
@@ -45,7 +44,7 @@ void RicDeleteWellPathFeature::onActionTriggered( bool isChecked )
     const auto wellPaths = caf::SelectionManager::instance()->objectsByType<RimWellPath>();
     if ( !wellPaths.empty() )
     {
-        auto wpc = RimTools::wellPathCollection();
+        auto wpc = RimWellPathCollection::instance();
 
         for ( auto w : wellPaths )
         {

--- a/ApplicationLibCode/Commands/WellPathCommands/RicDuplicateWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicDuplicateWellPathFeature.cpp
@@ -24,7 +24,6 @@
 
 #include "RimModeledWellPath.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDef.h"
 
@@ -71,7 +70,7 @@ RimWellPath* RicDuplicateWellPathFeature::duplicateWellPath( RimWellPath* wellPa
     if ( wellPath == nullptr ) return nullptr;
 
     RimProject*            project            = RimProject::current();
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( project && wellPathCollection )
     {
         auto newModeledWellPath = wellPath->copyObject<RimModeledWellPath>();

--- a/ApplicationLibCode/Commands/WellPathCommands/RicHideGridGeometryFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicHideGridGeometryFeature.cpp
@@ -26,7 +26,6 @@
 #include "RimGridView.h"
 #include "RimIntersectionCollection.h"
 #include "RimSimWellInViewCollection.h"
-#include "RimTools.h"
 #include "WellPath/RimWellPathCollection.h"
 
 #include "RiuMainWindow.h"
@@ -83,7 +82,7 @@ void RicHideGridGeometryFeature::onActionTriggered( bool isChecked )
     gridView->scheduleCreateDisplayModelAndRedraw();
 
     // Force all well paths visible
-    if ( auto wellPathColl = RimTools::wellPathCollection() )
+    if ( auto wellPathColl = RimWellPathCollection::instance() )
     {
         wellPathColl->isActive           = true;
         wellPathColl->wellPathVisibility = RimWellPathCollection::FORCE_ALL_ON;

--- a/ApplicationLibCode/Commands/WellPathCommands/RicNewEditableWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicNewEditableWellPathFeature.cpp
@@ -27,7 +27,6 @@
 #include "RimModeledWellPath.h"
 #include "RimOilField.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDef.h"
@@ -35,6 +34,8 @@
 #include "Riu3DMainWindowTools.h"
 
 #include "cafSelectionManager.h"
+
+#include "cvfBoundingBox.h"
 
 #include <QAction>
 
@@ -71,8 +72,7 @@ void RicNewEditableWellPathFeature::onActionTriggered( bool isChecked )
     RimProject* project = RimProject::current();
     if ( project && RimProject::current()->activeOilField() )
     {
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-        if ( wellPathCollection )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             std::vector<RimWellPath*> newWellPaths;
             auto                      newModeledWellPath = new RimModeledWellPath();

--- a/ApplicationLibCode/Commands/WellPathCommands/RicNewWellPathLateralAtDepthFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicNewWellPathLateralAtDepthFeature.cpp
@@ -26,7 +26,6 @@
 #include "RimFishbonesCollection.h"
 #include "RimModeledWellPath.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDef.h"
@@ -83,7 +82,7 @@ void RicNewWellPathLateralAtDepthFeature::setupActionLook( QAction* actionToSetu
 RimModeledWellPath* RicNewWellPathLateralAtDepthFeature::createLateralAtMeasuredDepth( RimWellPath* parentWellPath, double parentWellMD )
 {
     RimProject*            project      = RimProject::current();
-    RimWellPathCollection* wellPathColl = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathColl = RimWellPathCollection::instance();
     if ( project && wellPathColl )
     {
         auto newModeledWellPath = new RimModeledWellPath();

--- a/ApplicationLibCode/Commands/WellPathCommands/RicPasteModeledWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicPasteModeledWellPathFeature.cpp
@@ -25,7 +25,6 @@ CAF_CMD_SOURCE_INIT( RicPasteModeledWellPathFeature, "RicPasteModeledWellPathFea
 #include "RimModeledWellPath.h"
 #include "RimOilField.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathFracture.h"
 #include "RimWellPathTieIn.h"
@@ -65,8 +64,7 @@ void RicPasteModeledWellPathFeature::onActionTriggered( bool isChecked )
 
     if ( proj && proj->activeOilField() )
     {
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-        if ( wellPathCollection )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             RimModeledWellPath* wellPathToSelect = nullptr;
             for ( auto sourceWellPath : modeledWellPathsFromClipboard() )
@@ -76,7 +74,7 @@ void RicPasteModeledWellPathFeature::onActionTriggered( bool isChecked )
                 wellPathToSelect = destinationWellPath;
             }
 
-            RimTools::wellPathCollection()->rebuildWellPathNodes();
+            RimWellPathCollection::instance()->rebuildWellPathNodes();
 
             wellPathCollection->uiCapability()->updateConnectedEditors();
 
@@ -121,7 +119,7 @@ std::vector<RimModeledWellPath*> RicPasteModeledWellPathFeature::modeledWellPath
 //--------------------------------------------------------------------------------------------------
 void RicPasteModeledWellPathFeature::duplicateLaterals( const RimModeledWellPath* source, RimModeledWellPath* destination )
 {
-    auto wpc = RimTools::wellPathCollection();
+    auto wpc = RimWellPathCollection::instance();
 
     auto sourceLaterals = wpc->connectedWellPathLaterals( source );
 
@@ -144,7 +142,7 @@ RimModeledWellPath* RicPasteModeledWellPathFeature::duplicateAndInitializeWellPa
 {
     if ( !sourceWellPath ) return nullptr;
 
-    auto wpc = RimTools::wellPathCollection();
+    auto wpc = RimWellPathCollection::instance();
 
     auto*   destinationWellPath = sourceWellPath->copyObject<RimModeledWellPath>();
     QString name                = sourceWellPath->name() + "(copy)";

--- a/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicSetParentWellPathFeature.cpp
@@ -91,7 +91,7 @@ void RicSetParentWellPathFeature::onActionTriggered( bool isChecked )
     auto selectedWellPath = caf::SelectionManager::instance()->selectedItemOfType<RimWellPath>();
     if ( !selectedWellPath ) return;
 
-    auto wpc = RimTools::wellPathCollection();
+    auto wpc = RimWellPathCollection::instance();
     if ( !wpc ) return;
 
     std::vector<RimWellPath*> wellPathCandidates;

--- a/ApplicationLibCode/Commands/WellPathCommands/RicShowAllGeometryFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicShowAllGeometryFeature.cpp
@@ -24,7 +24,6 @@
 #include "RimFaultInViewCollection.h"
 #include "RimGridView.h"
 #include "RimIntersectionCollection.h"
-#include "RimTools.h"
 #include "WellPath/RimWellPathCollection.h"
 
 #include "RiuMainWindow.h"
@@ -73,7 +72,7 @@ void RicShowAllGeometryFeature::onActionTriggered( bool isChecked )
     gridView->scheduleCreateDisplayModelAndRedraw();
 
     // Restore well path visibility to individual control
-    if ( auto wellPathColl = RimTools::wellPathCollection() )
+    if ( auto wellPathColl = RimWellPathCollection::instance() )
     {
         wellPathColl->wellPathVisibility = RimWellPathCollection::ALL_ON;
         wellPathColl->updateConnectedEditors();

--- a/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
@@ -38,7 +38,6 @@
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
 #include "RimRegularLegendConfig.h"
-#include "RimTools.h"
 #include "RimValveCollection.h"
 #include "RimWellIASettings.h"
 #include "RimWellIASettingsCollection.h"
@@ -306,7 +305,7 @@ void RivWellPathPartMgr::appendWellMeasurementsToModel( cvf::ModelBasicList*    
     RimGridView* gridView = dynamic_cast<RimGridView*>( m_rimView.p() );
     if ( !gridView ) return;
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( !wellPathCollection ) return;
 
     RimWellMeasurementCollection* wellMeasurementCollection = wellPathCollection->measurementCollection();

--- a/ApplicationLibCode/ModelVisualization/RivWellPathsPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellPathsPartMgr.cpp
@@ -20,7 +20,6 @@
 
 #include "RimEclipseView.h"
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 
 #include "RivWellPathPartMgr.h"
@@ -132,7 +131,7 @@ void RivWellPathsPartMgr::createPartManagersIfRequired()
 //--------------------------------------------------------------------------------------------------
 bool RivWellPathsPartMgr::isWellPathVisible() const
 {
-    auto wellPathColl = RimTools::wellPathCollection();
+    auto wellPathColl = RimWellPathCollection::instance();
 
     if ( !wellPathColl->isActive() ) return false;
     if ( wellPathColl->wellPathVisibility() == RimWellPathCollection::FORCE_ALL_OFF ) return false;

--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
@@ -38,7 +38,6 @@
 #include "RimOilField.h"
 #include "RimProject.h"
 #include "RimSeismicView.h"
-#include "RimTools.h"
 #include "RimViewController.h"
 #include "RimViewLinker.h"
 #include "RimViewManipulator.h"
@@ -811,7 +810,7 @@ caf::PdmObjectHandle* Rim3dView::implementingPdmObject()
 //--------------------------------------------------------------------------------------------------
 RimWellPathCollection* Rim3dView::wellPathCollection() const
 {
-    return RimTools::wellPathCollection();
+    return RimWellPathCollection::instance();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimGridView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridView.cpp
@@ -475,8 +475,7 @@ void RimGridView::clearReservoirCellVisibilities()
 //--------------------------------------------------------------------------------------------------
 void RimGridView::addRequiredUiTreeObjects( caf::PdmUiTreeOrdering& uiTreeOrdering )
 {
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-    if ( wellPathCollection )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         const RimWellMeasurementCollection* measurementCollection = wellPathCollection->measurementCollection();
         if ( !measurementCollection->measurements().empty() )

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -569,8 +569,7 @@ void RimProject::setProjectFileNameAndUpdateDependencies( const QString& project
 
     if ( ensembleFileSetCollection() ) ensembleFileSetCollection()->updateFilePathsFromProjectPath( newProjectPath, oldProjectPath );
 
-    auto* wellPathColl = RimTools::wellPathCollection();
-    if ( wellPathColl )
+    if ( auto* wellPathColl = RimWellPathCollection::instance() )
     {
         for ( auto wellPath : wellPathColl->allWellPaths() )
         {

--- a/ApplicationLibCode/ProjectDataModel/RimTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimTools.cpp
@@ -274,8 +274,7 @@ void RimTools::wellPathOptionItemsSubset( const std::vector<RimWellPath*>& wellP
 {
     if ( !options ) return;
 
-    auto wellPathColl = RimTools::wellPathCollection();
-    if ( wellPathColl )
+    if ( auto wellPathColl = RimWellPathCollection::instance() )
     {
         std::vector<RimWellPath*> wellPathsToInclude;
 
@@ -302,8 +301,7 @@ void RimTools::wellPathOptionItems( QList<caf::PdmOptionItemInfo>* options )
 {
     if ( !options ) return;
 
-    auto wellPathColl = RimTools::wellPathCollection();
-    if ( wellPathColl )
+    if ( auto wellPathColl = RimWellPathCollection::instance() )
     {
         optionItemsForSpecifiedWellPaths( wellPathColl->allWellPaths(), options );
     }
@@ -327,8 +325,7 @@ void RimTools::wellPathWithFormationsOptionItems( QList<caf::PdmOptionItemInfo>*
 //--------------------------------------------------------------------------------------------------
 void RimTools::wellPathWithFormations( std::vector<RimWellPath*>* wellPaths )
 {
-    auto wellPathColl = RimTools::wellPathCollection();
-    if ( wellPathColl )
+    if ( auto wellPathColl = RimWellPathCollection::instance() )
     {
         for ( RimWellPath* wellPath : wellPathColl->allWellPaths() )
         {
@@ -553,17 +550,9 @@ void RimTools::colorLegendOptionItems( QList<caf::PdmOptionItemInfo>* options )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RimWellPathCollection* RimTools::wellPathCollection()
-{
-    return RimWellPathCollection::instance();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 RimWellPath* RimTools::firstWellPath()
 {
-    auto wellpathcoll = wellPathCollection();
+    auto wellpathcoll = RimWellPathCollection::instance();
     auto wellpaths    = wellpathcoll->allWellPaths();
 
     if ( !wellpaths.empty() ) return wellpaths[0];

--- a/ApplicationLibCode/ProjectDataModel/RimTools.h
+++ b/ApplicationLibCode/ProjectDataModel/RimTools.h
@@ -37,7 +37,6 @@ class PdmObjectHandle;
 
 class RimGeoMechCase;
 class RimEclipseCase;
-class RimWellPathCollection;
 class RimValveTemplateCollection;
 class RimCase;
 class RimWellPath;
@@ -75,8 +74,7 @@ public:
 
     static void faultOptionItems( QList<caf::PdmOptionItemInfo>* options, RimFaultInViewCollection* coll );
 
-    static RimWellPathCollection* wellPathCollection();
-    static RimWellPath*           firstWellPath();
+    static RimWellPath* firstWellPath();
 
     static RimValveTemplateCollection* valveTemplateCollection();
 

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
@@ -260,7 +260,7 @@ RimStimPlanModel::RimStimPlanModel()
 RimStimPlanModel::~RimStimPlanModel()
 {
     RimWellPath*           wellPath           = m_thicknessDirectionWellPath.value();
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
     if ( wellPath && wellPathCollection )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogLasFileCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogLasFileCurve.cpp
@@ -29,7 +29,6 @@
 #include "Well/RigWellPath.h"
 
 #include "RimProject.h"
-#include "RimTools.h"
 #include "RimWellLogChannel.h"
 #include "RimWellLogLasFile.h"
 #include "RimWellLogPlot.h"
@@ -358,8 +357,7 @@ QList<caf::PdmOptionItemInfo> RimWellLogLasFileCurve::calculateValueOptions( con
 
     if ( fieldNeedingOptions == &m_wellPath )
     {
-        auto wellPathColl = RimTools::wellPathCollection();
-        if ( wellPathColl )
+        if ( auto wellPathColl = RimWellPathCollection::instance() )
         {
             for ( auto wellPath : wellPathColl->allWellPaths() )
             {

--- a/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementCurve.cpp
@@ -75,7 +75,7 @@ void RimWellMeasurementCurve::onLoadDataAndUpdate( bool updateParentPlot )
 {
     auto wellLogPlot = firstAncestorOrThisOfTypeAsserted<RimDepthTrackPlot>();
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( m_wellPath && !m_measurementKind().isEmpty() && wellPathCollection )
     {
         const RimWellMeasurementCollection* measurementCollection = wellPathCollection->measurementCollection();
@@ -257,8 +257,7 @@ QList<caf::PdmOptionItemInfo> RimWellMeasurementCurve::calculateValueOptions( co
     {
         std::set<QString> kindNames;
 
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-        if ( wellPathCollection )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             const RimWellMeasurementCollection* measurementCollection = wellPathCollection->measurementCollection();
             for ( RimWellMeasurement* measurement : measurementCollection->measurements() )

--- a/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInView.cpp
@@ -22,7 +22,6 @@
 #include "RimGridView.h"
 #include "RimProject.h"
 #include "RimRegularLegendConfig.h"
-#include "RimTools.h"
 #include "RimWellLogTrack.h"
 #include "RimWellMeasurement.h"
 #include "RimWellMeasurementCollection.h"
@@ -205,7 +204,7 @@ RimRegularLegendConfig* RimWellMeasurementInView::legendConfig()
 //--------------------------------------------------------------------------------------------------
 bool RimWellMeasurementInView::updateLegendData()
 {
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
     if ( !wellPathCollection ) return false;
 
     RimWellMeasurementCollection* wellMeasurementCollection = wellPathCollection->measurementCollection();
@@ -305,8 +304,7 @@ QList<caf::PdmOptionItemInfo> RimWellMeasurementInView::calculateValueOptions( c
     QList<caf::PdmOptionItemInfo> options;
     if ( fieldNeedingOptions == &m_wells )
     {
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-        if ( wellPathCollection )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             std::vector<RimWellMeasurement*> measurements = wellPathCollection->measurementCollection()->measurements();
 
@@ -329,8 +327,7 @@ QList<caf::PdmOptionItemInfo> RimWellMeasurementInView::calculateValueOptions( c
     }
     else if ( fieldNeedingOptions == &m_qualityFilter )
     {
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-        if ( wellPathCollection )
+        if ( auto wellPathCollection = RimWellPathCollection::instance() )
         {
             std::vector<RimWellMeasurement*> measurements = wellPathCollection->measurementCollection()->measurements();
 
@@ -388,8 +385,7 @@ bool RimWellMeasurementInView::isWellChecked( const QString& wellName ) const
 //--------------------------------------------------------------------------------------------------
 void RimWellMeasurementInView::setAllWellsSelected()
 {
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-    if ( wellPathCollection )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         std::vector<RimWellMeasurement*> measurements = wellPathCollection->measurementCollection()->measurements();
 
@@ -415,8 +411,7 @@ void RimWellMeasurementInView::setAllWellsSelected()
 //--------------------------------------------------------------------------------------------------
 void RimWellMeasurementInView::setAllQualitiesSelected()
 {
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-    if ( wellPathCollection )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         std::vector<RimWellMeasurement*> measurements = wellPathCollection->measurementCollection()->measurements();
 

--- a/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInViewCollection.cpp
@@ -22,7 +22,6 @@
 #include "RimGridView.h"
 #include "RimProject.h"
 #include "RimRegularLegendConfig.h"
-#include "RimTools.h"
 #include "RimWellLogTrack.h"
 #include "RimWellMeasurement.h"
 #include "RimWellMeasurementCollection.h"
@@ -88,7 +87,7 @@ std::vector<RimWellMeasurementInView*> RimWellMeasurementInViewCollection::visib
 
     if ( m_linkWellVisibility )
     {
-        RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+        RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
         auto wellPath = wellPathCollection->tryFindMatchingWellPath( wellName );
         if ( wellPath && !wellPath->showWellPath() ) return {};
@@ -130,8 +129,7 @@ void RimWellMeasurementInViewCollection::fieldChangedByUi( const caf::PdmFieldHa
 //--------------------------------------------------------------------------------------------------
 void RimWellMeasurementInViewCollection::syncWithChangesInWellMeasurementCollection()
 {
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
-    if ( wellPathCollection )
+    if ( auto wellPathCollection = RimWellPathCollection::instance() )
     {
         const RimWellMeasurementCollection* measurementCollection = wellPathCollection->measurementCollection();
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.h
@@ -22,8 +22,6 @@
 
 #include "RiaDefines.h"
 
-#include "Well/RigOsduWellLogData.h"
-
 #include "cafAppEnum.h"
 #include "cafPdmChildArrayField.h"
 #include "cafPdmField.h"

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDefTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDefTools.cpp
@@ -19,7 +19,6 @@
 #include "RimWellPathGeometryDefTools.h"
 
 #include "RimModeledWellPath.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathGeometryDef.h"
 #include "RimWellPathTarget.h"
@@ -52,7 +51,7 @@ std::vector<RimWellPathGeometryDef*> RimWellPathGeometryDefTools::linkedDefiniti
 {
     std::vector<RimWellPathGeometryDef*> linkedWellPathGeoDefs;
 
-    for ( auto w : RimTools::wellPathCollection()->allWellPaths() )
+    for ( auto w : RimWellPathCollection::instance()->allWellPaths() )
     {
         auto modeledWellPath = dynamic_cast<RimModeledWellPath*>( w );
         if ( !modeledWellPath ) continue;

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathTieIn.cpp
@@ -268,14 +268,14 @@ void RimWellPathTieIn::fieldChangedByUi( const caf::PdmFieldHandle* changedField
     {
         updateFirstTargetFromParentWell();
 
-        RimTools::wellPathCollection()->rebuildWellPathNodes();
+        RimWellPathCollection::instance()->rebuildWellPathNodes();
     }
 
     updateChildWellGeometry();
 
     // Update all well paths to make sure the visibility of completion settings is updated
     // Completions settings is only visible for top-level wells, not for tie-in wells
-    RimTools::wellPathCollection()->updateAllRequiredEditors();
+    RimWellPathCollection::instance()->updateAllRequiredEditors();
 
     if ( changedField == &m_parentWell && m_childWell )
     {

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcPerforationInterval.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcPerforationInterval.cpp
@@ -21,7 +21,6 @@
 #include "RimEclipseCase.h"
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
-#include "RimTools.h"
 #include "RimWellPathCollection.h"
 #include "RimWellPathValve.h"
 
@@ -66,7 +65,7 @@ std::expected<caf::PdmObjectHandle*, QString> RimcPerforationInterval_addValve::
     valve->setMeasuredDepthAndCount( m_startMd(), spacing, m_valveCount() );
     valve->applyValveLabelAndIcon();
 
-    RimWellPathCollection* wellPathCollection = RimTools::wellPathCollection();
+    RimWellPathCollection* wellPathCollection = RimWellPathCollection::instance();
 
     wellPathCollection->uiCapability()->updateConnectedEditors();
     wellPathCollection->scheduleRedrawAffectedViews();

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcProject.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcProject.cpp
@@ -305,7 +305,7 @@ RimProject_wellPathCollection::RimProject_wellPathCollection( caf::PdmObjectHand
 //--------------------------------------------------------------------------------------------------
 std::expected<caf::PdmObjectHandle*, QString> RimProject_wellPathCollection::execute()
 {
-    auto wellPathCollection = RimTools::wellPathCollection();
+    auto wellPathCollection = RimWellPathCollection::instance();
     if ( !wellPathCollection )
     {
         return std::unexpected( "No well path collection found." );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp
@@ -38,7 +38,6 @@
 #include "RimStimPlanFractureTemplate.h"
 #include "RimStimPlanModel.h"
 #include "RimThermalFractureTemplate.h"
-#include "RimTools.h"
 #include "RimValveCollection.h"
 #include "RimWellPath.h"
 #include "RimWellPathCollection.h"
@@ -205,7 +204,7 @@ std::expected<caf::PdmObjectHandle*, QString> RimcWellPath_appendPerforationInte
 
     wellPath->perforationIntervalCollection()->appendPerforation( perforationInterval );
 
-    auto* wellPathCollection = RimTools::wellPathCollection();
+    auto* wellPathCollection = RimWellPathCollection::instance();
 
     wellPathCollection->uiCapability()->updateConnectedEditors();
     wellPathCollection->scheduleRedrawAffectedViews();
@@ -663,7 +662,7 @@ std::expected<caf::PdmObjectHandle*, QString> RimcWellPath_appendLateralFromGeom
 
         lateral->connectWellPaths( mainWell, measuredDepth );
 
-        auto wellPathCollection = RimTools::wellPathCollection();
+        auto wellPathCollection = RimWellPathCollection::instance();
         wellPathCollection->rebuildWellPathNodes();
 
         mainWell->updateAllRequiredEditors();
@@ -847,7 +846,7 @@ std::expected<caf::PdmObjectHandle*, QString> RimcWellPath_addIcvValve::execute(
 
         if ( valve )
         {
-            if ( auto wellPathCollection = RimTools::wellPathCollection() )
+            if ( auto wellPathCollection = RimWellPathCollection::instance() )
             {
                 wellPathCollection->updateConnectedEditors();
                 wellPathCollection->scheduleRedrawAffectedViews();


### PR DESCRIPTION
Remove the redundant wrapper function and update all call sites to use
RimWellPathCollection::instance() directly.
