### PR TITLE
Summary plot stepping improvements

### DIFF
--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryPlotTemplateTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryPlotTemplateTools.cpp
@@ -217,6 +217,8 @@ RimSummaryMultiPlot* RicSummaryPlotTemplateTools::create( const QString&        
     newSummaryPlot->loadDataAndUpdate();
     collections->updateConnectedEditors();
 
+    newSummaryPlot->updatePlots();
+
     return newSummaryPlot;
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramMultiPlot.cpp
@@ -46,7 +46,6 @@ CAF_PDM_SOURCE_INIT( RimHistogramMultiPlot, "MultiHistogramPlot" );
 ///
 //--------------------------------------------------------------------------------------------------
 RimHistogramMultiPlot::RimHistogramMultiPlot()
-    : duplicatePlot( this )
 {
     CAF_PDM_InitObject( "Multi Histogram Plot", ":/HistogramPlotLight16x16.png" );
     setDeletable( true );
@@ -54,18 +53,12 @@ RimHistogramMultiPlot::RimHistogramMultiPlot()
     CAF_PDM_InitField( &m_autoPlotTitle, "AutoPlotTitle", true, "Auto Plot Title" );
     CAF_PDM_InitField( &m_autoSubPlotTitle, "AutoSubPlotTitle", true, "Auto Sub Plot Title" );
 
-    CAF_PDM_InitField( &m_createPlotDuplicate, "DuplicatePlot", false, "", "", "Duplicate Plot" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_createPlotDuplicate );
-    m_createPlotDuplicate.uiCapability()->setUiIconFromResourceString( ":/Copy.svg" );
-
     CAF_PDM_InitField( &m_disableWheelZoom, "DisableWheelZoom", true, "", "", "Disable Mouse Wheel Zooming in Multi Histogram Plot" );
     caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_disableWheelZoom );
     m_disableWheelZoom.uiCapability()->setUiIconFromResourceString( ":/DisableZoom.png" );
 
     CAF_PDM_InitField( &m_autoAdjustAppearance, "AutoAdjustAppearance", true, "Auto Plot Settings" );
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_autoAdjustAppearance );
-    CAF_PDM_InitField( &m_allow3DSelectionLink, "Allow3DSelectionLink", true, "Allow Well Selection from 3D View" );
-    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_allow3DSelectionLink );
 
     CAF_PDM_InitField( &m_hidePlotsWithValuesBelow, "HidePlotsWithValuesBelow", false, "" );
     caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_hidePlotsWithValuesBelow );
@@ -190,11 +183,6 @@ void RimHistogramMultiPlot::fieldChangedByUi( const caf::PdmFieldHandle* changed
     {
         m_hidePlotsWithValuesBelow = false;
         updatePlotVisibility();
-    }
-    else if ( changedField == &m_createPlotDuplicate )
-    {
-        m_createPlotDuplicate = false;
-        duplicate();
     }
     else if ( changedField == &m_autoAdjustAppearance )
     {
@@ -441,14 +429,6 @@ void RimHistogramMultiPlot::updatePlotVisibility()
     updateLayout();
 
     if ( !m_viewer.isNull() ) m_viewer->scheduleUpdate();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimHistogramMultiPlot::duplicate()
-{
-    duplicatePlot.send( this );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramMultiPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramMultiPlot.h
@@ -24,8 +24,6 @@
 #include "cafPdmUiItem.h"
 #include "cafSignal.h"
 
-#include <QList>
-
 #include <vector>
 
 class RimHistogramPlot;
@@ -38,9 +36,6 @@ class RimPlotAxisProperties;
 class RimHistogramMultiPlot : public RimMultiPlot
 {
     CAF_PDM_HEADER_INIT;
-
-public:
-    caf::Signal<RimHistogramMultiPlot*> duplicatePlot;
 
 public:
     RimHistogramMultiPlot();
@@ -62,21 +57,15 @@ public:
 
     void syncAxisRanges();
 
-    void histogramPlotItemInfos( QList<caf::PdmOptionItemInfo>* optionInfos ) const;
-
     std::vector<RimHistogramPlot*> histogramPlots() const;
     std::vector<RimHistogramPlot*> visibleHistogramPlots() const;
 
     void makeSureIsVisible( RimHistogramPlot* plot );
 
-    void setSubPlotAxesLinked( bool enable );
-    bool isSubPlotAxesLinked() const;
-
     std::pair<int, int> gridLayoutInfoForSubPlot( RimHistogramPlot* histogramPlot ) const;
 
     void zoomAll() override;
 
-    void setDefaultRangeAggregationSteppingDimension();
     void analyzePlotsAndAdjustAppearanceSettings();
 
     void keepVisiblePageAfterUpdate( bool keepPage );
@@ -97,15 +86,7 @@ private:
 
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
 
-    void computeAggregatedAxisRange();
-    void updateSourceStepper();
-
     void updatePlotVisibility();
-
-    void duplicate();
-
-    void appendSubPlotByStepping( int direction );
-    void appendCurveByStepping( int direction );
 
     void onSubPlotChanged( const caf::SignalEmitter* emitter );
     void onSubPlotAxisChanged( const caf::SignalEmitter* emitter, RimHistogramPlot* summaryPlot );
@@ -117,12 +98,8 @@ private:
     caf::PdmField<bool> m_autoPlotTitle;
     caf::PdmField<bool> m_autoSubPlotTitle;
     caf::PdmField<bool> m_disableWheelZoom;
-    caf::PdmField<bool> m_createPlotDuplicate;
     caf::PdmField<bool> m_autoAdjustAppearance;
-    caf::PdmField<bool> m_allow3DSelectionLink;
-
-    caf::PdmField<bool>   m_hidePlotsWithValuesBelow;
-    caf::PdmField<double> m_plotFilterYAxisThreshold;
+    caf::PdmField<bool> m_hidePlotsWithValuesBelow;
 
     std::map<RimHistogramPlot*, std::pair<int, int>> m_gridLayoutInfo;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.cpp
@@ -112,7 +112,6 @@ void RimSummaryMultiPlot::clearLayoutInfo()
 ///
 //--------------------------------------------------------------------------------------------------
 RimSummaryMultiPlot::RimSummaryMultiPlot()
-    : duplicatePlot( this )
 {
     CAF_PDM_InitObject( "Multi Summary Plot", ":/SummaryPlotLight16x16.png" );
     setDeletable( true );
@@ -492,7 +491,10 @@ void RimSummaryMultiPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedFi
     else if ( changedField == &m_createPlotDuplicate )
     {
         m_createPlotDuplicate = false;
-        duplicate();
+        if ( auto plotCollection = RimMainPlotCollection::current()->summaryMultiPlotCollection() )
+        {
+            plotCollection->duplicatePlot( this );
+        }
     }
     else if ( changedField == &m_appendNextPlot )
     {
@@ -689,6 +691,8 @@ std::vector<caf::PdmFieldHandle*> RimSummaryMultiPlot::fieldsToShowInToolbar()
     auto& sourceObject = m_sourceStepping();
     if ( sourceObject )
     {
+        sourceObject->setSourceSteppingObject( steppingSourceObject() );
+
         auto fields = sourceObject->fieldsToShowInToolbar();
         toolBarFields.insert( std::end( toolBarFields ), std::begin( fields ), std::end( fields ) );
     }
@@ -1305,14 +1309,6 @@ void RimSummaryMultiPlot::summaryPlotItemInfos( QList<caf::PdmOptionItemInfo>* o
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryMultiPlot::duplicate()
-{
-    duplicatePlot.send( this );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void RimSummaryMultiPlot::analyzePlotsAndAdjustAppearanceSettings()
 {
     if ( m_autoAdjustAppearance )
@@ -1614,88 +1610,148 @@ void RimSummaryMultiPlot::onPlotAdditionOrRemoval()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RimSummaryMultiPlot::isStepDimensionSharedAmongSubPlots()
+{
+    using Dim = RimSummaryDataSourceStepping::SourceSteppingDimension;
+
+    populateNameHelper( m_nameHelper.get() );
+
+    switch ( m_sourceStepping->stepDimension() )
+    {
+        case Dim::SUMMARY_CASE:
+        case Dim::ENSEMBLE:
+            return m_nameHelper->isCaseInTitle();
+        case Dim::WELL:
+            return m_nameHelper->isWellNameInTitle();
+        case Dim::GROUP:
+            return m_nameHelper->isGroupNameInTitle();
+        case Dim::NETWORK:
+            return m_nameHelper->isNetworkInTitle();
+        case Dim::REGION:
+            return m_nameHelper->isRegionInTitle();
+        case Dim::VECTOR:
+            return !m_nameHelper->titleVectorName().empty();
+        case Dim::BLOCK:
+            return m_nameHelper->isBlockInTitle();
+        case Dim::WELL_SEGMENT:
+            return m_nameHelper->isSegmentInTitle();
+        case Dim::WELL_CONNECTION:
+            return m_nameHelper->isConnectionInTitle();
+        case Dim::WELL_COMPLETION_NUMBER:
+            return m_nameHelper->isWellCompletionInTitle();
+        default:
+            break;
+    }
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::PdmObject* RimSummaryMultiPlot::steppingSourceObject()
+{
+    if ( !isStepDimensionSharedAmongSubPlots() )
+    {
+        auto* selectedPlot = caf::SelectionManager::instance()->selectedItemOfType<RimSummaryPlot>();
+        if ( selectedPlot && selectedPlot->firstAncestorOrThisOfType<RimSummaryMultiPlot>() == this ) return selectedPlot;
+    }
+    return this;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimSummaryMultiPlot::appendSubPlotByStepping( int direction )
 {
-    std::vector<RimSummaryPlot*> plotsForStepping;
+    m_sourceStepping->setSourceSteppingObject( steppingSourceObject() );
 
-    bool isMultiPlotSelected = ( caf::SelectionManager::instance()->selectedItemOfType<RimSummaryMultiPlot>() != nullptr );
-    if ( isMultiPlotSelected )
+    auto applySteppingToPlots = []( const std::vector<RimSummaryPlot*>& summaryPlots, RimSummaryPlotSourceStepping* sourceStepper, int direction )
     {
-        duplicate();
+        if ( !sourceStepper ) return;
 
-        // The duplicate operation selects duplicated plot by default. Select this as current item to continue stepping on this plot
-        RiuPlotMainWindowTools::selectAsCurrentItem( this );
+        for ( auto newPlot : summaryPlots )
+        {
+            if ( sourceStepper->stepDimension() == RimSummaryDataSourceStepping::SourceSteppingDimension::SUMMARY_CASE )
+            {
+                RimSummaryCase* newCase = sourceStepper->stepCase( direction );
+                for ( auto curve : newPlot->allCurves() )
+                {
+                    curve->setSummaryCaseY( newCase );
 
-        plotsForStepping = summaryPlots();
+                    // NOTE: If summary cross plots should be handled here, we also need to call
+                    // curve->setSummaryCaseX( newCase );
+                    // Setting summaryCaseX with a default uninitialized summary address causes issues for the summary
+                    // name analyzer
+                }
+            }
+            else if ( sourceStepper->stepDimension() == RimSummaryDataSourceStepping::SourceSteppingDimension::ENSEMBLE )
+            {
+                RimSummaryEnsemble* newEnsemble = sourceStepper->stepEnsemble( direction );
+                for ( auto curveSet : newPlot->curveSets() )
+                {
+                    curveSet->setSummaryEnsemble( newEnsemble );
+                }
+            }
+            else
+            {
+                std::vector<RiaSummaryCurveAddress> newCurveAdrs;
+
+                auto curveAddressProviders = RiaSummaryAddressModifier::createAddressProviders( newPlot );
+                for ( const auto& adr : RiaSummaryAddressModifier::curveAddresses( curveAddressProviders ) )
+                {
+                    const auto adrX = sourceStepper->stepAddress( adr.summaryAddressX(), direction );
+                    const auto adrY = sourceStepper->stepAddress( adr.summaryAddressY(), direction );
+                    newCurveAdrs.push_back( RiaSummaryCurveAddress( adrX, adrY ) );
+                }
+
+                RiaSummaryAddressModifier::applyAddressesToCurveAddressProviders( curveAddressProviders, newCurveAdrs );
+            }
+        }
+    };
+
+    if ( m_sourceStepping()->isAtEnd( direction ) ) return;
+
+    if ( caf::SelectionManager::instance()->selectedItemOfType<RimSummaryMultiPlot>() != nullptr )
+    {
+        if ( auto plotCollection = RimMainPlotCollection::current()->summaryMultiPlotCollection() )
+        {
+            auto copy = plotCollection->duplicatePlot( this );
+
+            applySteppingToPlots( copy->summaryPlots(), m_sourceStepping(), direction );
+
+            copy->loadDataAndUpdate();
+            copy->updateConnectedEditors();
+            copy->updateSourceStepper();
+        }
     }
     else
     {
         std::vector<RimPlot*> plots = m_sourceStepping->plotsMatchingStepSettings( summaryPlots() );
         if ( !plots.empty() )
         {
-            auto newPlots = RiaSummaryPlotTools::duplicatePlots( plots );
+            std::vector<RimSummaryPlot*> summaryPlots;
+            auto                         newPlots = RiaSummaryPlotTools::duplicatePlots( plots );
             for ( auto plot : newPlots )
             {
                 if ( RimSummaryPlot* newPlot = dynamic_cast<RimSummaryPlot*>( plot ) )
                 {
                     addPlot( newPlot );
                     newPlot->resolveReferencesRecursively();
-
-                    plotsForStepping.push_back( newPlot );
+                    summaryPlots.push_back( newPlot );
                 }
             }
+            applySteppingToPlots( summaryPlots, m_sourceStepping(), direction );
         }
-    }
 
-    for ( auto newPlot : plotsForStepping )
-    {
-        if ( m_sourceStepping()->stepDimension() == RimSummaryDataSourceStepping::SourceSteppingDimension::SUMMARY_CASE )
-        {
-            RimSummaryCase* newCase = m_sourceStepping()->stepCase( direction );
-            for ( auto curve : newPlot->allCurves() )
-            {
-                curve->setSummaryCaseY( newCase );
+        loadDataAndUpdate();
+        updateConnectedEditors();
 
-                // NOTE: If summary cross plots should be handled here, we also need to call
-                // curve->setSummaryCaseX( newCase );
-                // Setting summaryCaseX with a default uninitialized summary address causes issues for the summary
-                // name analyzer
-            }
-        }
-        else if ( m_sourceStepping()->stepDimension() == RimSummaryDataSourceStepping::SourceSteppingDimension::ENSEMBLE )
-        {
-            RimSummaryEnsemble* newEnsemble = m_sourceStepping()->stepEnsemble( direction );
-            for ( auto curveSet : newPlot->curveSets() )
-            {
-                curveSet->setSummaryEnsemble( newEnsemble );
-            }
-        }
-        else
-        {
-            std::vector<RiaSummaryCurveAddress> newCurveAdrs;
-
-            auto curveAddressProviders = RiaSummaryAddressModifier::createAddressProviders( newPlot );
-            for ( const auto& adr : RiaSummaryAddressModifier::curveAddresses( curveAddressProviders ) )
-            {
-                const auto adrX = m_sourceStepping()->stepAddress( adr.summaryAddressX(), direction );
-                const auto adrY = m_sourceStepping()->stepAddress( adr.summaryAddressY(), direction );
-                newCurveAdrs.push_back( RiaSummaryCurveAddress( adrX, adrY ) );
-            }
-
-            RiaSummaryAddressModifier::applyAddressesToCurveAddressProviders( curveAddressProviders, newCurveAdrs );
-        }
-    }
-
-    loadDataAndUpdate();
-    updateConnectedEditors();
-
-    if ( !isMultiPlotSelected && !summaryPlots().empty() )
-    {
-        // Select the last plot in the list as the current item to be able to append plots for the next object type (well, region, etc.)
         RiuPlotMainWindowTools::selectAsCurrentItem( summaryPlots().back() );
+
+        updateSourceStepper();
     }
 
-    updateSourceStepper();
     RiuPlotMainWindowTools::refreshToolbars();
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.h
@@ -24,8 +24,6 @@
 #include "cafPdmChildField.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiItem.h"
-#include "cafSignal.h"
-
 #include <QList>
 
 #include <vector>
@@ -44,9 +42,6 @@ class RimSummaryPlotReadOut;
 class RimSummaryMultiPlot : public RimMultiPlot, public RimSummaryDataSourceStepping
 {
     CAF_PDM_HEADER_INIT;
-
-public:
-    caf::Signal<RimSummaryMultiPlot*> duplicatePlot;
 
 public:
     enum class AxisRangeAggregation
@@ -144,10 +139,11 @@ private:
     void        setAutoValueStates();
     static void setAutoValueStatesForPlot( RimSummaryPlot* summaryPlot, bool isMinMaxOverridden, bool isAppearanceOverridden );
 
-    void duplicate();
-
     void appendSubPlotByStepping( int direction );
     void appendCurveByStepping( int direction );
+
+    bool            isStepDimensionSharedAmongSubPlots();
+    caf::PdmObject* steppingSourceObject();
 
     void onSubPlotChanged( const caf::SignalEmitter* emitter );
     void onSubPlotAxisChanged( const caf::SignalEmitter* emitter, RimSummaryPlot* summaryPlot );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlotCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlotCollection.cpp
@@ -61,10 +61,6 @@ RimSummaryMultiPlotCollection::~RimSummaryMultiPlotCollection()
 //--------------------------------------------------------------------------------------------------
 void RimSummaryMultiPlotCollection::initAfterRead()
 {
-    for ( auto& plot : m_summaryMultiPlots )
-    {
-        plot->duplicatePlot.connect( this, &RimSummaryMultiPlotCollection::onDuplicatePlot );
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -89,7 +85,6 @@ std::vector<RimSummaryMultiPlot*> RimSummaryMultiPlotCollection::multiPlots() co
 void RimSummaryMultiPlotCollection::addSummaryMultiPlot( RimSummaryMultiPlot* plot )
 {
     m_summaryMultiPlots().push_back( plot );
-    plot->duplicatePlot.connect( this, &RimSummaryMultiPlotCollection::onDuplicatePlot );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -116,23 +111,6 @@ void RimSummaryMultiPlotCollection::loadDataAndUpdateAllPlots()
 size_t RimSummaryMultiPlotCollection::plotCount() const
 {
     return m_summaryMultiPlots.size();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimSummaryMultiPlotCollection::onDuplicatePlot( const caf::SignalEmitter* emitter, RimSummaryMultiPlot* plotToDuplicate )
-{
-    duplicatePlot( plotToDuplicate );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimSummaryMultiPlotCollection::onRefreshTree( const caf::SignalEmitter* emitter, RimSummaryMultiPlot* plotRequesting )
-{
-    if ( !plotRequesting ) return;
-    updateConnectedEditors();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -224,9 +202,9 @@ void RimSummaryMultiPlotCollection::summaryPlotItemInfos( QList<caf::PdmOptionIt
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryMultiPlotCollection::duplicatePlot( RimSummaryMultiPlot* plotToDuplicate )
+RimSummaryMultiPlot* RimSummaryMultiPlotCollection::duplicatePlot( RimSummaryMultiPlot* plotToDuplicate )
 {
-    if ( !plotToDuplicate ) return;
+    if ( !plotToDuplicate ) return nullptr;
 
     auto plotCopy = plotToDuplicate->copyObject<RimSummaryMultiPlot>();
     addSummaryMultiPlot( plotCopy );
@@ -239,6 +217,8 @@ void RimSummaryMultiPlotCollection::duplicatePlot( RimSummaryMultiPlot* plotToDu
     updateConnectedEditors();
 
     RiuPlotMainWindowTools::selectAsCurrentItem( plotCopy );
+
+    return plotCopy;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlotCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlotCollection.h
@@ -44,10 +44,10 @@ public:
 
     std::vector<RimSummaryMultiPlot*> multiPlots() const;
 
-    void addSummaryMultiPlot( RimSummaryMultiPlot* plot );
-    void summaryPlotItemInfos( QList<caf::PdmOptionItemInfo>* optionInfos ) const;
-    void duplicatePlot( RimSummaryMultiPlot* plotToDuplicate );
-    void removePlotNoUpdate( RimSummaryMultiPlot* plotToRemove );
+    void                 addSummaryMultiPlot( RimSummaryMultiPlot* plot );
+    void                 summaryPlotItemInfos( QList<caf::PdmOptionItemInfo>* optionInfos ) const;
+    RimSummaryMultiPlot* duplicatePlot( RimSummaryMultiPlot* plotToDuplicate );
+    void                 removePlotNoUpdate( RimSummaryMultiPlot* plotToRemove );
 
     void updateSummaryNameHasChanged();
 
@@ -58,9 +58,6 @@ private:
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
     void onChildrenUpdated( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& updatedObjects ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
-
-    void onDuplicatePlot( const caf::SignalEmitter* emitter, RimSummaryMultiPlot* plotToDuplicate );
-    void onRefreshTree( const caf::SignalEmitter* emitter, RimSummaryMultiPlot* plotRequesting );
 
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.cpp
@@ -521,8 +521,6 @@ void RimSummaryPlotSourceStepping::fieldChangedByUi( const caf::PdmFieldHandle* 
 
     if ( triggerLoadDataAndUpdate )
     {
-        auto summaryPlot = firstAncestorOrThisOfType<RimSummaryPlot>();
-
         RimSummaryMultiPlot* summaryMultiPlot = dynamic_cast<RimSummaryMultiPlot*>( m_objectForSourceStepping.p() );
         if ( summaryMultiPlot )
         {
@@ -537,10 +535,16 @@ void RimSummaryPlotSourceStepping::fieldChangedByUi( const caf::PdmFieldHandle* 
         }
         else
         {
-            summaryPlot->updatePlotTitle();
-            summaryPlot->loadDataAndUpdate();
-            summaryPlot->updateConnectedEditors();
-            summaryPlot->curvesChanged.send();
+            RimSummaryPlot* summaryPlot = dynamic_cast<RimSummaryPlot*>( m_objectForSourceStepping.p() );
+            if ( !summaryPlot ) summaryPlot = firstAncestorOrThisOfType<RimSummaryPlot>();
+
+            if ( summaryPlot )
+            {
+                summaryPlot->updatePlotTitle();
+                summaryPlot->loadDataAndUpdate();
+                summaryPlot->updateConnectedEditors();
+                summaryPlot->curvesChanged.send();
+            }
         }
 
         updateAllRequiredEditors();
@@ -1350,6 +1354,40 @@ RimSummaryDataSourceStepping::SourceSteppingDimension RimSummaryPlotSourceSteppi
 void RimSummaryPlotSourceStepping::setStepDimension( RimSummaryDataSourceStepping::SourceSteppingDimension dimension )
 {
     m_stepDimension = dimension;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimSummaryPlotSourceStepping::isAtEnd( int direction )
+{
+    caf::PdmValueField* valueField = fieldToModify();
+    if ( !valueField ) return true;
+
+    QList<caf::PdmOptionItemInfo> options = calculateValueOptions( valueField );
+    if ( options.isEmpty() ) return true;
+
+    QVariant                              currentValue  = valueField->toQVariant();
+    caf::PdmPointer<caf::PdmObjectHandle> currentHandle = currentValue.value<caf::PdmPointer<caf::PdmObjectHandle>>();
+    int                                   currentIndex  = -1;
+    for ( int i = 0; i < options.size(); i++ )
+    {
+        QVariant                              optionValue  = options[i].value();
+        caf::PdmPointer<caf::PdmObjectHandle> optionHandle = optionValue.value<caf::PdmPointer<caf::PdmObjectHandle>>();
+        if ( optionHandle )
+        {
+            if ( currentHandle == optionHandle ) currentIndex = i;
+        }
+        else if ( currentValue == optionValue )
+        {
+            currentIndex = i;
+        }
+    }
+
+    if ( currentIndex == -1 ) return false;
+
+    int nextIndex = currentIndex + direction;
+    return ( nextIndex < 0 || nextIndex >= options.size() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlotSourceStepping.h
@@ -60,6 +60,8 @@ public:
     RimSummaryCase*          stepCase( int direction );
     RimSummaryEnsemble*      stepEnsemble( int direction );
 
+    bool isAtEnd( int direction );
+
     void syncWithStepper( RimSummaryPlotSourceStepping* other );
     void setStep( QString stepIdentifier );
 

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -758,8 +758,8 @@ void RiuPlotMainWindow::updateMultiPlotToolBar()
             if ( !m_multiPlotToolBarEditor->isEditorDataEqualAndValid( toolBarFields ) )
             {
                 m_multiPlotToolBarEditor->setFields( toolBarFields );
-                m_multiPlotToolBarEditor->updateUi();
             }
+            m_multiPlotToolBarEditor->updateUi();
             m_multiPlotToolBarEditor->show();
         }
 


### PR DESCRIPTION
## Summary
- Remove unused `duplicatePlot` signal and duplicate button from `RimHistogramMultiPlot` (signal had no listeners)
- Remove `duplicatePlot` signal from `RimSummaryMultiPlot`, calling collection directly instead
- Add `isAtEnd()` to `RimSummaryPlotSourceStepping` to check boundary conditions before stepping
- Fix source stepping for sub-plots: resolve stepping source object from selection context
- Add `isStepDimensionSharedAmongSubPlots()` and `steppingSourceObject()` to improve per-sub-plot vs. whole-plot stepping logic
- Refactor `appendSubPlotByStepping` to use the new helpers and correctly apply stepping to duplicated plots
- Fix toolbar update to always call `updateUi()` regardless of field equality check
- Call `updatePlots()` after creating a plot from template