### PR TITLE
Make it possible to compute contour map based on shared grid

### DIFF
--- a/ApplicationLibCode/Commands/RicNewStatisticsContourMapFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewStatisticsContourMapFeature.cpp
@@ -19,6 +19,7 @@
 #include "RicNewStatisticsContourMapFeature.h"
 
 #include "ContourMap/RimStatisticsContourMap.h"
+#include "RimReservoirGridEnsemble.h"
 #include "RimReservoirGridEnsembleBase.h"
 
 #include "Riu3DMainWindowTools.h"
@@ -27,6 +28,8 @@
 #include "cafSelectionManager.h"
 
 #include <QAction>
+#include <QMessageBox>
+#include <QPushButton>
 
 CAF_CMD_SOURCE_INIT( RicNewStatisticsContourMapFeature, "RicNewStatisticsContourMapFeature" );
 
@@ -41,6 +44,29 @@ void RicNewStatisticsContourMapFeature::addStatisticsContourMap( RimReservoirGri
     if ( cases.empty() ) return;
 
     auto statisticsContourMap = new RimStatisticsContourMap();
+
+    if ( auto* gridEnsemble = dynamic_cast<RimReservoirGridEnsemble*>( ensemble ) )
+    {
+        if ( gridEnsemble->hasSharedGrid() )
+        {
+            QMessageBox msgBox;
+            msgBox.setWindowTitle( "Grid Import Mode" );
+            msgBox.setText( "This grid ensemble has identical IJK for all realizations. Select how grids should be loaded when "
+                            "computing statistics." );
+            auto* reuseButton  = msgBox.addButton( "Reuse Grid from First Realization", QMessageBox::AcceptRole );
+            auto* importButton = msgBox.addButton( "Import All Grids", QMessageBox::RejectRole );
+            msgBox.setDefaultButton( reuseButton );
+            msgBox.exec();
+
+            if ( msgBox.clickedButton() == importButton )
+                statisticsContourMap->setGridImportMode( RimStatisticsContourMap::GridImportMode::INDIVIDUAL_GRIDS );
+        }
+        else
+        {
+            statisticsContourMap->setGridImportMode( RimStatisticsContourMap::GridImportMode::INDIVIDUAL_GRIDS );
+        }
+    }
+
     statisticsContourMap->setEclipseCase( cases[0] );
     ensemble->addStatisticsContourMap( statisticsContourMap );
 

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp
@@ -249,7 +249,7 @@ void RimEclipseContourMapProjection::updateGridInformation()
 
     cvf::BoundingBox gridBoundingBox = eclipseCase->activeCellsBoundingBox();
     m_contourMapGrid                 = std::make_unique<RigContourMapGrid>( gridBoundingBox, sampleSpacing() );
-    m_contourMapProjection           = std::make_unique<RigEclipseContourMapProjection>( *m_contourMapGrid, *eclipseCaseData, *resultData );
+    m_contourMapProjection = std::make_unique<RigEclipseContourMapProjection>( m_contourMapGrid.get(), eclipseCaseData, resultData );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
@@ -43,6 +43,7 @@
 #include "RimEclipseCase.h"
 #include "RimEclipseCaseEnsemble.h"
 #include "RimEclipseContourMapProjection.h"
+#include "RimEclipseResultCase.h"
 #include "RimEclipseResultDefinition.h"
 #include "RimReservoirGridEnsemble.h"
 #include "RimSimWellInViewCollection.h"
@@ -59,12 +60,60 @@
 #include "cafProgressInfo.h"
 
 #include <limits>
+#include <optional>
 #include <set>
+
+namespace
+{
+std::optional<std::set<int>>
+    findKLayersForFormations( RimEclipseCase* eCase, const std::vector<QString>& selectedFormations, RimFormationNames* fallbackFormationNames )
+{
+    if ( selectedFormations.empty() ) return std::set<int>{};
+
+    auto formationNames = eCase->activeFormationNames();
+    if ( !formationNames ) formationNames = fallbackFormationNames;
+    if ( !formationNames ) return std::nullopt;
+
+    auto fData = formationNames->formationNamesData();
+    if ( !fData ) return std::nullopt;
+
+    return fData->findKLayers( selectedFormations );
+}
+
+void extractCaseResults( RigEclipseContourMapProjection&                     projection,
+                         const RigEclipseResultAddress&                      resultAddress,
+                         bool                                                hasDynamicResult,
+                         RigContourMapCalculator::ResultAggregationType      resultAggregation,
+                         RigFloodingSettings&                                floodSettings,
+                         const std::vector<std::pair<int, int>>&             localToGlobalTimeSteps,
+                         std::map<size_t, std::vector<std::vector<double>>>& timestepResults )
+{
+    if ( hasDynamicResult )
+    {
+        for ( auto [localTs, globalTs] : localToGlobalTimeSteps )
+        {
+            timestepResults[globalTs].push_back( projection.generateResults( resultAddress, resultAggregation, localTs, floodSettings ) );
+        }
+    }
+    else
+    {
+        timestepResults[0].push_back( projection.generateResults( resultAddress, resultAggregation, 0, floodSettings ) );
+    }
+}
+} // namespace
 
 CAF_PDM_SOURCE_INIT( RimStatisticsContourMap, "RimStatisticalContourMap" );
 
 namespace caf
 {
+template <>
+void caf::AppEnum<RimStatisticsContourMap::GridImportMode>::setUp()
+{
+    addItem( RimStatisticsContourMap::GridImportMode::SHARED_GRID, "SHARED_GRID", "Reuse Grid from First Realization" );
+    addItem( RimStatisticsContourMap::GridImportMode::INDIVIDUAL_GRIDS, "INDIVIDUAL_GRIDS", "Import All Grids" );
+    setDefault( RimStatisticsContourMap::GridImportMode::SHARED_GRID );
+}
+
 template <>
 void caf::AppEnum<RimStatisticsContourMap::StatisticsType>::setUp()
 {
@@ -95,6 +144,8 @@ RimStatisticsContourMap::RimStatisticsContourMap()
                        "ensemble." );
 
     CAF_PDM_InitFieldNoDefault( &m_resolution, "Resolution", "Sampling Resolution" );
+
+    CAF_PDM_InitFieldNoDefault( &m_gridImportMode, "GridImportMode", "Grid Import Mode" );
 
     CAF_PDM_InitFieldNoDefault( &m_resultAggregation, "ResultAggregation", "Result Aggregation" );
 
@@ -189,6 +240,12 @@ void RimStatisticsContourMap::defineUiOrdering( QString uiConfigName, caf::PdmUi
     }
 
     genGrp->add( &m_resolution );
+
+    if ( auto* gridEnsemble = firstAncestorOrThisOfType<RimReservoirGridEnsembleBase>() )
+    {
+        if ( gridEnsemble->gridMode() == RimReservoirGridEnsembleBase::GridModeType::SHARED_GRID ) genGrp->add( &m_gridImportMode );
+    }
+
     genGrp->add( &m_primaryCase );
     genGrp->add( &m_boundingBoxExpPercent );
 
@@ -248,6 +305,14 @@ void RimStatisticsContourMap::setEclipseCase( RimEclipseCase* eCase )
         view->setEclipseCase( eCase );
     }
     m_resultDefinition->updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimStatisticsContourMap::setGridImportMode( GridImportMode mode )
+{
+    m_gridImportMode = mode;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -425,7 +490,7 @@ void RimStatisticsContourMap::initAfterRead()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimStatisticsContourMap::doStatisticsCalculation( std::map<size_t, std::vector<std::vector<double>>>& timestepResults )
+void RimStatisticsContourMap::doStatisticsCalculation( TimestepResultsMap& timestepResults )
 {
     m_timeResults.clear();
 
@@ -521,56 +586,125 @@ void RimStatisticsContourMap::computeStatistics()
     if ( cases.empty() ) return;
     if ( eclipseCase() == nullptr ) return;
 
-    RigFloodingSettings floodSettings( m_oilFloodingType(), m_userDefinedFloodingOil(), m_gasFloodingType(), m_userDefinedFloodingGas() );
-    RigContourMapCalculator::ResultAggregationType resultAggregation = m_resultAggregation();
-
     cvf::BoundingBox gridBoundingBox = eclipseCase()->activeCellsBoundingBox();
     gridBoundingBox.expandPercent( m_boundingBoxExpPercent() );
 
     double sampleSpacing = 1.0;
-    if ( auto mainGrid = eclipseCase()->mainGrid() )
-    {
-        sampleSpacing = sampleSpacingFactor() * mainGrid->characteristicIJCellSize();
-    }
+    if ( auto mainGrid = eclipseCase()->mainGrid() ) sampleSpacing = sampleSpacingFactor() * mainGrid->characteristicIJCellSize();
 
     auto contourMapGrid = std::make_unique<RigContourMapGrid>( gridBoundingBox, sampleSpacing );
 
-    const size_t nCases = cases.size();
+    TimestepResultsMap timestepResults;
+    caf::ProgressInfo  progInfo( cases.size(), QString( "Reading Eclipse Ensemble" ) );
 
-    std::map<size_t, std::vector<std::vector<double>>> timestep_results;
+    auto oldReaderType = RiaPreferencesGrid::current()->gridModelReaderOverride();
+    RiaPreferencesGrid::current()->setGridModelReaderOverride( RiaDefines::GridModelReader::OPM_COMMON );
 
-    caf::ProgressInfo progInfo( nCases, QString( "Reading Eclipse Ensemble" ) );
+    auto gridEnsemble  = firstAncestorOrThisOfType<RimReservoirGridEnsembleBase>();
+    bool useSharedGrid = gridEnsemble && gridEnsemble->gridMode() == RimReservoirGridEnsembleBase::GridModeType::SHARED_GRID &&
+                         m_gridImportMode() == GridImportMode::SHARED_GRID;
 
+    if ( useSharedGrid )
+        computeStatisticsSharedGrid( contourMapGrid.get(), timestepResults, progInfo );
+    else
+        computeStatisticsIndividualGrids( contourMapGrid.get(), timestepResults, progInfo );
+
+    RiaPreferencesGrid::current()->setGridModelReaderOverride( oldReaderType );
+
+    m_contourMapGrid = std::move( contourMapGrid );
+    doStatisticsCalculation( timestepResults );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimStatisticsContourMap::computeStatisticsSharedGrid( RigContourMapGrid*  contourMapGrid,
+                                                           TimestepResultsMap& timestepResults,
+                                                           caf::ProgressInfo&  progInfo )
+{
+    auto readerSettings                = RiaPreferencesGrid::gridOnlyReaderSettings();
+    readerSettings.onlyLoadActiveCells = true;
+
+    RifReaderSettings primaryOldSettings = eclipseCase()->readerSettings();
+    eclipseCase()->setReaderSettings( readerSettings );
+
+    if ( !eclipseCase()->ensureReservoirCaseIsOpen() )
+    {
+        eclipseCase()->setReaderSettings( primaryOldSettings );
+        return;
+    }
+
+    auto primaryCaseData   = eclipseCase()->eclipseCaseData();
+    auto primaryResultData = primaryCaseData->results( RiaDefines::PorosityModelType::MATRIX_MODEL );
+
+    RigEclipseContourMapProjection sharedProjection( contourMapGrid, primaryCaseData, primaryResultData );
+
+    auto kLayers = findKLayersForFormations( eclipseCase(), selectedFormations(), activeFormationNames() );
+    if ( !kLayers )
+    {
+        RiaLogging::warning( "Formation names are missing for primary case, skipping statistics computation." );
+        eclipseCase()->setReaderSettings( primaryOldSettings );
+        return;
+    }
+
+    RigFloodingSettings floodSettings( m_oilFloodingType(), m_userDefinedFloodingOil(), m_gasFloodingType(), m_userDefinedFloodingGas() );
+    RigContourMapCalculator::ResultAggregationType resultAggregation = m_resultAggregation();
+
+    sharedProjection.generateGridMapping( resultAggregation, {}, *kLayers, selectedPolygons() );
+
+    auto         cases        = ensembleCases();
+    auto         casesInViews = ensembleCasesInViews();
+    const size_t nCases       = cases.size();
+    int          i            = 1;
+
+    for ( RimEclipseCase* eCase : cases )
+    {
+        auto task = progInfo.task( QString( "Processing Case %1 of %2" ).arg( i++ ).arg( nCases ) );
+
+        RifReaderSettings oldSettings = eCase->readerSettings();
+        eCase->setReaderSettings( readerSettings );
+
+        if ( eCase->ensureReservoirCaseIsOpen() )
+        {
+            RiaLogging::info( QString( "Processing Grid: %1" ).arg( eCase->caseUserDescription() ) );
+
+            auto eclipseCaseData = eCase->eclipseCaseData();
+            sharedProjection.updateRealizationData( eclipseCaseData->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL ),
+                                                    eclipseCaseData->results( RiaDefines::PorosityModelType::MATRIX_MODEL ) );
+            extractCaseResults( sharedProjection,
+                                m_resultDefinition()->eclipseResultAddress(),
+                                m_resultDefinition()->hasDynamicResult(),
+                                resultAggregation,
+                                floodSettings,
+                                mapLocalToGlobalTimeSteps( eCase->timeStepDates() ),
+                                timestepResults );
+        }
+
+        eCase->setReaderSettings( oldSettings );
+        if ( eCase->views().empty() && eCase != eclipseCase() && !casesInViews.contains( eCase ) ) eCase->closeReservoirCase();
+    }
+
+    eclipseCase()->setReaderSettings( primaryOldSettings );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimStatisticsContourMap::computeStatisticsIndividualGrids( RigContourMapGrid*  contourMapGrid,
+                                                                TimestepResultsMap& timestepResults,
+                                                                caf::ProgressInfo&  progInfo )
+{
     auto readerSettings                = RiaPreferencesGrid::gridOnlyReaderSettings();
     readerSettings.onlyLoadActiveCells = true;
     auto casesInViews                  = ensembleCasesInViews();
-    auto oldReaderType                 = RiaPreferencesGrid::current()->gridModelReaderOverride();
-    RiaPreferencesGrid::current()->setGridModelReaderOverride( RiaDefines::GridModelReader::OPM_COMMON );
 
-    // For shared grids (RimReservoirGridEnsemble in shared mode), the grid geometry is identical
-    // across all cases, so the expensive grid mapping only needs to be computed once.
-    std::unique_ptr<RigEclipseContourMapProjection> sharedProjection;
-    if ( auto* gridEnsemble = firstAncestorOrThisOfType<RimReservoirGridEnsembleBase>() )
-    {
-        if ( ( gridEnsemble->gridMode() == RimReservoirGridEnsembleBase::GridModeType::SHARED_GRID ) &&
-             eclipseCase()->ensureReservoirCaseIsOpen() )
-        {
-            std::set<int> sharedKLayers;
-            auto          formationNames = selectedFormations();
-            if ( !formationNames.empty() )
-            {
-                if ( auto names = activeFormationNames() )
-                    if ( auto fData = names->formationNamesData() ) sharedKLayers = fData->findKLayers( formationNames );
-            }
+    RigFloodingSettings floodSettings( m_oilFloodingType(), m_userDefinedFloodingOil(), m_gasFloodingType(), m_userDefinedFloodingGas() );
+    RigContourMapCalculator::ResultAggregationType resultAggregation = m_resultAggregation();
 
-            auto* primaryCaseData   = eclipseCase()->eclipseCaseData();
-            auto* primaryResultData = primaryCaseData->results( RiaDefines::PorosityModelType::MATRIX_MODEL );
-            sharedProjection = std::make_unique<RigEclipseContourMapProjection>( *contourMapGrid, *primaryCaseData, *primaryResultData );
-            sharedProjection->generateGridMapping( resultAggregation, {}, sharedKLayers, selectedPolygons() );
-        }
-    }
+    auto         cases  = ensembleCases();
+    const size_t nCases = cases.size();
+    int          i      = 1;
 
-    int i = 1;
     for ( RimEclipseCase* eCase : cases )
     {
         auto task = progInfo.task( QString( "Processing Case %1 of %2" ).arg( i++ ).arg( nCases ) );
@@ -585,113 +719,29 @@ void RimStatisticsContourMap::computeStatistics()
             auto eclipseCaseData = eCase->eclipseCaseData();
             auto resultData      = eclipseCaseData->results( RiaDefines::PorosityModelType::MATRIX_MODEL );
 
-            if ( sharedProjection )
+            RigEclipseContourMapProjection contourMapProjection( contourMapGrid, eclipseCaseData, resultData );
+
+            auto kLayers = findKLayersForFormations( eCase, selectedFormations(), activeFormationNames() );
+            if ( kLayers )
             {
-                // Shared grid mode: grid mapping was already computed from the primary case.
-                // Only extract results from the per-case result data.
-                if ( m_resultDefinition()->hasDynamicResult() )
-                {
-                    for ( auto [localTs, globalTs] : mapLocalToGlobalTimeSteps( eCase->timeStepDates() ) )
-                    {
-                        auto result = RigEclipseContourMapProjection::generateResults( *sharedProjection,
-                                                                                       *contourMapGrid,
-                                                                                       *resultData,
-                                                                                       m_resultDefinition()->eclipseResultAddress(),
-                                                                                       resultAggregation,
-                                                                                       localTs,
-                                                                                       floodSettings )
-                                          .second;
-                        timestep_results[globalTs].push_back( result );
-                    }
-                }
-                else
-                {
-                    auto result = RigEclipseContourMapProjection::generateResults( *sharedProjection,
-                                                                                   *contourMapGrid,
-                                                                                   *resultData,
-                                                                                   m_resultDefinition()->eclipseResultAddress(),
-                                                                                   resultAggregation,
-                                                                                   0,
-                                                                                   floodSettings )
-                                      .second;
-                    timestep_results[0].push_back( result );
-                }
+                contourMapProjection.generateGridMapping( resultAggregation, {}, *kLayers, selectedPolygons() );
+                extractCaseResults( contourMapProjection,
+                                    m_resultDefinition()->eclipseResultAddress(),
+                                    m_resultDefinition()->hasDynamicResult(),
+                                    resultAggregation,
+                                    floodSettings,
+                                    mapLocalToGlobalTimeSteps( eCase->timeStepDates() ),
+                                    timestepResults );
             }
             else
             {
-                // Individual grids: compute grid mapping per case.
-                RigEclipseContourMapProjection contourMapProjection( *contourMapGrid, *eclipseCaseData, *resultData );
-
-                std::set<int> usedKLayers;
-                auto          selectedFormations = this->selectedFormations();
-
-                bool formationNamesOk = true;
-                if ( !selectedFormations.empty() )
-                {
-                    auto formationNames = eCase->activeFormationNames();
-                    if ( !formationNames ) formationNames = activeFormationNames();
-
-                    if ( formationNames )
-                    {
-                        if ( auto fData = formationNames->formationNamesData() )
-                        {
-                            usedKLayers = fData->findKLayers( selectedFormations );
-                        }
-                        else
-                        {
-                            formationNamesOk = false;
-                        }
-                    }
-                    else
-                    {
-                        formationNamesOk = false;
-                    }
-                }
-
-                if ( formationNamesOk )
-                {
-                    contourMapProjection.generateGridMapping( resultAggregation, {}, usedKLayers, selectedPolygons() );
-
-                    if ( m_resultDefinition()->hasDynamicResult() )
-                    {
-                        for ( auto [localTs, globalTs] : mapLocalToGlobalTimeSteps( eCase->timeStepDates() ) )
-                        {
-                            std::vector<double> result = contourMapProjection.generateResults( m_resultDefinition()->eclipseResultAddress(),
-                                                                                               resultAggregation,
-                                                                                               localTs,
-                                                                                               floodSettings );
-                            timestep_results[globalTs].push_back( result );
-                        }
-                    }
-                    else
-                    {
-                        std::vector<double> result = contourMapProjection.generateResults( m_resultDefinition()->eclipseResultAddress(),
-                                                                                           resultAggregation,
-                                                                                           0,
-                                                                                           floodSettings );
-                        timestep_results[0].push_back( result );
-                    }
-                }
-                else
-                {
-                    RiaLogging::warning(
-                        QString( "Formation names are missing for case %1, skipping case." ).arg( eCase->caseUserDescription() ) );
-                }
+                RiaLogging::warning( QString( "Formation names are missing for case %1, skipping case." ).arg( eCase->caseUserDescription() ) );
             }
         }
+
         eCase->setReaderSettings( oldSettings );
-
-        if ( eCase->views().empty() && eCase != eclipseCase() && !casesInViews.contains( eCase ) )
-        {
-            eCase->closeReservoirCase();
-        }
+        if ( eCase->views().empty() && eCase != eclipseCase() && !casesInViews.contains( eCase ) ) eCase->closeReservoirCase();
     }
-
-    RiaPreferencesGrid::current()->setGridModelReaderOverride( oldReaderType );
-
-    m_contourMapGrid = std::move( contourMapGrid );
-
-    doStatisticsCalculation( timestep_results );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.h
@@ -31,9 +31,16 @@
 #include "cvfVector3.h"
 
 #include <map>
+#include <optional>
 #include <utility>
 #include <vector>
 
+namespace caf
+{
+class ProgressInfo;
+}
+
+class RigContourMapGrid;
 class RimEclipseCase;
 class RimEclipseResultDefinition;
 class RimEclipseCaseEnsemble;
@@ -62,10 +69,18 @@ public:
         MAX
     };
 
+    enum class GridImportMode
+    {
+        SHARED_GRID,
+        INDIVIDUAL_GRIDS
+    };
+
     RimStatisticsContourMap();
 
     void            setEclipseCase( RimEclipseCase* eclipseCase );
     RimEclipseCase* eclipseCase() const;
+
+    void setGridImportMode( GridImportMode mode );
 
     QString ensembleName() const;
 
@@ -100,9 +115,13 @@ protected:
     void switchToSelectedSourceCase();
 
 private:
+    using TimestepResultsMap = std::map<size_t, std::vector<std::vector<double>>>;
+
     void computeStatistics();
+    void computeStatisticsSharedGrid( RigContourMapGrid* contourMapGrid, TimestepResultsMap& timestepResults, caf::ProgressInfo& progInfo );
+    void computeStatisticsIndividualGrids( RigContourMapGrid* contourMapGrid, TimestepResultsMap& timestepResults, caf::ProgressInfo& progInfo );
     void onComputeStatisticsClicked();
-    void doStatisticsCalculation( std::map<size_t, std::vector<std::vector<double>>>& timestep_results );
+    void doStatisticsCalculation( TimestepResultsMap& timestep_results );
 
     RimFormationNames*           activeFormationNames() const;
     std::vector<RimEclipseCase*> ensembleCases() const;
@@ -110,6 +129,7 @@ private:
 
     std::vector<std::pair<int, int>> mapLocalToGlobalTimeSteps( std::vector<QDateTime> localDates ) const;
 
+private:
     caf::PdmField<double>                                     m_boundingBoxExpPercent;
     caf::PdmField<RimContourMapProjection::ResultAggregation> m_resultAggregation;
     caf::PdmField<std::vector<int>>                           m_selectedTimeSteps;
@@ -119,6 +139,7 @@ private:
     caf::PdmPtrField<RimEclipseCase*>                         m_primaryCase;
     caf::PdmPtrArrayField<RimPolygon*>                        m_selectedPolygons;
 
+    caf::PdmField<caf::AppEnum<GridImportMode>>                                   m_gridImportMode;
     caf::PdmField<caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>> m_resolution;
 
     caf::PdmField<caf::AppEnum<RigFloodingSettings::FloodingType>> m_oilFloodingType;

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMapProjection.cpp
@@ -207,7 +207,7 @@ void RimStatisticsContourMapProjection::updateGridInformation()
     contourMap->ensureResultsComputed();
 
     m_contourMapGrid       = std::make_unique<RigContourMapGrid>( *contourMap->contourMapGrid() );
-    m_contourMapProjection = std::make_unique<RigStatisticsContourMapProjection>( *m_contourMapGrid );
+    m_contourMapProjection = std::make_unique<RigStatisticsContourMapProjection>( m_contourMapGrid.get() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechContourMapProjection.cpp
@@ -237,8 +237,8 @@ void RimGeoMechContourMapProjection::updateGridInformation()
     expandedBoundingBox = cvf::BoundingBox( minExpandedPoint, maxExpandedPoint );
 
     m_contourMapGrid       = std::make_unique<RigContourMapGrid>( gridBoundingBox, expandedBoundingBox, sampleSpacing() );
-    m_contourMapProjection = std::make_unique<RigGeoMechContourMapProjection>( *geoMechCase->geoMechData(),
-                                                                               *m_contourMapGrid,
+    m_contourMapProjection = std::make_unique<RigGeoMechContourMapProjection>( geoMechCase->geoMechData(),
+                                                                               m_contourMapGrid.get(),
                                                                                m_limitToPorePressureRegions,
                                                                                m_paddingAroundPorePressureRegion );
 }

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.cpp
@@ -34,7 +34,7 @@
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RigContourMapProjection::RigContourMapProjection( const RigContourMapGrid& contourMapGrid )
+RigContourMapProjection::RigContourMapProjection( const RigContourMapGrid* contourMapGrid )
     : m_contourMapGrid( contourMapGrid )
     , m_currentResultTimestep( -1 )
 {
@@ -50,7 +50,7 @@ std::vector<std::vector<std::pair<size_t, double>>>
                                                   const std::vector<std::vector<cvf::Vec3d>>&    limitToPolygons )
 {
     m_projected3dGridIndices =
-        RigContourMapCalculator::generateGridMapping( *this, m_contourMapGrid, resultAggregation, weights, kLayers, limitToPolygons );
+        RigContourMapCalculator::generateGridMapping( *this, *m_contourMapGrid, resultAggregation, weights, kLayers, limitToPolygons );
     return m_projected3dGridIndices;
 }
 
@@ -100,7 +100,7 @@ double RigContourMapProjection::sumAllValues() const
 //--------------------------------------------------------------------------------------------------
 cvf::Vec2ui RigContourMapProjection::numberOfElementsIJ() const
 {
-    return m_contourMapGrid.numberOfElementsIJ();
+    return m_contourMapGrid->numberOfElementsIJ();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -108,7 +108,7 @@ cvf::Vec2ui RigContourMapProjection::numberOfElementsIJ() const
 //--------------------------------------------------------------------------------------------------
 cvf::Vec2ui RigContourMapProjection::numberOfVerticesIJ() const
 {
-    return m_contourMapGrid.numberOfVerticesIJ();
+    return m_contourMapGrid->numberOfVerticesIJ();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -116,7 +116,7 @@ cvf::Vec2ui RigContourMapProjection::numberOfVerticesIJ() const
 //--------------------------------------------------------------------------------------------------
 size_t RigContourMapProjection::vertexIndex( unsigned int i, unsigned int j ) const
 {
-    return m_contourMapGrid.vertexIndexFromIJ( i, j );
+    return m_contourMapGrid->vertexIndexFromIJ( i, j );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -124,7 +124,7 @@ size_t RigContourMapProjection::vertexIndex( unsigned int i, unsigned int j ) co
 //--------------------------------------------------------------------------------------------------
 double RigContourMapProjection::valueAtVertex( unsigned int i, unsigned int j ) const
 {
-    size_t index = m_contourMapGrid.vertexIndexFromIJ( i, j );
+    size_t index = m_contourMapGrid->vertexIndexFromIJ( i, j );
     if ( index < numberOfVertices() )
     {
         return m_aggregatedVertexResults.at( index );
@@ -137,7 +137,7 @@ double RigContourMapProjection::valueAtVertex( unsigned int i, unsigned int j ) 
 //--------------------------------------------------------------------------------------------------
 unsigned int RigContourMapProjection::numberOfCells() const
 {
-    return m_contourMapGrid.numberOfCells();
+    return m_contourMapGrid->numberOfCells();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -148,7 +148,7 @@ unsigned int RigContourMapProjection::numberOfValidCells() const
     unsigned int validCount = 0u;
     for ( unsigned int i = 0; i < numberOfCells(); ++i )
     {
-        cvf::Vec2ui ij = m_contourMapGrid.ijFromCellIndex( i );
+        cvf::Vec2ui ij = m_contourMapGrid->ijFromCellIndex( i );
         if ( hasResultInCell( ij.x(), ij.y() ) )
         {
             validCount++;
@@ -174,7 +174,7 @@ bool RigContourMapProjection::checkForMapIntersection( const cvf::Vec3d& domainP
     CVF_TIGHT_ASSERT( contourMapPoint );
     CVF_TIGHT_ASSERT( valueAtPoint );
 
-    const cvf::Vec3d& minPoint = m_contourMapGrid.expandedBoundingBox().min();
+    const cvf::Vec3d& minPoint = m_contourMapGrid->expandedBoundingBox().min();
     cvf::Vec3d        mapPos3d = domainPoint3d - minPoint;
     cvf::Vec2d        mapPos2d( mapPos3d.x(), mapPos3d.y() );
     cvf::Vec2d        gridorigin( minPoint.x(), minPoint.y() );
@@ -195,7 +195,7 @@ bool RigContourMapProjection::checkForMapIntersection( const cvf::Vec3d& domainP
 //--------------------------------------------------------------------------------------------------
 cvf::Vec3d RigContourMapProjection::origin3d() const
 {
-    return m_contourMapGrid.expandedBoundingBox().min();
+    return m_contourMapGrid->expandedBoundingBox().min();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -203,7 +203,7 @@ cvf::Vec3d RigContourMapProjection::origin3d() const
 //--------------------------------------------------------------------------------------------------
 double RigContourMapProjection::topDepthBoundingBox() const
 {
-    return m_contourMapGrid.expandedBoundingBox().max().z();
+    return m_contourMapGrid->expandedBoundingBox().max().z();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -273,7 +273,7 @@ void RigContourMapProjection::generateVertexResults()
 #pragma omp parallel for
     for ( int index = 0; index < static_cast<int>( nVertices ); ++index )
     {
-        cvf::Vec2ui ij                   = m_contourMapGrid.ijFromVertexIndex( index );
+        cvf::Vec2ui ij                   = m_contourMapGrid->ijFromVertexIndex( index );
         m_aggregatedVertexResults[index] = calculateValueAtVertex( ij.x(), ij.y() );
     }
 }
@@ -316,10 +316,10 @@ double RigContourMapProjection::sumTriangleAreas( const std::vector<cvf::Vec4d>&
 //--------------------------------------------------------------------------------------------------
 double RigContourMapProjection::interpolateValue( const cvf::Vec2d& gridPos2d ) const
 {
-    cvf::Vec2ui cellContainingPoint = m_contourMapGrid.ijFromLocalPos( gridPos2d );
-    cvf::Vec2d  cellCenter          = m_contourMapGrid.cellCenterPosition( cellContainingPoint.x(), cellContainingPoint.y() );
+    cvf::Vec2ui cellContainingPoint = m_contourMapGrid->ijFromLocalPos( gridPos2d );
+    cvf::Vec2d  cellCenter          = m_contourMapGrid->cellCenterPosition( cellContainingPoint.x(), cellContainingPoint.y() );
 
-    double                    sampleSpacing = m_contourMapGrid.sampleSpacing();
+    double                    sampleSpacing = m_contourMapGrid->sampleSpacing();
     std::array<cvf::Vec3d, 4> x;
     x[0] = cvf::Vec3d( cellCenter + cvf::Vec2d( -sampleSpacing * 0.5, -sampleSpacing * 0.5 ), 0.0 );
     x[1] = cvf::Vec3d( cellCenter + cvf::Vec2d( sampleSpacing * 0.5, -sampleSpacing * 0.5 ), 0.0 );
@@ -370,7 +370,7 @@ double RigContourMapProjection::interpolateValue( const cvf::Vec2d& gridPos2d ) 
 //--------------------------------------------------------------------------------------------------
 double RigContourMapProjection::valueInCell( unsigned int i, unsigned int j ) const
 {
-    size_t index = m_contourMapGrid.cellIndexFromIJ( i, j );
+    size_t index = m_contourMapGrid->cellIndexFromIJ( i, j );
     if ( index < numberOfCells() )
     {
         return m_aggregatedResults.at( index );
@@ -396,8 +396,8 @@ double RigContourMapProjection::calculateValueAtVertex( unsigned int vi, unsigne
 
     if ( vi > 0u ) averageIs.push_back( vi - 1 );
     if ( vj > 0u ) averageJs.push_back( vj - 1 );
-    if ( vi < m_contourMapGrid.mapSize().x() ) averageIs.push_back( vi );
-    if ( vj < m_contourMapGrid.mapSize().y() ) averageJs.push_back( vj );
+    if ( vi < m_contourMapGrid->mapSize().x() ) averageIs.push_back( vi );
+    if ( vj < m_contourMapGrid->mapSize().y() ) averageJs.push_back( vj );
 
     RiaWeightedMeanCalculator<double> calc;
     for ( unsigned int j : averageJs )
@@ -445,7 +445,7 @@ bool RigContourMapProjection::contourMapCellContainsOnlyInactiveCells( unsigned 
 //--------------------------------------------------------------------------------------------------
 std::vector<std::pair<size_t, double>> RigContourMapProjection::cellsAtIJ( unsigned int i, unsigned int j ) const
 {
-    size_t cellIndex = m_contourMapGrid.cellIndexFromIJ( i, j );
+    size_t cellIndex = m_contourMapGrid->cellIndexFromIJ( i, j );
     if ( cellIndex < m_projected3dGridIndices.size() )
     {
         return m_projected3dGridIndices[cellIndex];
@@ -458,7 +458,7 @@ std::vector<std::pair<size_t, double>> RigContourMapProjection::cellsAtIJ( unsig
 //--------------------------------------------------------------------------------------------------
 std::vector<double> RigContourMapProjection::xVertexPositions() const
 {
-    return m_contourMapGrid.xVertexPositions();
+    return m_contourMapGrid->xVertexPositions();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -466,7 +466,7 @@ std::vector<double> RigContourMapProjection::xVertexPositions() const
 //--------------------------------------------------------------------------------------------------
 std::vector<double> RigContourMapProjection::yVertexPositions() const
 {
-    return m_contourMapGrid.yVertexPositions();
+    return m_contourMapGrid->yVertexPositions();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapProjection.h
@@ -42,7 +42,7 @@ class RigContourMapProjection
 public:
     using CellIndexAndResult = std::pair<size_t, double>;
 
-    RigContourMapProjection( const RigContourMapGrid& );
+    RigContourMapProjection( const RigContourMapGrid* );
 
     void clearResults();
     void clearGridMapping();
@@ -130,5 +130,5 @@ protected:
 
     std::optional<std::pair<double, double>> m_valueFilter;
 
-    const RigContourMapGrid& m_contourMapGrid;
+    const RigContourMapGrid* m_contourMapGrid;
 };

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
@@ -38,17 +38,17 @@
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RigEclipseContourMapProjection::RigEclipseContourMapProjection( const RigContourMapGrid& contourMapGrid,
-                                                                RigEclipseCaseData&      eclipseCaseData,
-                                                                RigCaseCellResultsData&  resultData )
+RigEclipseContourMapProjection::RigEclipseContourMapProjection( const RigContourMapGrid* contourMapGrid,
+                                                                RigEclipseCaseData*      eclipseCaseData,
+                                                                RigCaseCellResultsData*  resultData )
     : RigContourMapProjection( contourMapGrid )
     , m_eclipseCaseData( eclipseCaseData )
     , m_resultData( resultData )
     , m_kLayers( 0u )
     , m_useActiveCellInfo( true )
 {
-    m_mainGrid       = m_eclipseCaseData.mainGrid();
-    m_activeCellInfo = m_eclipseCaseData.activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
+    m_mainGrid       = m_eclipseCaseData->mainGrid();
+    m_activeCellInfo = m_eclipseCaseData->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
     m_kLayers        = m_mainGrid->cellCountK();
 }
 
@@ -62,13 +62,22 @@ RigEclipseContourMapProjection::~RigEclipseContourMapProjection()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RigEclipseContourMapProjection::updateRealizationData( RigActiveCellInfo* activeCellInfo, RigCaseCellResultsData* resultData )
+{
+    m_activeCellInfo = activeCellInfo;
+    m_resultData     = resultData;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RigEclipseContourMapProjection::generateAndSaveResults( const RigEclipseResultAddress&                 resultAddress,
                                                              RigContourMapCalculator::ResultAggregationType resultAggregation,
                                                              int                                            timeStep,
                                                              RigFloodingSettings&                           floodingSettings )
 {
     std::tie( m_useActiveCellInfo, m_aggregatedResults ) =
-        generateResults( *this, m_contourMapGrid, m_resultData, resultAddress, resultAggregation, timeStep, floodingSettings );
+        generateResults( *this, *m_contourMapGrid, *m_resultData, resultAddress, resultAggregation, timeStep, floodingSettings );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -80,7 +89,7 @@ std::vector<double> RigEclipseContourMapProjection::generateResults( const RigEc
                                                                      RigFloodingSettings&                           floodingSettings ) const
 {
     std::pair<bool, std::vector<double>> result =
-        generateResults( *this, m_contourMapGrid, m_resultData, resultAddress, resultAggregation, timeStep, floodingSettings );
+        generateResults( *this, *m_contourMapGrid, *m_resultData, resultAddress, resultAggregation, timeStep, floodingSettings );
     return result.second;
 }
 
@@ -327,7 +336,7 @@ size_t RigEclipseContourMapProjection::gridResultIndex( size_t globalCellIdx ) c
 //--------------------------------------------------------------------------------------------------
 bool RigEclipseContourMapProjection::isCellActive( size_t globalCellIdx ) const
 {
-    if ( m_useActiveCellInfo && m_activeCellInfo.notNull() )
+    if ( m_useActiveCellInfo && m_activeCellInfo != nullptr )
     {
         return m_activeCellInfo->isActive( globalCellIdx );
     }

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.h
@@ -41,9 +41,9 @@ class RigCaseCellResultsData;
 class RigEclipseContourMapProjection : public RigContourMapProjection
 {
 public:
-    RigEclipseContourMapProjection( const RigContourMapGrid& contourMapGrid,
-                                    RigEclipseCaseData&      eclipseCaseData,
-                                    RigCaseCellResultsData&  resultData );
+    RigEclipseContourMapProjection( const RigContourMapGrid* contourMapGrid,
+                                    RigEclipseCaseData*      eclipseCaseData,
+                                    RigCaseCellResultsData*  resultData );
     virtual ~RigEclipseContourMapProjection();
 
     void generateAndSaveResults( const RigEclipseResultAddress&                 resultAddress,
@@ -63,6 +63,8 @@ public:
                                                                  RigContourMapCalculator::ResultAggregationType resultAggregation,
                                                                  int                                            timeStep,
                                                                  RigFloodingSettings&                           floodingSettings );
+
+    void updateRealizationData( RigActiveCellInfo* activeCellInfo, RigCaseCellResultsData* resultData );
 
     std::vector<bool> getMapCellVisibility( int viewStepIndex, RigContourMapCalculator::ResultAggregationType resultAggregation ) override;
     bool              isCellActive( size_t globalCellIdx ) const override;
@@ -87,10 +89,10 @@ protected:
                                                             RigFloodingSettings&                           floodingSettings );
 
 protected:
-    RigEclipseCaseData&         m_eclipseCaseData;
-    RigCaseCellResultsData&     m_resultData;
-    cvf::ref<RigMainGrid>       m_mainGrid;
-    cvf::ref<RigActiveCellInfo> m_activeCellInfo;
-    size_t                      m_kLayers;
-    bool                        m_useActiveCellInfo;
+    RigEclipseCaseData*     m_eclipseCaseData;
+    RigCaseCellResultsData* m_resultData;
+    RigMainGrid*            m_mainGrid;
+    RigActiveCellInfo*      m_activeCellInfo;
+    size_t                  m_kLayers;
+    bool                    m_useActiveCellInfo;
 };

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.cpp
@@ -42,8 +42,8 @@
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RigGeoMechContourMapProjection::RigGeoMechContourMapProjection( RigGeoMechCaseData&      caseData,
-                                                                const RigContourMapGrid& contourMapGrid,
+RigGeoMechContourMapProjection::RigGeoMechContourMapProjection( RigGeoMechCaseData*      caseData,
+                                                                const RigContourMapGrid* contourMapGrid,
                                                                 bool                     limitToPorePressureRegions,
                                                                 double                   paddingAroundPorePressureRegion )
     : RigContourMapProjection( contourMapGrid )
@@ -52,7 +52,7 @@ RigGeoMechContourMapProjection::RigGeoMechContourMapProjection( RigGeoMechCaseDa
     , m_paddingAroundPorePressureRegion( paddingAroundPorePressureRegion )
     , m_kLayers( 0u )
 {
-    m_femPart     = m_caseData.femParts()->part( 0 );
+    m_femPart     = m_caseData->femParts()->part( 0 );
     m_femPartGrid = m_femPart->getOrCreateStructGrid();
     m_kLayers     = m_femPartGrid->cellCountK();
     m_femPart->ensureIntersectionSearchTreeIsBuilt();
@@ -143,11 +143,11 @@ std::vector<bool> RigGeoMechContourMapProjection::getMapCellVisibility( RigFemRe
         cvf::BoundingBox validResBoundingBox;
         for ( size_t cellIndex = 0; cellIndex < cellResults.size(); ++cellIndex )
         {
-            cvf::Vec2ui ij = m_contourMapGrid.ijFromCellIndex( cellIndex );
+            cvf::Vec2ui ij = m_contourMapGrid->ijFromCellIndex( cellIndex );
             if ( cellResults[cellIndex] != std::numeric_limits<double>::infinity() )
             {
                 distanceImage[ij.x()][ij.y()] = 1u;
-                validResBoundingBox.add( cvf::Vec3d( m_contourMapGrid.cellCenterPosition( ij.x(), ij.y() ), 0.0 ) );
+                validResBoundingBox.add( cvf::Vec3d( m_contourMapGrid->cellCenterPosition( ij.x(), ij.y() ), 0.0 ) );
             }
             else
             {
@@ -162,12 +162,12 @@ std::vector<bool> RigGeoMechContourMapProjection::getMapCellVisibility( RigFemRe
             cvf::Vec3d porExtent   = validResBoundingBox.extent();
             double     radius      = std::max( porExtent.x(), porExtent.y() ) * 0.25;
             double     expansion   = m_paddingAroundPorePressureRegion * radius;
-            size_t     cellPadding = std::ceil( expansion / m_contourMapGrid.sampleSpacing() );
+            size_t     cellPadding = std::ceil( expansion / m_contourMapGrid->sampleSpacing() );
             for ( size_t cellIndex = 0; cellIndex < cellResults.size(); ++cellIndex )
             {
                 if ( !mapCellVisibility[cellIndex] )
                 {
-                    cvf::Vec2ui ij = m_contourMapGrid.ijFromCellIndex( cellIndex );
+                    cvf::Vec2ui ij = m_contourMapGrid->ijFromCellIndex( cellIndex );
                     if ( distanceImage[ij.x()][ij.y()] < cellPadding * cellPadding )
                     {
                         mapCellVisibility[cellIndex] = true;
@@ -198,11 +198,11 @@ std::vector<double> RigGeoMechContourMapProjection::generateResultsFromAddress( 
                                                                                 RigContourMapCalculator::ResultAggregationType resultAggregation,
                                                                                 int viewerStepIndex ) const
 {
-    RigFemPartResultsCollection* resultCollection  = m_caseData.femPartResults();
+    RigFemPartResultsCollection* resultCollection  = m_caseData->femPartResults();
     size_t                       nCells            = numberOfCells();
     std::vector<double>          aggregatedResults = std::vector<double>( nCells, std::numeric_limits<double>::infinity() );
 
-    auto [stepIdx, frameIdx] = m_caseData.femPartResults()->stepListIndexToTimeStepAndDataFrameIndex( viewerStepIndex );
+    auto [stepIdx, frameIdx] = m_caseData->femPartResults()->stepListIndexToTimeStepAndDataFrameIndex( viewerStepIndex );
 
     bool wasInvalid = false;
     if ( !resultAddress.isValid() )
@@ -247,7 +247,7 @@ std::vector<double> RigGeoMechContourMapProjection::generateResultsFromAddress( 
     {
         if ( mapCellVisibility.empty() || mapCellVisibility[index] )
         {
-            cvf::Vec2ui ij           = m_contourMapGrid.ijFromCellIndex( index );
+            cvf::Vec2ui ij           = m_contourMapGrid->ijFromCellIndex( index );
             aggregatedResults[index] = calculateValueInMapCell( ij.x(), ij.y(), resultValues, resultAggregation );
         }
     }

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigGeoMechContourMapProjection.h
@@ -34,8 +34,8 @@ class RigGeoMechCaseData;
 class RigGeoMechContourMapProjection : public RigContourMapProjection
 {
 public:
-    RigGeoMechContourMapProjection( RigGeoMechCaseData& caseData,
-                                    const RigContourMapGrid&,
+    RigGeoMechContourMapProjection( RigGeoMechCaseData* caseData,
+                                    const RigContourMapGrid*,
                                     bool   limitToPorePressureRegions,
                                     double paddingAroundPorePressureRegion );
 
@@ -73,7 +73,7 @@ protected:
     std::vector<double> gridCellValues( RigFemResultAddress resAddr, std::vector<float>& resultValues ) const;
 
 protected:
-    RigGeoMechCaseData&       m_caseData;
+    RigGeoMechCaseData*       m_caseData;
     bool                      m_limitToPorePressureRegions;
     double                    m_paddingAroundPorePressureRegion;
     cvf::ref<RigFemPart>      m_femPart;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.cpp
@@ -29,7 +29,7 @@
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-RigStatisticsContourMapProjection::RigStatisticsContourMapProjection( const RigContourMapGrid& contourMapGrid )
+RigStatisticsContourMapProjection::RigStatisticsContourMapProjection( const RigContourMapGrid* contourMapGrid )
     : RigContourMapProjection( contourMapGrid )
 {
 }
@@ -130,7 +130,7 @@ std::vector<bool> RigStatisticsContourMapProjection::getMapCellVisibility( int v
 //--------------------------------------------------------------------------------------------------
 std::vector<std::pair<size_t, double>> RigStatisticsContourMapProjection::cellsAtIJ( unsigned int i, unsigned int j ) const
 {
-    size_t cellIndex = m_contourMapGrid.cellIndexFromIJ( i, j );
+    size_t cellIndex = m_contourMapGrid->cellIndexFromIJ( i, j );
     if ( cellIndex < m_aggregatedResults.size() && !std::isinf( m_aggregatedResults[cellIndex] ) &&
          !std::isnan( m_aggregatedResults[cellIndex] ) )
     {

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigStatisticsContourMapProjection.h
@@ -32,7 +32,7 @@ class RigContourMapGrid;
 class RigStatisticsContourMapProjection : public RigContourMapProjection
 {
 public:
-    RigStatisticsContourMapProjection( const RigContourMapGrid& contourMapGrid );
+    RigStatisticsContourMapProjection( const RigContourMapGrid* contourMapGrid );
     virtual ~RigStatisticsContourMapProjection();
 
     std::vector<std::pair<size_t, double>> cellsAtIJ( unsigned int i, unsigned int j ) const override;


### PR DESCRIPTION
**Make it possible to compute contour map based on shared grid**

When computing ensemble statistics contour maps, the grid mapping (overlap volumes / ray lengths from 3D cells to 2D map cells) was previously recomputed for every realization. For ensembles using a shared grid, this expensive geometric computation can be done once and reused across all realizations.

**Changes**

- Add a **Grid Import Mode** option to `RimStatisticsContourMap` (`Reuse Grid from First Realization` / `Import All Grids`), available when the ensemble uses a shared grid.
- Add `updateRealizationData()` to `RigEclipseContourMapProjection`, allowing active cell info and result data to be swapped per realization without rebuilding the grid mapping.
- Implement separate code paths in `computeStatistics()`: `computeStatisticsSharedGrid()` calls `generateGridMapping()` once on the primary case and iterates realizations via `updateRealizationData()`; `computeStatisticsIndividualGrids()` builds a full projection per case as before.

**Refactoring**

- Replace `const &` and `cvf::ref<>` members with naked pointers in `RigContourMapProjection` and all subclasses (`RigEclipseContourMapProjection`, `RigGeoMechContourMapProjection`, `RigStatisticsContourMapProjection`), enabling the member reseating required by `updateRealizationData()`.
- Split the large `computeStatistics()` method into focused helpers and move `findKLayersForFormations` and `extractCaseResults` to an anonymous namespace.