### PR TITLE
Crash reporting: Use SA_SIGINFO on Linux for enhanced crash diagnostics

### DIFF
--- a/ApplicationExeCode/RiaMain.cpp
+++ b/ApplicationExeCode/RiaMain.cpp
@@ -47,6 +47,9 @@
 #include <signal.h>
 
 void manageSegFailure( int signalCode );
+#ifndef WIN32
+void manageSegFailureSA( int signalCode, siginfo_t* info, void* ucontext );
+#endif
 
 RiaApplication* createApplication( int& argc, char* argv[] )
 {
@@ -137,12 +140,26 @@ int main( int argc, char* argv[] )
     setlocale( LC_NUMERIC, "C" );
 
     // Set up signal handlers
+#ifndef WIN32
+    // Use SA_SIGINFO on Linux to capture fault address, signal code, and program counter
+    struct sigaction sa{};
+    sa.sa_sigaction = manageSegFailureSA;
+    sa.sa_flags     = SA_SIGINFO;
+    sigemptyset( &sa.sa_mask );
+    sigaction( SIGINT, &sa, nullptr );
+    sigaction( SIGILL, &sa, nullptr );
+    sigaction( SIGFPE, &sa, nullptr );
+    sigaction( SIGSEGV, &sa, nullptr );
+    sigaction( SIGTERM, &sa, nullptr );
+    sigaction( SIGABRT, &sa, nullptr );
+#else
     signal( SIGINT, manageSegFailure );
     signal( SIGILL, manageSegFailure );
     signal( SIGFPE, manageSegFailure );
     signal( SIGSEGV, manageSegFailure );
     signal( SIGTERM, manageSegFailure );
     signal( SIGABRT, manageSegFailure );
+#endif
 
     // Handle the command line arguments.
     // Todo: Move to a one-shot timer, delaying the execution until we are inside the event loop.

--- a/ApplicationExeCode/RiaMainTools.cpp
+++ b/ApplicationExeCode/RiaMainTools.cpp
@@ -32,7 +32,14 @@
 
 #include <QDir>
 
+#include <map>
+#include <sstream>
 #include <stacktrace>
+
+#ifndef WIN32
+#include <signal.h>
+#include <ucontext.h>
+#endif
 
 namespace internal
 {
@@ -48,17 +55,96 @@ std::string formatStacktrace( const std::stacktrace& st )
     }
     return ss.str();
 }
+
+#ifndef WIN32
+static std::string signalCodeDescription( int signo, int siCode )
+{
+    switch ( signo )
+    {
+        case SIGSEGV:
+            switch ( siCode )
+            {
+                case SEGV_MAPERR:
+                    return "address not mapped (SEGV_MAPERR)";
+                case SEGV_ACCERR:
+                    return "invalid access permissions (SEGV_ACCERR)";
+                default:
+                    return "unknown SIGSEGV code";
+            }
+        case SIGFPE:
+            switch ( siCode )
+            {
+                case FPE_INTDIV:
+                    return "integer divide by zero (FPE_INTDIV)";
+                case FPE_INTOVF:
+                    return "integer overflow (FPE_INTOVF)";
+                case FPE_FLTDIV:
+                    return "floating-point divide by zero (FPE_FLTDIV)";
+                case FPE_FLTOVF:
+                    return "floating-point overflow (FPE_FLTOVF)";
+                case FPE_FLTUND:
+                    return "floating-point underflow (FPE_FLTUND)";
+                case FPE_FLTRES:
+                    return "floating-point inexact result (FPE_FLTRES)";
+                case FPE_FLTINV:
+                    return "invalid floating-point operation (FPE_FLTINV)";
+                case FPE_FLTSUB:
+                    return "subscript out of range (FPE_FLTSUB)";
+                default:
+                    return "unknown SIGFPE code";
+            }
+        case SIGILL:
+            switch ( siCode )
+            {
+                case ILL_ILLOPC:
+                    return "illegal opcode (ILL_ILLOPC)";
+                case ILL_ILLOPN:
+                    return "illegal operand (ILL_ILLOPN)";
+                case ILL_ILLADR:
+                    return "illegal addressing mode (ILL_ILLADR)";
+                case ILL_ILLTRP:
+                    return "illegal trap (ILL_ILLTRP)";
+                case ILL_PRVOPC:
+                    return "privileged opcode (ILL_PRVOPC)";
+                case ILL_PRVREG:
+                    return "privileged register (ILL_PRVREG)";
+                case ILL_COPROC:
+                    return "coprocessor error (ILL_COPROC)";
+                case ILL_BADSTK:
+                    return "internal stack error (ILL_BADSTK)";
+                default:
+                    return "unknown SIGILL code";
+            }
+        case SIGBUS:
+            switch ( siCode )
+            {
+                case BUS_ADRALN:
+                    return "invalid address alignment (BUS_ADRALN)";
+                case BUS_ADRERR:
+                    return "nonexistent physical address (BUS_ADRERR)";
+                case BUS_OBJERR:
+                    return "object-specific hardware error (BUS_OBJERR)";
+                default:
+                    return "unknown SIGBUS code";
+            }
+        default:
+            return "";
+    }
+}
+#endif
 } // namespace internal
 
 //--------------------------------------------------------------------------------------------------
+/// Shared crash logging: writes to file logger and OpenTelemetry.
+/// extraAttrs may include platform-specific context like fault address and signal code description.
 ///
+/// Note: Executing logging functions from a signal handler is not async-signal-safe, but works as
+/// expected on Windows. Behavior on Linux is undefined, but will work in most cases.
+/// https://github.com/gabime/spdlog/issues/1607
 //--------------------------------------------------------------------------------------------------
-void manageSegFailure( int signalCode )
+static void performCrashLogging( int signalCode, const std::map<std::string, std::string>& extraAttrs )
 {
-    // Executing function here is not safe, but works as expected on Windows. Behavior on Linux is undefined, but will
-    // work in some cases.
-    // https://github.com/gabime/spdlog/issues/1607
-
+    auto st      = std::stacktrace::current();
     auto loggers = RiaLogging::loggerInstances();
 
     for ( auto logger : loggers )
@@ -66,12 +152,15 @@ void manageSegFailure( int signalCode )
         if ( auto fileLogger = dynamic_cast<RiaFileLogger*>( logger ) )
         {
             auto versionText = QString( STRPRODUCTVER );
-            auto str =
-                QString( "Segmentation fault (signal code: %1) - ResInsight version %2" ).arg( signalCode ).arg( versionText );
-
+            auto str = QString( "Crash (signal: %1) - ResInsight version %2" ).arg( signalCode ).arg( versionText );
             fileLogger->error( str.toStdString().data() );
 
-            auto        st      = std::stacktrace::current();
+            for ( const auto& [key, value] : extraAttrs )
+            {
+                std::string line = key + ": " + value;
+                fileLogger->error( line.data() );
+            }
+
             std::string message = "Stack trace:\n" + internal::formatStacktrace( st );
             logger->error( message.data() );
 
@@ -79,16 +168,66 @@ void manageSegFailure( int signalCode )
         }
     }
 
-    // Report crash to OpenTelemetry if enabled and initialized
     auto& otelManager = RiaOpenTelemetryManager::instance();
     if ( otelManager.isEnabled() )
     {
-        auto st = std::stacktrace::current();
-        otelManager.reportCrash( signalCode, st );
+        otelManager.reportCrash( signalCode, st, extraAttrs );
     }
+}
 
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void manageSegFailure( int signalCode )
+{
+    performCrashLogging( signalCode, {} );
     exit( 1 );
 }
+
+#ifndef WIN32
+//--------------------------------------------------------------------------------------------------
+/// SA_SIGINFO-compatible handler: captures fault address, signal code, and program counter
+/// for enhanced crash diagnostics on Linux.
+//--------------------------------------------------------------------------------------------------
+void manageSegFailureSA( int signalCode, siginfo_t* info, void* ucontext )
+{
+    std::map<std::string, std::string> extraAttrs;
+
+    if ( info )
+    {
+        std::ostringstream addrStr;
+        addrStr << "0x" << std::hex << reinterpret_cast<uintptr_t>( info->si_addr );
+        extraAttrs["crash.fault_address"] = addrStr.str();
+
+        std::string codeDesc = internal::signalCodeDescription( signalCode, info->si_code );
+        if ( !codeDesc.empty() )
+        {
+            extraAttrs["crash.signal_code"] = codeDesc;
+        }
+    }
+
+#if defined( __x86_64__ )
+    if ( ucontext )
+    {
+        auto*              ctx = static_cast<ucontext_t*>( ucontext );
+        std::ostringstream pcStr;
+        pcStr << "0x" << std::hex << static_cast<uintptr_t>( ctx->uc_mcontext.gregs[REG_RIP] );
+        extraAttrs["crash.program_counter"] = pcStr.str();
+    }
+#elif defined( __aarch64__ )
+    if ( ucontext )
+    {
+        auto*              ctx = static_cast<ucontext_t*>( ucontext );
+        std::ostringstream pcStr;
+        pcStr << "0x" << std::hex << ctx->uc_mcontext.pc;
+        extraAttrs["crash.program_counter"] = pcStr.str();
+    }
+#endif
+
+    performCrashLogging( signalCode, extraAttrs );
+    exit( 1 );
+}
+#endif
 
 namespace RiaMainTools
 {

--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
@@ -327,7 +327,7 @@ static std::string extractRelevantPath( const std::string& fullPath )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RiaOpenTelemetryManager::reportCrash( int signalCode, const std::stacktrace& trace )
+void RiaOpenTelemetryManager::reportCrash( int signalCode, const std::stacktrace& trace, const std::map<std::string, std::string>& extraAttributes )
 {
     if ( !isEnabled() )
     {
@@ -377,6 +377,12 @@ void RiaOpenTelemetryManager::reportCrash( int signalCode, const std::stacktrace
     attributes["crash.parsed_stack_json"] = QString::fromUtf8( QJsonDocument( jsonFrames ).toJson( QJsonDocument::Compact ) ).toStdString();
     attributes["service.name"]            = RiaPreferencesOpenTelemetry::current()->serviceName().toStdString();
     attributes["service.version"]         = RiaPreferencesOpenTelemetry::current()->serviceVersion().toStdString();
+
+    // Merge platform-specific crash context (fault address, signal code, program counter)
+    for ( const auto& [key, value] : extraAttributes )
+    {
+        attributes[key] = value;
+    }
 
     // Add system information
     addOsInfo( attributes );

--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.h
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.h
@@ -88,7 +88,7 @@ public:
 
     // Event reporting
     void reportEventAsync( const std::string& eventName, const std::map<std::string, std::string>& attributes );
-    void reportCrash( int signalCode, const std::stacktrace& trace );
+    void reportCrash( int signalCode, const std::stacktrace& trace, const std::map<std::string, std::string>& extraAttributes = {} );
 
     // Configuration
     bool isEnabled() const;


### PR DESCRIPTION
Switch signal handler registration from signal() to sigaction(SA_SIGINFO) on Linux to capture fault address, signal code description, and program counter at crash time. These are logged to the file logger and included in OpenTelemetry crash reports.

Example output from Linux:


```
2026-03-23 09:01:45.276] [rotating_logger] [info] Setting number of threads to 3 from Preferences
[2026-03-23 09:01:51.235] [rotating_logger] [error] Crash (signal: 11) - ResInsight version 2026.02.1-dev.03
[2026-03-23 09:01:51.235] [rotating_logger] [error] crash.fault_address: 0x3ea00005bc1
[2026-03-23 09:01:51.235] [rotating_logger] [error] crash.program_counter: 0x70b07529eb2c
[2026-03-23 09:01:51.235] [rotating_logger] [error] crash.signal_code: unknown SIGSEGV code
[2026-03-23 09:01:51.631] [rotating_logger] [error] Stack trace:
  [0] performCrashLogging at /home/builder/gitroot/ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
  [1] manageSegFailureSA(int, siginfo_t*, void*) at /home/builder/gitroot/ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
  [2]  at ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
  [3] __pthread_kill_implementation at ./nptl/pthread_kill.c:44
  [4] __GI_raise at ../sysdeps/posix/raise.c:26
  [5]  at :0
  [6] QAction::triggered(bool) at :0
  [7] QAction::activate(QAction::ActionEvent) at :0
  [8]  at :0
  [9]  at :0
  [10] QWidget::event(QEvent*) at :0
  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
  [12] QApplication::notify(QObject*, QEvent*) at :0
  [13] RiaGuiApplication::notify(QObject*, QEvent*) at /home/builder/gitroot/ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
  [16]  at :0
  [17]  at :0
  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
  [19] RiaGuiApplication::notify(QObject*, QEvent*) at /home/builder/gitroot/ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
  [23]  at :0
  [24]  at :0
  [25]  at :0
  [26] g_main_context_iteration at :0
  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
  [29] QCoreApplication::exec() at :0
  [30] main at /home/builder/gitroot/ResInsight/ApplicationExeCode/RiaMain.cpp:226
  [31] __libc_start_call_main at ../sysdeps/nptl/libc_start_call_main.h:58
  [32] __libc_start_main_impl at ../csu/libc-start.c:360
  [33] _start at :0
  [34]  at :0

[2026-03-23 09:01:51.835] [rotating_logger] [error] Crash reported to OpenTelemetry (signal: 11)



```