### PR TITLE
CompletionExport: Simplified MSW export

### DIFF
--- a/ApplicationLibCode/Commands/CMakeLists.txt
+++ b/ApplicationLibCode/Commands/CMakeLists.txt
@@ -89,8 +89,10 @@ if(RESINSIGHT_ENABLE_PRECOMPILED_HEADERS)
 endif()
 
 target_include_directories(
-  ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-                          ${CMAKE_CURRENT_SOURCE_DIR}/EclipseCommands
+  ${PROJECT_NAME}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+          ${CMAKE_CURRENT_SOURCE_DIR}/EclipseCommands
+          ${CMAKE_CURRENT_SOURCE_DIR}/CompletionExportCommands
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/ApplicationLibCode/Commands/CompletionExportCommands/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/CMakeLists_files.cmake
@@ -20,6 +20,8 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicWellPathFractureReportItem.h
     ${CMAKE_CURRENT_LIST_DIR}/RicExportCompletionsForTemporaryLgrsFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicWellPathExportMswTableData.h
+    ${CMAKE_CURRENT_LIST_DIR}/MswExport/RicWellPathExportMswGeometryPath.h
+    ${CMAKE_CURRENT_LIST_DIR}/MswExport/RicMswBranchBuilder.h
     ${CMAKE_CURRENT_LIST_DIR}/RicMswTableDataTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RicScheduleDataGenerator.h
     ${CMAKE_CURRENT_LIST_DIR}/RicTransmissibilityCalculator.h
@@ -47,6 +49,8 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicWellPathFractureReportItem.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicExportCompletionsForTemporaryLgrsFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicWellPathExportMswTableData.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/MswExport/RicWellPathExportMswGeometryPath.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/MswExport/RicMswBranchBuilder.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicMswTableDataTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicScheduleDataGenerator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicTransmissibilityCalculator.cpp

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -1,0 +1,850 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicMswBranchBuilder.h"
+
+#include "RicExportFractureCompletionsImpl.h"
+#include "RicMswTableDataTools.h"
+
+#include "RigActiveCellInfo.h"
+#include "RigEclipseCaseData.h"
+#include "RigGridBase.h"
+#include "RigMainGrid.h"
+#include "Well/RigWellPathIntersectionTools.h"
+
+#include "RimEclipseCase.h"
+#include "RimFishbones.h"
+#include "RimFishbonesCollection.h"
+#include "RimFractureTemplate.h"
+#include "RimMswCompletionParameters.h"
+#include "RimPerforationCollection.h"
+#include "RimPerforationInterval.h"
+#include "RimWellPath.h"
+#include "RimWellPathCompletions.h"
+#include "RimWellPathFracture.h"
+#include "RimWellPathFractureCollection.h"
+#include "RimWellPathValve.h"
+
+#include "RiaLogging.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace RicMswBranchBuilder
+{
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<RigMswCellIntersection>
+    toMswCellIntersection( const WellPathCellIntersectionInfo& cellInfo, const RigMainGrid* mainGrid, double distanceStart, double distanceEnd )
+{
+    if ( cellInfo.globCellIndex >= mainGrid->totalCellCount() ) return std::nullopt;
+
+    size_t             localIdx  = 0;
+    const RigGridBase* localGrid = mainGrid->gridAndGridLocalIdxFromGlobalCellIdx( cellInfo.globCellIndex, &localIdx );
+
+    size_t i, j, k;
+    localGrid->ijkFromCellIndex( localIdx, &i, &j, &k );
+    if ( mainGrid->isDualPorosity() ) k += mainGrid->cellCountK();
+
+    RigMswCellIntersection ci;
+    ci.i             = i + 1; // 1-based
+    ci.j             = j + 1;
+    ci.k             = k + 1;
+    ci.distanceStart = distanceStart;
+    ci.distanceEnd   = distanceEnd;
+    if ( localGrid != mainGrid ) ci.gridName = localGrid->gridName();
+    return ci;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double segmentMidpointMD( const std::vector<CellSegmentEntry>& cellSegMap, int segmentNumber )
+{
+    for ( const auto& entry : cellSegMap )
+    {
+        if ( entry.lastSubSegmentNumber == segmentNumber ) return 0.5 * ( entry.cellStartMD + entry.cellEndMD );
+    }
+    return 0.0;
+}
+
+// Range-based lookup: find the segment whose [cellStartMD, cellEndMD] range contains md.
+// Used for ICD valves where the valve overlap start always falls within the host main-bore cell.
+// Fractures use findOutletSegmentForMD (midpoint-based) to match the tree approach.
+int findContainingSegmentForMD( const std::vector<CellSegmentEntry>& cellSegMap, double md )
+{
+    if ( cellSegMap.empty() ) return 1;
+
+    for ( const auto& entry : cellSegMap )
+    {
+        if ( md >= entry.cellStartMD && md < entry.cellEndMD ) return entry.lastSubSegmentNumber;
+    }
+
+    // Fallback: md is beyond all segments — return the last segment.
+    return cellSegMap.back().lastSubSegmentNumber;
+}
+
+int findOutletSegmentForMD( const std::vector<CellSegmentEntry>& cellSegMap, double md )
+{
+    if ( cellSegMap.empty() ) return 1;
+
+    // Match the tree-based logic (findClosestSegmentWithLowerMD): find the sub-segment whose
+    // midpoint is closest to, but not greater than, the given MD.  Range-based lookup is
+    // incorrect when a cell's midpoint lies above the completion MD (e.g. a fracture near the
+    // heel of a long cell), which would assign the wrong outlet segment.
+    const CellSegmentEntry* best     = nullptr;
+    double                  bestDist = std::numeric_limits<double>::infinity();
+
+    for ( const auto& entry : cellSegMap )
+    {
+        const double midpoint = 0.5 * ( entry.cellStartMD + entry.cellEndMD );
+        const double dist     = md - midpoint;
+        if ( dist >= 0.0 && dist < bestDist )
+        {
+            best     = &entry;
+            bestDist = dist;
+        }
+    }
+
+    // Fallback: md is shallower than all segment midpoints — connect to the first (shallowest) segment.
+    return best ? best->lastSubSegmentNumber : cellSegMap.front().lastSubSegmentNumber;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RigMswBranch buildMainBoreBranchFromGeometry( const RimWellPath*                                wellPath,
+                                              const std::vector<WellPathCellIntersectionInfo>&  filteredIntersections,
+                                              const RigMainGrid*                                mainGrid,
+                                              const std::vector<const RimPerforationInterval*>& perforationIntervals,
+                                              const std::set<const RimPerforationInterval*>&    valvedIntervals,
+                                              const std::string&                                infoType,
+                                              double                                            heelMD,
+                                              double                                            heelTVD,
+                                              int                                               branchNumber,
+                                              int&                                              segmentNumber,
+                                              int                                               outletSegmentNumber,
+                                              double                                            maxSegmentLength,
+                                              const std::vector<std::pair<double, double>>&     customSegmentIntervals,
+                                              const std::optional<QDateTime>&                   exportDate,
+                                              RiaDefines::EclipseUnitSystem                     unitSystem,
+                                              std::vector<CellSegmentEntry>*                    cellSegMap,
+                                              const RigActiveCellInfo*                          activeCellInfo )
+{
+    std::vector<RigMswSegment> result;
+
+    const double segmentLengthThreshold = 1.0e-3;
+
+    double prevOutMD  = heelMD;
+    double prevOutTVD = heelTVD;
+    int    prevSegNum = outletSegmentNumber;
+    bool   firstSeg   = true;
+
+    for ( const auto& cellInfo : filteredIntersections )
+    {
+        const double cellLength = std::fabs( cellInfo.endMD - cellInfo.startMD );
+        if ( cellLength <= segmentLengthThreshold )
+        {
+            RiaLogging::info( QString( "Skipping segment, threshold = %1, length = %2" ).arg( segmentLengthThreshold ).arg( cellLength ) );
+            continue;
+        }
+
+        // Collect COMPSEGS only for bare perforations (no active valve) on the main bore.
+        // Valved perforations get their COMPSEGS on the valve segment.
+        std::vector<RigMswCellIntersection> cellCompsegs;
+        for ( const auto* perf : perforationIntervals )
+        {
+            if ( valvedIntervals.count( perf ) ) continue; // valve handles this interval
+            if ( exportDate.has_value() && !perf->isActiveOnDate( exportDate.value() ) ) continue;
+
+            const double overlapStart = std::max( perf->startMD(), cellInfo.startMD );
+            const double overlapEnd   = std::min( perf->endMD(), cellInfo.endMD );
+            if ( overlapEnd > overlapStart )
+            {
+                if ( activeCellInfo && cellInfo.globCellIndex < mainGrid->totalCellCount() &&
+                     !activeCellInfo->isActive( cellInfo.globCellIndex ) )
+                    continue;
+                if ( auto ci = toMswCellIntersection( cellInfo, mainGrid, overlapStart, overlapEnd ) ) cellCompsegs.push_back( *ci );
+            }
+        }
+
+        const auto subSegs =
+            RicMswTableDataTools::createSubSegmentMDPairs( cellInfo.startMD, cellInfo.endMD, maxSegmentLength, customSegmentIntervals );
+
+        bool firstSubSeg   = true;
+        int  lastSubSegNum = prevSegNum;
+        for ( const auto& [subStartMD, subEndMD] : subSegs )
+        {
+            const double midPointMD  = 0.5 * ( subStartMD + subEndMD );
+            const double midPointTVD = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, midPointMD );
+
+            double curPrevOutMD  = prevOutMD;
+            double curPrevOutTVD = prevOutTVD;
+            if ( midPointMD < curPrevOutMD )
+            {
+                curPrevOutMD  = heelMD;
+                curPrevOutTVD = heelTVD;
+            }
+
+            double length = 0.0;
+            double depth  = 0.0;
+            if ( infoType == "INC" )
+            {
+                length = midPointMD - curPrevOutMD;
+                depth  = midPointTVD - curPrevOutTVD;
+            }
+            else
+            {
+                length = midPointMD;
+                depth  = midPointTVD;
+            }
+
+            double diameter  = 0.0;
+            double roughness = 0.0;
+            if ( exportDate.has_value() )
+            {
+                diameter  = wellPath->mswCompletionParameters()->getDiameterAtMD( midPointMD, unitSystem, *exportDate );
+                roughness = wellPath->mswCompletionParameters()->getRoughnessAtMD( midPointMD, unitSystem, *exportDate );
+            }
+            else
+            {
+                diameter  = wellPath->mswCompletionParameters()->getDiameterAtMD( midPointMD, unitSystem );
+                roughness = wellPath->mswCompletionParameters()->getRoughnessAtMD( midPointMD, unitSystem );
+            }
+
+            RigMswSegment seg;
+            seg.segmentNumber       = segmentNumber;
+            seg.outletSegmentNumber = prevSegNum;
+            seg.length              = length;
+            seg.depth               = depth;
+            seg.diameter            = diameter;
+            seg.roughness           = roughness;
+            seg.sourceWellName      = wellPath->name().toStdString();
+            if ( firstSeg && firstSubSeg )
+            {
+                seg.description = "Segments on main bore";
+                firstSeg        = false;
+            }
+            if ( firstSubSeg ) seg.intersections = cellCompsegs;
+
+            lastSubSegNum = segmentNumber;
+            prevSegNum    = segmentNumber++;
+            prevOutMD     = midPointMD;
+            prevOutTVD    = midPointTVD;
+            firstSubSeg   = false;
+            if ( cellSegMap ) cellSegMap->push_back( { subStartMD, subEndMD, lastSubSegNum } );
+            result.push_back( std::move( seg ) );
+        }
+    }
+
+    return RigMswBranch{ branchNumber, std::nullopt, std::move( result ) };
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildValveBranchesFromGeometry( const RimWellPath*                                wellPath,
+                                                          const std::vector<WellPathCellIntersectionInfo>&  filteredIntersections,
+                                                          const RigMainGrid*                                mainGrid,
+                                                          const std::vector<const RimPerforationInterval*>& perforationIntervals,
+                                                          const std::vector<CellSegmentEntry>&              cellSegMap,
+                                                          const std::string&                                infoType,
+                                                          const std::string&                                wellNameForExport,
+                                                          int&                                              segmentNumber,
+                                                          int&                                              branchNumber,
+                                                          double                                            maxSegmentLength,
+                                                          const std::vector<std::pair<double, double>>&     customSegmentIntervals,
+                                                          const std::optional<QDateTime>&                   exportDate,
+                                                          RiaDefines::EclipseUnitSystem                     unitSystem )
+{
+    std::vector<RigMswBranch> result;
+
+    const auto linerDiameter   = wellPath->mswCompletionParameters()->linerDiameter( unitSystem );
+    const auto roughnessFactor = wellPath->mswCompletionParameters()->roughnessFactor( unitSystem );
+
+    for ( const auto* perf : perforationIntervals )
+    {
+        if ( exportDate.has_value() && !perf->isActiveOnDate( exportDate.value() ) ) continue;
+
+        auto valves = perf->descendantsIncludingThisOfType<RimWellPathValve>();
+        for ( const auto* valve : valves )
+        {
+            if ( !valve->isChecked() ) continue;
+            if ( exportDate.has_value() && !valve->isActiveOnDate( exportDate.value() ) ) continue;
+
+            const auto valveType = valve->componentType();
+            const bool isIcdOrIcv =
+                ( valveType == RiaDefines::WellPathComponentType::ICD || valveType == RiaDefines::WellPathComponentType::ICV );
+            const bool isAicdOrSicd =
+                ( valveType == RiaDefines::WellPathComponentType::AICD || valveType == RiaDefines::WellPathComponentType::SICD );
+            if ( !isIcdOrIcv && !isAicdOrSicd ) continue;
+
+            const auto& valveLocations = valve->valveLocations();
+            const auto& valveSegs      = valve->valveSegments(); // one (startMD, endMD) per location
+
+            // ICD: one branch per overlapping cell with proportional area, matching tree approach
+            if ( valveType == RiaDefines::WellPathComponentType::ICD )
+            {
+                for ( size_t vi = 0; vi < valveLocations.size(); ++vi )
+                {
+                    const double valveSegStart = valveSegs[vi].first;
+                    const double valveSegEnd   = valveSegs[vi].second;
+
+                    // Collect cells overlapping this ICD's coverage range and total overlap length
+                    struct CellEntry
+                    {
+                        RigMswCellIntersection ci;
+                        double                 overlapMD;
+                    };
+                    std::vector<CellEntry> cells;
+                    double                 totalOverlapMD = 0.0;
+                    for ( const auto& cellInfo : filteredIntersections )
+                    {
+                        const double overlapStart = std::max( valveSegStart, cellInfo.startMD );
+                        const double overlapEnd   = std::min( valveSegEnd, cellInfo.endMD );
+                        if ( overlapEnd <= overlapStart ) continue;
+                        if ( auto ci = toMswCellIntersection( cellInfo, mainGrid, overlapStart, overlapEnd ) )
+                        {
+                            double overlapMD = overlapEnd - overlapStart;
+                            cells.push_back( { *ci, overlapMD } );
+                            totalOverlapMD += overlapMD;
+                        }
+                    }
+
+                    // One branch+segment per cell with area proportional to overlap length
+                    for ( auto& entry : cells )
+                    {
+                        const int    cellBranch = ++branchNumber;
+                        const int    outletSeg  = findContainingSegmentForMD( cellSegMap, entry.ci.distanceStart );
+                        const double valveMD    = segmentMidpointMD( cellSegMap, outletSeg );
+                        const double valveEndMD = valveMD + RicMswTableDataTools::valveSegmentLength;
+                        const double startTVD   = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveMD );
+                        const double endTVD     = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveEndMD );
+
+                        double length = 0.0, depth = 0.0;
+                        if ( infoType == "INC" )
+                        {
+                            length = valveEndMD - valveMD;
+                            depth  = endTVD - startTVD;
+                        }
+                        else
+                        {
+                            length = valveEndMD;
+                            depth  = endTVD;
+                        }
+
+                        RigMswSegment seg;
+                        seg.segmentNumber       = segmentNumber;
+                        seg.outletSegmentNumber = outletSeg;
+                        seg.length              = length;
+                        seg.depth               = depth;
+                        seg.diameter            = linerDiameter;
+                        seg.roughness           = roughnessFactor;
+                        seg.sourceWellName      = wellPath->name().toStdString();
+                        seg.description         = QString( "%1 #%2" ).arg( valve->name() ).arg( vi + 1 ).toStdString();
+                        seg.intersections       = { entry.ci };
+
+                        WsegvalvRow wv;
+                        wv.well          = wellNameForExport;
+                        wv.segmentNumber = segmentNumber;
+                        wv.cv            = valve->flowCoefficient();
+                        wv.area          = totalOverlapMD > 0.0 ? valve->area( unitSystem ) * entry.overlapMD / totalOverlapMD : 0.0;
+                        wv.status        = valve->isOpen() ? "OPEN" : "SHUT";
+                        wv.description   = valve->name().toStdString();
+                        seg.wsegvalvData = wv;
+
+                        segmentNumber++;
+                        result.push_back( RigMswBranch{ cellBranch, std::nullopt, { std::move( seg ) } } );
+                    }
+                }
+                continue;
+            }
+
+            // AICD: one branch per overlapping cell with proportional flow scaling factor, matching tree approach
+            if ( valveType == RiaDefines::WellPathComponentType::AICD )
+            {
+                const RimWellPathAicdParameters* aicdParams = valve->aicdParameters();
+                if ( aicdParams && aicdParams->isValid() )
+                {
+                    const auto aicdValues = aicdParams->doubleValues();
+
+                    auto setOptional = []( double value ) -> std::optional<double>
+                    { return std::isinf( value ) ? std::nullopt : std::optional<double>{ value }; };
+
+                    for ( size_t vi = 0; vi < valveLocations.size(); ++vi )
+                    {
+                        const double valveSegStart = valveSegs[vi].first;
+                        const double valveSegEnd   = valveSegs[vi].second;
+
+                        struct CellEntry
+                        {
+                            RigMswCellIntersection ci;
+                            double                 overlapMD;
+                        };
+                        std::vector<CellEntry> cells;
+                        double                 totalOverlapMD = 0.0;
+                        for ( const auto& cellInfo : filteredIntersections )
+                        {
+                            const double overlapStart = std::max( valveSegStart, cellInfo.startMD );
+                            const double overlapEnd   = std::min( valveSegEnd, cellInfo.endMD );
+                            if ( overlapEnd <= overlapStart ) continue;
+                            if ( auto ci = toMswCellIntersection( cellInfo, mainGrid, overlapStart, overlapEnd ) )
+                            {
+                                cells.push_back( { *ci, overlapEnd - overlapStart } );
+                                totalOverlapMD += overlapEnd - overlapStart;
+                            }
+                        }
+
+                        for ( auto& entry : cells )
+                        {
+                            const int    cellBranch = ++branchNumber;
+                            const int    outletSeg  = findContainingSegmentForMD( cellSegMap, entry.ci.distanceStart );
+                            const double valveMD    = segmentMidpointMD( cellSegMap, outletSeg );
+                            const double valveEndMD = valveMD + RicMswTableDataTools::valveSegmentLength;
+                            const double startTVD   = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveMD );
+                            const double endTVD     = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveEndMD );
+
+                            double length = 0.0, depth = 0.0;
+                            if ( infoType == "INC" )
+                            {
+                                length = valveEndMD - valveMD;
+                                depth  = endTVD - startTVD;
+                            }
+                            else
+                            {
+                                length = valveEndMD;
+                                depth  = endTVD;
+                            }
+
+                            RigMswSegment seg;
+                            seg.segmentNumber       = segmentNumber;
+                            seg.outletSegmentNumber = outletSeg;
+                            seg.length              = length;
+                            seg.depth               = depth;
+                            seg.diameter            = linerDiameter;
+                            seg.roughness           = roughnessFactor;
+                            seg.sourceWellName      = wellPath->name().toStdString();
+                            seg.description         = QString( "%1 #%2" ).arg( valve->name() ).arg( vi + 1 ).toStdString();
+                            seg.intersections       = { entry.ci };
+
+                            WsegaicdRow wa;
+                            wa.well                = wellNameForExport;
+                            wa.segment1            = segmentNumber;
+                            wa.segment2            = segmentNumber;
+                            wa.strength            = aicdValues[AICD_STRENGTH];
+                            wa.length              = totalOverlapMD > 0.0 ? totalOverlapMD / entry.overlapMD : 0.0;
+                            wa.densityCali         = setOptional( aicdValues[AICD_DENSITY_CALIB_FLUID] );
+                            wa.viscosityCali       = setOptional( aicdValues[AICD_VISCOSITY_CALIB_FLUID] );
+                            wa.criticalValue       = setOptional( aicdValues[AICD_CRITICAL_WATER_IN_LIQUID_FRAC] );
+                            wa.widthTrans          = setOptional( aicdValues[AICD_EMULSION_VISC_TRANS_REGION] );
+                            wa.maxViscRatio        = setOptional( aicdValues[AICD_MAX_RATIO_EMULSION_VISC] );
+                            wa.methodScalingFactor = 1;
+                            wa.maxAbsRate          = aicdValues[AICD_MAX_FLOW_RATE];
+                            wa.flowRateExponent    = aicdValues[AICD_VOL_FLOW_EXP];
+                            wa.viscExponent        = aicdValues[AICD_VISOSITY_FUNC_EXP];
+                            wa.status              = aicdParams->isOpen() ? "OPEN" : "SHUT";
+                            wa.description         = valve->name().toStdString();
+                            seg.wsegaicdData       = wa;
+
+                            segmentNumber++;
+                            result.push_back( RigMswBranch{ cellBranch, std::nullopt, { std::move( seg ) } } );
+                        }
+                    }
+                }
+                continue;
+            }
+
+            // ICV: one branch, one segment per valve location
+            const int valveBranch = ++branchNumber;
+
+            std::vector<RigMswSegment> branchSegs;
+            for ( size_t vi = 0; vi < valveLocations.size(); ++vi )
+            {
+                const double valveMD       = valveLocations[vi];
+                const double valveEndMD    = valveMD + RicMswTableDataTools::valveSegmentLength;
+                const double valveSegStart = valveSegs[vi].first;
+                const double valveSegEnd   = valveSegs[vi].second;
+
+                const int outletSeg = findOutletSegmentForMD( cellSegMap, valveMD );
+
+                const double valveStartTVD = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveMD );
+                const double valveEndTVD   = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveEndMD );
+
+                double length = 0.0;
+                double depth  = 0.0;
+                if ( infoType == "INC" )
+                {
+                    length = valveEndMD - valveMD;
+                    depth  = valveEndTVD - valveStartTVD;
+                }
+                else
+                {
+                    length = valveEndMD;
+                    depth  = valveEndTVD;
+                }
+
+                RigMswSegment valveSeg;
+                valveSeg.segmentNumber       = segmentNumber;
+                valveSeg.outletSegmentNumber = outletSeg;
+                valveSeg.length              = length;
+                valveSeg.depth               = depth;
+                valveSeg.diameter            = linerDiameter;
+                valveSeg.roughness           = roughnessFactor;
+                valveSeg.sourceWellName      = wellPath->name().toStdString();
+                valveSeg.description         = QString( "%1 #%2" ).arg( valve->name() ).arg( vi + 1 ).toStdString();
+
+                // COMPSEGS: cells that overlap this valve's coverage range (valveSegStart..valveSegEnd)
+                for ( const auto& cellInfo : filteredIntersections )
+                {
+                    const double overlapStart = std::max( valveSegStart, cellInfo.startMD );
+                    const double overlapEnd   = std::min( valveSegEnd, cellInfo.endMD );
+                    if ( overlapEnd > overlapStart )
+                    {
+                        if ( auto ci = toMswCellIntersection( cellInfo, mainGrid, overlapStart, overlapEnd ) )
+                            valveSeg.intersections.push_back( *ci );
+                    }
+                }
+
+                // WSEGVALV for ICV
+                WsegvalvRow wv;
+                wv.well               = wellNameForExport;
+                wv.segmentNumber      = segmentNumber;
+                wv.cv                 = valve->flowCoefficient();
+                wv.area               = valve->area( unitSystem );
+                wv.status             = valve->isOpen() ? "OPEN" : "SHUT";
+                wv.description        = valve->name().toStdString();
+                valveSeg.wsegvalvData = wv;
+
+                segmentNumber++;
+                branchSegs.push_back( std::move( valveSeg ) );
+            }
+            result.push_back( RigMswBranch{ valveBranch, std::nullopt, std::move( branchSegs ) } );
+        }
+    }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildFractureBranchesFromGeometry( RimEclipseCase*                      eclipseCase,
+                                                             const RimWellPath*                   wellPath,
+                                                             const RigMainGrid*                   mainGrid,
+                                                             const std::vector<CellSegmentEntry>& cellSegMap,
+                                                             const std::string&                   infoType,
+                                                             int&                                 segmentNumber,
+                                                             int&                                 branchNumber )
+{
+    std::vector<RigMswBranch> result;
+
+    const QString wellNameForExport = wellPath->completionSettings()->wellNameForExport();
+
+    for ( RimWellPathFracture* fracture : wellPath->fractureCollection()->activeFractures() )
+    {
+        fracture->ensureValidNonDarcyProperties();
+
+        double position = fracture->fractureMD();
+        double width    = fracture->fractureTemplate()->computeFractureWidth( fracture );
+
+        if ( fracture->fractureTemplate()->orientationType() == RimFractureTemplate::ALONG_WELL_PATH )
+        {
+            double perforationLength = fracture->fractureTemplate()->perforationLength();
+            position -= 0.5 * perforationLength;
+            width = perforationLength;
+        }
+
+        const double endMD    = position + width;
+        const double startTVD = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, position );
+        const double endTVD   = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, endMD );
+
+        double length = 0.0;
+        double depth  = 0.0;
+        if ( infoType == "INC" )
+        {
+            length = width;
+            depth  = endTVD - startTVD;
+        }
+        else
+        {
+            length = endMD;
+            depth  = endTVD;
+        }
+
+        const int outletSeg  = findOutletSegmentForMD( cellSegMap, position );
+        const int fracBranch = ++branchNumber;
+
+        // Get COMPSEGS cell intersections from fracture completion data
+        std::vector<RigCompletionData> completionData = RicExportFractureCompletionsImpl::generateCompdatValues( eclipseCase,
+                                                                                                                 wellNameForExport,
+                                                                                                                 wellPath->wellPathGeometry(),
+                                                                                                                 { fracture },
+                                                                                                                 nullptr,
+                                                                                                                 nullptr );
+
+        std::vector<RigMswCellIntersection> compsegs;
+        for ( const auto& compData : completionData )
+        {
+            const auto& cell = compData.completionDataGridCell();
+
+            // 0-based -> 1-based
+            size_t i = cell.localCellIndexI() + 1;
+            size_t j = cell.localCellIndexJ() + 1;
+            size_t k = cell.localCellIndexK() + 1;
+
+            // Shift K for dual porosity models
+            if ( mainGrid->isDualPorosity() ) k += mainGrid->cellCountK();
+
+            RigMswCellIntersection ci;
+            ci.i             = i;
+            ci.j             = j;
+            ci.k             = k;
+            ci.distanceStart = position;
+            ci.distanceEnd   = endMD;
+            ci.gridName      = cell.lgrName().toStdString();
+            compsegs.push_back( ci );
+        }
+
+        RigMswSegment seg;
+        seg.segmentNumber       = segmentNumber++;
+        seg.outletSegmentNumber = outletSeg;
+        seg.length              = length;
+        seg.depth               = depth;
+        seg.diameter            = 0.15; // RicMswSegment default (tree approach uses same value)
+        seg.roughness           = 5.0e-5; // RicMswSegment default (tree approach uses same value)
+        seg.sourceWellName      = wellPath->name().toStdString();
+        seg.description         = fracture->name().toStdString();
+        seg.intersections       = std::move( compsegs );
+
+        result.push_back( RigMswBranch{ fracBranch, std::nullopt, { std::move( seg ) } } );
+    }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildFishbonesBranchesFromGeometry( const RimEclipseCase*                            eclipseCase,
+                                                              const RimWellPath*                               wellPath,
+                                                              const RigMainGrid*                               mainGrid,
+                                                              const std::vector<WellPathCellIntersectionInfo>& filteredIntersections,
+                                                              const std::vector<CellSegmentEntry>&             cellSegMap,
+                                                              const std::string&                               infoType,
+                                                              const std::string&                               wellNameForExport,
+                                                              int&                                             segmentNumber,
+                                                              int&                                             branchNumber,
+                                                              RiaDefines::EclipseUnitSystem                    unitSystem )
+{
+    std::vector<RigMswBranch> result;
+
+    auto fishbonesSubs = wellPath->completions()->fishbonesCollection()->activeFishbonesSubs();
+    for ( const RimFishbones* subs : fishbonesSubs )
+    {
+        // Group laterals by sub index
+        std::map<size_t, std::vector<size_t>> subAndLateralIndices;
+        for ( const auto& [subIndex, lateralIndex] : subs->installedLateralIndices() )
+            subAndLateralIndices[subIndex].push_back( lateralIndex );
+
+        // Identify which filtered intersections are closest to each sub, and which
+        // intersection contains the sub's MD.  This mirrors appendFishbonesMswExportInfo.
+        const double fishboneSectionStart = subs->startMD();
+        const double fishboneSectionEnd   = subs->endMD();
+
+        std::map<size_t, std::vector<size_t>> closestSubForCellIntersections;
+        std::map<size_t, size_t>              cellIntersectionContainingSubIndex;
+
+        for ( size_t ii = 0; ii < filteredIntersections.size(); ++ii )
+        {
+            const auto& ci = filteredIntersections[ii];
+            if ( fishboneSectionEnd < ci.startMD || fishboneSectionStart > ci.endMD ) continue;
+
+            const double midpoint      = 0.5 * ( ci.startMD + ci.endMD );
+            size_t       closestSubIdx = 0;
+            double       closestDist   = std::numeric_limits<double>::infinity();
+
+            for ( const auto& [subIdx, lats] : subAndLateralIndices )
+            {
+                const double subMD = subs->measuredDepth( subIdx );
+                if ( ci.startMD <= subMD && subMD <= ci.endMD ) cellIntersectionContainingSubIndex[subIdx] = ii;
+
+                const double dist = std::abs( subMD - midpoint );
+                if ( dist < closestDist )
+                {
+                    closestDist   = dist;
+                    closestSubIdx = subIdx;
+                }
+            }
+            closestSubForCellIntersections[closestSubIdx].push_back( ii );
+        }
+
+        // ICD parameters
+        const double icdOrificeRadius = subs->icdOrificeDiameter( unitSystem ) / 2.0;
+        const double icdArea          = icdOrificeRadius * icdOrificeRadius * cvf::PI_D * static_cast<double>( subs->icdCount() );
+        const double icdCv            = subs->icdFlowCoefficient();
+
+        // Track used global cell indices to deduplicate COMPSEGS, matching the tree's intersectedCells logic.
+        std::set<size_t> usedGlobalCellIndices;
+
+        for ( const auto& [subIndex, lateralIndices] : subAndLateralIndices )
+        {
+            const double subEndMd      = subs->measuredDepth( subIndex );
+            const double startValveMd  = subEndMd - RicMswTableDataTools::valveSegmentLength;
+            const double startValveTVD = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, startValveMd );
+            const double endValveTVD   = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, subEndMd );
+
+            const int outletSeg = findOutletSegmentForMD( cellSegMap, subEndMd );
+            const int icdBranch = ++branchNumber;
+            const int icdSegNum = segmentNumber++;
+
+            // COMPSEGS for the ICD segment: cells closest to this sub, clipped to [startValveMd, subEndMd]
+            std::set<size_t> icdCellIndices;
+            if ( closestSubForCellIntersections.count( subIndex ) )
+            {
+                for ( auto idx : closestSubForCellIntersections[subIndex] )
+                    icdCellIndices.insert( idx );
+            }
+            if ( cellIntersectionContainingSubIndex.count( subIndex ) )
+                icdCellIndices.insert( cellIntersectionContainingSubIndex[subIndex] );
+
+            std::vector<RigMswCellIntersection> icdCompsegs;
+            for ( auto idx : icdCellIndices )
+            {
+                const auto&  ci           = filteredIntersections[idx];
+                const double overlapStart = std::max( startValveMd, ci.startMD );
+                const double overlapEnd   = std::min( subEndMd, ci.endMD );
+                if ( overlapEnd <= overlapStart ) continue;
+                if ( auto mci = toMswCellIntersection( ci, mainGrid, overlapStart, overlapEnd ) )
+                {
+                    icdCompsegs.push_back( *mci );
+                    usedGlobalCellIndices.insert( ci.globCellIndex );
+                }
+            }
+
+            double icdLength = 0.0;
+            double icdDepth  = 0.0;
+            if ( infoType == "INC" )
+            {
+                icdLength = subEndMd - startValveMd;
+                icdDepth  = endValveTVD - startValveTVD;
+            }
+            else
+            {
+                icdLength = subEndMd;
+                icdDepth  = endValveTVD;
+            }
+
+            RigMswSegment icdSeg;
+            icdSeg.segmentNumber       = icdSegNum;
+            icdSeg.outletSegmentNumber = outletSeg;
+            icdSeg.length              = icdLength;
+            icdSeg.depth               = icdDepth;
+            // Use RigMswSegment defaults for diameter/roughness (matching tree approach for fishbones ICD)
+            icdSeg.sourceWellName = wellPath->name().toStdString();
+            icdSeg.description    = QString( "ICD sub %1" ).arg( subIndex + 1 ).toStdString();
+            icdSeg.intersections  = std::move( icdCompsegs );
+
+            WsegvalvRow wv;
+            wv.well             = wellNameForExport;
+            wv.segmentNumber    = icdSegNum;
+            wv.cv               = icdCv;
+            wv.area             = icdArea;
+            wv.status           = "OPEN";
+            wv.description      = QString( "ICD sub %1" ).arg( subIndex + 1 ).toStdString();
+            icdSeg.wsegvalvData = wv;
+
+            result.push_back( RigMswBranch{ icdBranch, std::nullopt, { std::move( icdSeg ) } } );
+
+            // Lateral sub-segments
+            for ( size_t lateralIndex : lateralIndices )
+            {
+                auto lateralCoordMDPairs = subs->coordsAndMDForLateral( subIndex, lateralIndex );
+                if ( lateralCoordMDPairs.empty() ) continue;
+
+                std::vector<cvf::Vec3d> lateralCoords;
+                std::vector<double>     lateralMDs;
+                for ( auto& [coord, md] : lateralCoordMDPairs )
+                {
+                    lateralCoords.push_back( coord );
+                    lateralMDs.push_back( md );
+                }
+
+                auto lateralIntersections = RigWellPathIntersectionTools::findCellIntersectionInfosAlongPath( eclipseCase->eclipseCaseData(),
+                                                                                                              wellPath->name(),
+                                                                                                              lateralCoords,
+                                                                                                              lateralMDs );
+
+                if ( lateralIntersections.empty() ) continue;
+
+                const int  latBranch    = ++branchNumber;
+                double     prevMD       = lateralMDs.front();
+                double     prevTVD      = -lateralCoords.front().z();
+                int        latOutletSeg = icdSegNum;
+                bool       firstLatSeg  = true;
+                const auto lateralLabel = QString( "Lateral %1" ).arg( lateralIndex + 1 ).toStdString();
+
+                std::vector<RigMswSegment> latSegs;
+                for ( const auto& cellIntInfo : lateralIntersections )
+                {
+                    if ( auto mci = toMswCellIntersection( cellIntInfo, mainGrid, cellIntInfo.startMD, cellIntInfo.endMD ) )
+                    {
+                        double len = 0.0;
+                        double dep = 0.0;
+                        if ( infoType == "INC" )
+                        {
+                            len = cellIntInfo.endMD - prevMD;
+                            dep = cellIntInfo.endTVD() - prevTVD;
+                        }
+                        else
+                        {
+                            len = cellIntInfo.endMD;
+                            dep = cellIntInfo.endTVD();
+                        }
+
+                        // Deduplicate COMPSEGS: skip cells already connected (matching tree intersectedCells logic)
+                        const bool isNewCell = usedGlobalCellIndices.insert( cellIntInfo.globCellIndex ).second;
+
+                        RigMswSegment latSeg;
+                        latSeg.segmentNumber       = segmentNumber++;
+                        latSeg.outletSegmentNumber = latOutletSeg;
+                        latSeg.length              = len;
+                        latSeg.depth               = dep;
+                        latSeg.diameter            = subs->equivalentDiameter( unitSystem );
+                        latSeg.roughness           = subs->openHoleRoughnessFactor( unitSystem );
+                        latSeg.sourceWellName      = wellPath->name().toStdString();
+                        if ( firstLatSeg ) latSeg.description = lateralLabel;
+                        latSeg.intersections = isNewCell ? std::vector<RigMswCellIntersection>{ *mci } : std::vector<RigMswCellIntersection>{};
+
+                        latOutletSeg = latSeg.segmentNumber;
+                        prevMD       = cellIntInfo.endMD;
+                        prevTVD      = cellIntInfo.endTVD();
+                        firstLatSeg  = false;
+                        latSegs.push_back( std::move( latSeg ) );
+                    }
+                }
+                result.push_back( RigMswBranch{ latBranch, std::nullopt, std::move( latSegs ) } );
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace RicMswBranchBuilder

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
@@ -1,0 +1,139 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "CompletionsMsw/RigMswSegment.h"
+#include "RiaDefines.h"
+#include "RigActiveCellInfo.h"
+#include "Well/RigWellLogExtractor.h"
+
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <QDateTime>
+
+class RimEclipseCase;
+class RimWellPath;
+class RigMainGrid;
+class RimPerforationInterval;
+
+//--------------------------------------------------------------------------------------------------
+/// Free functions that build RigMswSegment lists directly from well-path geometry and Rim
+/// completion objects — without creating the intermediate RicMswBranch / RicMswItem tree.
+///
+/// Extracted from the former `internal` anonymous namespace in RicWellPathExportMswGeometryPath.cpp
+/// so that they can be called from other translation units and unit-tested in isolation.
+//--------------------------------------------------------------------------------------------------
+namespace RicMswBranchBuilder
+{
+
+//--------------------------------------------------------------------------------------------------
+/// Mapping from a sub-segment's MD range to its main-bore segment number.
+/// One entry is emitted per sub-segment (a cell split into N sub-segments produces N entries).
+/// Used by valve, fracture, and lateral builders to locate the outlet segment for a given MD.
+//--------------------------------------------------------------------------------------------------
+struct CellSegmentEntry
+{
+    double cellStartMD;
+    double cellEndMD;
+    int    lastSubSegmentNumber;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// Convert a WellPathCellIntersectionInfo global-cell index to a RigMswCellIntersection (1-based i,j,k).
+/// Returns std::nullopt for gap-segments (globCellIndex >= totalCellCount).|
+//--------------------------------------------------------------------------------------------------
+std::optional<RigMswCellIntersection>
+    toMswCellIntersection( const WellPathCellIntersectionInfo& cellInfo, const RigMainGrid* mainGrid, double distanceStart, double distanceEnd );
+
+//--------------------------------------------------------------------------------------------------
+/// Find the main-bore outlet segment number for a given measured depth.
+/// Returns 1 (heel) if cellSegMap is empty; returns the last entry's segment number if md is
+/// beyond the end of all mapped cells.
+//--------------------------------------------------------------------------------------------------
+int findOutletSegmentForMD( const std::vector<CellSegmentEntry>& cellSegMap, double md );
+
+//--------------------------------------------------------------------------------------------------
+/// Build main-bore WELSEGS segments directly from well-path geometry.
+/// For each grid-cell intersection overlapping a bare perforation (no active valve) a COMPSEGS
+/// entry is embedded.  Optionally fills cellSegMap for later valve outlet-segment lookups.
+//--------------------------------------------------------------------------------------------------
+RigMswBranch buildMainBoreBranchFromGeometry( const RimWellPath*                                wellPath,
+                                              const std::vector<WellPathCellIntersectionInfo>&  filteredIntersections,
+                                              const RigMainGrid*                                mainGrid,
+                                              const std::vector<const RimPerforationInterval*>& perforationIntervals,
+                                              const std::set<const RimPerforationInterval*>&    valvedIntervals,
+                                              const std::string&                                infoType,
+                                              double                                            heelMD,
+                                              double                                            heelTVD,
+                                              int                                               branchNumber,
+                                              int&                                              segmentNumber,
+                                              int                                               outletSegmentNumber,
+                                              double                                            maxSegmentLength,
+                                              const std::vector<std::pair<double, double>>&     customSegmentIntervals,
+                                              const std::optional<QDateTime>&                   exportDate,
+                                              RiaDefines::EclipseUnitSystem                     unitSystem,
+                                              std::vector<CellSegmentEntry>*                    cellSegMap,
+                                              const RigActiveCellInfo*                          activeCellInfo = nullptr );
+
+//--------------------------------------------------------------------------------------------------
+/// Build WELSEGS + COMPSEGS segments for ICD/ICV/AICD/SICD valve completions.
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildValveBranchesFromGeometry( const RimWellPath*                                wellPath,
+                                                          const std::vector<WellPathCellIntersectionInfo>&  filteredIntersections,
+                                                          const RigMainGrid*                                mainGrid,
+                                                          const std::vector<const RimPerforationInterval*>& perforationIntervals,
+                                                          const std::vector<CellSegmentEntry>&              cellSegMap,
+                                                          const std::string&                                infoType,
+                                                          const std::string&                                wellNameForExport,
+                                                          int&                                              segmentNumber,
+                                                          int&                                              branchNumber,
+                                                          double                                            maxSegmentLength,
+                                                          const std::vector<std::pair<double, double>>&     customSegmentIntervals,
+                                                          const std::optional<QDateTime>&                   exportDate,
+                                                          RiaDefines::EclipseUnitSystem                     unitSystem );
+
+//--------------------------------------------------------------------------------------------------
+/// Build WELSEGS + COMPSEGS segments for fracture completions.
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildFractureBranchesFromGeometry( RimEclipseCase*                      eclipseCase,
+                                                             const RimWellPath*                   wellPath,
+                                                             const RigMainGrid*                   mainGrid,
+                                                             const std::vector<CellSegmentEntry>& cellSegMap,
+                                                             const std::string&                   infoType,
+                                                             int&                                 segmentNumber,
+                                                             int&                                 branchNumber );
+
+//--------------------------------------------------------------------------------------------------
+/// Build WELSEGS + COMPSEGS + WSEGVALV segments for fishbones completions.
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildFishbonesBranchesFromGeometry( const RimEclipseCase*                            eclipseCase,
+                                                              const RimWellPath*                               wellPath,
+                                                              const RigMainGrid*                               mainGrid,
+                                                              const std::vector<WellPathCellIntersectionInfo>& filteredIntersections,
+                                                              const std::vector<CellSegmentEntry>&             cellSegMap,
+                                                              const std::string&                               infoType,
+                                                              const std::string&                               wellNameForExport,
+                                                              int&                                             segmentNumber,
+                                                              int&                                             branchNumber,
+                                                              RiaDefines::EclipseUnitSystem                    unitSystem );
+
+} // namespace RicMswBranchBuilder

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
@@ -1,0 +1,495 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicWellPathExportMswGeometryPath.h"
+
+#include "RicMswBranchBuilder.h"
+#include "RicMswTableDataTools.h"
+#include "RicWellPathExportMswTableData.h"
+
+#include "CompletionsMsw/RigMswTableData.h"
+
+#include "RigActiveCellInfo.h"
+#include "RigEclipseCaseData.h"
+#include "Well/RigWellPath.h"
+
+#include "RimEclipseCase.h"
+#include "RimMswCompletionParameters.h"
+#include "RimPerforationCollection.h"
+#include "RimPerforationInterval.h"
+#include "RimValveCollection.h"
+#include "RimWellPath.h"
+#include "RimWellPathCompletionSettings.h"
+#include "RimWellPathTieIn.h"
+#include "RimWellPathValve.h"
+
+#include <algorithm>
+
+namespace RicWellPathExportMswGeometryPath
+{
+
+using CompletionType = RicWellPathExportMswTableData::CompletionType;
+
+//--------------------------------------------------------------------------------------------------
+/// Recursively build all WELSEGS/COMPSEGS/valve segments for one lateral (child well path)
+/// and any of its own child laterals.
+//--------------------------------------------------------------------------------------------------
+std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 eclipseCase,
+                                                const RimWellPath*              wellPath,
+                                                const RigMainGrid*              mainGrid,
+                                                int                             outletSegNum,
+                                                CompletionType                  completionType,
+                                                const std::optional<QDateTime>& exportDate,
+                                                int&                            segmentNumber,
+                                                int&                            branchNumber,
+                                                RiaDefines::EclipseUnitSystem   unitSystem )
+{
+    std::vector<RigMswBranch> result;
+    auto                      mswParameters = wellPath->mswCompletionParameters();
+    if ( !mswParameters ) return result;
+
+    const std::string infoType          = mswParameters->lengthAndDepth().text().toStdString();
+    const double      tieInMD           = wellPath->wellPathTieIn()->tieInMeasuredDepth();
+    const double      tieInTVD          = -wellPath->wellPathGeometry()->interpolatedPointAlongWellPath( tieInMD ).z();
+    const std::string wellNameForExport = wellPath->completionSettings()->wellNameForExport().toStdString();
+
+    const int lateralBranchNum = ++branchNumber;
+    int       childOutletSeg   = outletSegNum;
+
+    // Optional ICV valve at the tie-in point — stored on the branch, not as a separate branch
+    std::optional<RigMswSegment> tieInValve;
+    const RimWellPathValve*      outletValve = wellPath->wellPathTieIn()->outletValve();
+    if ( outletValve && outletValve->isChecked() )
+    {
+        const bool isActive = !exportDate.has_value() || outletValve->isActiveOnDate( *exportDate );
+        if ( isActive )
+        {
+            const double valveMD       = wellPath->wellPathTieIn()->branchValveMeasuredDepth();
+            const double offset        = ( valveMD == tieInMD ) ? RicMswTableDataTools::valveSegmentLength : 0.0;
+            const double valveEndMD    = valveMD + offset;
+            const double valveStartTVD = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveMD );
+            const double valveEndTVD   = RicMswTableDataTools::tvdFromMeasuredDepth( wellPath, valveEndMD );
+
+            double length = 0.0;
+            double depth  = 0.0;
+            if ( infoType == "INC" )
+            {
+                length = valveEndMD - valveMD;
+                depth  = valveEndTVD - valveStartTVD;
+            }
+            else
+            {
+                length = valveEndMD;
+                depth  = valveEndTVD;
+            }
+
+            const int valveSegNum = segmentNumber++;
+
+            RigMswSegment valveSeg;
+            valveSeg.segmentNumber       = valveSegNum;
+            valveSeg.outletSegmentNumber = outletSegNum;
+            valveSeg.length              = length;
+            valveSeg.depth               = depth;
+            valveSeg.diameter            = mswParameters->linerDiameter( unitSystem );
+            valveSeg.roughness           = mswParameters->roughnessFactor( unitSystem );
+            valveSeg.sourceWellName      = wellPath->name().toStdString();
+            valveSeg.description = QString( "%1 valve for %2" ).arg( outletValve->componentLabel() ).arg( wellPath->name() ).toStdString();
+
+            WsegvalvRow wv;
+            wv.well               = wellNameForExport;
+            wv.segmentNumber      = valveSegNum;
+            wv.cv                 = outletValve->flowCoefficient();
+            wv.area               = outletValve->area( unitSystem );
+            wv.status             = outletValve->isOpen() ? "OPEN" : "SHUT";
+            wv.description        = valveSeg.description;
+            valveSeg.wsegvalvData = wv;
+
+            tieInValve     = std::move( valveSeg );
+            childOutletSeg = valveSegNum;
+        }
+    }
+
+    // Child main-bore segments
+    auto cellIntersections = RicWellPathExportMswTableData::generateCellSegments( eclipseCase, wellPath );
+    auto filteredIntersections =
+        RicWellPathExportMswTableData::filterIntersections( cellIntersections, tieInMD, wellPath->wellPathGeometry(), eclipseCase );
+
+    const bool includePerforations = ( completionType & CompletionType::PERFORATIONS ) == CompletionType::PERFORATIONS;
+    const std::vector<const RimPerforationInterval*> perforationIntervals =
+        includePerforations ? wellPath->perforationIntervalCollection()->activePerforations() : std::vector<const RimPerforationInterval*>();
+
+    std::set<const RimPerforationInterval*> valvedIntervals;
+    for ( const auto* perf : perforationIntervals )
+    {
+        if ( exportDate.has_value() && !perf->isActiveOnDate( exportDate.value() ) ) continue;
+        for ( const auto* valve : perf->descendantsIncludingThisOfType<RimWellPathValve>() )
+        {
+            if ( !valve->isChecked() ) continue;
+            if ( exportDate.has_value() && !valve->isActiveOnDate( exportDate.value() ) ) continue;
+            const auto t = valve->componentType();
+            if ( t == RiaDefines::WellPathComponentType::ICD || t == RiaDefines::WellPathComponentType::ICV ||
+                 t == RiaDefines::WellPathComponentType::AICD || t == RiaDefines::WellPathComponentType::SICD )
+            {
+                valvedIntervals.insert( perf );
+                break;
+            }
+        }
+    }
+
+    std::vector<RicMswBranchBuilder::CellSegmentEntry> childCellSegMap;
+
+    const RigActiveCellInfo* activeCellInfo = eclipseCase->eclipseCaseData()->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
+
+    auto lateralBranch = RicMswBranchBuilder::buildMainBoreBranchFromGeometry( wellPath,
+                                                                               filteredIntersections,
+                                                                               mainGrid,
+                                                                               perforationIntervals,
+                                                                               valvedIntervals,
+                                                                               infoType,
+                                                                               tieInMD,
+                                                                               tieInTVD,
+                                                                               lateralBranchNum,
+                                                                               segmentNumber,
+                                                                               childOutletSeg,
+                                                                               mswParameters->maxSegmentLength(),
+                                                                               {},
+                                                                               exportDate,
+                                                                               unitSystem,
+                                                                               &childCellSegMap,
+                                                                               activeCellInfo );
+    if ( tieInValve && !lateralBranch.segments.empty() ) lateralBranch.segments.front().description.clear();
+    lateralBranch.tieInValve = std::move( tieInValve );
+
+    // Standalone valves (from valveCollection, not inside perforation intervals)
+    for ( const auto* valve : wellPath->valveCollection()->activeValves() )
+    {
+        if ( exportDate.has_value() && !valve->isActiveOnDate( *exportDate ) ) continue;
+
+        const int segNum = RicMswBranchBuilder::findOutletSegmentForMD( childCellSegMap, valve->startMD() );
+        for ( auto& seg : lateralBranch.segments )
+        {
+            if ( seg.segmentNumber == segNum )
+            {
+                WsegvalvRow wv;
+                wv.well          = wellNameForExport;
+                wv.segmentNumber = segNum;
+                wv.cv            = valve->flowCoefficient();
+                wv.area          = valve->area( unitSystem );
+                wv.status        = valve->isOpen() ? "OPEN" : "SHUT";
+                wv.description   = valve->name().toStdString();
+                seg.wsegvalvData = wv;
+                break;
+            }
+        }
+    }
+
+    result.push_back( std::move( lateralBranch ) );
+
+    auto valveBranches = RicMswBranchBuilder::buildValveBranchesFromGeometry( wellPath,
+                                                                              filteredIntersections,
+                                                                              mainGrid,
+                                                                              perforationIntervals,
+                                                                              childCellSegMap,
+                                                                              infoType,
+                                                                              wellNameForExport,
+                                                                              segmentNumber,
+                                                                              branchNumber,
+                                                                              mswParameters->maxSegmentLength(),
+                                                                              {},
+                                                                              exportDate,
+                                                                              unitSystem );
+    result.insert( result.end(), std::make_move_iterator( valveBranches.begin() ), std::make_move_iterator( valveBranches.end() ) );
+
+    if ( ( completionType & CompletionType::FRACTURES ) == CompletionType::FRACTURES )
+    {
+        auto fracBranches = RicMswBranchBuilder::buildFractureBranchesFromGeometry( eclipseCase,
+                                                                                    wellPath,
+                                                                                    mainGrid,
+                                                                                    childCellSegMap,
+                                                                                    infoType,
+                                                                                    segmentNumber,
+                                                                                    branchNumber );
+        result.insert( result.end(), std::make_move_iterator( fracBranches.begin() ), std::make_move_iterator( fracBranches.end() ) );
+    }
+
+    if ( ( completionType & CompletionType::FISHBONES ) == CompletionType::FISHBONES )
+    {
+        auto fishBranches = RicMswBranchBuilder::buildFishbonesBranchesFromGeometry( eclipseCase,
+                                                                                     wellPath,
+                                                                                     mainGrid,
+                                                                                     filteredIntersections,
+                                                                                     childCellSegMap,
+                                                                                     infoType,
+                                                                                     wellNameForExport,
+                                                                                     segmentNumber,
+                                                                                     branchNumber,
+                                                                                     unitSystem );
+        result.insert( result.end(), std::make_move_iterator( fishBranches.begin() ), std::make_move_iterator( fishBranches.end() ) );
+    }
+
+    // Recurse into grandchildren
+    for ( auto* grandchild : RicWellPathExportMswTableData::wellPathsWithTieIn( wellPath ) )
+    {
+        const int grandchildOutlet =
+            RicMswBranchBuilder::findOutletSegmentForMD( childCellSegMap, grandchild->wellPathTieIn()->branchValveMeasuredDepth() );
+        auto grandchildBranches =
+            buildLateralBranches( eclipseCase, grandchild, mainGrid, grandchildOutlet, completionType, exportDate, segmentNumber, branchNumber, unitSystem );
+        result.insert( result.end(), std::make_move_iterator( grandchildBranches.begin() ), std::make_move_iterator( grandchildBranches.end() ) );
+    }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Build MSW export data directly from well-path geometry and Rim completion objects,
+/// without building the RicMswBranch / RicMswItem tree.
+///
+/// Currently implemented: main-bore WELSEGS segments + perforation COMPSEGS entries.
+/// TODO: valve completions (ICD/AICD/SICD/ICV), fishbones laterals, fractures, tie-in wells.
+//--------------------------------------------------------------------------------------------------
+RigMswWellExportData buildMswWellExportData( RimEclipseCase*                               eclipseCase,
+                                             const RimWellPath*                            wellPath,
+                                             double                                        maxSegmentLength,
+                                             const std::vector<std::pair<double, double>>& customSegmentIntervals,
+                                             CompletionType                                completionType,
+                                             const std::optional<QDateTime>&               exportDate )
+{
+    auto mswParameters = wellPath->mswCompletionParameters();
+    CVF_ASSERT( mswParameters );
+
+    const RiaDefines::EclipseUnitSystem unitSystem = eclipseCase->eclipseCaseData()->unitsType();
+    const RigMainGrid*                  mainGrid   = eclipseCase->mainGrid();
+    const std::string                   infoType   = mswParameters->lengthAndDepth().text().toStdString();
+
+    auto cellIntersections = RicWellPathExportMswTableData::generateCellSegments( eclipseCase, wellPath );
+    double initialMD = RicWellPathExportMswTableData::computeIntitialMeasuredDepth( eclipseCase, wellPath, mswParameters, cellIntersections );
+    double initialTVD = -wellPath->wellPathGeometry()->interpolatedPointAlongWellPath( initialMD ).z();
+
+    auto filteredIntersections =
+        RicWellPathExportMswTableData::filterIntersections( cellIntersections, initialMD, wellPath->wellPathGeometry(), eclipseCase );
+
+    WelsegsHeader header;
+    header.well               = wellPath->completionSettings()->wellNameForExport().toStdString();
+    header.topLength          = initialMD;
+    header.topDepth           = initialTVD;
+    header.infoType           = infoType;
+    header.pressureComponents = mswParameters->pressureDrop().text().toStdString();
+
+    const bool includePerforations = ( completionType & CompletionType::PERFORATIONS ) == CompletionType::PERFORATIONS;
+    const std::vector<const RimPerforationInterval*> perforationIntervals =
+        includePerforations ? wellPath->perforationIntervalCollection()->activePerforations() : std::vector<const RimPerforationInterval*>();
+
+    // Determine which perforation intervals have at least one active, checked valve.
+    // Main bore COMPSEGS are skipped for these; the valve builder will emit them instead.
+    std::set<const RimPerforationInterval*> valvedIntervals;
+    for ( const auto* perf : perforationIntervals )
+    {
+        if ( exportDate.has_value() && !perf->isActiveOnDate( exportDate.value() ) ) continue;
+        for ( const auto* valve : perf->descendantsIncludingThisOfType<RimWellPathValve>() )
+        {
+            if ( !valve->isChecked() ) continue;
+            if ( exportDate.has_value() && !valve->isActiveOnDate( exportDate.value() ) ) continue;
+            const auto t = valve->componentType();
+            if ( t == RiaDefines::WellPathComponentType::ICD || t == RiaDefines::WellPathComponentType::ICV ||
+                 t == RiaDefines::WellPathComponentType::AICD || t == RiaDefines::WellPathComponentType::SICD )
+            {
+                valvedIntervals.insert( perf );
+                break;
+            }
+        }
+    }
+
+    int                                                segmentNumber = 2; // Segment 1 is the implicit well heel.
+    int                                                branchNumber  = 1; // Incremented for each new branch.
+    std::vector<RicMswBranchBuilder::CellSegmentEntry> cellSegMap;
+
+    const RigActiveCellInfo* activeCellInfo = eclipseCase->eclipseCaseData()->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
+
+    auto mainBoreBranch = RicMswBranchBuilder::buildMainBoreBranchFromGeometry( wellPath,
+                                                                                filteredIntersections,
+                                                                                mainGrid,
+                                                                                perforationIntervals,
+                                                                                valvedIntervals,
+                                                                                infoType,
+                                                                                initialMD,
+                                                                                initialTVD,
+                                                                                branchNumber,
+                                                                                segmentNumber,
+                                                                                1, // outlet = heel (segment 1)
+                                                                                maxSegmentLength,
+                                                                                customSegmentIntervals,
+                                                                                exportDate,
+                                                                                unitSystem,
+                                                                                &cellSegMap,
+                                                                                activeCellInfo );
+
+    const std::string wellNameForExport = wellPath->completionSettings()->wellNameForExport().toStdString();
+
+    // Standalone valves (from valveCollection, not inside perforation intervals)
+    for ( const auto* valve : wellPath->valveCollection()->activeValves() )
+    {
+        if ( exportDate.has_value() && !valve->isActiveOnDate( *exportDate ) ) continue;
+
+        const int segNum = RicMswBranchBuilder::findOutletSegmentForMD( cellSegMap, valve->startMD() );
+        for ( auto& seg : mainBoreBranch.segments )
+        {
+            if ( seg.segmentNumber == segNum )
+            {
+                WsegvalvRow wv;
+                wv.well          = wellNameForExport;
+                wv.segmentNumber = segNum;
+                wv.cv            = valve->flowCoefficient();
+                wv.area          = valve->area( unitSystem );
+                wv.status        = valve->isOpen() ? "OPEN" : "SHUT";
+                wv.description   = valve->name().toStdString();
+                seg.wsegvalvData = wv;
+                break;
+            }
+        }
+    }
+
+    auto valveBranches = RicMswBranchBuilder::buildValveBranchesFromGeometry( wellPath,
+                                                                              filteredIntersections,
+                                                                              mainGrid,
+                                                                              perforationIntervals,
+                                                                              cellSegMap,
+                                                                              infoType,
+                                                                              wellNameForExport,
+                                                                              segmentNumber,
+                                                                              branchNumber,
+                                                                              maxSegmentLength,
+                                                                              customSegmentIntervals,
+                                                                              exportDate,
+                                                                              unitSystem );
+
+    const bool                includeFractures = ( completionType & CompletionType::FRACTURES ) == CompletionType::FRACTURES;
+    std::vector<RigMswBranch> fractureBranches;
+    if ( includeFractures )
+    {
+        fractureBranches =
+            RicMswBranchBuilder::buildFractureBranchesFromGeometry( eclipseCase, wellPath, mainGrid, cellSegMap, infoType, segmentNumber, branchNumber );
+    }
+
+    const bool                includeFishbones = ( completionType & CompletionType::FISHBONES ) == CompletionType::FISHBONES;
+    std::vector<RigMswBranch> fishbonesBranches;
+    if ( includeFishbones )
+    {
+        fishbonesBranches = RicMswBranchBuilder::buildFishbonesBranchesFromGeometry( eclipseCase,
+                                                                                     wellPath,
+                                                                                     mainGrid,
+                                                                                     filteredIntersections,
+                                                                                     cellSegMap,
+                                                                                     infoType,
+                                                                                     wellNameForExport,
+                                                                                     segmentNumber,
+                                                                                     branchNumber,
+                                                                                     unitSystem );
+    }
+
+    // Tie-in child laterals (recursive)
+    std::vector<RigMswBranch> lateralBranches;
+    for ( auto* childWellPath : RicWellPathExportMswTableData::wellPathsWithTieIn( wellPath ) )
+    {
+        const int childOutlet =
+            RicMswBranchBuilder::findOutletSegmentForMD( cellSegMap, childWellPath->wellPathTieIn()->branchValveMeasuredDepth() );
+        auto childBranches =
+            buildLateralBranches( eclipseCase, childWellPath, mainGrid, childOutlet, completionType, exportDate, segmentNumber, branchNumber, unitSystem );
+        lateralBranches.insert( lateralBranches.end(),
+                                std::make_move_iterator( childBranches.begin() ),
+                                std::make_move_iterator( childBranches.end() ) );
+    }
+
+    RigMswWellExportData result;
+    result.header = header;
+    result.branches.push_back( std::move( mainBoreBranch ) );
+    result.branches.insert( result.branches.end(),
+                            std::make_move_iterator( valveBranches.begin() ),
+                            std::make_move_iterator( valveBranches.end() ) );
+    result.branches.insert( result.branches.end(),
+                            std::make_move_iterator( fractureBranches.begin() ),
+                            std::make_move_iterator( fractureBranches.end() ) );
+    result.branches.insert( result.branches.end(),
+                            std::make_move_iterator( fishbonesBranches.begin() ),
+                            std::make_move_iterator( fishbonesBranches.end() ) );
+    result.branches.insert( result.branches.end(),
+                            std::make_move_iterator( lateralBranches.begin() ),
+                            std::make_move_iterator( lateralBranches.end() ) );
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Populate RigMswTableData from a pre-built RigMswWellExportData.
+/// This replaces the recursive tree-based collection functions (collectWelsegsData etc.) with
+/// simple iteration over RigMswSegment objects.
+//--------------------------------------------------------------------------------------------------
+RigMswTableData collectTableData( const RigMswWellExportData& exportData, RiaDefines::EclipseUnitSystem unitSystem )
+{
+    RigMswTableData tableData( exportData.header.well, unitSystem );
+    tableData.setWelsegsHeader( exportData.header );
+
+    auto emitSegment = [&]( const RigMswBranch& branch, const RigMswSegment& seg )
+    {
+        // WELSEGS row
+        WelsegsRow welsegsRow;
+        welsegsRow.segment1       = seg.segmentNumber;
+        welsegsRow.segment2       = seg.segmentNumber;
+        welsegsRow.branch         = branch.branchNumber;
+        welsegsRow.joinSegment    = seg.outletSegmentNumber;
+        welsegsRow.length         = seg.length;
+        welsegsRow.depth          = seg.depth;
+        welsegsRow.diameter       = seg.diameter;
+        welsegsRow.roughness      = seg.roughness;
+        welsegsRow.description    = seg.description;
+        welsegsRow.sourceWellName = seg.sourceWellName;
+        tableData.addWelsegsRow( welsegsRow );
+
+        // COMPSEGS rows
+        for ( const auto& inter : seg.intersections )
+        {
+            CompsegsRow compRow;
+            compRow.i             = inter.i;
+            compRow.j             = inter.j;
+            compRow.k             = inter.k;
+            compRow.branch        = branch.branchNumber;
+            compRow.distanceStart = inter.distanceStart;
+            compRow.distanceEnd   = inter.distanceEnd;
+            compRow.gridName      = inter.gridName;
+            tableData.addCompsegsRow( compRow );
+        }
+
+        // WSEGVALV row
+        if ( seg.wsegvalvData ) tableData.addWsegvalvRow( *seg.wsegvalvData );
+
+        // WSEGAICD row
+        if ( seg.wsegaicdData ) tableData.addWsegaicdRow( *seg.wsegaicdData );
+
+        // WSEGSICD row
+        if ( seg.wsegsicdData ) tableData.addWsegsicdRow( *seg.wsegsicdData );
+    };
+
+    for ( const auto& branch : exportData.branches )
+    {
+        if ( branch.tieInValve ) emitSegment( branch, *branch.tieInValve );
+        for ( const auto& seg : branch.segments )
+            emitSegment( branch, seg );
+        tableData.addMswBranch( branch );
+    }
+    return tableData;
+}
+
+} // namespace RicWellPathExportMswGeometryPath

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h
@@ -1,0 +1,61 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RicWellPathExportMswTableData.h"
+
+#include "CompletionsMsw/RigMswSegment.h"
+#include "CompletionsMsw/RigMswTableData.h"
+
+#include <optional>
+#include <vector>
+
+#include <QDateTime>
+
+class RimEclipseCase;
+class RimWellPath;
+class RigMainGrid;
+
+//--------------------------------------------------------------------------------------------------
+/// Free functions that implement the direct geometry path for MSW export.
+/// These build WELSEGS/COMPSEGS/valve segment data directly from well-path geometry
+//--------------------------------------------------------------------------------------------------
+namespace RicWellPathExportMswGeometryPath
+{
+
+std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                               eclipseCase,
+                                                const RimWellPath*                            wellPath,
+                                                const RigMainGrid*                            mainGrid,
+                                                int                                           outletSegNum,
+                                                RicWellPathExportMswTableData::CompletionType completionType,
+                                                const std::optional<QDateTime>&               exportDate,
+                                                int&                                          segmentNumber,
+                                                int&                                          branchNumber,
+                                                RiaDefines::EclipseUnitSystem                 unitSystem );
+
+RigMswWellExportData buildMswWellExportData( RimEclipseCase*                               eclipseCase,
+                                             const RimWellPath*                            wellPath,
+                                             double                                        maxSegmentLength,
+                                             const std::vector<std::pair<double, double>>& customSegmentIntervals,
+                                             RicWellPathExportMswTableData::CompletionType completionType,
+                                             const std::optional<QDateTime>&               exportDate );
+
+RigMswTableData collectTableData( const RigMswWellExportData& exportData, RiaDefines::EclipseUnitSystem unitSystem );
+
+} // namespace RicWellPathExportMswGeometryPath

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicMswTableDataTools.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicMswTableDataTools.h
@@ -205,4 +205,6 @@ std::vector<std::pair<double, double>> createSubSegmentMDPairs( double          
 
 double tvdFromMeasuredDepth( gsl::not_null<const RimWellPath*> wellPath, double measuredDepth );
 
+inline constexpr double valveSegmentLength = 0.1;
+
 } // namespace RicMswTableDataTools

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
@@ -20,6 +20,7 @@
 
 #include "RiaLogging.h"
 
+#include "MswExport/RicWellPathExportMswGeometryPath.h"
 #include "RicExportCompletionDataSettingsUi.h"
 #include "RicExportFractureCompletionsImpl.h"
 #include "RicMswCompletions.h"
@@ -68,6 +69,57 @@ std::expected<RigMswTableData, std::string>
                                                              bool                            exportCompletionsAfterMainBoreSegments,
                                                              CompletionType                  completionType,
                                                              const std::optional<QDateTime>& exportDate )
+{
+    bool exportAsTree = true; // This can be made configurable if needed, but for now we will always export as tree structure to preserve
+                              // the hierarchy of the well path segments and completions
+
+    if ( exportAsTree )
+    {
+        return extractSingleWellMswDataTree( eclipseCase, wellPath, exportCompletionsAfterMainBoreSegments, completionType, exportDate );
+    }
+    else
+    {
+        return extractSingleWellMswDataGeometry( eclipseCase, wellPath, exportCompletionsAfterMainBoreSegments, completionType, exportDate );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::expected<RigMswTableData, std::string>
+    RicWellPathExportMswTableData::extractSingleWellMswDataGeometry( RimEclipseCase*                 eclipseCase,
+                                                                     RimWellPath*                    wellPath,
+                                                                     bool                            exportCompletionsAfterMainBoreSegments,
+                                                                     CompletionType                  completionType,
+                                                                     const std::optional<QDateTime>& exportDate )
+{
+    if ( !eclipseCase || !wellPath || eclipseCase->eclipseCaseData() == nullptr )
+        return std::unexpected( "Invalid eclipse case or well path provided" );
+
+    auto mswParameters = wellPath->mswCompletionParameters();
+    if ( !mswParameters ) return std::unexpected( "Missing MSW completion parameters" );
+
+    const std::vector<std::pair<double, double>> customSegmentIntervals = mswParameters->getSegmentIntervals();
+    auto                                         wellExportData = RicWellPathExportMswGeometryPath::buildMswWellExportData( eclipseCase,
+                                                                                    wellPath,
+                                                                                    mswParameters->maxSegmentLength(),
+                                                                                    customSegmentIntervals,
+                                                                                    completionType,
+                                                                                    exportDate );
+
+    auto unitSystem = eclipseCase->eclipseCaseData()->unitsType();
+    return RicWellPathExportMswGeometryPath::collectTableData( wellExportData, unitSystem );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::expected<RigMswTableData, std::string>
+    RicWellPathExportMswTableData::extractSingleWellMswDataTree( RimEclipseCase*                 eclipseCase,
+                                                                 RimWellPath*                    wellPath,
+                                                                 bool                            exportCompletionsAfterMainBoreSegments,
+                                                                 CompletionType                  completionType,
+                                                                 const std::optional<QDateTime>& exportDate )
 {
     if ( !eclipseCase || !wellPath || eclipseCase->eclipseCaseData() == nullptr )
     {

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.h
@@ -70,12 +70,39 @@ public:
                                                                                  CompletionType completionType = CompletionType::ALL,
                                                                                  const std::optional<QDateTime>& exportDate = std::nullopt );
 
+    static std::expected<RigMswTableData, std::string> extractSingleWellMswDataTree( RimEclipseCase* eclipseCase,
+                                                                                     RimWellPath*    wellPath,
+                                                                                     bool exportCompletionsAfterMainBoreSegments = true,
+                                                                                     CompletionType completionType = CompletionType::ALL,
+                                                                                     const std::optional<QDateTime>& exportDate = std::nullopt );
+
+    static std::expected<RigMswTableData, std::string>
+        extractSingleWellMswDataGeometry( RimEclipseCase*                 eclipseCase,
+                                          RimWellPath*                    wellPath,
+                                          bool                            exportCompletionsAfterMainBoreSegments = true,
+                                          CompletionType                  completionType                         = CompletionType::ALL,
+                                          const std::optional<QDateTime>& exportDate                             = std::nullopt );
+
     static CompletionType convertFromExportSettings( const class RicExportCompletionDataSettingsUi& settings );
 
     static void generateFishbonesMswExportInfoForWell( const RimEclipseCase* eclipseCase,
                                                        const RimWellPath*    wellPath,
                                                        RicMswExportInfo*     exportInfo,
                                                        RicMswBranch*         branch );
+
+    static std::vector<WellPathCellIntersectionInfo> generateCellSegments( const RimEclipseCase* eclipseCase, const RimWellPath* wellPath );
+
+    static std::vector<WellPathCellIntersectionInfo> filterIntersections( const std::vector<WellPathCellIntersectionInfo>& intersections,
+                                                                          double                                           initialMD,
+                                                                          gsl::not_null<const RigWellPath*>                wellPathGeometry,
+                                                                          gsl::not_null<const RimEclipseCase*>             eclipseCase );
+
+    static std::vector<RimWellPath*> wellPathsWithTieIn( const RimWellPath* wellPath );
+
+    static double computeIntitialMeasuredDepth( const RimEclipseCase*                            eclipseCase,
+                                                const RimWellPath*                               wellPath,
+                                                const RimMswCompletionParameters*                mswParameters,
+                                                const std::vector<WellPathCellIntersectionInfo>& allIntersections );
 
 private:
     static void updateDataForMultipleItemsInSameGridCell( gsl::not_null<RicMswBranch*> branch );
@@ -102,18 +129,6 @@ private:
                                               const std::vector<WellPathCellIntersectionInfo>& cellIntersections,
                                               gsl::not_null<RicMswExportInfo*>                 exportInfo,
                                               gsl::not_null<RicMswBranch*>                     branch );
-
-    static std::vector<WellPathCellIntersectionInfo> generateCellSegments( const RimEclipseCase* eclipseCase, const RimWellPath* wellPath );
-
-    static double computeIntitialMeasuredDepth( const RimEclipseCase*                            eclipseCase,
-                                                const RimWellPath*                               wellPath,
-                                                const RimMswCompletionParameters*                mswParameters,
-                                                const std::vector<WellPathCellIntersectionInfo>& allIntersections );
-
-    static std::vector<WellPathCellIntersectionInfo> filterIntersections( const std::vector<WellPathCellIntersectionInfo>& intersections,
-                                                                          double                                           initialMD,
-                                                                          gsl::not_null<const RigWellPath*>                wellPathGeometry,
-                                                                          gsl::not_null<const RimEclipseCase*>             eclipseCase );
 
     static std::pair<double, double> calculateOverlapWithActiveCells( double startMD,
                                                                       double endMD,
@@ -184,8 +199,6 @@ private:
                                              gsl::not_null<int*>          branchNumber );
 
     static std::unique_ptr<RicMswBranch> createChildMswBranch( const RimWellPath* childWellPath );
-
-    static std::vector<RimWellPath*> wellPathsWithTieIn( const RimWellPath* wellPath );
 };
 
 ENABLE_BITMASK_OPERATORS( RicWellPathExportMswTableData::CompletionType )

--- a/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/CMakeLists_files.cmake
@@ -1,4 +1,5 @@
 set(SOURCE_GROUP_HEADER_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/RigMswSegment.h
     ${CMAKE_CURRENT_LIST_DIR}/RigMswTableRows.h
     ${CMAKE_CURRENT_LIST_DIR}/RigMswTableData.h
     ${CMAKE_CURRENT_LIST_DIR}/RigMswDataFormatter.h

--- a/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswSegment.h
+++ b/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswSegment.h
@@ -1,0 +1,95 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "RigMswTableRows.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+// clang-format off
+
+
+//==================================================================================================
+/// Grid-cell intersection for a single MSW segment.
+/// Used to populate the COMPSEGS (main grid) and COMPSEGL (LGR sub-grid) tables.
+//==================================================================================================
+struct RigMswCellIntersection
+{
+    size_t      i, j, k;        // Grid cell IJK indices (1-based)
+    double      distanceStart;  // Distance from well heel to start of intersection [m or ft]
+    double      distanceEnd;    // Distance from well heel to end of intersection [m or ft]
+    std::string gridName;       // Empty for main grid; LGR name for sub-grids (COMPSEGL)
+};
+
+//==================================================================================================
+/// Primary building block for the MSW export.
+/// Each RigMswSegment corresponds to exactly one row in the WELSEGS table.
+/// Cell intersections (COMPSEGS/COMPSEGL) and optional valve data are embedded.
+/// The branch number lives on the containing RigMswBranch, not here.
+//==================================================================================================
+struct RigMswSegment
+{
+    // WELSEGS fields
+    int    segmentNumber;        // ISEG1 / ISEG2
+    int    outletSegmentNumber;  // ISEG3 (parent/outlet segment)
+
+    double                length;    // LENGTH (incremental or absolute MD)
+    double                depth;     // DEPTH  (incremental or absolute TVD)
+    std::optional<double> diameter;  // ID      (liner inner diameter)
+    std::optional<double> roughness; // EPSILON (roughness factor)
+
+    std::string description;     // Comment shown in WELSEGS output
+    std::string sourceWellName;  // Name of the source well path object
+
+    // COMPSEGS / COMPSEGL: grid-cell intersections for this segment
+    std::vector<RigMswCellIntersection> intersections;
+
+    // Valve data — at most one type per segment
+    std::optional<WsegvalvRow> wsegvalvData;  // WSEGVALV: ICV / ICD valves
+    std::optional<WsegaicdRow> wsegaicdData;  // WSEGAICD: Autonomous ICD valves
+    std::optional<WsegsicdRow> wsegsicdData;  // WSEGSICD: Spiral ICD valves
+};
+
+
+//==================================================================================================
+/// One branch in the MSW export.
+/// All segments share the same IBRANCH number, which is stored here rather than per-segment.
+/// An optional tie-in valve segment (ICV) may appear at the start of lateral branches.
+//==================================================================================================
+struct RigMswBranch
+{
+    int                          branchNumber;  // IBRANCH for all segments in this branch
+    std::optional<RigMswSegment> tieInValve;    // Optional ICV at the tie-in point (laterals only)
+    std::vector<RigMswSegment>   segments;      // Segments of this branch
+};
+
+
+//==================================================================================================
+/// Complete pre-computed MSW export data for one well.
+/// Contains all information needed to write WELSEGS, COMPSEGS, and valve tables without
+/// any further tree traversal.
+//==================================================================================================
+struct RigMswWellExportData
+{
+    WelsegsHeader               header;    // WELSEGS well-level header
+    std::vector<RigMswBranch>   branches;  // One entry per branch
+};
+
+// clang-format on

--- a/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswTableData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswTableData.cpp
@@ -80,6 +80,22 @@ void RigMswTableData::addWsegsicdRow( const WsegsicdRow& row )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RigMswTableData::addMswBranch( RigMswBranch branch )
+{
+    m_mswBranches.push_back( std::move( branch ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+const std::vector<RigMswBranch>& RigMswTableData::mswBranches() const
+{
+    return m_mswBranches;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RigMswTableData::hasLgrData() const
 {
     return std::any_of( m_compsegsData.begin(), m_compsegsData.end(), []( const CompsegsRow& row ) { return row.isLgrGrid(); } );

--- a/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswTableData.h
+++ b/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswTableData.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "RiaDefines.h"
+#include "RigMswSegment.h"
 #include "RigMswTableRows.h"
 
 #include <vector>
@@ -46,6 +47,10 @@ public:
     void addWsegvalvRow( const WsegvalvRow& row );
     void addWsegaicdRow( const WsegaicdRow& row );
     void addWsegsicdRow( const WsegsicdRow& row );
+
+    // Branch list — the primary building block for the new MSW export approach
+    void                             addMswBranch( RigMswBranch branch );
+    const std::vector<RigMswBranch>& mswBranches() const;
 
     // Metadata
     std::string                   wellName() const { return m_wellName; }
@@ -78,4 +83,6 @@ private:
     std::vector<WsegvalvRow> m_wsegvalvData;
     std::vector<WsegaicdRow> m_wsegaicdData;
     std::vector<WsegsicdRow> m_wsegsicdData;
+
+    std::vector<RigMswBranch> m_mswBranches;
 };

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -133,6 +133,10 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCalculation-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaConnectorTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellTargetMappingTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicWellPathExportMswGeometryPath-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicMswBranchBuilder-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigMswTableData-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicWellPathExportMswTableData-Test.cpp
 )
 
 if(RESINSIGHT_ENABLE_GRPC)
@@ -211,7 +215,9 @@ target_include_directories(
   ResInsight-tests
   PUBLIC ${CMAKE_BINARY_DIR}/Generated
          "$<TARGET_PROPERTY:ApplicationLibCode,PUBLIC_INCLUDE_DIRECTORIES>"
-         ${RI_PRIVATE_INCLUDES} ${PROJECT_SOURCE_DIR}/Commands
+         ${RI_PRIVATE_INCLUDES}
+         ${PROJECT_SOURCE_DIR}/Commands
+         ${PROJECT_SOURCE_DIR}/Commands/CompletionExportCommands
 )
 
 target_compile_features(ResInsight-tests PRIVATE cxx_std_20)

--- a/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
@@ -1,0 +1,260 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "CompletionExportCommands/MswExport/RicMswBranchBuilder.h"
+
+#include "RifReaderMockModel.h"
+#include "RigEclipseCaseData.h"
+#include "RigMainGrid.h"
+
+using namespace RicMswBranchBuilder;
+
+//==================================================================================================
+// findOutletSegmentForMD tests
+//==================================================================================================
+
+//--------------------------------------------------------------------------------------------------
+/// Empty map returns 1 (heel segment).
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_EmptyMap )
+{
+    std::vector<CellSegmentEntry> map;
+    EXPECT_EQ( 1, findOutletSegmentForMD( map, 500.0 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD falls within the first cell's range.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDInFirstCell )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 }, { 300.0, 400.0, 7 } };
+    EXPECT_EQ( 5, findOutletSegmentForMD( map, 150.0 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD falls within the middle cell's range.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDInMiddleCell )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 }, { 300.0, 400.0, 7 } };
+    EXPECT_EQ( 6, findOutletSegmentForMD( map, 250.0 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD falls within the last cell's range.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDInLastCell )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 }, { 300.0, 400.0, 7 } };
+    EXPECT_EQ( 7, findOutletSegmentForMD( map, 350.0 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD exactly at the start of the first cell — shallower than the first midpoint (100),
+/// so no midpoint is at or below md; fallback = first (shallowest) segment.
+/// MD exactly at the shared boundary (200) — midpoint of first cell (150) is below 200,
+/// midpoint of second cell (250) is above 200; closest-below midpoint is 150 → seg 5.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDAtCellStart )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 } };
+    EXPECT_EQ( 5, findOutletSegmentForMD( map, 100.0 ) ); // shallower than midpoint 150 → first seg
+    EXPECT_EQ( 5, findOutletSegmentForMD( map, 200.0 ) ); // midpoint 150 ≤ 200 < midpoint 250 → seg 5
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD=200 sits between midpoint 150 (seg 5) and midpoint 250 (seg 6).
+/// Closest midpoint at-or-below is 150 → seg 5.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDAtCellEnd_ExclusiveBoundary )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 } };
+    EXPECT_EQ( 5, findOutletSegmentForMD( map, 200.0 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD before all segment midpoints — no midpoint is at or below md;
+/// fallback = first (shallowest) segment.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDBelowAllCells )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 } };
+    EXPECT_EQ( 5, findOutletSegmentForMD( map, 50.0 ) ); // shallower than all midpoints → first seg
+}
+
+//--------------------------------------------------------------------------------------------------
+/// MD beyond the last cell returns the last cell's segment number (fallback).
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_MDBeyondAllCells )
+{
+    std::vector<CellSegmentEntry> map = { { 100.0, 200.0, 5 }, { 200.0, 300.0, 6 }, { 300.0, 400.0, 7 } };
+    EXPECT_EQ( 7, findOutletSegmentForMD( map, 999.0 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Single-cell map.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, FindOutlet_SingleCell )
+{
+    std::vector<CellSegmentEntry> map = { { 0.0, 100.0, 3 } };
+    EXPECT_EQ( 3, findOutletSegmentForMD( map, 50.0 ) );
+    EXPECT_EQ( 3, findOutletSegmentForMD( map, 0.0 ) );
+    EXPECT_EQ( 3, findOutletSegmentForMD( map, 200.0 ) ); // beyond → fallback = 3
+}
+
+//==================================================================================================
+// toMswCellIntersection tests
+//==================================================================================================
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Creates a minimal 2x2x3 mock grid (12 cells, IJK layout: I fast, then J, then K).
+//--------------------------------------------------------------------------------------------------
+cvf::ref<RigEclipseCaseData> makeMockGrid()
+{
+    cvf::ref<RigEclipseCaseData> caseData = new RigEclipseCaseData( nullptr );
+    cvf::ref<RifReaderMockModel> reader   = new RifReaderMockModel;
+    reader->setWorldCoordinates( cvf::Vec3d( 0, 0, 0 ), cvf::Vec3d( 100, 100, 100 ) );
+    reader->setCellCounts( cvf::Vec3st( 2, 2, 3 ) );
+    reader->enableWellData( false );
+    reader->open( "", caseData.p() );
+    caseData->mainGrid()->computeCachedData();
+    return caseData;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Build a minimal WellPathCellIntersectionInfo with only globCellIndex set.
+//--------------------------------------------------------------------------------------------------
+WellPathCellIntersectionInfo makeCellInfo( size_t globCellIndex )
+{
+    WellPathCellIntersectionInfo info{};
+    info.globCellIndex = globCellIndex;
+    return info;
+}
+} // anonymous namespace
+
+//--------------------------------------------------------------------------------------------------
+/// A gap segment (globCellIndex >= totalCellCount) returns nullopt.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, ToMswCellIntersection_GapSegmentReturnsNullopt )
+{
+    auto         caseData = makeMockGrid();
+    RigMainGrid* grid     = caseData->mainGrid();
+
+    // 2x2x3 = 12 cells; index 12 is out of range
+    auto result = toMswCellIntersection( makeCellInfo( 12 ), grid, 0.0, 10.0 );
+    EXPECT_FALSE( result.has_value() );
+
+    auto result2 = toMswCellIntersection( makeCellInfo( 999 ), grid, 0.0, 10.0 );
+    EXPECT_FALSE( result2.has_value() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Cell index 0 is (I=0,J=0,K=0) in 0-based → (1,1,1) in 1-based.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, ToMswCellIntersection_CellZero_OneBasedIJK )
+{
+    auto         caseData = makeMockGrid();
+    RigMainGrid* grid     = caseData->mainGrid();
+
+    auto result = toMswCellIntersection( makeCellInfo( 0 ), grid, 50.0, 60.0 );
+    ASSERT_TRUE( result.has_value() );
+    EXPECT_EQ( 1u, result->i );
+    EXPECT_EQ( 1u, result->j );
+    EXPECT_EQ( 1u, result->k );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Distance parameters are passed through unchanged.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, ToMswCellIntersection_DistancesPassedThrough )
+{
+    auto         caseData = makeMockGrid();
+    RigMainGrid* grid     = caseData->mainGrid();
+
+    auto result = toMswCellIntersection( makeCellInfo( 0 ), grid, 123.4, 567.8 );
+    ASSERT_TRUE( result.has_value() );
+    EXPECT_DOUBLE_EQ( 123.4, result->distanceStart );
+    EXPECT_DOUBLE_EQ( 567.8, result->distanceEnd );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A main-grid cell has an empty gridName.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, ToMswCellIntersection_MainGridHasEmptyGridName )
+{
+    auto         caseData = makeMockGrid();
+    RigMainGrid* grid     = caseData->mainGrid();
+
+    auto result = toMswCellIntersection( makeCellInfo( 0 ), grid, 0.0, 1.0 );
+    ASSERT_TRUE( result.has_value() );
+    EXPECT_TRUE( result->gridName.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// IJK indexing: for a 2x2x3 grid (nI=2, nJ=2, nK=3), globalIdx = i + j*nI + k*nI*nJ.
+/// Cell at (1,0,0) has globalIdx = 1 → (2,1,1) in 1-based.
+/// Cell at (0,1,0) has globalIdx = 2 → (1,2,1) in 1-based.
+/// Cell at (0,0,2) has globalIdx = 8 → (1,1,3) in 1-based.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, ToMswCellIntersection_IJKMapping )
+{
+    auto         caseData = makeMockGrid();
+    RigMainGrid* grid     = caseData->mainGrid();
+
+    // globalIdx=1: i=1,j=0,k=0 → (2,1,1) 1-based
+    auto r1 = toMswCellIntersection( makeCellInfo( 1 ), grid, 0.0, 1.0 );
+    ASSERT_TRUE( r1.has_value() );
+    EXPECT_EQ( 2u, r1->i );
+    EXPECT_EQ( 1u, r1->j );
+    EXPECT_EQ( 1u, r1->k );
+
+    // globalIdx=2: i=0,j=1,k=0 → (1,2,1) 1-based
+    auto r2 = toMswCellIntersection( makeCellInfo( 2 ), grid, 0.0, 1.0 );
+    ASSERT_TRUE( r2.has_value() );
+    EXPECT_EQ( 1u, r2->i );
+    EXPECT_EQ( 2u, r2->j );
+    EXPECT_EQ( 1u, r2->k );
+
+    // globalIdx=8: i=0,j=0,k=2 → (1,1,3) 1-based
+    auto r8 = toMswCellIntersection( makeCellInfo( 8 ), grid, 0.0, 1.0 );
+    ASSERT_TRUE( r8.has_value() );
+    EXPECT_EQ( 1u, r8->i );
+    EXPECT_EQ( 1u, r8->j );
+    EXPECT_EQ( 3u, r8->k );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Dual-porosity: K index is shifted up by cellCountK.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, ToMswCellIntersection_DualPorosity_KShifted )
+{
+    auto         caseData = makeMockGrid();
+    RigMainGrid* grid     = caseData->mainGrid();
+    grid->setDualPorosity( true );
+
+    const size_t cellCountK = grid->cellCountK(); // 3
+
+    // Cell index 0: (i=0,j=0,k=0) → 1-based k = 1 + cellCountK = 4
+    auto result = toMswCellIntersection( makeCellInfo( 0 ), grid, 0.0, 1.0 );
+    ASSERT_TRUE( result.has_value() );
+    EXPECT_EQ( 1u + cellCountK, result->k );
+}

--- a/ApplicationLibCode/UnitTests/RicWellPathExportMswGeometryPath-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicWellPathExportMswGeometryPath-Test.cpp
@@ -1,0 +1,419 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h"
+
+#include "CompletionsMsw/RigMswSegment.h"
+#include "CompletionsMsw/RigMswTableData.h"
+#include "CompletionsMsw/RigMswTableRows.h"
+
+#include "RiaDefines.h"
+
+namespace
+{
+
+//--------------------------------------------------------------------------------------------------
+/// Build a minimal valid RigMswSegment with no intersections or valve data.
+//--------------------------------------------------------------------------------------------------
+RigMswSegment makeSegment( int segNum, int outletSegNum, double length = 10.0, double depth = 5.0 )
+{
+    RigMswSegment seg;
+    seg.segmentNumber       = segNum;
+    seg.outletSegmentNumber = outletSegNum;
+    seg.length              = length;
+    seg.depth               = depth;
+    seg.diameter            = 0.15;
+    seg.roughness           = 1.0e-5;
+    seg.description         = "test segment";
+    seg.sourceWellName      = "TestWell";
+    return seg;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Build a minimal RigMswBranch with the given branch number and segments.
+//--------------------------------------------------------------------------------------------------
+RigMswBranch makeBranch( int branchNum, std::vector<RigMswSegment> segs )
+{
+    return RigMswBranch{ branchNum, std::nullopt, std::move( segs ) };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Build a minimal valid WelsegsHeader.
+//--------------------------------------------------------------------------------------------------
+WelsegsHeader makeHeader( const std::string& wellName = "TestWell" )
+{
+    WelsegsHeader hdr;
+    hdr.well      = wellName;
+    hdr.topDepth  = 100.0;
+    hdr.topLength = 200.0;
+    hdr.infoType  = "INC";
+    return hdr;
+}
+
+} // anonymous namespace
+
+//--------------------------------------------------------------------------------------------------
+/// Empty segment list — returns valid RigMswTableData with no rows; header well name is set.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, EmptySegmentList )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader( "Well_A" );
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    EXPECT_EQ( "Well_A", result.wellName() );
+    EXPECT_EQ( "Well_A", result.welsegsHeader().well );
+    EXPECT_TRUE( result.welsegsData().empty() );
+    EXPECT_TRUE( result.compsegsData().empty() );
+    EXPECT_TRUE( result.wsegvalvData().empty() );
+    EXPECT_TRUE( result.wsegaicdData().empty() );
+    EXPECT_TRUE( result.wsegsicdData().empty() );
+    EXPECT_TRUE( result.mswBranches().empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Single segment with no intersections and no valves — 1 WELSEGS row, 0 COMPSEGS.
+/// Verify all mapped fields.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, SingleSegmentNoIntersections )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg   = makeSegment( 2, 1, 25.0, 12.5 );
+    seg.description     = "main bore";
+    seg.sourceWellName  = "WP_1";
+    exportData.branches = { makeBranch( 1, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 1u, result.welsegsData().size() );
+    EXPECT_TRUE( result.compsegsData().empty() );
+    EXPECT_TRUE( result.wsegvalvData().empty() );
+
+    const WelsegsRow& row = result.welsegsData()[0];
+    EXPECT_EQ( 2, row.segment1 );
+    EXPECT_EQ( 2, row.segment2 );
+    EXPECT_EQ( 1, row.branch );
+    EXPECT_EQ( 1, row.joinSegment );
+    EXPECT_DOUBLE_EQ( 25.0, row.length );
+    EXPECT_DOUBLE_EQ( 12.5, row.depth );
+    EXPECT_TRUE( row.diameter.has_value() );
+    EXPECT_DOUBLE_EQ( 0.15, *row.diameter );
+    EXPECT_TRUE( row.roughness.has_value() );
+    EXPECT_DOUBLE_EQ( 1.0e-5, *row.roughness );
+    EXPECT_EQ( "main bore", row.description );
+    EXPECT_EQ( "WP_1", row.sourceWellName );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Single segment with multiple cell intersections — COMPSEGS count equals intersection count.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, SegmentWithMultipleIntersections )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg = makeSegment( 2, 1 );
+
+    RigMswCellIntersection ci1{ 3, 5, 7, 100.0, 110.0, "" };
+    RigMswCellIntersection ci2{ 3, 5, 8, 110.0, 120.0, "" };
+    RigMswCellIntersection ci3{ 4, 5, 8, 120.0, 130.0, "" };
+    seg.intersections = { ci1, ci2, ci3 };
+
+    exportData.branches = { makeBranch( 1, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 1u, result.welsegsData().size() );
+    ASSERT_EQ( 3u, result.compsegsData().size() );
+
+    const CompsegsRow& r0 = result.compsegsData()[0];
+    EXPECT_EQ( 3u, r0.i );
+    EXPECT_EQ( 5u, r0.j );
+    EXPECT_EQ( 7u, r0.k );
+    EXPECT_EQ( 1, r0.branch );
+    EXPECT_DOUBLE_EQ( 100.0, r0.distanceStart );
+    EXPECT_DOUBLE_EQ( 110.0, r0.distanceEnd );
+    EXPECT_TRUE( r0.isMainGrid() );
+
+    const CompsegsRow& r2 = result.compsegsData()[2];
+    EXPECT_EQ( 4u, r2.i );
+    EXPECT_EQ( 5u, r2.j );
+    EXPECT_EQ( 8u, r2.k );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Main-grid vs LGR intersection — LGR row has non-empty gridName.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, MainGridAndLgrIntersections )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg = makeSegment( 2, 1 );
+
+    RigMswCellIntersection mainGridCell{ 1, 2, 3, 50.0, 60.0, "" };
+    RigMswCellIntersection lgrCell{ 4, 5, 6, 60.0, 70.0, "LGR_NEAR_WELL" };
+    seg.intersections = { mainGridCell, lgrCell };
+
+    exportData.branches = { makeBranch( 1, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 2u, result.compsegsData().size() );
+
+    const CompsegsRow& main = result.compsegsData()[0];
+    EXPECT_TRUE( main.isMainGrid() );
+    EXPECT_TRUE( main.gridName.empty() );
+
+    const CompsegsRow& lgr = result.compsegsData()[1];
+    EXPECT_TRUE( lgr.isLgrGrid() );
+    EXPECT_EQ( "LGR_NEAR_WELL", lgr.gridName );
+    EXPECT_EQ( 4u, lgr.i );
+    EXPECT_EQ( 5u, lgr.j );
+    EXPECT_EQ( 6u, lgr.k );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Segment with wsegvalvData — 1 WSEGVALV row added; no WSEGAICD or WSEGSICD rows.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, SegmentWithWsegvalvData )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg = makeSegment( 3, 2 );
+
+    WsegvalvRow wv;
+    wv.well          = "TestWell";
+    wv.segmentNumber = 3;
+    wv.cv            = 0.75;
+    wv.area          = 1.2e-4;
+    wv.status        = "OPEN";
+    wv.description   = "ICD valve";
+    seg.wsegvalvData = wv;
+
+    exportData.branches = { makeBranch( 2, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 1u, result.welsegsData().size() );
+    ASSERT_EQ( 1u, result.wsegvalvData().size() );
+    EXPECT_TRUE( result.wsegaicdData().empty() );
+    EXPECT_TRUE( result.wsegsicdData().empty() );
+
+    const WsegvalvRow& row = result.wsegvalvData()[0];
+    EXPECT_EQ( "TestWell", row.well );
+    EXPECT_EQ( 3, row.segmentNumber );
+    EXPECT_DOUBLE_EQ( 0.75, row.cv );
+    EXPECT_DOUBLE_EQ( 1.2e-4, row.area );
+    ASSERT_TRUE( row.status.has_value() );
+    EXPECT_EQ( "OPEN", *row.status );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Segment with wsegaicdData — 1 WSEGAICD row added; no WSEGVALV or WSEGSICD rows.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, SegmentWithWsegaicdData )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg = makeSegment( 4, 2 );
+
+    WsegaicdRow aicd;
+    aicd.well             = "TestWell";
+    aicd.segment1         = 4;
+    aicd.segment2         = 4;
+    aicd.strength         = 1.5e-5;
+    aicd.maxAbsRate       = 1000.0;
+    aicd.flowRateExponent = 0.9;
+    aicd.viscExponent     = 0.1;
+    seg.wsegaicdData      = aicd;
+
+    exportData.branches = { makeBranch( 2, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 1u, result.welsegsData().size() );
+    EXPECT_TRUE( result.wsegvalvData().empty() );
+    ASSERT_EQ( 1u, result.wsegaicdData().size() );
+    EXPECT_TRUE( result.wsegsicdData().empty() );
+
+    const WsegaicdRow& row = result.wsegaicdData()[0];
+    EXPECT_EQ( "TestWell", row.well );
+    EXPECT_EQ( 4, row.segment1 );
+    EXPECT_DOUBLE_EQ( 1.5e-5, row.strength );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Segment with wsegsicdData — 1 WSEGSICD row added; no WSEGVALV or WSEGAICD rows.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, SegmentWithWsegsicdData )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg = makeSegment( 5, 3 );
+
+    WsegsicdRow sicd;
+    sicd.well        = "TestWell";
+    sicd.segment1    = 5;
+    sicd.segment2    = 5;
+    sicd.strength    = 2.0e-5;
+    sicd.maxAbsRate  = 500.0;
+    seg.wsegsicdData = sicd;
+
+    exportData.branches = { makeBranch( 3, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 1u, result.welsegsData().size() );
+    EXPECT_TRUE( result.wsegvalvData().empty() );
+    EXPECT_TRUE( result.wsegaicdData().empty() );
+    ASSERT_EQ( 1u, result.wsegsicdData().size() );
+
+    const WsegsicdRow& row = result.wsegsicdData()[0];
+    EXPECT_EQ( "TestWell", row.well );
+    EXPECT_EQ( 5, row.segment1 );
+    EXPECT_DOUBLE_EQ( 2.0e-5, row.strength );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Multiple segments — WELSEGS count equals segment count;
+/// COMPSEGS count equals total intersections across all segments.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, MultipleSegments )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg1 = makeSegment( 2, 1 );
+    seg1.intersections = { RigMswCellIntersection{ 1, 1, 1, 0.0, 10.0, "" }, RigMswCellIntersection{ 1, 1, 2, 10.0, 20.0, "" } };
+
+    RigMswSegment seg2 = makeSegment( 3, 2 );
+    seg2.intersections = { RigMswCellIntersection{ 2, 1, 2, 20.0, 30.0, "" } };
+
+    RigMswSegment seg3 = makeSegment( 4, 3 );
+    // No intersections
+
+    exportData.branches = { makeBranch( 1, { seg1, seg2, seg3 } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    EXPECT_EQ( 3u, result.welsegsData().size() );
+    EXPECT_EQ( 3u, result.compsegsData().size() ); // 2 + 1 + 0
+    ASSERT_EQ( 1u, result.mswBranches().size() );
+    EXPECT_EQ( 3u, result.mswBranches()[0].segments.size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Segment numbering and outlet segment — joinSegment in WelsegsRow matches outletSegmentNumber.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, OutletSegmentNumberMapping )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    // Simulate a chain: 2->1 (heel), 3->2, 4->3
+    RigMswSegment seg2 = makeSegment( 2, 1 );
+    RigMswSegment seg3 = makeSegment( 3, 2 );
+    RigMswSegment seg4 = makeSegment( 4, 3 );
+
+    exportData.branches = { makeBranch( 1, { seg2, seg3, seg4 } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 3u, result.welsegsData().size() );
+    EXPECT_EQ( 2, result.welsegsData()[0].segment1 );
+    EXPECT_EQ( 1, result.welsegsData()[0].joinSegment );
+
+    EXPECT_EQ( 3, result.welsegsData()[1].segment1 );
+    EXPECT_EQ( 2, result.welsegsData()[1].joinSegment );
+
+    EXPECT_EQ( 4, result.welsegsData()[2].segment1 );
+    EXPECT_EQ( 3, result.welsegsData()[2].joinSegment );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// segment1 == segment2 in each WELSEGS row (single-segment entries).
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, Segment1EqualsSegment2 )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    exportData.branches = { makeBranch( 1, { makeSegment( 2, 1 ) } ),
+                            makeBranch( 2, { makeSegment( 5, 2 ) } ),
+                            makeBranch( 3, { makeSegment( 9, 5 ) } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    for ( const auto& row : result.welsegsData() )
+    {
+        EXPECT_EQ( row.segment1, row.segment2 );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// COMPSEGS branch number is inherited from the parent segment's branchNumber.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, CompsegsInheritsBranchFromSegment )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment seg   = makeSegment( 3, 2 ); // branch comes from the enclosing RigMswBranch (branchNumber=7)
+    seg.intersections   = { RigMswCellIntersection{ 1, 2, 3, 10.0, 20.0, "" }, RigMswCellIntersection{ 1, 2, 4, 20.0, 30.0, "" } };
+    exportData.branches = { makeBranch( 7, { seg } ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 2u, result.compsegsData().size() );
+    for ( const auto& row : result.compsegsData() )
+    {
+        EXPECT_EQ( 7, row.branch );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Header fields (topDepth, topLength, infoType) are propagated into the result.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, HeaderFieldsPropagated )
+{
+    WelsegsHeader hdr;
+    hdr.well      = "DeepWell";
+    hdr.topDepth  = 1234.5;
+    hdr.topLength = 2345.6;
+    hdr.infoType  = "ABS";
+
+    RigMswWellExportData exportData;
+    exportData.header = hdr;
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_FIELD );
+
+    EXPECT_EQ( "DeepWell", result.welsegsHeader().well );
+    EXPECT_DOUBLE_EQ( 1234.5, result.welsegsHeader().topDepth );
+    EXPECT_DOUBLE_EQ( 2345.6, result.welsegsHeader().topLength );
+    EXPECT_EQ( "ABS", result.welsegsHeader().infoType );
+    EXPECT_EQ( RiaDefines::EclipseUnitSystem::UNITS_FIELD, result.unitSystem() );
+}

--- a/ApplicationLibCode/UnitTests/RicWellPathExportMswTableData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicWellPathExportMswTableData-Test.cpp
@@ -1,0 +1,222 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RiaApplication.h"
+#include "RiaTestDataDirectory.h"
+
+#include "CompletionExportCommands/RicWellPathExportMswTableData.h"
+
+#include "CompletionsMsw/RigMswDataFormatter.h"
+#include "CompletionsMsw/RigMswTableData.h"
+#include "CompletionsMsw/RigMswTableRows.h"
+
+#include "RifTextDataTableFormatter.h"
+
+#include "RimEclipseCase.h"
+#include "RimProject.h"
+#include "RimWellPath.h"
+
+#include <QDir>
+#include <QFile>
+#include <QTextStream>
+
+#include <algorithm>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+
+//--------------------------------------------------------------------------------------------------
+/// Write MSW table data for one well to a file, creating parent directories as needed.
+//--------------------------------------------------------------------------------------------------
+void writeMswTableDataToFile( const RigMswTableData& tableData, const QString& filePath )
+{
+    QFileInfo fileInfo( filePath );
+    QDir().mkpath( fileInfo.absolutePath() );
+
+    QFile file( filePath );
+    if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) ) return;
+
+    QTextStream               stream( &file );
+    RifTextDataTableFormatter formatter( stream );
+    RigMswDataFormatter::formatMswTables( formatter, tableData );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Write COMPSEGL (LGR) table data to a separate file.
+//--------------------------------------------------------------------------------------------------
+void writeMswLgrTableDataToFile( const RigMswTableData& tableData, const QString& filePath )
+{
+    if ( !tableData.hasLgrData() ) return;
+
+    QFileInfo fileInfo( filePath );
+    QDir().mkpath( fileInfo.absolutePath() );
+
+    QFile file( filePath );
+    if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) ) return;
+
+    QTextStream               stream( &file );
+    RifTextDataTableFormatter formatter( stream );
+    RigMswDataFormatter::formatCompsegsTable( formatter, tableData, true );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extract {i, j, k, gridName} tuples from COMPSEGS data, sorted for stable comparison.
+//--------------------------------------------------------------------------------------------------
+std::vector<std::tuple<size_t, size_t, size_t, std::string>> extractSortedCells( const RigMswTableData& data )
+{
+    std::vector<std::tuple<size_t, size_t, size_t, std::string>> cells;
+    for ( const auto& row : data.compsegsData() )
+    {
+        cells.emplace_back( row.i, row.j, row.k, row.gridName );
+    }
+    std::sort( cells.begin(), cells.end() );
+    return cells;
+}
+
+} // anonymous namespace
+
+//==================================================================================================
+//
+// Parameterized integration tests: Tree mode vs Geometry mode for all MSW project files.
+//
+// The test loads a ResInsight project file, extracts well MSW data using both the tree-based
+// (extractSingleWellMswDataTree) and geometry-based (extractSingleWellMswDataGeometry)
+// algorithms, and verifies that both produce equivalent results for every well path:
+//
+//   - The same set of reservoir cells in COMPSEGS (sorted {i,j,k,gridName} tuples)
+//   - The same number of WSEGVALV, WSEGAICD, and WSEGSICD valve rows
+//
+//==================================================================================================
+
+class MswTreeVsGeometryTest : public testing::TestWithParam<std::string>
+{
+};
+
+TEST_P( MswTreeVsGeometryTest, CompareTreeAndGeometryModes )
+{
+    const std::string& projectFileName = GetParam();
+    QString            projectFilePath =
+        QString( "%1/msw-export/project-files/%2" ).arg( TEST_MODEL_DIR ).arg( QString::fromStdString( projectFileName ) );
+
+    // Strip extension for use as folder name, e.g. "base.rsp" -> "base"
+    const QString projectStem    = QFileInfo( QString::fromStdString( projectFileName ) ).completeBaseName();
+    const QString compareOutBase = QString( "%1/msw-export/compare-output/%2" ).arg( TEST_MODEL_DIR ).arg( projectStem );
+
+    if ( !QFile::exists( projectFilePath ) )
+    {
+        GTEST_SKIP() << "Project file not found: " << projectFilePath.toStdString();
+    }
+
+    bool loaded = RiaApplication::instance()->loadProject( projectFilePath );
+    ASSERT_TRUE( loaded ) << "Failed to load project: " << projectFilePath.toStdString();
+
+    RimProject* project = RiaApplication::instance()->project();
+    ASSERT_NE( project, nullptr );
+
+    auto eclipseCases = project->eclipseCases();
+    ASSERT_FALSE( eclipseCases.empty() ) << "No eclipse cases found in project";
+
+    RimEclipseCase* eclipseCase = eclipseCases[0];
+    ASSERT_NE( eclipseCase, nullptr );
+
+    if ( eclipseCase->eclipseCaseData() == nullptr )
+    {
+        GTEST_SKIP() << "Eclipse case data not loaded — EGRID file may be unavailable";
+    }
+
+    auto wellPaths = project->allWellPaths();
+    ASSERT_FALSE( wellPaths.empty() ) << "No well paths found in project";
+
+    int wellsWithData = 0;
+
+    for ( auto* wellPath : wellPaths )
+    {
+        ASSERT_NE( wellPath, nullptr );
+
+        if ( !wellPath->isTopLevelWellPath() ) continue;
+
+        auto treeResult     = RicWellPathExportMswTableData::extractSingleWellMswDataTree( eclipseCase, wellPath );
+        auto geometryResult = RicWellPathExportMswTableData::extractSingleWellMswDataGeometry( eclipseCase, wellPath );
+
+        // If one mode fails, the other should fail too (no MSW data for this well path).
+        if ( !treeResult.has_value() && !geometryResult.has_value() )
+        {
+            continue;
+        }
+
+        ASSERT_TRUE( treeResult.has_value() ) << "Tree mode failed for well '" << wellPath->name().toStdString()
+                                              << "': " << treeResult.error();
+        ASSERT_TRUE( geometryResult.has_value() )
+            << "Geometry mode failed for well '" << wellPath->name().toStdString() << "': " << geometryResult.error();
+
+        const std::string wellName     = treeResult->wellName();
+        const QString     wellFileName = QString::fromStdString( wellName ) + ".txt";
+
+        // Export both modes to files for side-by-side comparison
+        writeMswTableDataToFile( *treeResult, compareOutBase + "/tree/" + wellFileName );
+        writeMswTableDataToFile( *geometryResult, compareOutBase + "/geometry/" + wellFileName );
+
+        // Export LGR (COMPSEGL) data to separate files if present
+        const QString lgrFileName = QString::fromStdString( wellName ) + "_LGR.txt";
+        writeMswLgrTableDataToFile( *treeResult, compareOutBase + "/tree/" + lgrFileName );
+        writeMswLgrTableDataToFile( *geometryResult, compareOutBase + "/geometry/" + lgrFileName );
+
+        // Both modes must produce data for the same well.
+        EXPECT_EQ( wellName, geometryResult->wellName() ) << "Well name mismatch for: " << wellPath->name().toStdString();
+
+        // Both modes must connect to the same set of reservoir cells.
+        auto treeCells     = extractSortedCells( *treeResult );
+        auto geometryCells = extractSortedCells( *geometryResult );
+
+        EXPECT_EQ( treeCells, geometryCells ) << "COMPSEGS cells differ between Tree and Geometry modes for well '" << wellName << "'";
+
+        // Both modes must produce the same number of valve rows for each valve type.
+        EXPECT_EQ( treeResult->wsegvalvData().size(), geometryResult->wsegvalvData().size() )
+            << "WSEGVALV row count differs for well '" << wellName << "'";
+
+        EXPECT_EQ( treeResult->wsegaicdData().size(), geometryResult->wsegaicdData().size() )
+            << "WSEGAICD row count differs for well '" << wellName << "'";
+
+        EXPECT_EQ( treeResult->wsegsicdData().size(), geometryResult->wsegsicdData().size() )
+            << "WSEGSICD row count differs for well '" << wellName << "'";
+
+        ++wellsWithData;
+    }
+
+    EXPECT_GT( wellsWithData, 0 ) << "No well paths produced MSW data — check project file and well path MSW parameters";
+}
+
+INSTANTIATE_TEST_SUITE_P( MswExportProjectFiles,
+                          MswTreeVsGeometryTest,
+                          testing::Values( "base.rsp",
+                                           "fracture.rsp",
+                                           "perf_lateral.rsp",
+                                           "perf-lgr.rsp",
+                                           "perf_valve.rsp",
+                                           "two_wells.rsp",
+                                           "perf-lgr-two-wells.rsp",
+                                           "perf_aicd.rsp",
+                                           "fishbones.rsp",
+                                           "multiple_laterals.rsp",
+                                           "tie-in-custom-valve-location.rsp",
+                                           "standalone-valve.rsp" ) );

--- a/ApplicationLibCode/UnitTests/RigMswTableData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigMswTableData-Test.cpp
@@ -1,0 +1,300 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "CompletionsMsw/RigMswTableData.h"
+#include "CompletionsMsw/RigMswTableRows.h"
+
+#include "RiaDefines.h"
+
+namespace
+{
+
+constexpr auto METRIC = RiaDefines::EclipseUnitSystem::UNITS_METRIC;
+
+WelsegsRow makeWelsegsRow( int segNum, int joinSeg = 1 )
+{
+    WelsegsRow row;
+    row.segment1    = segNum;
+    row.segment2    = segNum;
+    row.branch      = 1;
+    row.joinSegment = joinSeg;
+    row.length      = 10.0;
+    row.depth       = 5.0;
+    return row;
+}
+
+CompsegsRow makeCompsegsRow( size_t i, size_t j, size_t k, const std::string& gridName = "" )
+{
+    CompsegsRow row;
+    row.i             = i;
+    row.j             = j;
+    row.k             = k;
+    row.branch        = 1;
+    row.distanceStart = 0.0;
+    row.distanceEnd   = 10.0;
+    row.gridName      = gridName;
+    return row;
+}
+
+} // anonymous namespace
+
+//==================================================================================================
+// isEmpty
+//==================================================================================================
+
+TEST( RigMswTableData, IsEmpty_NewObject )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    EXPECT_TRUE( td.isEmpty() );
+}
+
+TEST( RigMswTableData, IsEmpty_WithWelsegsRow )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addWelsegsRow( makeWelsegsRow( 2 ) );
+    EXPECT_FALSE( td.isEmpty() );
+}
+
+TEST( RigMswTableData, IsEmpty_WithCompsegsRow )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1 ) );
+    EXPECT_FALSE( td.isEmpty() );
+}
+
+TEST( RigMswTableData, IsEmpty_WithWsegvalvRow )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    WsegvalvRow     wv;
+    wv.well          = "Well_A";
+    wv.segmentNumber = 2;
+    wv.cv            = 0.5;
+    wv.area          = 1e-4;
+    td.addWsegvalvRow( wv );
+    EXPECT_FALSE( td.isEmpty() );
+}
+
+TEST( RigMswTableData, IsEmpty_WithWsegaicdRow )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    WsegaicdRow     aicd;
+    aicd.well             = "Well_A";
+    aicd.segment1         = 2;
+    aicd.segment2         = 2;
+    aicd.strength         = 1e-5;
+    aicd.maxAbsRate       = 1000.0;
+    aicd.flowRateExponent = 0.9;
+    aicd.viscExponent     = 0.1;
+    td.addWsegaicdRow( aicd );
+    EXPECT_FALSE( td.isEmpty() );
+}
+
+// isEmpty() does not check wsegsicdData — document that behaviour explicitly.
+TEST( RigMswTableData, IsEmpty_WsegsicdOnlyIsConsideredEmpty )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    WsegsicdRow     sicd;
+    sicd.well       = "Well_A";
+    sicd.segment1   = 2;
+    sicd.segment2   = 2;
+    sicd.strength   = 2e-5;
+    sicd.maxAbsRate = 500.0;
+    td.addWsegsicdRow( sicd );
+
+    // isEmpty() does not inspect wsegsicdData, so it returns true even though
+    // there is a WSEGSICD row present.
+    EXPECT_TRUE( td.isEmpty() );
+    EXPECT_FALSE( td.wsegsicdData().empty() ); // data IS there
+}
+
+//==================================================================================================
+// hasLgrData / mainGridCompsegsData / lgrCompsegsData
+//==================================================================================================
+
+TEST( RigMswTableData, HasLgrData_NoCompsegs )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    EXPECT_FALSE( td.hasLgrData() );
+}
+
+TEST( RigMswTableData, HasLgrData_OnlyMainGrid )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1, "" ) );
+    td.addCompsegsRow( makeCompsegsRow( 2, 1, 1, "" ) );
+    EXPECT_FALSE( td.hasLgrData() );
+}
+
+TEST( RigMswTableData, HasLgrData_OneLgrRow )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1, "" ) );
+    td.addCompsegsRow( makeCompsegsRow( 2, 1, 1, "LGR1" ) );
+    EXPECT_TRUE( td.hasLgrData() );
+}
+
+TEST( RigMswTableData, HasLgrData_AllLgrRows )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1, "LGR1" ) );
+    td.addCompsegsRow( makeCompsegsRow( 2, 1, 1, "LGR2" ) );
+    EXPECT_TRUE( td.hasLgrData() );
+}
+
+TEST( RigMswTableData, MainGridCompsegsData_FiltersCorrectly )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1, "" ) );
+    td.addCompsegsRow( makeCompsegsRow( 2, 1, 1, "LGR1" ) );
+    td.addCompsegsRow( makeCompsegsRow( 3, 1, 1, "" ) );
+
+    auto mainRows = td.mainGridCompsegsData();
+    ASSERT_EQ( 2u, mainRows.size() );
+    EXPECT_EQ( 1u, mainRows[0].i );
+    EXPECT_EQ( 3u, mainRows[1].i );
+    for ( const auto& r : mainRows )
+        EXPECT_TRUE( r.isMainGrid() );
+}
+
+TEST( RigMswTableData, LgrCompsegsData_FiltersCorrectly )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1, "" ) );
+    td.addCompsegsRow( makeCompsegsRow( 2, 1, 1, "LGR1" ) );
+    td.addCompsegsRow( makeCompsegsRow( 3, 1, 1, "LGR2" ) );
+
+    auto lgrRows = td.lgrCompsegsData();
+    ASSERT_EQ( 2u, lgrRows.size() );
+    EXPECT_EQ( "LGR1", lgrRows[0].gridName );
+    EXPECT_EQ( "LGR2", lgrRows[1].gridName );
+    for ( const auto& r : lgrRows )
+        EXPECT_TRUE( r.isLgrGrid() );
+}
+
+TEST( RigMswTableData, MainGridAndLgrCompsegsData_NoOverlap )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1, "" ) );
+    td.addCompsegsRow( makeCompsegsRow( 2, 1, 1, "LGR1" ) );
+
+    auto mainRows = td.mainGridCompsegsData();
+    auto lgrRows  = td.lgrCompsegsData();
+
+    EXPECT_EQ( 1u, mainRows.size() );
+    EXPECT_EQ( 1u, lgrRows.size() );
+    EXPECT_EQ( mainRows.size() + lgrRows.size(), td.compsegsData().size() );
+}
+
+//==================================================================================================
+// validationErrors / isValid
+//==================================================================================================
+
+TEST( RigMswTableData, ValidationErrors_EmptyWellName )
+{
+    RigMswTableData td( "", METRIC );
+    td.addWelsegsRow( makeWelsegsRow( 2 ) );
+
+    auto errors = td.validationErrors();
+    EXPECT_FALSE( errors.empty() );
+    bool foundWellNameError = std::any_of( errors.begin(), errors.end(), []( const QString& e ) { return e.contains( "Well name" ); } );
+    EXPECT_TRUE( foundWellNameError );
+    EXPECT_FALSE( td.isValid() );
+}
+
+TEST( RigMswTableData, ValidationErrors_NoWelsegsRows )
+{
+    RigMswTableData td( "Well_A", METRIC );
+
+    auto errors = td.validationErrors();
+    EXPECT_FALSE( errors.empty() );
+    bool foundWelsegsError = std::any_of( errors.begin(), errors.end(), []( const QString& e ) { return e.contains( "WELSEGS" ); } );
+    EXPECT_TRUE( foundWelsegsError );
+    EXPECT_FALSE( td.isValid() );
+}
+
+TEST( RigMswTableData, ValidationErrors_DuplicateSegmentNumber )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addWelsegsRow( makeWelsegsRow( 2 ) );
+    td.addWelsegsRow( makeWelsegsRow( 3 ) );
+    td.addWelsegsRow( makeWelsegsRow( 2 ) ); // duplicate
+
+    auto errors = td.validationErrors();
+    EXPECT_FALSE( errors.empty() );
+    bool foundDuplicateError =
+        std::any_of( errors.begin(), errors.end(), []( const QString& e ) { return e.contains( "Duplicate" ) || e.contains( "2" ); } );
+    EXPECT_TRUE( foundDuplicateError );
+    EXPECT_FALSE( td.isValid() );
+}
+
+TEST( RigMswTableData, ValidationErrors_MultipleErrors )
+{
+    // Empty well name AND no WELSEGS → two separate errors
+    RigMswTableData td( "", METRIC );
+
+    auto errors = td.validationErrors();
+    EXPECT_GE( errors.size(), 2u );
+    EXPECT_FALSE( td.isValid() );
+}
+
+TEST( RigMswTableData, IsValid_ValidData )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    td.addWelsegsRow( makeWelsegsRow( 2, 1 ) );
+    td.addWelsegsRow( makeWelsegsRow( 3, 2 ) );
+
+    EXPECT_TRUE( td.validationErrors().empty() );
+    EXPECT_TRUE( td.isValid() );
+}
+
+//==================================================================================================
+// Metadata accessors
+//==================================================================================================
+
+TEST( RigMswTableData, WellNameAndUnitSystem )
+{
+    RigMswTableData td( "MyWell", RiaDefines::EclipseUnitSystem::UNITS_FIELD );
+    EXPECT_EQ( "MyWell", td.wellName() );
+    EXPECT_EQ( RiaDefines::EclipseUnitSystem::UNITS_FIELD, td.unitSystem() );
+}
+
+TEST( RigMswTableData, HasWelsegsData_HasCompsegsData_HasValveData )
+{
+    RigMswTableData td( "Well_A", METRIC );
+    EXPECT_FALSE( td.hasWelsegsData() );
+    EXPECT_FALSE( td.hasCompsegsData() );
+    EXPECT_FALSE( td.hasWsegvalvData() );
+    EXPECT_FALSE( td.hasWsegaicdData() );
+    EXPECT_FALSE( td.hasWsegsicdData() );
+
+    td.addWelsegsRow( makeWelsegsRow( 2 ) );
+    EXPECT_TRUE( td.hasWelsegsData() );
+
+    td.addCompsegsRow( makeCompsegsRow( 1, 1, 1 ) );
+    EXPECT_TRUE( td.hasCompsegsData() );
+
+    WsegvalvRow wv;
+    wv.well          = "Well_A";
+    wv.segmentNumber = 2;
+    wv.cv            = 0.5;
+    wv.area          = 1e-4;
+    td.addWsegvalvRow( wv );
+    EXPECT_TRUE( td.hasWsegvalvData() );
+}

--- a/TestModels/msw-export/.gitignore
+++ b/TestModels/msw-export/.gitignore
@@ -1,1 +1,2 @@
 output
+compare-output

--- a/TestModels/msw-export/project-files/multiple_laterals.rsp
+++ b/TestModels/msw-export/project-files/multiple_laterals.rsp
@@ -1,0 +1,3991 @@
+<?xml version="1.0"?>
+<ResInsightProject>
+    <DocumentFileName>C:/gitroot/ResInsight/TestModels/msw-export/project-files/multiple_laterals.rsp</DocumentFileName>
+    <ProjectFileVersionString>2025.12.0</ProjectFileVersionString>
+    <ReferencedExternalFiles>
+        $PathId_001$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.EGRID;
+        $PathId_002$ $PathId_008$/BASE_MODEL_1.EGRID;
+        $PathId_002_Name$ BASE_MODEL_1 - Opm Flow Simulation;
+        $PathId_003$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.SMSPEC;
+        $PathId_004$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.RFT;
+        $PathId_005$ $PathId_008$/BASE_MODEL_1.SMSPEC;
+        $PathId_006$ $PathId_008$/BASE_MODEL_1.RFT;
+        $PathId_007$ C:/gitroot/ResInsight/TestModels/msw-export/BASE_MODEL_1.DATA;
+        $PathId_008$ C:/gitroot/ResInsight/TestModels/msw-export/output;
+        $PathId_009$ C:/Users/MagneSjaastad;
+    </ReferencedExternalFiles>
+    <EnsembleFileSetCollection>
+        <EnsembleFileSetCollection>
+            <FileSets/>
+        </EnsembleFileSetCollection>
+    </EnsembleFileSetCollection>
+    <OilFields>
+        <ResInsightOilField>
+            <AnalysisModels>
+                <ResInsightAnalysisModels>
+                    <Reservoirs>
+                        <EclipseCase>
+                            <Name>BASE_MODEL_1</Name>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <Id>0</Id>
+                            <FilePath>$PathId_001$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>2</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Polyline</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <CameraPositionProxy>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPositionProxy>
+                                            <CameraPointOfInterestProxy>0 0 0</CameraPointOfInterestProxy>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>400</Width>
+                                                    <Height>400</Height>
+                                                    <IsMaximized>True </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <Id>0</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>0.887413859821513 -0.458102404953474 -0.0513695237716532 -1786.96519872632 0.450269092969932 0.837532339905 0.309511427138467 -2542.12101191402 -0.0987642916884356 -0.297794839090772 0.949507160846185 -6132.15182585478 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>1212.32299477896 2244.11325739229 461.586580071941</CameraPointOfInterest>
+                                            <CameraPositionProxy>0.887413859821513 -0.458102404953474 -0.0513695237716532 -1786.96519872632 0.450269092969932 0.837532339905 0.309511427138467 -2542.12101191402 -0.0987642916884356 -0.297794839090772 0.949507160846185 -6132.15182585478 0 0 0 1</CameraPositionProxy>
+                                            <CameraPointOfInterestProxy>1212.32299477896 2244.11325739229 461.586580071941</CameraPointOfInterestProxy>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Polyline</UserDescription>
+                                                            <Type>CS_POLYLINE</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath></WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points>2178.14013712842 2279.31916920047 -2606.253254059 3346.04282521766 3705.68716983182 -2647.25015118923 4474.7336269588 5197.91817541397 -2686.87083859125 </Points>
+                                                            <PointsUi>2178.14013712842 2279.31916920047 2606.253254059 3346.04282521766 3705.68716983182 2647.25015118923 4474.7336269588 5197.91817541397 2686.87083859125 </PointsUi>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>True </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters>
+                                                        <CellRangeFilter>
+                                                            <UserDescription>Range Filter 1</UserDescription>
+                                                            <Active>True </Active>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <FilterType>INCLUDE</FilterType>
+                                                            <GridIndex>0</GridIndex>
+                                                            <PropagateToSubGrids>True </PropagateToSubGrids>
+                                                            <StartIndexI>1</StartIndexI>
+                                                            <CellCountI>6</CellCountI>
+                                                            <StartIndexJ>1</StartIndexJ>
+                                                            <CellCountJ>8</CellCountJ>
+                                                            <StartIndexK>6</StartIndexK>
+                                                            <CellCountK>1</CellCountK>
+                                                        </CellRangeFilter>
+                                                    </CellFilters>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>True </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase></WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsActive>True </IsActive>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <WellTargetMappings/>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                        <EclipseCase>
+                            <Name>$PathId_002_Name$</Name>
+                            <NameSetting>CUSTOM_NAME</NameSetting>
+                            <Id>1</Id>
+                            <FilePath>$PathId_002$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>3</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Well-1</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <CameraPositionProxy>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPositionProxy>
+                                            <CameraPointOfInterestProxy>0 0 0</CameraPointOfInterestProxy>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>1174</Width>
+                                                    <Height>480</Height>
+                                                    <IsMaximized>True </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <Id>1</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>-0.680664039507489 0.719291506084811 0.138982713297706 -898.943881453335 -0.17691384210483 -0.345485725382072 0.92159704102657 -379.255128571302 0.710913467162534 0.602709998947643 0.36241233336557 -7677.41559943489 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>5.16684795681658 2322.61551929043 598.023098712781</CameraPointOfInterest>
+                                            <CameraPositionProxy>-0.680664039507489 0.719291506084811 0.138982713297706 -898.943881453335 -0.17691384210483 -0.345485725382072 0.92159704102657 -379.255128571302 0.710913467162534 0.602709998947643 0.36241233336557 -7677.41559943489 0 0 0 1</CameraPositionProxy>
+                                            <CameraPointOfInterestProxy>5.16684795681658 2322.61551929043 598.023098712781</CameraPointOfInterestProxy>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Well-1</UserDescription>
+                                                            <Type>CS_WELL_PATH</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath>.. .. .. .. .. .. WellPathCollection 0 WellPaths 0</WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points></Points>
+                                                            <PointsUi></PointsUi>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>True </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters>
+                                                        <CellRangeFilter>
+                                                            <UserDescription>Range Filter 1</UserDescription>
+                                                            <Active>True </Active>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <FilterType>INCLUDE</FilterType>
+                                                            <GridIndex>0</GridIndex>
+                                                            <PropagateToSubGrids>True </PropagateToSubGrids>
+                                                            <StartIndexI>1</StartIndexI>
+                                                            <CellCountI>6</CellCountI>
+                                                            <StartIndexJ>1</StartIndexJ>
+                                                            <CellCountJ>8</CellCountJ>
+                                                            <StartIndexK>7</StartIndexK>
+                                                            <CellCountK>1</CellCountK>
+                                                        </CellRangeFilter>
+                                                    </CellFilters>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>False </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>False </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>False </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>False </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>False </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>False </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>False </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>Well-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.752941191196442 0.752941191196442 0.752941191196442</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>True </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase>.. .. .. .. .. SummaryCaseCollection 0 SummaryCases 1</WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsActive>True </IsActive>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <WellTargetMappings/>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                    </Reservoirs>
+                    <CaseGroups/>
+                    <CaseEnsembles/>
+                </ResInsightAnalysisModels>
+            </AnalysisModels>
+            <GeoMechModels/>
+            <WellPathCollection>
+                <WellPaths>
+                    <Active>True </Active>
+                    <ShowWellPathLabel>True </ShowWellPathLabel>
+                    <WellPathLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellPathLabelColor>
+                    <GlobalWellPathVisibility>ALL_ON</GlobalWellPathVisibility>
+                    <WellPathRadiusScale>0.1</WellPathRadiusScale>
+                    <WellPathClip>True </WellPathClip>
+                    <WellPathClipZDistance>100</WellPathClipZDistance>
+                    <WellPaths>
+                        <ModeledWellPath>
+                            <Name>Well-1</Name>
+                            <AirGap>0</AirGap>
+                            <DatumElevation>0</DatumElevation>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName>Well-1</SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.788235306739807 0.5686274766922 0.788235306739807</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>3100 - 3800</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>3100</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>3800</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves>
+                                                        <WellPathValve>
+                                                            <Name>1 ICD: 3100 - 3800</Name>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ValveTemplate>.. .. .. .. .. .. CompletionTemplateCollection 0 ValveTemplates 0 ValveDefinitions 1</ValveTemplate>
+                                                            <StartMeasuredDepth>3100</StartMeasuredDepth>
+                                                            <ValveLocations>
+                                                                <RimMultipleValveLocations>
+                                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                                    <RangeStart>3100</RangeStart>
+                                                                    <RangeEnd>3800</RangeEnd>
+                                                                    <ValveSpacing>700</ValveSpacing>
+                                                                    <RangeValveCount>1</RangeValveCount>
+                                                                    <LocationOfValves>3100 </LocationOfValves>
+                                                                </RimMultipleValveLocations>
+                                                            </ValveLocations>
+                                                            <EditTemplate>False </EditTemplate>
+                                                            <CreateTemplate>False </CreateTemplate>
+                                                        </WellPathValve>
+                                                    </Valves>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-1</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport>PROD_N</WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                    <MswLinerDiameter>0.152</MswLinerDiameter>
+                                    <MswRoughness>1e-05</MswRoughness>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath></ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>0</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <EditTemplate>False </EditTemplate>
+                                            <CreateTemplate>False </CreateTemplate>
+                                        </WellPathValve>
+                                    </Valve>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>0</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>-29.9498740653398 799.654971524146 41.5302941929508</TargetPoint>
+                                            <TargetPointForDisplay>-29.9498740653398 799.654971524146 41.5302941929508</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>2929.59590165926</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>82.4608803117543</Inclination>
+                                            <EstimatedDogleg1>2.99999998032033</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>82.4608803117543</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1236.9904202153 1260.26083230065 91.6253907017731</TargetPoint>
+                                            <TargetPointForDisplay>1236.9904202153 1260.26083230065 91.6253907017731</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>4278.72842337795</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.9848467503234</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.9848467503234</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>False </IsEnabled>
+                                            <TargetPoint>1929.51139254053 2455.31736287457 120.824833681511</TargetPoint>
+                                            <TargetPointForDisplay>1929.51139254053 2455.31736287457 120.824833681511</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>4276.79051372505</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>36.591018613603</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>88.1528471139157</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>36.591018613603</EstimatedAzimuth>
+                                            <EstimatedInclination>88.1528471139157</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>False </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>True </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>False </AttachedToParentWell>
+                                    <FixedWellPathPoints></FixedWellPathPoints>
+                                    <FixedMeasuredDepths></FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                        <ModeledWellPath>
+                            <Name>Well-A Y1</Name>
+                            <AirGap>0</AirGap>
+                            <DatumElevation>0</DatumElevation>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName>Well-1</SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.788235306739807 0.5686274766922 0.788235306739807</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>3100 - 3800</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>3100</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>3800</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves>
+                                                        <WellPathValve>
+                                                            <Name>1 ICD: 3100 - 3800</Name>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ValveTemplate>.. .. .. .. .. .. CompletionTemplateCollection 0 ValveTemplates 0 ValveDefinitions 1</ValveTemplate>
+                                                            <StartMeasuredDepth>3100</StartMeasuredDepth>
+                                                            <ValveLocations>
+                                                                <RimMultipleValveLocations>
+                                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                                    <RangeStart>3100</RangeStart>
+                                                                    <RangeEnd>3800</RangeEnd>
+                                                                    <ValveSpacing>700</ValveSpacing>
+                                                                    <RangeValveCount>1</RangeValveCount>
+                                                                    <LocationOfValves>3100 </LocationOfValves>
+                                                                </RimMultipleValveLocations>
+                                                            </ValveLocations>
+                                                            <EditTemplate>False </EditTemplate>
+                                                            <CreateTemplate>False </CreateTemplate>
+                                                        </WellPathValve>
+                                                    </Valves>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-A</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport>PROD_N</WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                    <MswLinerDiameter>0.152</MswLinerDiameter>
+                                    <MswRoughness>1e-05</MswRoughness>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath></ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>0</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <EditTemplate>False </EditTemplate>
+                                            <CreateTemplate>False </CreateTemplate>
+                                        </WellPathValve>
+                                    </Valve>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>0</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>-66.680747767422 1771.67924436726 41.5305944053571</TargetPoint>
+                                            <TargetPointForDisplay>-66.680747767422 1771.67924436726 41.5305944053571</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>2929.59621168536</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408675</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>82.4608814024017</Inclination>
+                                            <EstimatedDogleg1>2.9999999803195</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408675</EstimatedAzimuth>
+                                            <EstimatedInclination>82.4608814024017</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1200.25954651322 2232.28510514377 91.6256909141794</TargetPoint>
+                                            <TargetPointForDisplay>1200.25954651322 2232.28510514377 91.6256909141794</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>4278.72873331875</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408675</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.9848467038311</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408675</EstimatedAzimuth>
+                                            <EstimatedInclination>87.9848467038311</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>False </IsEnabled>
+                                            <TargetPoint>1929.51139254053 2455.31736287457 120.824833681511</TargetPoint>
+                                            <TargetPointForDisplay>1929.51139254053 2455.31736287457 120.824833681511</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>4276.79364211089</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>36.591018613603</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>88.1528471139157</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>36.591018613603</EstimatedAzimuth>
+                                            <EstimatedInclination>88.1528471139157</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>False </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>True </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>False </AttachedToParentWell>
+                                    <FixedWellPathPoints></FixedWellPathPoints>
+                                    <FixedMeasuredDepths></FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                        <ModeledWellPath>
+                            <Name>Well-A Y2</Name>
+                            <AirGap>0</AirGap>
+                            <DatumElevation>0</DatumElevation>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName></SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.999000012874603 0.333000004291534 0.999000012874603</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>5608.97 - 5658.97</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>5608.96827136789</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>5658.96827136789</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>0</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>0</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-AY2</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius></DrainageRadius>
+                                    <WellGroupNameForExport></WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                    <MswLinerDiameter>0.152</MswLinerDiameter>
+                                    <MswRoughness>1e-05</MswRoughness>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath>.. .. WellPaths 1</ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>3910.86540565273</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <EditTemplate>False </EditTemplate>
+                                            <CreateTemplate>False </CreateTemplate>
+                                        </WellPathValve>
+                                    </Valve>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>3910.86540565273</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>854.875545746363 2106.71810274452 75.3269616962002</TargetPoint>
+                                            <TargetPointForDisplay>854.875545746363 2106.71810274452 75.3269616962002</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>3910.86540565273</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>True </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408672</Azimuth>
+                                            <UseFixedInclination>True </UseFixedInclination>
+                                            <Inclination>87.6687558785366</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>13.9075217513136</EstimatedDogleg2>
+                                            <EstimatedAzimuth>0</EstimatedAzimuth>
+                                            <EstimatedInclination>0</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1252.15936901406 1559.79704185415 66.2473750356635</TargetPoint>
+                                            <TargetPointForDisplay>1252.15936901406 1559.79704185415 66.2473750356635</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>4658.61568867443</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>111.560681488621</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>89.4717148741383</Inclination>
+                                            <EstimatedDogleg1>6.41851652618612</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>111.560681488621</EstimatedAzimuth>
+                                            <EstimatedInclination>89.4717148741383</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1982.87108380485 2525.86375438885 115.383899965237</TargetPoint>
+                                            <TargetPointForDisplay>1982.87108380485 2525.86375438885 115.383899965237</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>6211.40536462013</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>-7.51487342818931</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>88.2772404338134</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>-7.51487342818931</EstimatedAzimuth>
+                                            <EstimatedInclination>88.2772404338134</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>True </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>True </AttachedToParentWell>
+                                    <FixedWellPathPoints>1811.6088805114 4129.51421896629 0 1811.78500985458 4129.57825213982 -14.6532830225551 1812.15070631508 4129.71120389274 -44.6507592495266 1812.52666740963 4129.84788743209 -74.6480918129894 1812.91289308842 4129.98830273978 -104.645276736311 1813.30938330025 4130.13244979717 -134.642310042878 1813.71613799255 4130.28032858516 -164.639187756098 1814.13315711141 4130.43193908414 -194.635905899399 1814.56044060153 4130.58728127403 -224.63246049623 1814.99798840628 4130.74635513422 -254.628847570061 1815.44580046766 4130.90916064362 -284.625063144385 1815.90387672628 4131.07569778066 -314.621103242718 1816.37221712143 4131.24596652325 -344.616963888599 1816.85082159106 4131.41996684883 -374.61264110559 1817.33969007165 4131.59769873432 -404.608130917278 1817.83882249845 4131.77916215618 -434.603429347275 1818.34821880526 4131.96435709033 -464.598532419218 1818.86787892456 4132.15328351223 -494.593436156771 1819.3978027875 4132.34594139685 -524.588136583622 1819.93799032374 4132.54233071862 -554.582629723488 1820.48844146176 4132.74245145153 -584.576911600113 1821.04915612856 4132.94630356904 -614.57097823727 1821.6201342498 4133.15388704413 -644.564825658757 1822.20137574978 4133.36520184927 -674.558449888406 1822.79288055145 4133.58024795647 -704.551846950074 1823.3946485764 4133.7990253372 -734.545012867652 1824.00667974487 4134.02153396246 -764.537943665059 1824.62897397572 4134.24777380276 -794.530635366246 1825.26153118644 4134.47774482811 -824.523083995196 1825.90435129317 4134.71144700802 -854.515285575924 1826.55743421071 4134.94888031151 -884.507236132477 1827.22077985251 4135.19004470711 -914.498931688937 1827.89438813056 4135.43494016284 -944.490368269418 1828.57825895562 4135.68356664622 -974.48154189807 1829.27239223702 4135.93592412433 -1004.47244859908 1829.97678788273 4136.19201256369 -1034.46308439665 1830.6914457994 4136.45183193036 -1064.45344531506 1831.41636589225 4136.71538218988 -1094.44352737859 1832.15154806522 4136.98266330734 -1124.43332661157 1832.89699222082 4137.25367524729 -1154.42283903836 1833.65269826022 4137.52841797379 -1184.41206068338 1834.41866608329 4137.80689145046 -1214.40098757105 1835.19489558843 4138.08909564034 -1244.38961572587 1835.98138667278 4138.37503050604 -1274.37794117236 1836.77813923205 4138.66469600966 -1304.36595993507 1837.58515316065 4138.95809211278 -1334.35366803862 1838.40242835155 4139.25521877652 -1364.34106150763 1839.22996469645 4139.5560759615 -1394.3281363668 1840.06776208563 4139.86066362781 -1424.31488864086 1840.91582040802 4140.1689817351 -1454.30131435458 1841.77413955121 4140.48103024248 -1484.28740953276 1842.6427194014 4140.79680910858 -1514.27317020027 1843.52155984346 4141.11631829155 -1544.258592382 1844.41066076087 4141.43955774904 -1574.24367210291 1845.31002203579 4141.76652743818 -1604.22840538799 1846.21964354899 4142.09722731563 -1634.21278826227 1847.13952517985 4142.43165733756 -1664.19681675083 1848.06966680646 4142.76981745963 -1694.18048687882 1849.01006830551 4143.11170763701 -1724.1637946714 1849.96072955232 4143.45732782439 -1754.14673615381 1850.92165042089 4143.80667797593 -1784.12930735131 1851.89283078382 4144.15975804533 -1814.11150428924 1852.87427051234 4144.51656798578 -1844.09332299297 1853.86596947638 4144.87710774999 -1874.07475948792 1854.86792754444 4145.24137729014 -1904.05580979957 1855.88014458375 4145.60937655797 -1934.03646995344 1856.90262046008 4145.98110550468 -1964.01673597511 1857.93535503787 4146.356564081 -1993.99660389021 1858.97834818026 4146.73575223714 -2023.97606972442 1860.03159974897 4147.11866992285 -2053.95512950348 1861.09510960434 4147.50531708735 -2083.93377925318 1862.16887760542 4147.8956936794 -2113.91201499936 1862.43839376455 4147.99367834611 -2121.39185439288 1864.24569207528 4148.65073550804 -2151.32682549177 1867.50082695221 4149.83416475778 -2181.12286781509 1872.1951428837 4151.5408193177 -2210.70075269784 1878.31615752798 4153.76616113671 -2239.9818315629 1885.84759490404 4156.50427295709 -2268.8882450502 1894.76942867005 4159.74787404867 -2297.34313004732 1905.05793537406 4163.48833956855 -2325.27082407109 1916.68575753541 4167.71572349483 -2352.59706645662 1929.62197638925 4172.41878507339 -2379.24919581889 1943.83219410049 4177.58501870749 -2405.15634326175 1959.27862522883 4183.2006872105 -2430.24962082071 1975.92019720146 4189.25085833359 -2454.46230463828 1993.71265952646 4195.71944447102 -2477.73001238497 2012.60870145624 4202.58924543767 -2499.99087445399 2032.55807778845 4209.84199420486 -2521.1856984746 2053.50774246962 4217.45840547303 -2541.25812670662 2075.40198964638 4225.41822695193 -2560.1547858975 2098.18260178916 4233.7002932122 -2577.82542920356 2121.78900449454 4242.2825819649 -2594.22306979804 2146.1584275546 4251.14227261953 -2609.30410581062 2171.226071865 4260.25580696472 -2623.02843626625 2196.92528172792 4269.59895181032 -2635.35956771495 2223.18772209177 4279.14686342422 -2646.26471126912 2249.9435602564 4288.87415359271 -2655.71486979029 2277.12165156053 4298.75495712853 -2663.68491499344 2304.64972855776 4308.76300064729 -2670.15365426398 2330.08819523244 4318.01135030703 -2674.74344238364 2358.10328185584 4328.1964499105 -2678.07355973861 2381.80299095993 4336.81266092007 -2679.34202930003 2409.9902554795 4347.06035711821 -2680.02233449386 2438.1771358722 4357.30791366408 -2680.72042631391 2466.36362222466 4367.5553269536 -2681.43630451465 2494.54970462368 4377.80259338275 -2682.16996884432 2522.73537315615 4388.04970934754 -2682.92141904488 2550.92061790915 4398.29667124406 -2683.69065485205 2579.1054289699 4408.54347546843 -2684.47767599528 2607.28979642576 4418.79011841684 -2685.28248219778 2635.47371036424 4429.03659648553 -2686.10507317651 2663.65716087304 4439.2829060708 -2686.94544864213 2691.84013804 4449.52904356902 -2687.80360829912 2720.02263195312 4459.7750053766 -2688.67955184564 2748.2046327006 4470.02078789002 -2689.57327897362 2776.38613037078 4480.26638750584 -2690.48478936873 2804.56711505219 4490.51180062066 -2691.41408271043 2832.74757683356 4500.75702363115 -2692.36115867183 2860.92750580377 4511.00205293406 -2693.32601691988 2889.1068920519 4521.2468849262 -2694.30865711522 2917.28572566724 4531.49151600445 -2695.30907891226 2945.46399673925 4541.73594256576 -2696.32728195917 2973.6416953576 4551.98016100714 -2697.3632658978 3001.81881161216 4562.22416772571 -2698.41703036383 3029.99533559299 4572.46795911861 -2699.48857498665 3058.17125739037 4582.71153158311 -2700.57789938939 3086.34656709481 4592.95488151653 -2701.68500318891 3114.52125479701 4603.19800531625 -2702.80988599588 3142.6953105879 4613.44089937978 -2703.95254741465 3170.86872455862 4623.68356010466 -2705.11298704336 3199.04148680055 4633.92598388854 -2706.29120447386 3227.21358740529 4644.16816712914 -2707.48719929179 3251.64448874622 4653.05020868429 -2708.53980967448 </FixedWellPathPoints>
+                                    <FixedMeasuredDepths>0 14.6544814009895 44.6544814009895 74.6544814009895 104.654481400989 134.654481400989 164.654481400989 194.654481400989 224.654481400989 254.654481400989 284.654481400989 314.654481400989 344.654481400989 374.654481400989 404.654481400989 434.654481400989 464.654481400989 494.654481400989 524.654481400989 554.654481400989 584.654481400989 614.654481400989 644.654481400989 674.654481400989 704.654481400989 734.654481400989 764.654481400989 794.654481400989 824.654481400989 854.654481400989 884.654481400989 914.654481400989 944.654481400989 974.654481400989 1004.65448140099 1034.65448140099 1064.65448140099 1094.65448140099 1124.65448140099 1154.65448140099 1184.65448140099 1214.65448140099 1244.65448140099 1274.65448140099 1304.65448140099 1334.65448140099 1364.65448140099 1394.65448140099 1424.65448140099 1454.65448140099 1484.65448140099 1514.65448140099 1544.65448140099 1574.65448140099 1604.65448140099 1634.65448140099 1664.65448140099 1694.65448140099 1724.65448140099 1754.65448140099 1784.65448140099 1814.65448140099 1844.65448140099 1874.65448140099 1904.65448140099 1934.65448140099 1964.65448140099 1994.65448140099 2024.65448140099 2054.65448140099 2084.65448140099 2114.65448140099 2122.13981621993 2152.13981621993 2182.13981621993 2212.13981621993 2242.13981621993 2272.13981621993 2302.13981621993 2332.13981621993 2362.13981621993 2392.13981621993 2422.13981621993 2452.13981621993 2482.13981621993 2512.13981621993 2542.13981621993 2572.13981621993 2602.13981621993 2632.13981621993 2662.13981621993 2692.13981621993 2722.13981621993 2752.13981621993 2782.13981621993 2812.13981621993 2842.13981621993 2872.13981621993 2902.13981621993 2929.59621168536 2959.59621168536 2984.84872617641 3014.84872617641 3044.84872617641 3074.84872617641 3104.84872617641 3134.84872617641 3164.84872617641 3194.84872617641 3224.84872617641 3254.84872617641 3284.84872617641 3314.84872617641 3344.84872617641 3374.84872617641 3404.84872617641 3434.84872617641 3464.84872617641 3494.84872617641 3524.84872617641 3554.84872617641 3584.84872617641 3614.84872617641 3644.84872617641 3674.84872617641 3704.84872617641 3734.84872617641 3764.84872617641 3794.84872617641 3824.84872617641 3854.84872617641 3884.84872617641 3910.86540565273 </FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                        <ModeledWellPath>
+                            <Name>Well-A Y3</Name>
+                            <AirGap>0</AirGap>
+                            <DatumElevation>0</DatumElevation>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName></SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.999000012874603 0.333000004291534 0.999000012874603</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>6187.96 - 6237.96</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>6187.95897100374</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>6237.95897100374</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>0</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>0</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-AY3</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius></DrainageRadius>
+                                    <WellGroupNameForExport></WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                    <MswLinerDiameter>0.152</MswLinerDiameter>
+                                    <MswRoughness>1e-05</MswRoughness>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath>.. .. WellPaths 2</ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>4970.71455778928</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <EditTemplate>False </EditTemplate>
+                                            <CreateTemplate>False </CreateTemplate>
+                                        </WellPathValve>
+                                    </Valve>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>4970.71455778928</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1558.65413397248 1527.95413689344 72.2661701679885</TargetPoint>
+                                            <TargetPointForDisplay>1558.65413397248 1527.95413689344 72.2661701679885</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>4970.71455778928</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>True </UseFixedAzimuth>
+                                            <Azimuth>80.3640054612327</Azimuth>
+                                            <UseFixedInclination>True </UseFixedInclination>
+                                            <Inclination>88.3750459666982</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>14.9166364261176</EstimatedDogleg2>
+                                            <EstimatedAzimuth>0</EstimatedAzimuth>
+                                            <EstimatedInclination>0</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1717.82369829835 865.792437234034 51.9170327046186</TargetPoint>
+                                            <TargetPointForDisplay>1717.82369829835 865.792437234034 51.9170327046186</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>5721.47475675245</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>169.97838683083</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>91.9915215026354</Inclination>
+                                            <EstimatedDogleg1>1.09168552825495</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>169.97838683083</EstimatedAzimuth>
+                                            <EstimatedInclination>91.9915215026354</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1802.74830325687 -57.1179400321034 13.7042092474994</TargetPoint>
+                                            <TargetPointForDisplay>1802.74830325687 -57.1179400321034 13.7042092474994</TargetPointForDisplay>
+                                            <TargetMeasuredDepth>6649.12914179237</TargetMeasuredDepth>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>174.871871385561</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>92.3708077456533</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>174.871871385561</EstimatedAzimuth>
+                                            <EstimatedInclination>92.3708077456533</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>True </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>True </AttachedToParentWell>
+                                    <FixedWellPathPoints>1811.6088805114 4129.51421896629 0 1811.78500985458 4129.57825213982 -14.6532830225551 1812.15070631508 4129.71120389274 -44.6507592495266 1812.52666740963 4129.84788743209 -74.6480918129894 1812.91289308842 4129.98830273978 -104.645276736311 1813.30938330025 4130.13244979717 -134.642310042878 1813.71613799255 4130.28032858516 -164.639187756098 1814.13315711141 4130.43193908414 -194.635905899399 1814.56044060153 4130.58728127403 -224.63246049623 1814.99798840628 4130.74635513422 -254.628847570061 1815.44580046766 4130.90916064362 -284.625063144385 1815.90387672628 4131.07569778066 -314.621103242718 1816.37221712143 4131.24596652325 -344.616963888599 1816.85082159106 4131.41996684883 -374.61264110559 1817.33969007165 4131.59769873432 -404.608130917278 1817.83882249845 4131.77916215618 -434.603429347275 1818.34821880526 4131.96435709033 -464.598532419218 1818.86787892456 4132.15328351223 -494.593436156771 1819.3978027875 4132.34594139685 -524.588136583622 1819.93799032374 4132.54233071862 -554.582629723488 1820.48844146176 4132.74245145153 -584.576911600113 1821.04915612856 4132.94630356904 -614.57097823727 1821.6201342498 4133.15388704413 -644.564825658757 1822.20137574978 4133.36520184927 -674.558449888406 1822.79288055145 4133.58024795647 -704.551846950074 1823.3946485764 4133.7990253372 -734.545012867652 1824.00667974487 4134.02153396246 -764.537943665059 1824.62897397572 4134.24777380276 -794.530635366246 1825.26153118644 4134.47774482811 -824.523083995196 1825.90435129317 4134.71144700802 -854.515285575924 1826.55743421071 4134.94888031151 -884.507236132477 1827.22077985251 4135.19004470711 -914.498931688937 1827.89438813056 4135.43494016284 -944.490368269418 1828.57825895562 4135.68356664622 -974.48154189807 1829.27239223702 4135.93592412433 -1004.47244859908 1829.97678788273 4136.19201256369 -1034.46308439665 1830.6914457994 4136.45183193036 -1064.45344531506 1831.41636589225 4136.71538218988 -1094.44352737859 1832.15154806522 4136.98266330734 -1124.43332661157 1832.89699222082 4137.25367524729 -1154.42283903836 1833.65269826022 4137.52841797379 -1184.41206068338 1834.41866608329 4137.80689145046 -1214.40098757105 1835.19489558843 4138.08909564034 -1244.38961572587 1835.98138667278 4138.37503050604 -1274.37794117236 1836.77813923205 4138.66469600966 -1304.36595993507 1837.58515316065 4138.95809211278 -1334.35366803862 1838.40242835155 4139.25521877652 -1364.34106150763 1839.22996469645 4139.5560759615 -1394.3281363668 1840.06776208563 4139.86066362781 -1424.31488864086 1840.91582040802 4140.1689817351 -1454.30131435458 1841.77413955121 4140.48103024248 -1484.28740953276 1842.6427194014 4140.79680910858 -1514.27317020027 1843.52155984346 4141.11631829155 -1544.258592382 1844.41066076087 4141.43955774904 -1574.24367210291 1845.31002203579 4141.76652743818 -1604.22840538799 1846.21964354899 4142.09722731563 -1634.21278826227 1847.13952517985 4142.43165733756 -1664.19681675083 1848.06966680646 4142.76981745963 -1694.18048687882 1849.01006830551 4143.11170763701 -1724.1637946714 1849.96072955232 4143.45732782439 -1754.14673615381 1850.92165042089 4143.80667797593 -1784.12930735131 1851.89283078382 4144.15975804533 -1814.11150428924 1852.87427051234 4144.51656798578 -1844.09332299297 1853.86596947638 4144.87710774999 -1874.07475948792 1854.86792754444 4145.24137729014 -1904.05580979957 1855.88014458375 4145.60937655797 -1934.03646995344 1856.90262046008 4145.98110550468 -1964.01673597511 1857.93535503787 4146.356564081 -1993.99660389021 1858.97834818026 4146.73575223714 -2023.97606972442 1860.03159974897 4147.11866992285 -2053.95512950348 1861.09510960434 4147.50531708735 -2083.93377925318 1862.16887760542 4147.8956936794 -2113.91201499936 1862.43839376455 4147.99367834611 -2121.39185439288 1864.24569207528 4148.65073550804 -2151.32682549177 1867.50082695221 4149.83416475778 -2181.12286781509 1872.1951428837 4151.5408193177 -2210.70075269784 1878.31615752798 4153.76616113671 -2239.9818315629 1885.84759490404 4156.50427295709 -2268.8882450502 1894.76942867005 4159.74787404867 -2297.34313004732 1905.05793537406 4163.48833956855 -2325.27082407109 1916.68575753541 4167.71572349483 -2352.59706645662 1929.62197638925 4172.41878507339 -2379.24919581889 1943.83219410049 4177.58501870749 -2405.15634326175 1959.27862522883 4183.2006872105 -2430.24962082071 1975.92019720146 4189.25085833359 -2454.46230463828 1993.71265952646 4195.71944447102 -2477.73001238497 2012.60870145624 4202.58924543767 -2499.99087445399 2032.55807778845 4209.84199420486 -2521.1856984746 2053.50774246962 4217.45840547303 -2541.25812670662 2075.40198964638 4225.41822695193 -2560.1547858975 2098.18260178916 4233.7002932122 -2577.82542920356 2121.78900449454 4242.2825819649 -2594.22306979804 2146.1584275546 4251.14227261953 -2609.30410581062 2171.226071865 4260.25580696472 -2623.02843626625 2196.92528172792 4269.59895181032 -2635.35956771495 2223.18772209177 4279.14686342422 -2646.26471126912 2249.9435602564 4288.87415359271 -2655.71486979029 2277.12165156053 4298.75495712853 -2663.68491499344 2304.64972855776 4308.76300064729 -2670.15365426398 2330.08819523244 4318.01135030703 -2674.74344238364 2358.10328185584 4328.1964499105 -2678.07355973861 2381.80299095993 4336.81266092007 -2679.34202930003 2409.9902554795 4347.06035711821 -2680.02233449386 2438.1771358722 4357.30791366408 -2680.72042631391 2466.36362222466 4367.5553269536 -2681.43630451465 2494.54970462368 4377.80259338275 -2682.16996884432 2522.73537315615 4388.04970934754 -2682.92141904488 2550.92061790915 4398.29667124406 -2683.69065485205 2579.1054289699 4408.54347546843 -2684.47767599528 2607.28979642576 4418.79011841684 -2685.28248219778 2635.47371036424 4429.03659648553 -2686.10507317651 2663.65716087304 4439.2829060708 -2686.94544864213 2691.84013804 4449.52904356902 -2687.80360829912 2720.02263195312 4459.7750053766 -2688.67955184564 2748.2046327006 4470.02078789002 -2689.57327897362 2776.38613037078 4480.26638750584 -2690.48478936873 2804.56711505219 4490.51180062066 -2691.41408271043 2832.74757683356 4500.75702363115 -2692.36115867183 2860.92750580377 4511.00205293406 -2693.32601691988 2889.1068920519 4521.2468849262 -2694.30865711522 2917.28572566724 4531.49151600445 -2695.30907891226 2945.46399673925 4541.73594256576 -2696.32728195917 2973.6416953576 4551.98016100714 -2697.3632658978 3001.81881161216 4562.22416772571 -2698.41703036383 3029.99533559299 4572.46795911861 -2699.48857498665 3058.17125739037 4582.71153158311 -2700.57789938939 3086.34656709481 4592.95488151653 -2701.68500318891 3114.52125479701 4603.19800531625 -2702.80988599588 3142.6953105879 4613.44089937978 -2703.95254741465 3170.86872455862 4623.68356010466 -2705.11298704336 3199.04148680055 4633.92598388854 -2706.29120447386 3227.21358740529 4644.16816712914 -2707.48719929179 3251.64448874622 4653.05020868429 -2708.53980967448 3251.64448874622 4653.05020868429 -2708.53980967448 3260.23485631632 4655.82212435942 -2708.89890515499 3269.005488659 4657.95909614189 -2709.23984646077 3277.9095293215 4659.44970741847 -2709.56081213821 3286.89940912703 4660.28599470896 -2709.86008745196 3295.92710030952 4660.46349021055 -2710.13607354587 3304.94437309843 4659.98124566668 -2710.38729598469 3313.90305338272 4658.84183743306 -2710.61241263119 3322.75528007746 4657.05135271367 -2710.81022081638 3331.45376081812 4654.61935704032 -2710.97966376469 3339.95202461652 4651.55884316949 -2711.11983623975 3348.20467012866 4647.88616166956 -2711.2299893805 3356.16760820801 4643.620933569 -2711.30953470196 3363.79829744852 4638.7859455326 -2711.35804723915 3371.05597145888 4633.40702812532 -2711.37526781744 3377.90185665404 4627.51291781443 -2711.36110443717 3384.2993794001 4621.13510344709 -2711.31563276514 3390.21436140631 4614.3076580235 -2711.23909573039 3395.61520232003 4607.06705666444 -2711.13190222635 3400.47304854927 4599.4519817456 -2710.99462492637 3404.76194741087 4591.50311623993 -2710.82799722423 3408.45898578079 4583.26292637179 -2710.63290931609 3411.54441250574 4574.77543474436 -2710.41040344461 3413.36157835642 4568.59784945584 -2710.23566457208 3488.43486618223 4286.42681777103 -2702.01757922667 3494.15331087564 4267.71423162228 -2701.49029611534 3501.22342004757 4249.46802012912 -2701.01192386582 3509.60742216419 4231.78566232307 -2700.58501814637 3519.26052631603 4214.76162488919 -2700.21185966914 3530.13116151016 4198.48685748476 -2699.8944420056 3542.16125218435 4183.04830684748 -2699.63446093609 3555.28652847148 4168.52845228904 -2699.43330539019 3569.43686955652 4155.00486505544 -2699.29205002647 3584.53667829178 4142.54979390839 -2699.21144949125 3600.50528506908 4131.22977914169 -2699.19193438689 3617.25737879113 4121.10529709459 -2699.23360897141 3634.70346263978 4112.23043706148 -2699.33625060142 3648.92831201392 4106.12914779392 -2699.46022301394 3677.10331223979 4095.83987144258 -2699.76772337063 3705.77721857639 4087.03841941479 -2700.13642329395 3734.87143783956 4079.74891587878 -2700.56531220303 3764.3062247966 4073.99134085704 -2701.05321454319 3794.00090074246 4069.78147546252 -2701.59879300801 3823.87407463443 4067.13085864363 -2702.20055220487 3853.84386617931 4066.04675555682 -2702.85684275362 3883.82813026167 4066.53213765332 -2703.56586580748 3913.74468209783 4068.58567453452 -2704.32567798356 3943.51152249868 4072.20173759859 -2705.13419668948 3955.42307697234 4074.28624283321 -2705.47901814627 </FixedWellPathPoints>
+                                    <FixedMeasuredDepths>0 14.6544814009895 44.6544814009895 74.6544814009895 104.654481400989 134.654481400989 164.654481400989 194.654481400989 224.654481400989 254.654481400989 284.654481400989 314.654481400989 344.654481400989 374.654481400989 404.654481400989 434.654481400989 464.654481400989 494.654481400989 524.654481400989 554.654481400989 584.654481400989 614.654481400989 644.654481400989 674.654481400989 704.654481400989 734.654481400989 764.654481400989 794.654481400989 824.654481400989 854.654481400989 884.654481400989 914.654481400989 944.654481400989 974.654481400989 1004.65448140099 1034.65448140099 1064.65448140099 1094.65448140099 1124.65448140099 1154.65448140099 1184.65448140099 1214.65448140099 1244.65448140099 1274.65448140099 1304.65448140099 1334.65448140099 1364.65448140099 1394.65448140099 1424.65448140099 1454.65448140099 1484.65448140099 1514.65448140099 1544.65448140099 1574.65448140099 1604.65448140099 1634.65448140099 1664.65448140099 1694.65448140099 1724.65448140099 1754.65448140099 1784.65448140099 1814.65448140099 1844.65448140099 1874.65448140099 1904.65448140099 1934.65448140099 1964.65448140099 1994.65448140099 2024.65448140099 2054.65448140099 2084.65448140099 2114.65448140099 2122.13981621993 2152.13981621993 2182.13981621993 2212.13981621993 2242.13981621993 2272.13981621993 2302.13981621993 2332.13981621993 2362.13981621993 2392.13981621993 2422.13981621993 2452.13981621993 2482.13981621993 2512.13981621993 2542.13981621993 2572.13981621993 2602.13981621993 2632.13981621993 2662.13981621993 2692.13981621993 2722.13981621993 2752.13981621993 2782.13981621993 2812.13981621993 2842.13981621993 2872.13981621993 2902.13981621993 2929.59621168536 2959.59621168536 2984.84872617641 3014.84872617641 3044.84872617641 3074.84872617641 3104.84872617641 3134.84872617641 3164.84872617641 3194.84872617641 3224.84872617641 3254.84872617641 3284.84872617641 3314.84872617641 3344.84872617641 3374.84872617641 3404.84872617641 3434.84872617641 3464.84872617641 3494.84872617641 3524.84872617641 3554.84872617641 3584.84872617641 3614.84872617641 3644.84872617641 3674.84872617641 3704.84872617641 3734.84872617641 3764.84872617641 3794.84872617641 3824.84872617641 3854.84872617641 3884.84872617641 3910.86540565273 3910.86540565273 3919.90107046085 3928.93673526896 3937.97240007708 3947.0080648852 3956.04372969332 3965.07939450144 3974.11505930955 3983.15072411767 3992.18638892579 4001.22205373391 4010.25771854203 4019.29338335014 4028.32904815826 4037.36471296638 4046.4003777745 4055.43604258262 4064.47170739074 4073.50737219885 4082.54303700697 4091.57870181509 4100.61436662321 4109.65003143133 4116.09243643799 4408.19520361726 4427.77351339395 4447.35182317064 4466.93013294733 4486.50844272402 4506.08675250071 4525.6650622774 4545.24337205409 4564.82168183078 4584.39999160748 4603.97830138417 4623.55661116086 4643.13492093755 4658.61568867443 4688.61568867443 4718.61568867443 4748.61568867443 4778.61568867443 4808.61568867443 4838.61568867443 4868.61568867443 4898.61568867443 4928.61568867443 4958.61568867443 4970.71455778928 </FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                    </WellPaths>
+                    <WellMeasurements>
+                        <WellMeasurements>
+                            <Measurements/>
+                            <ImportedFiles/>
+                        </WellMeasurements>
+                    </WellMeasurements>
+                </WellPaths>
+            </WellPathCollection>
+            <CompletionTemplateCollection>
+                <CompletionTemplateCollection>
+                    <FractureTemplates>
+                        <FractureTemplateCollection>
+                            <DefaultUnitForTemplates>UNITS_METRIC</DefaultUnitForTemplates>
+                            <FractureDefinitions>
+                                <RimEllipseFractureTemplate>
+                                    <Id>0</Id>
+                                    <UserDescription>Ellipse Fracture Template</UserDescription>
+                                    <UnitSystem>UNITS_METRIC</UnitSystem>
+                                    <Orientation>Transverse</Orientation>
+                                    <UserDefinedPerforationLength>False </UserDefinedPerforationLength>
+                                    <AzimuthAngle>0</AzimuthAngle>
+                                    <SkinFactor>0</SkinFactor>
+                                    <PerforationLength>1</PerforationLength>
+                                    <PerforationEfficiency>1</PerforationEfficiency>
+                                    <WellDiameter>0.216</WellDiameter>
+                                    <ConductivityType>FiniteConductivity</ConductivityType>
+                                    <WellPathDepthAtFracture>25</WellPathDepthAtFracture>
+                                    <FractureContainmentField>
+                                        <FractureContainment>
+                                            <IsUsingFractureContainment>False </IsUsingFractureContainment>
+                                            <TopKLayer>0</TopKLayer>
+                                            <BaseKLayer>0</BaseKLayer>
+                                            <TruncateAtFaults>False </TruncateAtFaults>
+                                            <FaultThrowValue>0</FaultThrowValue>
+                                        </FractureContainment>
+                                    </FractureContainmentField>
+                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                    <FractureWidthType>FractureWidth</FractureWidthType>
+                                    <FractureWidth>0.01</FractureWidth>
+                                    <BetaFactorType>UserDefinedBetaFactor</BetaFactorType>
+                                    <InertialCoefficient>0.006083236</InertialCoefficient>
+                                    <PermeabilityType>FractureConductivity</PermeabilityType>
+                                    <RelativePermeability>1</RelativePermeability>
+                                    <EffectivePermeability>0</EffectivePermeability>
+                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                    <GasViscosity>0.02</GasViscosity>
+                                    <HeightScaleFactor>1</HeightScaleFactor>
+                                    <WidthScaleFactor>1</WidthScaleFactor>
+                                    <DFactorScaleFactor>1</DFactorScaleFactor>
+                                    <ConductivityFactor>1</ConductivityFactor>
+                                    <HalfLength>100</HalfLength>
+                                    <Height>75</Height>
+                                    <Width>0.01</Width>
+                                    <Permeability>100000</Permeability>
+                                </RimEllipseFractureTemplate>
+                            </FractureDefinitions>
+                            <NextValidFractureTemplateId>1</NextValidFractureTemplateId>
+                        </FractureTemplateCollection>
+                    </FractureTemplates>
+                    <StimPlanModelTemplates>
+                        <StimPlanModelTemplateCollection>
+                            <StimPlanModelTemplates/>
+                            <NextValidId>0</NextValidId>
+                        </StimPlanModelTemplateCollection>
+                    </StimPlanModelTemplates>
+                    <ValveTemplates>
+                        <ValveTemplateCollection>
+                            <ValveDefinitions>
+                                <ValveTemplate>
+                                    <Name>AICD: Valve Template #1</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>AICD</CompletionType>
+                                    <UserLabel>Valve Template #1</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICD: Valve Template #2</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICD</CompletionType>
+                                    <UserLabel>Valve Template #2</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICV: Valve Template #3</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICV</CompletionType>
+                                    <UserLabel>Valve Template #3</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                </ValveTemplate>
+                            </ValveDefinitions>
+                            <ValveUnits>UNITS_METRIC</ValveUnits>
+                        </ValveTemplateCollection>
+                    </ValveTemplates>
+                    <FractureGroupStatisticsCollection>
+                        <FractureGroupStatisticsCollection>
+                            <FractureGroupStatistics/>
+                        </FractureGroupStatisticsCollection>
+                    </FractureGroupStatisticsCollection>
+                </CompletionTemplateCollection>
+            </CompletionTemplateCollection>
+            <SummaryCaseCollection>
+                <SummaryCaseCollection>
+                    <SummaryCases>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_003$</SummaryHeaderFilename>
+                            <Id>1</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_004$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_005$</SummaryHeaderFilename>
+                            <Id>2</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_006$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                    </SummaryCases>
+                    <SummaryCaseCollections/>
+                </SummaryCaseCollection>
+            </SummaryCaseCollection>
+            <FormationNamesCollection>
+                <FormationNamesCollectionObject>
+                    <FormationNamesList/>
+                </FormationNamesCollectionObject>
+            </FormationNamesCollection>
+            <ObservedDataCollection>
+                <ObservedDataCollection>
+                    <ObservedDataArray/>
+                    <ObservedFmuRftDataArray/>
+                    <PressureDepthDataArray/>
+                </ObservedDataCollection>
+            </ObservedDataCollection>
+            <AnnotationCollection>
+                <RimAnnotationCollection>
+                    <IsActive>True </IsActive>
+                    <TextAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsActive>True </IsActive>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </TextAnnotations>
+                    <ReachCircleAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsActive>True </IsActive>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </ReachCircleAnnotations>
+                </RimAnnotationCollection>
+            </AnnotationCollection>
+            <EnsembleWellLogsCollection>
+                <EnsembleWellLogsCollection>
+                    <EnsembleWellLogsCollection/>
+                </EnsembleWellLogsCollection>
+            </EnsembleWellLogsCollection>
+            <PolygonCollection>
+                <PolygonCollection>
+                    <Polygons/>
+                    <PolygonFiles/>
+                </PolygonCollection>
+            </PolygonCollection>
+            <SurfaceCollection>
+                <SurfaceCollection>
+                    <SurfaceUserDescription>Surfaces</SurfaceUserDescription>
+                    <SubCollections/>
+                    <SurfacesField/>
+                </SurfaceCollection>
+            </SurfaceCollection>
+            <SeismicCollection>
+                <SeismicDataCollection>
+                    <SeismicData/>
+                    <DifferenceData/>
+                </SeismicDataCollection>
+            </SeismicCollection>
+            <SeismicViewCollection>
+                <SeismicViewCollection>
+                    <Views/>
+                </SeismicViewCollection>
+            </SeismicViewCollection>
+            <EclipseViewCollection>
+                <EclipseViewCollection>
+                    <Views/>
+                </EclipseViewCollection>
+            </EclipseViewCollection>
+            <ContourMaps>
+                <Eclipse2dViewCollection>
+                    <EclipseViews/>
+                </Eclipse2dViewCollection>
+            </ContourMaps>
+            <VfpDataCollection>
+                <RimVfpDataCollection>
+                    <VfpPlots/>
+                </RimVfpDataCollection>
+            </VfpDataCollection>
+            <CloudDataCollection>
+                <RimCloudDataSourceCollection>
+                    <SumoFieldId></SumoFieldId>
+                    <SumoCaseId></SumoCaseId>
+                    <SumoEnsembleNames></SumoEnsembleNames>
+                    <SumoDataSources/>
+                </RimCloudDataSourceCollection>
+            </CloudDataCollection>
+        </ResInsightOilField>
+    </OilFields>
+    <ColorLegendCollection>
+        <ColorLegendCollection>
+            <CustomColorLegends/>
+        </ColorLegendCollection>
+    </ColorLegendCollection>
+    <JobCollection>
+        <JobCollection>
+            <Jobs>
+                <OpmFlowJob>
+                    <Name>BASE_MODEL_1 - Opm Flow Simulation</Name>
+                    <DeckFile>$PathId_007$</DeckFile>
+                    <WorkDirectory>$PathId_008$</WorkDirectory>
+                    <WellPath>$ROOT$ OilFields 0 WellPathCollection 0 WellPaths 0</WellPath>
+                    <EclipseCase>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1</EclipseCase>
+                    <GridEnsemble></GridEnsemble>
+                    <SummaryEnsemble></SummaryEnsemble>
+                    <PauseBeforeRun>False </PauseBeforeRun>
+                    <AddNewWell>True </AddNewWell>
+                    <OpenWellDeckPosition>-1</OpenWellDeckPosition>
+                    <IncludeMswData>False </IncludeMswData>
+                    <AddToEnsemble>False </AddToEnsemble>
+                    <UseRestart>False </UseRestart>
+                    <CurrentRunID>0</CurrentRunID>
+                    <WellGroupName>PROD_N</WellGroupName>
+                    <WellOpenType>AtSelectedDate</WellOpenType>
+                    <WconprodKeyword>
+                        <KeywordWconprod>
+                            <status>OPEN</status>
+                            <target>LRAT</target>
+                            <orat>100</orat>
+                            <wrat>100</wrat>
+                            <grat>100</grat>
+                            <lrat>100</lrat>
+                            <resv>100</resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <alqWell></alqWell>
+                        </KeywordWconprod>
+                    </WconprodKeyword>
+                    <WconinjeKeyword>
+                        <KeywordWconinje>
+                            <type>WAT</type>
+                            <status>OPEN</status>
+                            <target>RATE</target>
+                            <rate></rate>
+                            <resv></resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <rsrvinj></rsrvinj>
+                        </KeywordWconinje>
+                    </WconinjeKeyword>
+                    <JobSettings>
+                        <OpmFlowJobSettings>
+                            <mpiProcesses>2</mpiProcesses>
+                            <threadsPerProcess>2</threadsPerProcess>
+                            <enableEsmry>True </enableEsmry>
+                            <enableTerminalOutput>True </enableTerminalOutput>
+                            <enableTuning>False </enableTuning>
+                            <ignoreKeywords></ignoreKeywords>
+                            <newtonMaxIterations>False  20</newtonMaxIterations>
+                            <parsingStrictness>normal</parsingStrictness>
+                            <relaxedMaxPvFraction>False  0.03</relaxedMaxPvFraction>
+                            <solverMaxTimeStepInDays>False  365</solverMaxTimeStepInDays>
+                            <solverMinTimeStepInDays>False  1e-12</solverMinTimeStepInDays>
+                            <minStrictCnvIter>False  -1</minStrictCnvIter>
+                            <minStrictMbIter>False  -1</minStrictMbIter>
+                            <minTimeStepBasedOnNewtonIterations>False  0</minTimeStepBasedOnNewtonIterations>
+                            <minTimeStepBeforeShuttingProblematicWellsInDays>False  0.01</minTimeStepBeforeShuttingProblematicWellsInDays>
+                            <toleranceCnv>False  0.01</toleranceCnv>
+                            <toleranceCnvEnergy>False  0.01</toleranceCnvEnergy>
+                            <toleranceCnvEnergyRelaxed>False  1</toleranceCnvEnergyRelaxed>
+                            <toleranceCnvRelaxed>False  1</toleranceCnvRelaxed>
+                            <toleranceEnergyBalance>False  1e-07</toleranceEnergyBalance>
+                            <toleranceEnergyBalanceRelaxed>False  1e-06</toleranceEnergyBalanceRelaxed>
+                            <toleranceMb>False  1e-07</toleranceMb>
+                            <toleranceMbRelaxed>False  1e-06</toleranceMbRelaxed>
+                            <tolerancePressureMsWells>False  1000</tolerancePressureMsWells>
+                            <toleranceWellControl>False  1e-07</toleranceWellControl>
+                            <toleranceWells>False  0.0001</toleranceWells>
+                            <wellGroupConstraintsMaxIterations>False  1</wellGroupConstraintsMaxIterations>
+                        </OpmFlowJobSettings>
+                    </JobSettings>
+                    <OpenTimeStep>6</OpenTimeStep>
+                    <EndTimeStep>0</EndTimeStep>
+                    <EndTimeStepEnabled>False </EndTimeStepEnabled>
+                    <AppendNewDates>False </AppendNewDates>
+                    <NewDatesInterval>1</NewDatesInterval>
+                    <NumberOfNewDates>12</NumberOfNewDates>
+                    <DateAppendType>AppendMonths</DateAppendType>
+                </OpmFlowJob>
+            </Jobs>
+        </JobCollection>
+    </JobCollection>
+    <MainPlotCollection>
+        <MainPlotCollection>
+            <Show>True </Show>
+            <WellLogPlotCollection>
+                <WellLogPlotCollection>
+                    <WellLogPlots/>
+                </WellLogPlotCollection>
+            </WellLogPlotCollection>
+            <RftPlotCollection>
+                <WellRftPlotCollection>
+                    <RftPlots/>
+                </WellRftPlotCollection>
+            </RftPlotCollection>
+            <PltPlotCollection>
+                <WellPltPlotCollection>
+                    <PltPlots/>
+                </WellPltPlotCollection>
+            </PltPlotCollection>
+            <SummaryMultiPlotCollection>
+                <RimSummaryMultiPlotCollection>
+                    <MultiSummaryPlots/>
+                    <UseCommonReadoutSettings>False </UseCommonReadoutSettings>
+                    <ReadOutSettings>
+                        <RimSummaryPlotReadOut>
+                            <ReadOutType>NONE</ReadOutType>
+                            <LineAppearance>
+                                <RimAnnotationLineAppearance>
+                                    <LineFieldsHidden>False </LineFieldsHidden>
+                                    <Color>0.250980406999588 0.250980406999588 0.250980406999588</Color>
+                                    <Thickness>2</Thickness>
+                                    <Style>STYLE_DASH</Style>
+                                </RimAnnotationLineAppearance>
+                            </LineAppearance>
+                            <VerticalLineLabelAlignment>LEFT</VerticalLineLabelAlignment>
+                            <HorizontalLineLabelAlignment>LEFT</HorizontalLineLabelAlignment>
+                        </RimSummaryPlotReadOut>
+                    </ReadOutSettings>
+                </RimSummaryMultiPlotCollection>
+            </SummaryMultiPlotCollection>
+            <AnalysisPlotCollection>
+                <AnalysisPlotCollection>
+                    <AnalysisPlots/>
+                </AnalysisPlotCollection>
+            </AnalysisPlotCollection>
+            <CorrelationPlotCollection>
+                <CorrelationPlotCollection>
+                    <CorrelationPlots/>
+                    <CorrelationReports/>
+                </CorrelationPlotCollection>
+            </CorrelationPlotCollection>
+            <SummaryCrossPlotCollection>
+                <SummaryCrossPlotCollection>
+                    <SummaryCrossPlots/>
+                </SummaryCrossPlotCollection>
+            </SummaryCrossPlotCollection>
+            <SummaryTableCollection>
+                <RimSummaryTableCollection>
+                    <SummaryTables/>
+                </RimSummaryTableCollection>
+            </SummaryTableCollection>
+            <FlowPlotCollection>
+                <FlowPlotCollection>
+                    <FlowCharacteristicsPlot>
+                        <FlowCharacteristicsPlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <FlowCase></FlowCase>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeSelectionType>SELECTED</TimeSelectionType>
+                            <SelectedTimeSteps></SelectedTimeSteps>
+                            <SelectedTimeStepsUi></SelectedTimeStepsUi>
+                            <CellPVThreshold>0.1</CellPVThreshold>
+                            <ShowLegend>True </ShowLegend>
+                            <CellFilter>CELLS_ACTIVE</CellFilter>
+                            <CellFilterView></CellFilterView>
+                            <TracerFilter></TracerFilter>
+                            <SelectedTracerNames></SelectedTracerNames>
+                            <MinCommunication>0</MinCommunication>
+                            <MaxTof>146000</MaxTof>
+                        </FlowCharacteristicsPlot>
+                    </FlowCharacteristicsPlot>
+                    <DefaultWellConnectivityTable>
+                        <RimWellConnectivityTable>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>0</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <CurveCase></CurveCase>
+                            <VisibleCellView></VisibleCellView>
+                            <ViewFilterType>FILTER_BY_VISIBLE_PRODUCERS</ViewFilterType>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeStepSelectopn>SINGLE_TIME_STEP</TimeStepSelectopn>
+                            <SelectProducersAndInjectorsForTimeSteps>True </SelectProducersAndInjectorsForTimeSteps>
+                            <ThresholdValue>0</ThresholdValue>
+                            <TimeSampleValueType>FLOW_RATE_FRACTION</TimeSampleValueType>
+                            <TimeStep></TimeStep>
+                            <TimeRangeValueType>ACCUMULATED_FLOW_VOLUME_FRACTION</TimeRangeValueType>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <SelectedProducerTracers></SelectedProducerTracers>
+                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                            <SyncSelectedProdInj>False </SyncSelectedProdInj>
+                            <SyncSelectedInjProd>False </SyncSelectedInjProd>
+                            <ShowValueLabels>False </ShowValueLabels>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisLabelFontSize>Medium</AxisLabelFontSize>
+                            <ValueLabelFontSize>Medium</ValueLabelFontSize>
+                            <LegendConfig>
+                                <Legend>
+                                    <ShowLegend>True </ShowLegend>
+                                    <NumberOfLevels>8</NumberOfLevels>
+                                    <Precision>4</Precision>
+                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 18</ColorLegend>
+                                    <MappingMode>LinearContinuous</MappingMode>
+                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                    <UserDefinedMax>1</UserDefinedMax>
+                                    <UserDefinedMin>0</UserDefinedMin>
+                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                    <ResultVariableUsage></ResultVariableUsage>
+                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                </Legend>
+                            </LegendConfig>
+                            <MappingType>LinearContinuous</MappingType>
+                            <RangeType>AUTOMATIC</RangeType>
+                        </RimWellConnectivityTable>
+                    </DefaultWellConnectivityTable>
+                    <DefaultWellAllocationOverTimePlot>
+                        <RimWellAllocationOverTimePlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>1</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Medium</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <RowSpan>ONE</RowSpan>
+                            <ColSpan>ONE</ColSpan>
+                            <PlotDescription>Default Well Allocation Over Time Plot</PlotDescription>
+                            <CurveCase></CurveCase>
+                            <WellName>None</WellName>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowValueType>FLOW_RATE</FlowValueType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisValueFontSize>Medium</AxisValueFontSize>
+                        </RimWellAllocationOverTimePlot>
+                    </DefaultWellAllocationOverTimePlot>
+                    <DefaultWellAllocationPlot>
+                        <WellAllocationPlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <PlotDescription>Default Flow Diagnostics Plot</PlotDescription>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <BranchDetection>True </BranchDetection>
+                            <CurveCase></CurveCase>
+                            <PlotTimeStep>0</PlotTimeStep>
+                            <WellName>None</WellName>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowType>ACCUMULATED</FlowType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AccumulatedWellFlowPlot>
+                                <WellLogPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>False </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>False </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <TemplateText>$CASE, $WELL</TemplateText>
+                                    <PlotNamingMethod>CUSTOM</PlotNamingMethod>
+                                    <DepthType>CONNECTION_NUMBER</DepthType>
+                                    <DepthUnit>UNIT_NONE</DepthUnit>
+                                    <MinimumDepth>0</MinimumDepth>
+                                    <MaximumDepth>1000</MaximumDepth>
+                                    <ShowDepthGridLines>GRID_X_MAJOR</ShowDepthGridLines>
+                                    <AutoScaleDepthEnabled>True </AutoScaleDepthEnabled>
+                                    <DepthAxisVisibility>ONE_VISIBLE</DepthAxisVisibility>
+                                    <ShowDepthMarkerLine>False </ShowDepthMarkerLine>
+                                    <AutoZoomMinDepthFactor>0</AutoZoomMinDepthFactor>
+                                    <AutoZoomMaxDepthFactor>0</AutoZoomMaxDepthFactor>
+                                    <DepthAnnotations/>
+                                    <SubTitleFontSize>Medium</SubTitleFontSize>
+                                    <AxisTitleFontSize>Medium</AxisTitleFontSize>
+                                    <AxisValueFontSize>Medium</AxisValueFontSize>
+                                    <NameConfig>
+                                        <RimWellLogPlotNameConfig>
+                                            <CustomCurveName>Accumulated Flow Chart</CustomCurveName>
+                                        </RimWellLogPlotNameConfig>
+                                    </NameConfig>
+                                    <FilterEnsembleCurveSet></FilterEnsembleCurveSet>
+                                    <DepthEqualization>NONE</DepthEqualization>
+                                    <Tracks/>
+                                    <DepthOrientation>VERTICAL</DepthOrientation>
+                                </WellLogPlot>
+                            </AccumulatedWellFlowPlot>
+                            <TotalWellFlowPlot>
+                                <TotalWellAllocationPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <PlotDescription>Total Allocation</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                </TotalWellAllocationPlot>
+                            </TotalWellFlowPlot>
+                            <WellAllocLegend>
+                                <WellAllocationPlotLegend>
+                                    <ShowPlotLegend>True </ShowPlotLegend>
+                                </WellAllocationPlotLegend>
+                            </WellAllocLegend>
+                            <TofAccumulatedPhaseFractionsPlot>
+                                <TofAccumulatedPhaseFractionsPlot>
+                                    <WindowController/>
+                                    <ShowWindow>False </ShowWindow>
+                                    <PlotDescription>Cumulative Saturation by Time of Flight</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <MaxTof>50</MaxTof>
+                                </TofAccumulatedPhaseFractionsPlot>
+                            </TofAccumulatedPhaseFractionsPlot>
+                        </WellAllocationPlot>
+                    </DefaultWellAllocationPlot>
+                    <WellDistributionPlotCollection>
+                        <WellDistributionPlotCollection>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>2</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <Case></Case>
+                            <TimeStepIndex>-1</TimeStepIndex>
+                            <WellName>None</WellName>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                            <MaximumTOF>20</MaximumTOF>
+                            <Plots>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>OIL_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>GAS_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>WATER_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                            </Plots>
+                            <ShowOil>True </ShowOil>
+                            <ShowGas>True </ShowGas>
+                            <ShowWater>True </ShowWater>
+                            <PlotDescription>Cumulative Phase Distribution Plots</PlotDescription>
+                        </WellDistributionPlotCollection>
+                    </WellDistributionPlotCollection>
+                    <StoredWellAllocationPlots/>
+                    <StoredFlowCharacteristicsPlots/>
+                </FlowPlotCollection>
+            </FlowPlotCollection>
+            <Rim3dCrossPlotCollection>
+                <RimGridCrossPlotCollection>
+                    <GridCrossPlots/>
+                </RimGridCrossPlotCollection>
+            </Rim3dCrossPlotCollection>
+            <RimSaturationPressurePlotCollection>
+                <RimSaturationPressurePlotCollection>
+                    <SaturationPressurePlots/>
+                </RimSaturationPressurePlotCollection>
+            </RimSaturationPressurePlotCollection>
+            <RimMultiPlotCollection>
+                <RimMultiPlotCollection>
+                    <MultiPlots/>
+                </RimMultiPlotCollection>
+            </RimMultiPlotCollection>
+            <StimPlanModelPlotCollection>
+                <StimPlanModelPlotCollection>
+                    <StimPlanModelPlots/>
+                </StimPlanModelPlotCollection>
+            </StimPlanModelPlotCollection>
+            <VfpPlotCollection>
+                <RimVfpPlotCollection>
+                    <CustomVfpPlots/>
+                </RimVfpPlotCollection>
+            </VfpPlotCollection>
+            <HistogramMultiPlotCollection>
+                <RimHistogramMultiPlotCollection>
+                    <HistogramMultiPlots/>
+                </RimHistogramMultiPlotCollection>
+            </HistogramMultiPlotCollection>
+        </MainPlotCollection>
+    </MainPlotCollection>
+    <PinnedFieldCollection>
+        <RimQuickAccessCollection>
+            <FieldReferencesGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0 RangeFilters 0 CellFilters 0</Object>
+                                    <FieldKeyword>StartIndexK</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0 RangeFilters 0 CellFilters 0</Object>
+                                    <FieldKeyword>StartIndexK</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+            </FieldReferencesGroup>
+        </RimQuickAccessCollection>
+    </PinnedFieldCollection>
+    <LinkedViews>
+        <RimViewLinkerCollection>
+            <Active>True </Active>
+            <ViewLinkers/>
+        </RimViewLinkerCollection>
+    </LinkedViews>
+    <CalculationCollection>
+        <RimSummaryCalculationCollection>
+            <Calculations/>
+        </RimSummaryCalculationCollection>
+    </CalculationCollection>
+    <GridCalculationCollection>
+        <RimGridCalculationCollection>
+            <Calculations/>
+        </RimGridCalculationCollection>
+    </GridCalculationCollection>
+    <MultiSnapshotDefinitions/>
+    <TreeViewStates>-1-110000010;-1-110000020;-1-110000040;-1-1100000;-1-11000;-1-110100040;-1-110100080;-1-1101000110;-1-1101000;-1-11010;-1-110;-1-130002000;-1-1300020;-1-13000;-1-13010003020;-1-1301000303020;-1-13010003030;-1-130100030;-1-1301000;-1-13010;-1-130||-1-110</TreeViewStates>
+    <TreeViewCurrentModelIndexPaths>3 0;1 0;0 0;3 0;2 0;0 0||1 0;0 0</TreeViewCurrentModelIndexPaths>
+    <PlotWindowTreeViewStates>-1-100|-1-100|||</PlotWindowTreeViewStates>
+    <PlotWindowTreeViewCurrentModelIndexPaths>||||</PlotWindowTreeViewCurrentModelIndexPaths>
+    <show3DWindow>True </show3DWindow>
+    <showPlotWindow>False </showPlotWindow>
+    <showPlotWindowOnTopOf3DWindow>False </showPlotWindowOnTopOf3DWindow>
+    <tiled3DWindow>False </tiled3DWindow>
+    <tiledPlotWindow>False </tiledPlotWindow>
+    <DialogData>
+        <RimDialogData>
+            <ExportCarfin>
+                <RicExportCarfinUi>
+                    <CellRange>
+                        <RicCellRangeUi>
+                            <Case></Case>
+                            <GridIndex>0</GridIndex>
+                            <StartIndexI>1</StartIndexI>
+                            <StartIndexJ>1</StartIndexJ>
+                            <StartIndexK>1</StartIndexK>
+                            <CellCountI>1</CellCountI>
+                            <CellCountJ>1</CellCountJ>
+                            <CellCountK>1</CellCountK>
+                        </RicCellRangeUi>
+                    </CellRange>
+                    <ExportFileName></ExportFileName>
+                    <CaseToApply></CaseToApply>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <MaxWellCount>8</MaxWellCount>
+                </RicExportCarfinUi>
+            </ExportCarfin>
+            <ExportCompletionData>
+                <RicExportCompletionDataSettingsUi>
+                    <Folder>C:/gitroot/ResInsight/TestModels/msw-export/output/completion-export</Folder>
+                    <CaseToApply>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0</CaseToApply>
+                    <FileSplit>SPLIT_ON_WELL</FileSplit>
+                    <compdatExport>TRANSMISSIBILITIES</compdatExport>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludeMSW>True </IncludeMSW>
+                    <UseLateralNTG>False </UseLateralNTG>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <IncludeFractures>True </IncludeFractures>
+                    <TransScalingType>False </TransScalingType>
+                    <TransScalingTimeStep>0</TransScalingTimeStep>
+                    <TransScalingWBHPSource>WBHP_SUMMARY</TransScalingWBHPSource>
+                    <TransScalingWBHP>200</TransScalingWBHP>
+                    <ExcludeMainBoreForFishbones>False </ExcludeMainBoreForFishbones>
+                    <ExportDataSourceAsComment>True </ExportDataSourceAsComment>
+                    <ExportWelspec>True </ExportWelspec>
+                    <CompletionWelspecAfterMainBore>True </CompletionWelspecAfterMainBore>
+                    <UseCustomFileName>False </UseCustomFileName>
+                    <CustomFileName></CustomFileName>
+                </RicExportCompletionDataSettingsUi>
+            </ExportCompletionData>
+            <MultipleFractionsData>
+                <RiuCreateMultipleFractionsUi>
+                    <SourceCase></SourceCase>
+                    <MinDistanceFromWellTd>10</MinDistanceFromWellTd>
+                    <MaxFracturesPerWell>10</MaxFracturesPerWell>
+                    <Options/>
+                    <FractureCreationSummary>-- Selected Wells
+
+</FractureCreationSummary>
+                </RiuCreateMultipleFractionsUi>
+            </MultipleFractionsData>
+            <HoloLenseExportToFolderData>
+                <RicHoloLensExportToFolderUi>
+                    <ViewForExport></ViewForExport>
+                    <ExportFolder></ExportFolder>
+                </RicHoloLensExportToFolderUi>
+            </HoloLenseExportToFolderData>
+            <ExportwellPathsData>
+                <RicExportWellPathsUi>
+                    <ExportFolder></ExportFolder>
+                    <MdStepSize>5</MdStepSize>
+                </RicExportWellPathsUi>
+            </ExportwellPathsData>
+            <ExportLgr>
+                <RicExportLgrUi>
+                    <ExportFolder></ExportFolder>
+                    <CaseToApply></CaseToApply>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFractures>True </IncludeFractures>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <SplitType>LGR_PER_COMPLETION</SplitType>
+                </RicExportLgrUi>
+            </ExportLgr>
+            <ExportSectorModel>
+                <RicExportEclipseInputGridUi>
+                    <ExportGrid>True </ExportGrid>
+                    <ExportGridFilename>GRID.GRDECL</ExportGridFilename>
+                    <ExportInLocalCoords>False </ExportInLocalCoords>
+                    <InvisibleCellActnum>False </InvisibleCellActnum>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>2147483647</MinI>
+                    <MinJ>2147483647</MinJ>
+                    <MinK>2147483647</MinK>
+                    <MaxI>-2147483647</MaxI>
+                    <MaxJ>-2147483647</MaxJ>
+                    <MaxK>-2147483647</MaxK>
+                    <ExportFaults>TO_SINGLE_RESULT_FILE</ExportFaults>
+                    <ExportFaultsFilename>FAULTS.GRDECL</ExportFaultsFilename>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <ExportParams>TO_SEPARATE_RESULT_FILES</ExportParams>
+                    <ExportParamsFilename>RESULTS.GRDECL</ExportParamsFilename>
+                    <ExportMainKeywords></ExportMainKeywords>
+                    <WriteEchoInGrdeclFiles>False </WriteEchoInGrdeclFiles>
+                    <ExportFolder>$PathId_009$</ExportFolder>
+                </RicExportEclipseInputGridUi>
+            </ExportSectorModel>
+            <MockModelSettings>
+                <MockModelSettings>
+                    <CellCountX>100</CellCountX>
+                    <CellCountY>100</CellCountY>
+                    <CellCountZ>10</CellCountZ>
+                    <TotalCellCount>0</TotalCellCount>
+                    <ResultCount>3</ResultCount>
+                    <TimeStepCount>10</TimeStepCount>
+                </MockModelSettings>
+            </MockModelSettings>
+            <CreateEnsembleSurfaceUi>
+                <RicCreateEnsembleSurfaceUi>
+                    <Layers></Layers>
+                    <AutoCreateEnsembleSurfaces>False </AutoCreateEnsembleSurfaces>
+                    <MinLayer>0</MinLayer>
+                    <MaxLayer>0</MaxLayer>
+                </RicCreateEnsembleSurfaceUi>
+            </CreateEnsembleSurfaceUi>
+            <CreateEnsembleWellLogUi>
+                <RicCreateEnsembleWellLogUi>
+                    <AutoCreateEnsembleWellLogs>True </AutoCreateEnsembleWellLogs>
+                    <TimeStep>0</TimeStep>
+                    <WellPathSource>FILE</WellPathSource>
+                    <WellPath></WellPath>
+                    <WellFilePath></WellFilePath>
+                    <SelectedProperties></SelectedProperties>
+                </RicCreateEnsembleWellLogUi>
+            </CreateEnsembleWellLogUi>
+            <ExportSectorModelUi>
+                <RicExportSectorModelUi>
+                    <ExportFolder>$PathId_009$</ExportFolder>
+                    <ExportDeckName></ExportDeckName>
+                    <PorvMultiplier>1000000</PorvMultiplier>
+                    <BoundaryCondition>OPERNUM_OPERATER</BoundaryCondition>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>2147483647</MinI>
+                    <MinJ>2147483647</MinJ>
+                    <MinK>2147483647</MinK>
+                    <MaxI>-2147483647</MaxI>
+                    <MaxJ>-2147483647</MaxJ>
+                    <MaxK>-2147483647</MaxK>
+                    <RefineGrid>False </RefineGrid>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <BcpropKeywords/>
+                    <CreateSimulationJob>False </CreateSimulationJob>
+                    <SimulationJobFolder></SimulationJobFolder>
+                    <SimulationJobName></SimulationJobName>
+                    <StartSimulationJobAfterExport>False </StartSimulationJobAfterExport>
+                    <EclipseCase></EclipseCase>
+                    <EclipseView></EclipseView>
+                </RicExportSectorModelUi>
+            </ExportSectorModelUi>
+        </RimDialogData>
+    </DialogData>
+    <TileMode3DWindow>UNDEFINED</TileMode3DWindow>
+    <TileModePlotWindow>UNDEFINED</TileModePlotWindow>
+    <AutomationSettings>
+        <RimAutomationSettings>
+            <CellSelectionDestination></CellSelectionDestination>
+            <CaseReloadIntervalSeconds>15</CaseReloadIntervalSeconds>
+        </RimAutomationSettings>
+    </AutomationSettings>
+</ResInsightProject>

--- a/TestModels/msw-export/project-files/standalone-valve.rsp
+++ b/TestModels/msw-export/project-files/standalone-valve.rsp
@@ -1,0 +1,3641 @@
+<?xml version="1.0"?>
+<ResInsightProject>
+    <DocumentFileName>C:/gitroot/ResInsight/TestModels/msw-export/project-files/standalone-valve.rsp</DocumentFileName>
+    <ProjectFileVersionString>2026.02.1-dev.03</ProjectFileVersionString>
+    <ReferencedExternalFiles>
+        $PathId_001$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.EGRID;
+        $PathId_002$ $PathId_008$/BASE_MODEL_1.EGRID;
+        $PathId_002_Name$ BASE_MODEL_1 - Opm Flow Simulation;
+        $PathId_003$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.SMSPEC;
+        $PathId_004$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.RFT;
+        $PathId_005$ $PathId_008$/BASE_MODEL_1.SMSPEC;
+        $PathId_006$ $PathId_008$/BASE_MODEL_1.RFT;
+        $PathId_007$ C:/gitroot/ResInsight/TestModels/msw-export/BASE_MODEL_1.DATA;
+        $PathId_008$ C:/gitroot/ResInsight/TestModels/msw-export/output;
+        $PathId_009$ C:/Users/MagneSjaastad;
+    </ReferencedExternalFiles>
+    <EnsembleFileSetCollection>
+        <EnsembleFileSetCollection>
+            <FileSets/>
+        </EnsembleFileSetCollection>
+    </EnsembleFileSetCollection>
+    <OilFields>
+        <ResInsightOilField>
+            <AnalysisModels>
+                <ResInsightAnalysisModels>
+                    <Reservoirs>
+                        <EclipseCase>
+                            <Name>BASE_MODEL_1</Name>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <Id>0</Id>
+                            <FilePath>$PathId_001$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>2</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Polyline</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>400</Width>
+                                                    <Height>400</Height>
+                                                    <IsMaximized>True </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <Id>0</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>0.97632950928567 -0.137488647856916 0.166965748009826 -948.850657993147 0.0570241855333973 0.908273139171251 0.414473336807392 -1758.09616328704 -0.208635882729353 -0.395141463744921 0.894614046428551 -1299.84686762372 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>2252.552044791 2881.10392006564 510.877714038926</CameraPointOfInterest>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Polyline</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_POLYLINE</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath></WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points>2178.14013712842 2279.31916920047 -2606.253254059 3346.04282521766 3705.68716983182 -2647.25015118923 4474.7336269588 5197.91817541397 -2686.87083859125 </Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>False </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters/>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>True </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase></WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsActive>True </IsActive>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <WellTargetMappings/>
+                            <ResultAliasNames/>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                        <EclipseCase>
+                            <Name>$PathId_002_Name$</Name>
+                            <NameSetting>CUSTOM_NAME</NameSetting>
+                            <Id>1</Id>
+                            <FilePath>$PathId_002$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>3</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Well-1 Y1</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>4</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Well-1 Y2</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 1</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>400</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>400</Width>
+                                                    <Height>400</Height>
+                                                    <IsMaximized>True </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <Id>1</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>-0.891899207874216 -0.34908711078127 0.287496073155323 1025.67049151023 0.440842266529062 -0.81291993952983 0.380551268499183 764.240017258542 0.100865747579961 0.466153795437947 0.878935003264708 -4146.72916540098 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>1155.63233152165 2050.31529376051 604.435812451607</CameraPointOfInterest>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Well-1 Y1</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_WELL_PATH</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath>.. .. .. .. .. .. WellPathCollection 0 WellPaths 0</WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points></Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Well-1 Y2</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_WELL_PATH</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath>.. .. .. .. .. .. WellPathCollection 0 WellPaths 1</WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points></Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>False </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters>
+                                                        <CellRangeFilter>
+                                                            <UserDescription>Range Filter 1</UserDescription>
+                                                            <Active>False </Active>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <FilterType>INCLUDE</FilterType>
+                                                            <GridIndex>0</GridIndex>
+                                                            <PropagateToSubGrids>True </PropagateToSubGrids>
+                                                            <StartIndexI>4</StartIndexI>
+                                                            <CellCountI>1</CellCountI>
+                                                            <StartIndexJ>1</StartIndexJ>
+                                                            <CellCountJ>8</CellCountJ>
+                                                            <StartIndexK>1</StartIndexK>
+                                                            <CellCountK>7</CellCountK>
+                                                        </CellRangeFilter>
+                                                    </CellFilters>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>False </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>Well-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.752941191196442 0.752941191196442 0.752941191196442</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase>.. .. .. .. .. SummaryCaseCollection 0 SummaryCases 1</WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsActive>True </IsActive>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <WellTargetMappings/>
+                            <ResultAliasNames/>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                    </Reservoirs>
+                    <CaseGroups/>
+                    <CaseEnsembles/>
+                    <ReservoirGridEnsembles/>
+                </ResInsightAnalysisModels>
+            </AnalysisModels>
+            <GeoMechModels/>
+            <WellPathCollection>
+                <WellPaths>
+                    <Active>True </Active>
+                    <ShowWellPathLabel>True </ShowWellPathLabel>
+                    <WellPathLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellPathLabelColor>
+                    <GlobalWellPathVisibility>ALL_ON</GlobalWellPathVisibility>
+                    <WellPathRadiusScale>0.1</WellPathRadiusScale>
+                    <WellPathClip>True </WellPathClip>
+                    <WellPathClipZDistance>100</WellPathClipZDistance>
+                    <WellPaths>
+                        <ModeledWellPath>
+                            <Name>Well-1 Y1</Name>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName>Well-1</SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.788235306739807 0.5686274766922 0.788235306739807</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>1010.74 - 1240.66</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>1010.74416575048</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>1240.66104192543</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Valves>
+                                        <ValveCollection>
+                                            <Name>Valves</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Valves>
+                                                <WellPathValve>
+                                                    <Name>ICV: 250</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ValveTemplate>.. .. .. .. .. CompletionTemplateCollection 0 ValveTemplates 0 ValveDefinitions 2</ValveTemplate>
+                                                    <StartMeasuredDepth>250</StartMeasuredDepth>
+                                                    <IsOpen>True </IsOpen>
+                                                    <ValveLocations>
+                                                        <RimMultipleValveLocations>
+                                                            <LocationMode>VALVE_COUNT</LocationMode>
+                                                            <RangeStart>333.756927776437</RangeStart>
+                                                            <RangeEnd>334.756927776437</RangeEnd>
+                                                            <ValveSpacing>10</ValveSpacing>
+                                                            <RangeValveCount>1</RangeValveCount>
+                                                            <LocationOfValves>333.756927776437 </LocationOfValves>
+                                                        </RimMultipleValveLocations>
+                                                    </ValveLocations>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2026_03_24-15:22:03</StartDate>
+                                                </WellPathValve>
+                                            </Valves>
+                                        </ValveCollection>
+                                    </Valves>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                    <MswSegments>
+                                        <RimMswSegmentCollection>
+                                            <Name>MSW Segments</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Segments/>
+                                        </RimMswSegmentCollection>
+                                    </MswSegments>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-1</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport>PROD_N</WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                            <CustomSegmentIntervals>
+                                                <CustomSegmentIntervalCollection>
+                                                    <Intervals/>
+                                                </CustomSegmentIntervalCollection>
+                                            </CustomSegmentIntervals>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath></ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>0</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <IsOpen>True </IsOpen>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <UseCustomStartDate>False </UseCustomStartDate>
+                                            <StartDate>2026_03_24-14:27:18</StartDate>
+                                        </WellPathValve>
+                                    </Valve>
+                                    <CustomOutletValveMd>False  0</CustomOutletValveMd>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>0</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>-29.9498740653398 799.654971524146 34.569094276821</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.5764369959842</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1236.9904202153 1260.26083230065 91.6253907017731</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.5764369959842</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>False </IsEnabled>
+                                            <TargetPoint>1929.51139254053 2455.31736287457 120.824833681511</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>36.591018613603</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>88.1528471139157</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>36.591018613603</EstimatedAzimuth>
+                                            <EstimatedInclination>88.1528471139157</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>False </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>False </AttachedToParentWell>
+                                    <FixedWellPathPoints></FixedWellPathPoints>
+                                    <FixedMeasuredDepths></FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                        <ModeledWellPath>
+                            <Name>Well-1 Y2</Name>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName></SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.999000012874603 0.333000004291534 0.999000012874603</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>1143.29 - 1193.29</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>1143.28791915069</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>1193.28791915069</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Valves>
+                                        <ValveCollection>
+                                            <Name>Valves</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Valves/>
+                                        </ValveCollection>
+                                    </Valves>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                    <MswSegments>
+                                        <RimMswSegmentCollection>
+                                            <Name>MSW Segments</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Segments/>
+                                        </RimMswSegmentCollection>
+                                    </MswSegments>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-1Y2</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport></WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                            <CustomSegmentIntervals>
+                                                <CustomSegmentIntervalCollection>
+                                                    <Intervals/>
+                                                </CustomSegmentIntervalCollection>
+                                            </CustomSegmentIntervals>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath>.. .. WellPaths 0</ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>593.00764320416</TieInMeasuredDepth>
+                                    <AddValveAtConnection>True </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name>ICV: 0</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate>.. .. .. .. CompletionTemplateCollection 0 ValveTemplates 0 ValveDefinitions 2</ValveTemplate>
+                                            <StartMeasuredDepth>400</StartMeasuredDepth>
+                                            <IsOpen>True </IsOpen>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>400</RangeStart>
+                                                    <RangeEnd>400</RangeEnd>
+                                                    <ValveSpacing>10</ValveSpacing>
+                                                    <RangeValveCount>1</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <UseCustomStartDate>False </UseCustomStartDate>
+                                            <StartDate>2026_03_24-14:27:18</StartDate>
+                                        </WellPathValve>
+                                    </Valve>
+                                    <CustomOutletValveMd>True  400</CustomOutletValveMd>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>593.00764320416</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>526.870385271002 1002.09124733542 59.6453365555876</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>True </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>True </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>7.28284504436248</EstimatedDogleg2>
+                                            <EstimatedAzimuth>0</EstimatedAzimuth>
+                                            <EstimatedInclination>0</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>778.73670504187 1618.01244807669 60.2691270096034</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>16.8962024903087</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>89.4227450741687</Inclination>
+                                            <EstimatedDogleg1>0.654681439261867</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>16.8962024903087</EstimatedAzimuth>
+                                            <EstimatedInclination>89.4227450741687</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>875.243167479895 2016.86335461115 66.6990428268277</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>13.4572193976147</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>89.0882931852312</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>13.4572193976147</EstimatedAzimuth>
+                                            <EstimatedInclination>89.0882931852312</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>True </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>True </AttachedToParentWell>
+                                    <FixedWellPathPoints>2366.81906893452 3345.98707746392 -2667.7819422551 2923.63932827086 3548.42335327519 -2692.85818453387 </FixedWellPathPoints>
+                                    <FixedMeasuredDepths>0 593.00764320416 </FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                    </WellPaths>
+                    <WellMeasurements>
+                        <WellMeasurements>
+                            <Measurements/>
+                            <ImportedFiles/>
+                        </WellMeasurements>
+                    </WellMeasurements>
+                    <EventTimeline>
+                        <WellEventTimeline>
+                            <Events/>
+                        </WellEventTimeline>
+                    </EventTimeline>
+                    <MswWellNameGrouping>USE_PREFERENCES</MswWellNameGrouping>
+                    <MswWellNameGroupingPattern>?*Y*</MswWellNameGroupingPattern>
+                    <MswEclipseCase></MswEclipseCase>
+                    <MswShowBands>True </MswShowBands>
+                    <MswAutoUpdateSegments>True </MswAutoUpdateSegments>
+                </WellPaths>
+            </WellPathCollection>
+            <CompletionTemplateCollection>
+                <CompletionTemplateCollection>
+                    <FractureTemplates>
+                        <FractureTemplateCollection>
+                            <DefaultUnitForTemplates>UNITS_METRIC</DefaultUnitForTemplates>
+                            <FractureDefinitions>
+                                <RimEllipseFractureTemplate>
+                                    <Id>0</Id>
+                                    <UserDescription>Ellipse Fracture Template</UserDescription>
+                                    <UnitSystem>UNITS_METRIC</UnitSystem>
+                                    <Orientation>Transverse</Orientation>
+                                    <UserDefinedPerforationLength>False </UserDefinedPerforationLength>
+                                    <AzimuthAngle>0</AzimuthAngle>
+                                    <SkinFactor>0</SkinFactor>
+                                    <PerforationLength>1</PerforationLength>
+                                    <PerforationEfficiency>1</PerforationEfficiency>
+                                    <WellDiameter>0.216</WellDiameter>
+                                    <ConductivityType>FiniteConductivity</ConductivityType>
+                                    <WellPathDepthAtFracture>25</WellPathDepthAtFracture>
+                                    <FractureContainmentField>
+                                        <FractureContainment>
+                                            <IsUsingFractureContainment>False </IsUsingFractureContainment>
+                                            <TopKLayer>0</TopKLayer>
+                                            <BaseKLayer>0</BaseKLayer>
+                                            <TruncateAtFaults>False </TruncateAtFaults>
+                                            <FaultThrowValue>0</FaultThrowValue>
+                                        </FractureContainment>
+                                    </FractureContainmentField>
+                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                    <FractureWidthType>FractureWidth</FractureWidthType>
+                                    <FractureWidth>0.01</FractureWidth>
+                                    <BetaFactorType>UserDefinedBetaFactor</BetaFactorType>
+                                    <InertialCoefficient>0.006083236</InertialCoefficient>
+                                    <PermeabilityType>FractureConductivity</PermeabilityType>
+                                    <RelativePermeability>1</RelativePermeability>
+                                    <EffectivePermeability>0</EffectivePermeability>
+                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                    <GasViscosity>0.02</GasViscosity>
+                                    <HeightScaleFactor>1</HeightScaleFactor>
+                                    <WidthScaleFactor>1</WidthScaleFactor>
+                                    <DFactorScaleFactor>1</DFactorScaleFactor>
+                                    <ConductivityFactor>1</ConductivityFactor>
+                                    <HalfLength>100</HalfLength>
+                                    <Height>75</Height>
+                                    <Width>0.01</Width>
+                                    <Permeability>100000</Permeability>
+                                </RimEllipseFractureTemplate>
+                            </FractureDefinitions>
+                            <NextValidFractureTemplateId>1</NextValidFractureTemplateId>
+                        </FractureTemplateCollection>
+                    </FractureTemplates>
+                    <StimPlanModelTemplates>
+                        <StimPlanModelTemplateCollection>
+                            <StimPlanModelTemplates/>
+                            <NextValidId>0</NextValidId>
+                        </StimPlanModelTemplateCollection>
+                    </StimPlanModelTemplates>
+                    <ValveTemplates>
+                        <ValveTemplateCollection>
+                            <ValveDefinitions>
+                                <ValveTemplate>
+                                    <Name>AICD: Valve Template #1</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>AICD</CompletionType>
+                                    <UserLabel>Valve Template #1</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICD: Valve Template #2</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICD</CompletionType>
+                                    <UserLabel>Valve Template #2</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICV: Valve Template #3</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICV</CompletionType>
+                                    <UserLabel>Valve Template #3</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                            </ValveDefinitions>
+                            <ValveUnits>UNITS_METRIC</ValveUnits>
+                        </ValveTemplateCollection>
+                    </ValveTemplates>
+                    <FractureGroupStatisticsCollection>
+                        <FractureGroupStatisticsCollection>
+                            <FractureGroupStatistics/>
+                        </FractureGroupStatisticsCollection>
+                    </FractureGroupStatisticsCollection>
+                </CompletionTemplateCollection>
+            </CompletionTemplateCollection>
+            <SummaryCaseCollection>
+                <SummaryCaseCollection>
+                    <SummaryCases>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_003$</SummaryHeaderFilename>
+                            <Id>1</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_004$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_005$</SummaryHeaderFilename>
+                            <Id>2</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_006$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                    </SummaryCases>
+                    <SummaryCaseCollections/>
+                </SummaryCaseCollection>
+            </SummaryCaseCollection>
+            <FormationNamesCollection>
+                <FormationNamesCollectionObject>
+                    <FormationNamesList/>
+                </FormationNamesCollectionObject>
+            </FormationNamesCollection>
+            <ObservedDataCollection>
+                <ObservedDataCollection>
+                    <ObservedDataArray/>
+                    <ObservedFmuRftDataArray/>
+                    <PressureDepthDataArray/>
+                </ObservedDataCollection>
+            </ObservedDataCollection>
+            <AnnotationCollection>
+                <RimAnnotationCollection>
+                    <IsActive>True </IsActive>
+                    <TextAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsActive>True </IsActive>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </TextAnnotations>
+                    <ReachCircleAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsActive>True </IsActive>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </ReachCircleAnnotations>
+                </RimAnnotationCollection>
+            </AnnotationCollection>
+            <EnsembleWellLogsCollection>
+                <EnsembleWellLogsCollection>
+                    <EnsembleWellLogsCollection/>
+                </EnsembleWellLogsCollection>
+            </EnsembleWellLogsCollection>
+            <PolygonCollection>
+                <PolygonCollection>
+                    <Polygons/>
+                    <PolygonFiles/>
+                </PolygonCollection>
+            </PolygonCollection>
+            <SurfaceCollection>
+                <SurfaceCollection>
+                    <SurfaceUserDescription>Surfaces</SurfaceUserDescription>
+                    <SubCollections/>
+                    <SurfacesField/>
+                </SurfaceCollection>
+            </SurfaceCollection>
+            <SeismicCollection>
+                <SeismicDataCollection>
+                    <SeismicData/>
+                    <DifferenceData/>
+                </SeismicDataCollection>
+            </SeismicCollection>
+            <SeismicViewCollection>
+                <SeismicViewCollection>
+                    <Views/>
+                </SeismicViewCollection>
+            </SeismicViewCollection>
+            <EclipseViewCollection>
+                <EclipseViewCollection>
+                    <Views/>
+                </EclipseViewCollection>
+            </EclipseViewCollection>
+            <ContourMaps>
+                <Eclipse2dViewCollection>
+                    <EclipseViews/>
+                </Eclipse2dViewCollection>
+            </ContourMaps>
+            <VfpDataCollection>
+                <RimVfpDataCollection>
+                    <VfpPlots/>
+                </RimVfpDataCollection>
+            </VfpDataCollection>
+            <CloudDataCollection>
+                <RimCloudDataSourceCollection>
+                    <SumoFieldId></SumoFieldId>
+                    <SumoCaseId></SumoCaseId>
+                    <SumoEnsembleNames></SumoEnsembleNames>
+                    <SumoDataSources/>
+                </RimCloudDataSourceCollection>
+            </CloudDataCollection>
+        </ResInsightOilField>
+    </OilFields>
+    <ColorLegendCollection>
+        <ColorLegendCollection>
+            <CustomColorLegends/>
+        </ColorLegendCollection>
+    </ColorLegendCollection>
+    <JobCollection>
+        <JobCollection>
+            <Jobs>
+                <OpmFlowJob>
+                    <Name>BASE_MODEL_1 - Opm Flow Simulation</Name>
+                    <DeckFile>$PathId_007$</DeckFile>
+                    <WorkDirectory>$PathId_008$</WorkDirectory>
+                    <WellPath>$ROOT$ OilFields 0 WellPathCollection 0 WellPaths 0</WellPath>
+                    <EclipseCase>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1</EclipseCase>
+                    <GridEnsemble></GridEnsemble>
+                    <SummaryEnsemble></SummaryEnsemble>
+                    <PauseBeforeRun>False </PauseBeforeRun>
+                    <AddNewWell>True </AddNewWell>
+                    <OpenWellDeckPosition>-1</OpenWellDeckPosition>
+                    <IncludeMswData>False </IncludeMswData>
+                    <AddToEnsemble>False </AddToEnsemble>
+                    <UseRestart>False </UseRestart>
+                    <CurrentRunID>0</CurrentRunID>
+                    <WellGroupName>PROD_N</WellGroupName>
+                    <WellOpenType>AtSelectedDate</WellOpenType>
+                    <WconprodKeyword>
+                        <KeywordWconprod>
+                            <status>OPEN</status>
+                            <target>LRAT</target>
+                            <orat>100</orat>
+                            <wrat>100</wrat>
+                            <grat>100</grat>
+                            <lrat>100</lrat>
+                            <resv>100</resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <alqWell></alqWell>
+                        </KeywordWconprod>
+                    </WconprodKeyword>
+                    <WconinjeKeyword>
+                        <KeywordWconinje>
+                            <type>WAT</type>
+                            <status>OPEN</status>
+                            <target>RATE</target>
+                            <rate></rate>
+                            <resv></resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <rsrvinj></rsrvinj>
+                        </KeywordWconinje>
+                    </WconinjeKeyword>
+                    <JobSettings>
+                        <OpmFlowJobSettings>
+                            <mpiProcesses>2</mpiProcesses>
+                            <threadsPerProcess>2</threadsPerProcess>
+                            <enableEsmry>True </enableEsmry>
+                            <enableTerminalOutput>True </enableTerminalOutput>
+                            <enableTuning>False </enableTuning>
+                            <ignoreKeywords></ignoreKeywords>
+                            <newtonMaxIterations>False  20</newtonMaxIterations>
+                            <parsingStrictness>normal</parsingStrictness>
+                            <relaxedMaxPvFraction>False  0.03</relaxedMaxPvFraction>
+                            <solverMaxTimeStepInDays>False  365</solverMaxTimeStepInDays>
+                            <solverMinTimeStepInDays>False  1e-12</solverMinTimeStepInDays>
+                            <minStrictCnvIter>False  -1</minStrictCnvIter>
+                            <minStrictMbIter>False  -1</minStrictMbIter>
+                            <minTimeStepBasedOnNewtonIterations>False  0</minTimeStepBasedOnNewtonIterations>
+                            <minTimeStepBeforeShuttingProblematicWellsInDays>False  0.01</minTimeStepBeforeShuttingProblematicWellsInDays>
+                            <toleranceCnv>False  0.01</toleranceCnv>
+                            <toleranceCnvEnergy>False  0.01</toleranceCnvEnergy>
+                            <toleranceCnvEnergyRelaxed>False  1</toleranceCnvEnergyRelaxed>
+                            <toleranceCnvRelaxed>False  1</toleranceCnvRelaxed>
+                            <toleranceEnergyBalance>False  1e-07</toleranceEnergyBalance>
+                            <toleranceEnergyBalanceRelaxed>False  1e-06</toleranceEnergyBalanceRelaxed>
+                            <toleranceMb>False  1e-07</toleranceMb>
+                            <toleranceMbRelaxed>False  1e-06</toleranceMbRelaxed>
+                            <tolerancePressureMsWells>False  1000</tolerancePressureMsWells>
+                            <toleranceWellControl>False  1e-07</toleranceWellControl>
+                            <toleranceWells>False  0.0001</toleranceWells>
+                            <wellGroupConstraintsMaxIterations>False  1</wellGroupConstraintsMaxIterations>
+                        </OpmFlowJobSettings>
+                    </JobSettings>
+                    <OpenTimeStep>6</OpenTimeStep>
+                    <EndTimeStep>0</EndTimeStep>
+                    <EndTimeStepEnabled>False </EndTimeStepEnabled>
+                    <AppendNewDates>False </AppendNewDates>
+                    <NewDatesInterval>1</NewDatesInterval>
+                    <NumberOfNewDates>12</NumberOfNewDates>
+                    <DateAppendType>AppendMonths</DateAppendType>
+                </OpmFlowJob>
+            </Jobs>
+        </JobCollection>
+    </JobCollection>
+    <MainPlotCollection>
+        <MainPlotCollection>
+            <Show>True </Show>
+            <WellLogPlotCollection>
+                <WellLogPlotCollection>
+                    <WellLogPlots/>
+                </WellLogPlotCollection>
+            </WellLogPlotCollection>
+            <RftPlotCollection>
+                <WellRftPlotCollection>
+                    <RftPlots/>
+                </WellRftPlotCollection>
+            </RftPlotCollection>
+            <PltPlotCollection>
+                <WellPltPlotCollection>
+                    <PltPlots/>
+                </WellPltPlotCollection>
+            </PltPlotCollection>
+            <SummaryMultiPlotCollection>
+                <RimSummaryMultiPlotCollection>
+                    <MultiSummaryPlots/>
+                    <UseCommonReadoutSettings>False </UseCommonReadoutSettings>
+                    <ReadOutSettings>
+                        <RimSummaryPlotReadOut>
+                            <ReadOutType>NONE</ReadOutType>
+                            <LineAppearance>
+                                <RimAnnotationLineAppearance>
+                                    <LineFieldsHidden>False </LineFieldsHidden>
+                                    <Color>0.250980406999588 0.250980406999588 0.250980406999588</Color>
+                                    <Thickness>2</Thickness>
+                                    <Style>STYLE_DASH</Style>
+                                </RimAnnotationLineAppearance>
+                            </LineAppearance>
+                            <VerticalLineLabelAlignment>LEFT</VerticalLineLabelAlignment>
+                            <HorizontalLineLabelAlignment>LEFT</HorizontalLineLabelAlignment>
+                        </RimSummaryPlotReadOut>
+                    </ReadOutSettings>
+                </RimSummaryMultiPlotCollection>
+            </SummaryMultiPlotCollection>
+            <AnalysisPlotCollection>
+                <AnalysisPlotCollection>
+                    <AnalysisPlots/>
+                </AnalysisPlotCollection>
+            </AnalysisPlotCollection>
+            <CorrelationPlotCollection>
+                <CorrelationPlotCollection>
+                    <CorrelationPlots/>
+                    <CorrelationReports/>
+                </CorrelationPlotCollection>
+            </CorrelationPlotCollection>
+            <SummaryCrossPlotCollection>
+                <SummaryCrossPlotCollection>
+                    <SummaryCrossPlots/>
+                </SummaryCrossPlotCollection>
+            </SummaryCrossPlotCollection>
+            <SummaryTableCollection>
+                <RimSummaryTableCollection>
+                    <SummaryTables/>
+                </RimSummaryTableCollection>
+            </SummaryTableCollection>
+            <FlowPlotCollection>
+                <FlowPlotCollection>
+                    <FlowCharacteristicsPlot>
+                        <FlowCharacteristicsPlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <FlowCase></FlowCase>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeSelectionType>SELECTED</TimeSelectionType>
+                            <SelectedTimeSteps></SelectedTimeSteps>
+                            <SelectedTimeStepsUi></SelectedTimeStepsUi>
+                            <CellPVThreshold>0.1</CellPVThreshold>
+                            <ShowLegend>True </ShowLegend>
+                            <CellFilter>CELLS_ACTIVE</CellFilter>
+                            <CellFilterView></CellFilterView>
+                            <TracerFilter></TracerFilter>
+                            <SelectedTracerNames></SelectedTracerNames>
+                            <MinCommunication>0</MinCommunication>
+                            <MaxTof>146000</MaxTof>
+                        </FlowCharacteristicsPlot>
+                    </FlowCharacteristicsPlot>
+                    <DefaultWellConnectivityTable>
+                        <RimWellConnectivityTable>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>0</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <CurveCase></CurveCase>
+                            <VisibleCellView></VisibleCellView>
+                            <ViewFilterType>FILTER_BY_VISIBLE_PRODUCERS</ViewFilterType>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeStepSelectopn>SINGLE_TIME_STEP</TimeStepSelectopn>
+                            <SelectProducersAndInjectorsForTimeSteps>True </SelectProducersAndInjectorsForTimeSteps>
+                            <ThresholdValue>0</ThresholdValue>
+                            <TimeSampleValueType>FLOW_RATE_FRACTION</TimeSampleValueType>
+                            <TimeStep></TimeStep>
+                            <TimeRangeValueType>ACCUMULATED_FLOW_VOLUME_FRACTION</TimeRangeValueType>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <SelectedProducerTracers></SelectedProducerTracers>
+                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                            <SyncSelectedProdInj>False </SyncSelectedProdInj>
+                            <SyncSelectedInjProd>False </SyncSelectedInjProd>
+                            <ShowValueLabels>False </ShowValueLabels>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisLabelFontSize>Medium</AxisLabelFontSize>
+                            <ValueLabelFontSize>Medium</ValueLabelFontSize>
+                            <LegendConfig>
+                                <Legend>
+                                    <ShowLegend>True </ShowLegend>
+                                    <NumberOfLevels>8</NumberOfLevels>
+                                    <Precision>4</Precision>
+                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 18</ColorLegend>
+                                    <MappingMode>LinearContinuous</MappingMode>
+                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                    <UserDefinedMax>1</UserDefinedMax>
+                                    <UserDefinedMin>0</UserDefinedMin>
+                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                    <ResultVariableUsage></ResultVariableUsage>
+                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                </Legend>
+                            </LegendConfig>
+                            <MappingType>LinearContinuous</MappingType>
+                            <RangeType>AUTOMATIC</RangeType>
+                        </RimWellConnectivityTable>
+                    </DefaultWellConnectivityTable>
+                    <DefaultWellAllocationOverTimePlot>
+                        <RimWellAllocationOverTimePlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>1</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Medium</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <RowSpan>ONE</RowSpan>
+                            <ColSpan>ONE</ColSpan>
+                            <PlotDescription>Default Well Allocation Over Time Plot</PlotDescription>
+                            <CurveCase></CurveCase>
+                            <WellName>None</WellName>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowValueType>FLOW_RATE</FlowValueType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisValueFontSize>Medium</AxisValueFontSize>
+                        </RimWellAllocationOverTimePlot>
+                    </DefaultWellAllocationOverTimePlot>
+                    <DefaultWellAllocationPlot>
+                        <WellAllocationPlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <PlotDescription>Default Flow Diagnostics Plot</PlotDescription>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <BranchDetection>True </BranchDetection>
+                            <CurveCase></CurveCase>
+                            <PlotTimeStep>0</PlotTimeStep>
+                            <WellName>None</WellName>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowType>ACCUMULATED</FlowType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AccumulatedWellFlowPlot>
+                                <WellLogPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>False </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>False </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <TemplateText>$CASE, $WELL</TemplateText>
+                                    <PlotNamingMethod>CUSTOM</PlotNamingMethod>
+                                    <DepthType>CONNECTION_NUMBER</DepthType>
+                                    <DepthUnit>UNIT_NONE</DepthUnit>
+                                    <MinimumDepth>0</MinimumDepth>
+                                    <MaximumDepth>1000</MaximumDepth>
+                                    <ShowDepthGridLines>GRID_X_MAJOR</ShowDepthGridLines>
+                                    <AutoScaleDepthEnabled>True </AutoScaleDepthEnabled>
+                                    <DepthAxisVisibility>ONE_VISIBLE</DepthAxisVisibility>
+                                    <ShowDepthMarkerLine>False </ShowDepthMarkerLine>
+                                    <AutoZoomMinDepthFactor>0</AutoZoomMinDepthFactor>
+                                    <AutoZoomMaxDepthFactor>0</AutoZoomMaxDepthFactor>
+                                    <DepthAnnotations/>
+                                    <SubTitleFontSize>Medium</SubTitleFontSize>
+                                    <AxisTitleFontSize>Medium</AxisTitleFontSize>
+                                    <AxisValueFontSize>Medium</AxisValueFontSize>
+                                    <NameConfig>
+                                        <RimWellLogPlotNameConfig>
+                                            <CustomCurveName>Accumulated Flow Chart</CustomCurveName>
+                                        </RimWellLogPlotNameConfig>
+                                    </NameConfig>
+                                    <FilterEnsembleCurveSet></FilterEnsembleCurveSet>
+                                    <DepthEqualization>NONE</DepthEqualization>
+                                    <Tracks/>
+                                    <DepthOrientation>VERTICAL</DepthOrientation>
+                                </WellLogPlot>
+                            </AccumulatedWellFlowPlot>
+                            <TotalWellFlowPlot>
+                                <TotalWellAllocationPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <PlotDescription>Total Allocation</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                </TotalWellAllocationPlot>
+                            </TotalWellFlowPlot>
+                            <WellAllocLegend>
+                                <WellAllocationPlotLegend>
+                                    <ShowPlotLegend>True </ShowPlotLegend>
+                                </WellAllocationPlotLegend>
+                            </WellAllocLegend>
+                            <TofAccumulatedPhaseFractionsPlot>
+                                <TofAccumulatedPhaseFractionsPlot>
+                                    <WindowController/>
+                                    <ShowWindow>False </ShowWindow>
+                                    <PlotDescription>Cumulative Saturation by Time of Flight</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <MaxTof>50</MaxTof>
+                                </TofAccumulatedPhaseFractionsPlot>
+                            </TofAccumulatedPhaseFractionsPlot>
+                        </WellAllocationPlot>
+                    </DefaultWellAllocationPlot>
+                    <WellDistributionPlotCollection>
+                        <WellDistributionPlotCollection>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>2</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <Case></Case>
+                            <TimeStepIndex>-1</TimeStepIndex>
+                            <WellName>None</WellName>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                            <MaximumTOF>20</MaximumTOF>
+                            <Plots>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>OIL_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>GAS_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>WATER_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                            </Plots>
+                            <ShowOil>True </ShowOil>
+                            <ShowGas>True </ShowGas>
+                            <ShowWater>True </ShowWater>
+                            <PlotDescription>Cumulative Phase Distribution Plots</PlotDescription>
+                        </WellDistributionPlotCollection>
+                    </WellDistributionPlotCollection>
+                    <StoredWellAllocationPlots/>
+                    <StoredFlowCharacteristicsPlots/>
+                </FlowPlotCollection>
+            </FlowPlotCollection>
+            <Rim3dCrossPlotCollection>
+                <RimGridCrossPlotCollection>
+                    <GridCrossPlots/>
+                </RimGridCrossPlotCollection>
+            </Rim3dCrossPlotCollection>
+            <RimSaturationPressurePlotCollection>
+                <RimSaturationPressurePlotCollection>
+                    <SaturationPressurePlots/>
+                </RimSaturationPressurePlotCollection>
+            </RimSaturationPressurePlotCollection>
+            <RimMultiPlotCollection>
+                <RimMultiPlotCollection>
+                    <MultiPlots/>
+                </RimMultiPlotCollection>
+            </RimMultiPlotCollection>
+            <StimPlanModelPlotCollection>
+                <StimPlanModelPlotCollection>
+                    <StimPlanModelPlots/>
+                </StimPlanModelPlotCollection>
+            </StimPlanModelPlotCollection>
+            <VfpPlotCollection>
+                <RimVfpPlotCollection>
+                    <CustomVfpPlots/>
+                </RimVfpPlotCollection>
+            </VfpPlotCollection>
+            <HistogramMultiPlotCollection>
+                <RimHistogramMultiPlotCollection>
+                    <HistogramMultiPlots/>
+                </RimHistogramMultiPlotCollection>
+            </HistogramMultiPlotCollection>
+        </MainPlotCollection>
+    </MainPlotCollection>
+    <PinnedFieldCollection>
+        <RimQuickAccessCollection>
+            <FieldReferencesGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0 RangeFilters 0 CellFilters 0</Object>
+                                    <FieldKeyword>StartIndexI</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+            </FieldReferencesGroup>
+        </RimQuickAccessCollection>
+    </PinnedFieldCollection>
+    <LinkedViews>
+        <RimViewLinkerCollection>
+            <Active>True </Active>
+            <ViewLinkers/>
+        </RimViewLinkerCollection>
+    </LinkedViews>
+    <CalculationCollection>
+        <RimSummaryCalculationCollection>
+            <Calculations/>
+        </RimSummaryCalculationCollection>
+    </CalculationCollection>
+    <GridCalculationCollection>
+        <RimGridCalculationCollection>
+            <Calculations/>
+        </RimGridCalculationCollection>
+    </GridCalculationCollection>
+    <MultiSnapshotDefinitions/>
+    <TreeViewStates>-1-1100000;-1-11000;-1-110100010;-1-110100040;-1-110100070;-1-110100080;-1-1101000100;-1-1101000110;-1-1101000;-1-11010;-1-110;-1-130000020;-1-130000040;-1-1300000;-1-13000;-1-130||-1-110</TreeViewStates>
+    <TreeViewCurrentModelIndexPaths>3 0;0 0;0 0;2 0;0 0||1 0;0 0</TreeViewCurrentModelIndexPaths>
+    <PlotWindowTreeViewStates>-1-100|-1-100|||</PlotWindowTreeViewStates>
+    <PlotWindowTreeViewCurrentModelIndexPaths>||||</PlotWindowTreeViewCurrentModelIndexPaths>
+    <show3DWindow>True </show3DWindow>
+    <showPlotWindow>False </showPlotWindow>
+    <showPlotWindowOnTopOf3DWindow>False </showPlotWindowOnTopOf3DWindow>
+    <tiled3DWindow>False </tiled3DWindow>
+    <tiledPlotWindow>False </tiledPlotWindow>
+    <DialogData>
+        <RimDialogData>
+            <ExportCarfin>
+                <RicExportCarfinUi>
+                    <CellRange>
+                        <RicCellRangeUi>
+                            <Case></Case>
+                            <GridIndex>0</GridIndex>
+                            <StartIndexI>1</StartIndexI>
+                            <StartIndexJ>1</StartIndexJ>
+                            <StartIndexK>1</StartIndexK>
+                            <CellCountI>1</CellCountI>
+                            <CellCountJ>1</CellCountJ>
+                            <CellCountK>1</CellCountK>
+                        </RicCellRangeUi>
+                    </CellRange>
+                    <ExportFileName></ExportFileName>
+                    <CaseToApply></CaseToApply>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <MaxWellCount>8</MaxWellCount>
+                </RicExportCarfinUi>
+            </ExportCarfin>
+            <ExportCompletionData>
+                <RicExportCompletionDataSettingsUi>
+                    <Folder>C:/gitroot/ResInsight/TestModels/msw-export/output/completion-export</Folder>
+                    <CaseToApply>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0</CaseToApply>
+                    <FileSplit>SPLIT_ON_WELL</FileSplit>
+                    <compdatExport>TRANSMISSIBILITIES</compdatExport>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludeMSW>True </IncludeMSW>
+                    <UseLateralNTG>False </UseLateralNTG>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <IncludeFractures>True </IncludeFractures>
+                    <TransScalingType>False </TransScalingType>
+                    <TransScalingTimeStep>0</TransScalingTimeStep>
+                    <TransScalingWBHPSource>WBHP_SUMMARY</TransScalingWBHPSource>
+                    <TransScalingWBHP>200</TransScalingWBHP>
+                    <ExcludeMainBoreForFishbones>False </ExcludeMainBoreForFishbones>
+                    <ExportDataSourceAsComment>True </ExportDataSourceAsComment>
+                    <ExportWelspec>True </ExportWelspec>
+                    <CompletionWelspecAfterMainBore>True </CompletionWelspecAfterMainBore>
+                    <UseCustomFileName>False </UseCustomFileName>
+                    <CustomFileName></CustomFileName>
+                </RicExportCompletionDataSettingsUi>
+            </ExportCompletionData>
+            <MultipleFractionsData>
+                <RiuCreateMultipleFractionsUi>
+                    <SourceCase></SourceCase>
+                    <MinDistanceFromWellTd>10</MinDistanceFromWellTd>
+                    <MaxFracturesPerWell>10</MaxFracturesPerWell>
+                    <Options/>
+                </RiuCreateMultipleFractionsUi>
+            </MultipleFractionsData>
+            <HoloLenseExportToFolderData>
+                <RicHoloLensExportToFolderUi>
+                    <ViewForExport></ViewForExport>
+                    <ExportFolder></ExportFolder>
+                </RicHoloLensExportToFolderUi>
+            </HoloLenseExportToFolderData>
+            <ExportwellPathsData>
+                <RicExportWellPathsUi>
+                    <ExportFolder></ExportFolder>
+                    <MdStepSize>5</MdStepSize>
+                </RicExportWellPathsUi>
+            </ExportwellPathsData>
+            <ExportLgr>
+                <RicExportLgrUi>
+                    <ExportFolder></ExportFolder>
+                    <CaseToApply></CaseToApply>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFractures>True </IncludeFractures>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <SplitType>LGR_PER_COMPLETION</SplitType>
+                </RicExportLgrUi>
+            </ExportLgr>
+            <ExportSectorModel>
+                <RicExportEclipseInputGridUi>
+                    <ExportGrid>True </ExportGrid>
+                    <ExportGridFilename>GRID.GRDECL</ExportGridFilename>
+                    <ExportInLocalCoords>False </ExportInLocalCoords>
+                    <InvisibleCellActnum>False </InvisibleCellActnum>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>2147483647</MinI>
+                    <MinJ>2147483647</MinJ>
+                    <MinK>2147483647</MinK>
+                    <MaxI>-2147483647</MaxI>
+                    <MaxJ>-2147483647</MaxJ>
+                    <MaxK>-2147483647</MaxK>
+                    <ExportFaults>TO_SINGLE_RESULT_FILE</ExportFaults>
+                    <ExportFaultsFilename>FAULTS.GRDECL</ExportFaultsFilename>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <ExportParams>TO_SEPARATE_RESULT_FILES</ExportParams>
+                    <ExportParamsFilename>RESULTS.GRDECL</ExportParamsFilename>
+                    <ExportMainKeywords></ExportMainKeywords>
+                    <WriteEchoInGrdeclFiles>False </WriteEchoInGrdeclFiles>
+                    <ExportFolder>$PathId_009$</ExportFolder>
+                </RicExportEclipseInputGridUi>
+            </ExportSectorModel>
+            <MockModelSettings>
+                <MockModelSettings>
+                    <CellCountX>100</CellCountX>
+                    <CellCountY>100</CellCountY>
+                    <CellCountZ>10</CellCountZ>
+                    <TotalCellCount>0</TotalCellCount>
+                    <ResultCount>3</ResultCount>
+                    <TimeStepCount>10</TimeStepCount>
+                </MockModelSettings>
+            </MockModelSettings>
+            <CreateEnsembleSurfaceUi>
+                <RicCreateEnsembleSurfaceUi>
+                    <Layers></Layers>
+                    <AutoCreateEnsembleSurfaces>False </AutoCreateEnsembleSurfaces>
+                    <MinLayer>0</MinLayer>
+                    <MaxLayer>0</MaxLayer>
+                </RicCreateEnsembleSurfaceUi>
+            </CreateEnsembleSurfaceUi>
+            <CreateEnsembleWellLogUi>
+                <RicCreateEnsembleWellLogUi>
+                    <AutoCreateEnsembleWellLogs>True </AutoCreateEnsembleWellLogs>
+                    <TimeStep>0</TimeStep>
+                    <WellPathSource>FILE</WellPathSource>
+                    <WellPath></WellPath>
+                    <WellFilePath></WellFilePath>
+                    <SelectedProperties></SelectedProperties>
+                </RicCreateEnsembleWellLogUi>
+            </CreateEnsembleWellLogUi>
+            <ExportSectorModelUi>
+                <RicExportSectorModelUi>
+                    <ExportFolder>$PathId_009$</ExportFolder>
+                    <ExportDeckName></ExportDeckName>
+                    <PorvMultiplier>1000000</PorvMultiplier>
+                    <BoundaryCondition>OPERNUM_OPERATER</BoundaryCondition>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>1</MinI>
+                    <MinJ>1</MinJ>
+                    <MinK>1</MinK>
+                    <MaxI>1</MaxI>
+                    <MaxJ>1</MaxJ>
+                    <MaxK>1</MaxK>
+                    <RefineGrid>False </RefineGrid>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <BcpropKeywords/>
+                    <KeywordsToRemove>ACTION ACTIONX ACTIONW BOX UDQ </KeywordsToRemove>
+                    <EnablePadding>False </EnablePadding>
+                    <PaddingNzUpper>0</PaddingNzUpper>
+                    <PaddingTopUpper>0</PaddingTopUpper>
+                    <PaddingUpperPorosity>0</PaddingUpperPorosity>
+                    <PaddingUpperEquilnum>1</PaddingUpperEquilnum>
+                    <PaddingNzLower>0</PaddingNzLower>
+                    <PaddingBottomLower>0</PaddingBottomLower>
+                    <PaddingMinThickness>0.1</PaddingMinThickness>
+                    <PaddingFillGaps>False </PaddingFillGaps>
+                    <PaddingMonotonicZcorn>False </PaddingMonotonicZcorn>
+                    <PaddingVerticalPillars>False </PaddingVerticalPillars>
+                    <CreateSimulationJob>False </CreateSimulationJob>
+                    <SimulationJobFolder></SimulationJobFolder>
+                    <SimulationJobName></SimulationJobName>
+                    <StartSimulationJobAfterExport>False </StartSimulationJobAfterExport>
+                    <EclipseCase></EclipseCase>
+                    <EclipseView></EclipseView>
+                </RicExportSectorModelUi>
+            </ExportSectorModelUi>
+        </RimDialogData>
+    </DialogData>
+    <TileMode3DWindow>UNDEFINED</TileMode3DWindow>
+    <TileModePlotWindow>UNDEFINED</TileModePlotWindow>
+    <AutomationSettings>
+        <RimAutomationSettings>
+            <CellSelectionDestination></CellSelectionDestination>
+            <CaseReloadIntervalSeconds>15</CaseReloadIntervalSeconds>
+        </RimAutomationSettings>
+    </AutomationSettings>
+</ResInsightProject>

--- a/TestModels/msw-export/project-files/tie-in-custom-valve-location.rsp
+++ b/TestModels/msw-export/project-files/tie-in-custom-valve-location.rsp
@@ -1,0 +1,3621 @@
+<?xml version="1.0"?>
+<ResInsightProject>
+    <DocumentFileName>C:/gitroot/ResInsight/TestModels/msw-export/project-files/tie-in-custom-valve-location.rsp</DocumentFileName>
+    <ProjectFileVersionString>2026.02.1-dev.03</ProjectFileVersionString>
+    <ReferencedExternalFiles>
+        $PathId_001$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.EGRID;
+        $PathId_002$ $PathId_008$/BASE_MODEL_1.EGRID;
+        $PathId_002_Name$ BASE_MODEL_1 - Opm Flow Simulation;
+        $PathId_003$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.SMSPEC;
+        $PathId_004$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.RFT;
+        $PathId_005$ $PathId_008$/BASE_MODEL_1.SMSPEC;
+        $PathId_006$ $PathId_008$/BASE_MODEL_1.RFT;
+        $PathId_007$ C:/gitroot/ResInsight/TestModels/msw-export/BASE_MODEL_1.DATA;
+        $PathId_008$ C:/gitroot/ResInsight/TestModels/msw-export/output;
+        $PathId_009$ C:/Users/MagneSjaastad;
+    </ReferencedExternalFiles>
+    <EnsembleFileSetCollection>
+        <EnsembleFileSetCollection>
+            <FileSets/>
+        </EnsembleFileSetCollection>
+    </EnsembleFileSetCollection>
+    <OilFields>
+        <ResInsightOilField>
+            <AnalysisModels>
+                <ResInsightAnalysisModels>
+                    <Reservoirs>
+                        <EclipseCase>
+                            <Name>BASE_MODEL_1</Name>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <Id>0</Id>
+                            <FilePath>$PathId_001$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>2</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Polyline</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>400</Width>
+                                                    <Height>400</Height>
+                                                    <IsMaximized>True </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <Id>0</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>0.976329509285655 -0.137488647856944 0.16696574800989 -2562.46558293672 0.0570241855332132 0.908273139170904 0.414473336808178 -2200.36740573527 -0.208635882729473 -0.395141463745709 0.894614046428174 -6592.30008518847 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>2252.552044791 2881.10392006564 510.877714038926</CameraPointOfInterest>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Polyline</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_POLYLINE</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath></WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points>2178.14013712842 2279.31916920047 -2606.253254059 3346.04282521766 3705.68716983182 -2647.25015118923 4474.7336269588 5197.91817541397 -2686.87083859125 </Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>False </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters/>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>True </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase></WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsActive>True </IsActive>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <WellTargetMappings/>
+                            <ResultAliasNames/>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                        <EclipseCase>
+                            <Name>$PathId_002_Name$</Name>
+                            <NameSetting>CUSTOM_NAME</NameSetting>
+                            <Id>1</Id>
+                            <FilePath>$PathId_002$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>3</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Well-1 Y1</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>0</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>-1</Width>
+                                                    <Height>-1</Height>
+                                                    <IsMaximized>False </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <Id>4</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Well-1 Y2</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 1</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <MdiWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <xPos>400</xPos>
+                                                    <yPos>0</yPos>
+                                                    <Width>400</Width>
+                                                    <Height>400</Height>
+                                                    <IsMaximized>True </IsMaximized>
+                                                </MdiWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <Id>1</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>-0.891899207874216 -0.34908711078127 0.287496073155323 1025.67049151023 0.440842266529062 -0.81291993952983 0.380551268499183 764.240017258542 0.100865747579961 0.466153795437947 0.878935003264708 -4146.72916540098 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>1155.63233152165 2050.31529376051 604.435812451607</CameraPointOfInterest>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>12</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Well-1 Y1</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_WELL_PATH</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath>.. .. .. .. .. .. WellPathCollection 0 WellPaths 0</WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points></Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <UserDescription>Well-1 Y2</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_WELL_PATH</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath>.. .. .. .. .. .. WellPathCollection 0 WellPaths 1</WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points></Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>False </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters>
+                                                        <CellRangeFilter>
+                                                            <UserDescription>Range Filter 1</UserDescription>
+                                                            <Active>False </Active>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <FilterType>INCLUDE</FilterType>
+                                                            <GridIndex>0</GridIndex>
+                                                            <PropagateToSubGrids>True </PropagateToSubGrids>
+                                                            <StartIndexI>4</StartIndexI>
+                                                            <CellCountI>1</CellCountI>
+                                                            <StartIndexJ>1</StartIndexJ>
+                                                            <CellCountJ>8</CellCountJ>
+                                                            <StartIndexK>1</StartIndexK>
+                                                            <CellCountK>7</CellCountK>
+                                                        </CellRangeFilter>
+                                                    </CellFilters>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>False </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>Well-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.752941191196442 0.752941191196442 0.752941191196442</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase>.. .. .. .. .. SummaryCaseCollection 0 SummaryCases 1</WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsActive>True </IsActive>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <WellTargetMappings/>
+                            <ResultAliasNames/>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                    </Reservoirs>
+                    <CaseGroups/>
+                    <CaseEnsembles/>
+                    <ReservoirGridEnsembles/>
+                </ResInsightAnalysisModels>
+            </AnalysisModels>
+            <GeoMechModels/>
+            <WellPathCollection>
+                <WellPaths>
+                    <Active>True </Active>
+                    <ShowWellPathLabel>True </ShowWellPathLabel>
+                    <WellPathLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellPathLabelColor>
+                    <GlobalWellPathVisibility>ALL_ON</GlobalWellPathVisibility>
+                    <WellPathRadiusScale>0.1</WellPathRadiusScale>
+                    <WellPathClip>True </WellPathClip>
+                    <WellPathClipZDistance>100</WellPathClipZDistance>
+                    <WellPaths>
+                        <ModeledWellPath>
+                            <Name>Well-1 Y1</Name>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName>Well-1</SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.788235306739807 0.5686274766922 0.788235306739807</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>1010.74 - 1240.66</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>1010.74416575048</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>1240.66104192543</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Valves>
+                                        <ValveCollection>
+                                            <Name>Valves</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Valves/>
+                                        </ValveCollection>
+                                    </Valves>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                    <MswSegments>
+                                        <RimMswSegmentCollection>
+                                            <Name>MSW Segments</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Segments/>
+                                        </RimMswSegmentCollection>
+                                    </MswSegments>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-1</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport>PROD_N</WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                            <CustomSegmentIntervals>
+                                                <CustomSegmentIntervalCollection>
+                                                    <Intervals/>
+                                                </CustomSegmentIntervalCollection>
+                                            </CustomSegmentIntervals>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath></ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>0</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <IsOpen>True </IsOpen>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <UseCustomStartDate>False </UseCustomStartDate>
+                                            <StartDate>2026_03_24-14:27:18</StartDate>
+                                        </WellPathValve>
+                                    </Valve>
+                                    <CustomOutletValveMd>False  0</CustomOutletValveMd>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>0</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>-29.9498740653398 799.654971524146 34.569094276821</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.5764369959842</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1236.9904202153 1260.26083230065 91.6253907017731</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.5764369959842</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>False </IsEnabled>
+                                            <TargetPoint>1929.51139254053 2455.31736287457 120.824833681511</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>36.591018613603</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>88.1528471139157</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>36.591018613603</EstimatedAzimuth>
+                                            <EstimatedInclination>88.1528471139157</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>False </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>False </AttachedToParentWell>
+                                    <FixedWellPathPoints></FixedWellPathPoints>
+                                    <FixedMeasuredDepths></FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                        <ModeledWellPath>
+                            <Name>Well-1 Y2</Name>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName></SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.999000012874603 0.333000004291534 0.999000012874603</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>1143.29 - 1193.29</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>1143.28791915069</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>1193.28791915069</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Valves>
+                                        <ValveCollection>
+                                            <Name>Valves</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Valves/>
+                                        </ValveCollection>
+                                    </Valves>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                    <MswSegments>
+                                        <RimMswSegmentCollection>
+                                            <Name>MSW Segments</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Segments/>
+                                        </RimMswSegmentCollection>
+                                    </MswSegments>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-1Y2</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport></WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                            <CustomSegmentIntervals>
+                                                <CustomSegmentIntervalCollection>
+                                                    <Intervals/>
+                                                </CustomSegmentIntervalCollection>
+                                            </CustomSegmentIntervals>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath>.. .. WellPaths 0</ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>593.00764320416</TieInMeasuredDepth>
+                                    <AddValveAtConnection>True </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name>ICV: 0</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate>.. .. .. .. CompletionTemplateCollection 0 ValveTemplates 0 ValveDefinitions 2</ValveTemplate>
+                                            <StartMeasuredDepth>400</StartMeasuredDepth>
+                                            <IsOpen>True </IsOpen>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>400</RangeStart>
+                                                    <RangeEnd>400</RangeEnd>
+                                                    <ValveSpacing>10</ValveSpacing>
+                                                    <RangeValveCount>1</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <UseCustomStartDate>False </UseCustomStartDate>
+                                            <StartDate>2026_03_24-14:27:18</StartDate>
+                                        </WellPathValve>
+                                    </Valve>
+                                    <CustomOutletValveMd>True  400</CustomOutletValveMd>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>593.00764320416</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>526.870385271002 1002.09124733542 59.6453365555876</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>True </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>True </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>7.28284504436249</EstimatedDogleg2>
+                                            <EstimatedAzimuth>0</EstimatedAzimuth>
+                                            <EstimatedInclination>0</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>778.73670504187 1618.01244807669 60.2691270096034</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>16.8962024903087</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>89.4227450741687</Inclination>
+                                            <EstimatedDogleg1>0.65468143926185</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>16.8962024903087</EstimatedAzimuth>
+                                            <EstimatedInclination>89.4227450741687</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>875.243167479895 2016.86335461115 66.6990428268277</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>13.4572193976147</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>89.0882931852312</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>13.4572193976147</EstimatedAzimuth>
+                                            <EstimatedInclination>89.0882931852312</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>True </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>True </AttachedToParentWell>
+                                    <FixedWellPathPoints>2366.81906893452 3345.98707746392 -2667.7819422551 2923.63932827086 3548.42335327519 -2692.85818453387 </FixedWellPathPoints>
+                                    <FixedMeasuredDepths>0 593.00764320416 </FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                    </WellPaths>
+                    <WellMeasurements>
+                        <WellMeasurements>
+                            <Measurements/>
+                            <ImportedFiles/>
+                        </WellMeasurements>
+                    </WellMeasurements>
+                    <EventTimeline>
+                        <WellEventTimeline>
+                            <Events/>
+                        </WellEventTimeline>
+                    </EventTimeline>
+                    <MswWellNameGrouping>USE_PREFERENCES</MswWellNameGrouping>
+                    <MswWellNameGroupingPattern>?*Y*</MswWellNameGroupingPattern>
+                    <MswEclipseCase></MswEclipseCase>
+                    <MswShowBands>True </MswShowBands>
+                    <MswAutoUpdateSegments>True </MswAutoUpdateSegments>
+                </WellPaths>
+            </WellPathCollection>
+            <CompletionTemplateCollection>
+                <CompletionTemplateCollection>
+                    <FractureTemplates>
+                        <FractureTemplateCollection>
+                            <DefaultUnitForTemplates>UNITS_METRIC</DefaultUnitForTemplates>
+                            <FractureDefinitions>
+                                <RimEllipseFractureTemplate>
+                                    <Id>0</Id>
+                                    <UserDescription>Ellipse Fracture Template</UserDescription>
+                                    <UnitSystem>UNITS_METRIC</UnitSystem>
+                                    <Orientation>Transverse</Orientation>
+                                    <UserDefinedPerforationLength>False </UserDefinedPerforationLength>
+                                    <AzimuthAngle>0</AzimuthAngle>
+                                    <SkinFactor>0</SkinFactor>
+                                    <PerforationLength>1</PerforationLength>
+                                    <PerforationEfficiency>1</PerforationEfficiency>
+                                    <WellDiameter>0.216</WellDiameter>
+                                    <ConductivityType>FiniteConductivity</ConductivityType>
+                                    <WellPathDepthAtFracture>25</WellPathDepthAtFracture>
+                                    <FractureContainmentField>
+                                        <FractureContainment>
+                                            <IsUsingFractureContainment>False </IsUsingFractureContainment>
+                                            <TopKLayer>0</TopKLayer>
+                                            <BaseKLayer>0</BaseKLayer>
+                                            <TruncateAtFaults>False </TruncateAtFaults>
+                                            <FaultThrowValue>0</FaultThrowValue>
+                                        </FractureContainment>
+                                    </FractureContainmentField>
+                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                    <FractureWidthType>FractureWidth</FractureWidthType>
+                                    <FractureWidth>0.01</FractureWidth>
+                                    <BetaFactorType>UserDefinedBetaFactor</BetaFactorType>
+                                    <InertialCoefficient>0.006083236</InertialCoefficient>
+                                    <PermeabilityType>FractureConductivity</PermeabilityType>
+                                    <RelativePermeability>1</RelativePermeability>
+                                    <EffectivePermeability>0</EffectivePermeability>
+                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                    <GasViscosity>0.02</GasViscosity>
+                                    <HeightScaleFactor>1</HeightScaleFactor>
+                                    <WidthScaleFactor>1</WidthScaleFactor>
+                                    <DFactorScaleFactor>1</DFactorScaleFactor>
+                                    <ConductivityFactor>1</ConductivityFactor>
+                                    <HalfLength>100</HalfLength>
+                                    <Height>75</Height>
+                                    <Width>0.01</Width>
+                                    <Permeability>100000</Permeability>
+                                </RimEllipseFractureTemplate>
+                            </FractureDefinitions>
+                            <NextValidFractureTemplateId>1</NextValidFractureTemplateId>
+                        </FractureTemplateCollection>
+                    </FractureTemplates>
+                    <StimPlanModelTemplates>
+                        <StimPlanModelTemplateCollection>
+                            <StimPlanModelTemplates/>
+                            <NextValidId>0</NextValidId>
+                        </StimPlanModelTemplateCollection>
+                    </StimPlanModelTemplates>
+                    <ValveTemplates>
+                        <ValveTemplateCollection>
+                            <ValveDefinitions>
+                                <ValveTemplate>
+                                    <Name>AICD: Valve Template #1</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>AICD</CompletionType>
+                                    <UserLabel>Valve Template #1</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICD: Valve Template #2</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICD</CompletionType>
+                                    <UserLabel>Valve Template #2</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICV: Valve Template #3</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICV</CompletionType>
+                                    <UserLabel>Valve Template #3</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                            </ValveDefinitions>
+                            <ValveUnits>UNITS_METRIC</ValveUnits>
+                        </ValveTemplateCollection>
+                    </ValveTemplates>
+                    <FractureGroupStatisticsCollection>
+                        <FractureGroupStatisticsCollection>
+                            <FractureGroupStatistics/>
+                        </FractureGroupStatisticsCollection>
+                    </FractureGroupStatisticsCollection>
+                </CompletionTemplateCollection>
+            </CompletionTemplateCollection>
+            <SummaryCaseCollection>
+                <SummaryCaseCollection>
+                    <SummaryCases>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_003$</SummaryHeaderFilename>
+                            <Id>1</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_004$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_005$</SummaryHeaderFilename>
+                            <Id>2</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_006$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                    </SummaryCases>
+                    <SummaryCaseCollections/>
+                </SummaryCaseCollection>
+            </SummaryCaseCollection>
+            <FormationNamesCollection>
+                <FormationNamesCollectionObject>
+                    <FormationNamesList/>
+                </FormationNamesCollectionObject>
+            </FormationNamesCollection>
+            <ObservedDataCollection>
+                <ObservedDataCollection>
+                    <ObservedDataArray/>
+                    <ObservedFmuRftDataArray/>
+                    <PressureDepthDataArray/>
+                </ObservedDataCollection>
+            </ObservedDataCollection>
+            <AnnotationCollection>
+                <RimAnnotationCollection>
+                    <IsActive>True </IsActive>
+                    <TextAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsActive>True </IsActive>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </TextAnnotations>
+                    <ReachCircleAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsActive>True </IsActive>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </ReachCircleAnnotations>
+                </RimAnnotationCollection>
+            </AnnotationCollection>
+            <EnsembleWellLogsCollection>
+                <EnsembleWellLogsCollection>
+                    <EnsembleWellLogsCollection/>
+                </EnsembleWellLogsCollection>
+            </EnsembleWellLogsCollection>
+            <PolygonCollection>
+                <PolygonCollection>
+                    <Polygons/>
+                    <PolygonFiles/>
+                </PolygonCollection>
+            </PolygonCollection>
+            <SurfaceCollection>
+                <SurfaceCollection>
+                    <SurfaceUserDescription>Surfaces</SurfaceUserDescription>
+                    <SubCollections/>
+                    <SurfacesField/>
+                </SurfaceCollection>
+            </SurfaceCollection>
+            <SeismicCollection>
+                <SeismicDataCollection>
+                    <SeismicData/>
+                    <DifferenceData/>
+                </SeismicDataCollection>
+            </SeismicCollection>
+            <SeismicViewCollection>
+                <SeismicViewCollection>
+                    <Views/>
+                </SeismicViewCollection>
+            </SeismicViewCollection>
+            <EclipseViewCollection>
+                <EclipseViewCollection>
+                    <Views/>
+                </EclipseViewCollection>
+            </EclipseViewCollection>
+            <ContourMaps>
+                <Eclipse2dViewCollection>
+                    <EclipseViews/>
+                </Eclipse2dViewCollection>
+            </ContourMaps>
+            <VfpDataCollection>
+                <RimVfpDataCollection>
+                    <VfpPlots/>
+                </RimVfpDataCollection>
+            </VfpDataCollection>
+            <CloudDataCollection>
+                <RimCloudDataSourceCollection>
+                    <SumoFieldId></SumoFieldId>
+                    <SumoCaseId></SumoCaseId>
+                    <SumoEnsembleNames></SumoEnsembleNames>
+                    <SumoDataSources/>
+                </RimCloudDataSourceCollection>
+            </CloudDataCollection>
+        </ResInsightOilField>
+    </OilFields>
+    <ColorLegendCollection>
+        <ColorLegendCollection>
+            <CustomColorLegends/>
+        </ColorLegendCollection>
+    </ColorLegendCollection>
+    <JobCollection>
+        <JobCollection>
+            <Jobs>
+                <OpmFlowJob>
+                    <Name>BASE_MODEL_1 - Opm Flow Simulation</Name>
+                    <DeckFile>$PathId_007$</DeckFile>
+                    <WorkDirectory>$PathId_008$</WorkDirectory>
+                    <WellPath>$ROOT$ OilFields 0 WellPathCollection 0 WellPaths 0</WellPath>
+                    <EclipseCase>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1</EclipseCase>
+                    <GridEnsemble></GridEnsemble>
+                    <SummaryEnsemble></SummaryEnsemble>
+                    <PauseBeforeRun>False </PauseBeforeRun>
+                    <AddNewWell>True </AddNewWell>
+                    <OpenWellDeckPosition>-1</OpenWellDeckPosition>
+                    <IncludeMswData>False </IncludeMswData>
+                    <AddToEnsemble>False </AddToEnsemble>
+                    <UseRestart>False </UseRestart>
+                    <CurrentRunID>0</CurrentRunID>
+                    <WellGroupName>PROD_N</WellGroupName>
+                    <WellOpenType>AtSelectedDate</WellOpenType>
+                    <WconprodKeyword>
+                        <KeywordWconprod>
+                            <status>OPEN</status>
+                            <target>LRAT</target>
+                            <orat>100</orat>
+                            <wrat>100</wrat>
+                            <grat>100</grat>
+                            <lrat>100</lrat>
+                            <resv>100</resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <alqWell></alqWell>
+                        </KeywordWconprod>
+                    </WconprodKeyword>
+                    <WconinjeKeyword>
+                        <KeywordWconinje>
+                            <type>WAT</type>
+                            <status>OPEN</status>
+                            <target>RATE</target>
+                            <rate></rate>
+                            <resv></resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <rsrvinj></rsrvinj>
+                        </KeywordWconinje>
+                    </WconinjeKeyword>
+                    <JobSettings>
+                        <OpmFlowJobSettings>
+                            <mpiProcesses>2</mpiProcesses>
+                            <threadsPerProcess>2</threadsPerProcess>
+                            <enableEsmry>True </enableEsmry>
+                            <enableTerminalOutput>True </enableTerminalOutput>
+                            <enableTuning>False </enableTuning>
+                            <ignoreKeywords></ignoreKeywords>
+                            <newtonMaxIterations>False  20</newtonMaxIterations>
+                            <parsingStrictness>normal</parsingStrictness>
+                            <relaxedMaxPvFraction>False  0.03</relaxedMaxPvFraction>
+                            <solverMaxTimeStepInDays>False  365</solverMaxTimeStepInDays>
+                            <solverMinTimeStepInDays>False  1e-12</solverMinTimeStepInDays>
+                            <minStrictCnvIter>False  -1</minStrictCnvIter>
+                            <minStrictMbIter>False  -1</minStrictMbIter>
+                            <minTimeStepBasedOnNewtonIterations>False  0</minTimeStepBasedOnNewtonIterations>
+                            <minTimeStepBeforeShuttingProblematicWellsInDays>False  0.01</minTimeStepBeforeShuttingProblematicWellsInDays>
+                            <toleranceCnv>False  0.01</toleranceCnv>
+                            <toleranceCnvEnergy>False  0.01</toleranceCnvEnergy>
+                            <toleranceCnvEnergyRelaxed>False  1</toleranceCnvEnergyRelaxed>
+                            <toleranceCnvRelaxed>False  1</toleranceCnvRelaxed>
+                            <toleranceEnergyBalance>False  1e-07</toleranceEnergyBalance>
+                            <toleranceEnergyBalanceRelaxed>False  1e-06</toleranceEnergyBalanceRelaxed>
+                            <toleranceMb>False  1e-07</toleranceMb>
+                            <toleranceMbRelaxed>False  1e-06</toleranceMbRelaxed>
+                            <tolerancePressureMsWells>False  1000</tolerancePressureMsWells>
+                            <toleranceWellControl>False  1e-07</toleranceWellControl>
+                            <toleranceWells>False  0.0001</toleranceWells>
+                            <wellGroupConstraintsMaxIterations>False  1</wellGroupConstraintsMaxIterations>
+                        </OpmFlowJobSettings>
+                    </JobSettings>
+                    <OpenTimeStep>6</OpenTimeStep>
+                    <EndTimeStep>0</EndTimeStep>
+                    <EndTimeStepEnabled>False </EndTimeStepEnabled>
+                    <AppendNewDates>False </AppendNewDates>
+                    <NewDatesInterval>1</NewDatesInterval>
+                    <NumberOfNewDates>12</NumberOfNewDates>
+                    <DateAppendType>AppendMonths</DateAppendType>
+                </OpmFlowJob>
+            </Jobs>
+        </JobCollection>
+    </JobCollection>
+    <MainPlotCollection>
+        <MainPlotCollection>
+            <Show>True </Show>
+            <WellLogPlotCollection>
+                <WellLogPlotCollection>
+                    <WellLogPlots/>
+                </WellLogPlotCollection>
+            </WellLogPlotCollection>
+            <RftPlotCollection>
+                <WellRftPlotCollection>
+                    <RftPlots/>
+                </WellRftPlotCollection>
+            </RftPlotCollection>
+            <PltPlotCollection>
+                <WellPltPlotCollection>
+                    <PltPlots/>
+                </WellPltPlotCollection>
+            </PltPlotCollection>
+            <SummaryMultiPlotCollection>
+                <RimSummaryMultiPlotCollection>
+                    <MultiSummaryPlots/>
+                    <UseCommonReadoutSettings>False </UseCommonReadoutSettings>
+                    <ReadOutSettings>
+                        <RimSummaryPlotReadOut>
+                            <ReadOutType>NONE</ReadOutType>
+                            <LineAppearance>
+                                <RimAnnotationLineAppearance>
+                                    <LineFieldsHidden>False </LineFieldsHidden>
+                                    <Color>0.250980406999588 0.250980406999588 0.250980406999588</Color>
+                                    <Thickness>2</Thickness>
+                                    <Style>STYLE_DASH</Style>
+                                </RimAnnotationLineAppearance>
+                            </LineAppearance>
+                            <VerticalLineLabelAlignment>LEFT</VerticalLineLabelAlignment>
+                            <HorizontalLineLabelAlignment>LEFT</HorizontalLineLabelAlignment>
+                        </RimSummaryPlotReadOut>
+                    </ReadOutSettings>
+                </RimSummaryMultiPlotCollection>
+            </SummaryMultiPlotCollection>
+            <AnalysisPlotCollection>
+                <AnalysisPlotCollection>
+                    <AnalysisPlots/>
+                </AnalysisPlotCollection>
+            </AnalysisPlotCollection>
+            <CorrelationPlotCollection>
+                <CorrelationPlotCollection>
+                    <CorrelationPlots/>
+                    <CorrelationReports/>
+                </CorrelationPlotCollection>
+            </CorrelationPlotCollection>
+            <SummaryCrossPlotCollection>
+                <SummaryCrossPlotCollection>
+                    <SummaryCrossPlots/>
+                </SummaryCrossPlotCollection>
+            </SummaryCrossPlotCollection>
+            <SummaryTableCollection>
+                <RimSummaryTableCollection>
+                    <SummaryTables/>
+                </RimSummaryTableCollection>
+            </SummaryTableCollection>
+            <FlowPlotCollection>
+                <FlowPlotCollection>
+                    <FlowCharacteristicsPlot>
+                        <FlowCharacteristicsPlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <FlowCase></FlowCase>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeSelectionType>SELECTED</TimeSelectionType>
+                            <SelectedTimeSteps></SelectedTimeSteps>
+                            <SelectedTimeStepsUi></SelectedTimeStepsUi>
+                            <CellPVThreshold>0.1</CellPVThreshold>
+                            <ShowLegend>True </ShowLegend>
+                            <CellFilter>CELLS_ACTIVE</CellFilter>
+                            <CellFilterView></CellFilterView>
+                            <TracerFilter></TracerFilter>
+                            <SelectedTracerNames></SelectedTracerNames>
+                            <MinCommunication>0</MinCommunication>
+                            <MaxTof>146000</MaxTof>
+                        </FlowCharacteristicsPlot>
+                    </FlowCharacteristicsPlot>
+                    <DefaultWellConnectivityTable>
+                        <RimWellConnectivityTable>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>0</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <CurveCase></CurveCase>
+                            <VisibleCellView></VisibleCellView>
+                            <ViewFilterType>FILTER_BY_VISIBLE_PRODUCERS</ViewFilterType>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeStepSelectopn>SINGLE_TIME_STEP</TimeStepSelectopn>
+                            <SelectProducersAndInjectorsForTimeSteps>True </SelectProducersAndInjectorsForTimeSteps>
+                            <ThresholdValue>0</ThresholdValue>
+                            <TimeSampleValueType>FLOW_RATE_FRACTION</TimeSampleValueType>
+                            <TimeStep></TimeStep>
+                            <TimeRangeValueType>ACCUMULATED_FLOW_VOLUME_FRACTION</TimeRangeValueType>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <SelectedProducerTracers></SelectedProducerTracers>
+                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                            <SyncSelectedProdInj>False </SyncSelectedProdInj>
+                            <SyncSelectedInjProd>False </SyncSelectedInjProd>
+                            <ShowValueLabels>False </ShowValueLabels>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisLabelFontSize>Medium</AxisLabelFontSize>
+                            <ValueLabelFontSize>Medium</ValueLabelFontSize>
+                            <LegendConfig>
+                                <Legend>
+                                    <ShowLegend>True </ShowLegend>
+                                    <NumberOfLevels>8</NumberOfLevels>
+                                    <Precision>4</Precision>
+                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 18</ColorLegend>
+                                    <MappingMode>LinearContinuous</MappingMode>
+                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                    <UserDefinedMax>1</UserDefinedMax>
+                                    <UserDefinedMin>0</UserDefinedMin>
+                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                    <ResultVariableUsage></ResultVariableUsage>
+                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                </Legend>
+                            </LegendConfig>
+                            <MappingType>LinearContinuous</MappingType>
+                            <RangeType>AUTOMATIC</RangeType>
+                        </RimWellConnectivityTable>
+                    </DefaultWellConnectivityTable>
+                    <DefaultWellAllocationOverTimePlot>
+                        <RimWellAllocationOverTimePlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>1</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Medium</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <RowSpan>ONE</RowSpan>
+                            <ColSpan>ONE</ColSpan>
+                            <PlotDescription>Default Well Allocation Over Time Plot</PlotDescription>
+                            <CurveCase></CurveCase>
+                            <WellName>None</WellName>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowValueType>FLOW_RATE</FlowValueType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisValueFontSize>Medium</AxisValueFontSize>
+                        </RimWellAllocationOverTimePlot>
+                    </DefaultWellAllocationOverTimePlot>
+                    <DefaultWellAllocationPlot>
+                        <WellAllocationPlot>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <PlotDescription>Default Flow Diagnostics Plot</PlotDescription>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <BranchDetection>True </BranchDetection>
+                            <CurveCase></CurveCase>
+                            <PlotTimeStep>0</PlotTimeStep>
+                            <WellName>None</WellName>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowType>ACCUMULATED</FlowType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AccumulatedWellFlowPlot>
+                                <WellLogPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>False </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>False </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <TemplateText>$CASE, $WELL</TemplateText>
+                                    <PlotNamingMethod>CUSTOM</PlotNamingMethod>
+                                    <DepthType>CONNECTION_NUMBER</DepthType>
+                                    <DepthUnit>UNIT_NONE</DepthUnit>
+                                    <MinimumDepth>0</MinimumDepth>
+                                    <MaximumDepth>1000</MaximumDepth>
+                                    <ShowDepthGridLines>GRID_X_MAJOR</ShowDepthGridLines>
+                                    <AutoScaleDepthEnabled>True </AutoScaleDepthEnabled>
+                                    <DepthAxisVisibility>ONE_VISIBLE</DepthAxisVisibility>
+                                    <ShowDepthMarkerLine>False </ShowDepthMarkerLine>
+                                    <AutoZoomMinDepthFactor>0</AutoZoomMinDepthFactor>
+                                    <AutoZoomMaxDepthFactor>0</AutoZoomMaxDepthFactor>
+                                    <DepthAnnotations/>
+                                    <SubTitleFontSize>Medium</SubTitleFontSize>
+                                    <AxisTitleFontSize>Medium</AxisTitleFontSize>
+                                    <AxisValueFontSize>Medium</AxisValueFontSize>
+                                    <NameConfig>
+                                        <RimWellLogPlotNameConfig>
+                                            <CustomCurveName>Accumulated Flow Chart</CustomCurveName>
+                                        </RimWellLogPlotNameConfig>
+                                    </NameConfig>
+                                    <FilterEnsembleCurveSet></FilterEnsembleCurveSet>
+                                    <DepthEqualization>NONE</DepthEqualization>
+                                    <Tracks/>
+                                    <DepthOrientation>VERTICAL</DepthOrientation>
+                                </WellLogPlot>
+                            </AccumulatedWellFlowPlot>
+                            <TotalWellFlowPlot>
+                                <TotalWellAllocationPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <PlotDescription>Total Allocation</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                </TotalWellAllocationPlot>
+                            </TotalWellFlowPlot>
+                            <WellAllocLegend>
+                                <WellAllocationPlotLegend>
+                                    <ShowPlotLegend>True </ShowPlotLegend>
+                                </WellAllocationPlotLegend>
+                            </WellAllocLegend>
+                            <TofAccumulatedPhaseFractionsPlot>
+                                <TofAccumulatedPhaseFractionsPlot>
+                                    <WindowController/>
+                                    <ShowWindow>False </ShowWindow>
+                                    <PlotDescription>Cumulative Saturation by Time of Flight</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <MaxTof>50</MaxTof>
+                                </TofAccumulatedPhaseFractionsPlot>
+                            </TofAccumulatedPhaseFractionsPlot>
+                        </WellAllocationPlot>
+                    </DefaultWellAllocationPlot>
+                    <WellDistributionPlotCollection>
+                        <WellDistributionPlotCollection>
+                            <WindowController>
+                                <MdiWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <xPos>0</xPos>
+                                    <yPos>0</yPos>
+                                    <Width>-1</Width>
+                                    <Height>-1</Height>
+                                    <IsMaximized>False </IsMaximized>
+                                </MdiWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <Id>2</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <Case></Case>
+                            <TimeStepIndex>-1</TimeStepIndex>
+                            <WellName>None</WellName>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                            <MaximumTOF>20</MaximumTOF>
+                            <Plots>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>OIL_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>GAS_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>WATER_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                            </Plots>
+                            <ShowOil>True </ShowOil>
+                            <ShowGas>True </ShowGas>
+                            <ShowWater>True </ShowWater>
+                            <PlotDescription>Cumulative Phase Distribution Plots</PlotDescription>
+                        </WellDistributionPlotCollection>
+                    </WellDistributionPlotCollection>
+                    <StoredWellAllocationPlots/>
+                    <StoredFlowCharacteristicsPlots/>
+                </FlowPlotCollection>
+            </FlowPlotCollection>
+            <Rim3dCrossPlotCollection>
+                <RimGridCrossPlotCollection>
+                    <GridCrossPlots/>
+                </RimGridCrossPlotCollection>
+            </Rim3dCrossPlotCollection>
+            <RimSaturationPressurePlotCollection>
+                <RimSaturationPressurePlotCollection>
+                    <SaturationPressurePlots/>
+                </RimSaturationPressurePlotCollection>
+            </RimSaturationPressurePlotCollection>
+            <RimMultiPlotCollection>
+                <RimMultiPlotCollection>
+                    <MultiPlots/>
+                </RimMultiPlotCollection>
+            </RimMultiPlotCollection>
+            <StimPlanModelPlotCollection>
+                <StimPlanModelPlotCollection>
+                    <StimPlanModelPlots/>
+                </StimPlanModelPlotCollection>
+            </StimPlanModelPlotCollection>
+            <VfpPlotCollection>
+                <RimVfpPlotCollection>
+                    <CustomVfpPlots/>
+                </RimVfpPlotCollection>
+            </VfpPlotCollection>
+            <HistogramMultiPlotCollection>
+                <RimHistogramMultiPlotCollection>
+                    <HistogramMultiPlots/>
+                </RimHistogramMultiPlotCollection>
+            </HistogramMultiPlotCollection>
+        </MainPlotCollection>
+    </MainPlotCollection>
+    <PinnedFieldCollection>
+        <RimQuickAccessCollection>
+            <FieldReferencesGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0 RangeFilters 0 CellFilters 0</Object>
+                                    <FieldKeyword>StartIndexI</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 1 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+            </FieldReferencesGroup>
+        </RimQuickAccessCollection>
+    </PinnedFieldCollection>
+    <LinkedViews>
+        <RimViewLinkerCollection>
+            <Active>True </Active>
+            <ViewLinkers/>
+        </RimViewLinkerCollection>
+    </LinkedViews>
+    <CalculationCollection>
+        <RimSummaryCalculationCollection>
+            <Calculations/>
+        </RimSummaryCalculationCollection>
+    </CalculationCollection>
+    <GridCalculationCollection>
+        <RimGridCalculationCollection>
+            <Calculations/>
+        </RimGridCalculationCollection>
+    </GridCalculationCollection>
+    <MultiSnapshotDefinitions/>
+    <TreeViewStates>-1-1100000;-1-11000;-1-110100010;-1-110100040;-1-110100070;-1-110100080;-1-1101000100;-1-1101000110;-1-1101000;-1-11010;-1-110;-1-1300000;-1-13000;-1-130||-1-110</TreeViewStates>
+    <TreeViewCurrentModelIndexPaths>3 0;0 0;0 0;3 0||1 0;0 0</TreeViewCurrentModelIndexPaths>
+    <PlotWindowTreeViewStates>-1-100|-1-100|||</PlotWindowTreeViewStates>
+    <PlotWindowTreeViewCurrentModelIndexPaths>||||</PlotWindowTreeViewCurrentModelIndexPaths>
+    <show3DWindow>True </show3DWindow>
+    <showPlotWindow>False </showPlotWindow>
+    <showPlotWindowOnTopOf3DWindow>False </showPlotWindowOnTopOf3DWindow>
+    <tiled3DWindow>False </tiled3DWindow>
+    <tiledPlotWindow>False </tiledPlotWindow>
+    <DialogData>
+        <RimDialogData>
+            <ExportCarfin>
+                <RicExportCarfinUi>
+                    <CellRange>
+                        <RicCellRangeUi>
+                            <Case></Case>
+                            <GridIndex>0</GridIndex>
+                            <StartIndexI>1</StartIndexI>
+                            <StartIndexJ>1</StartIndexJ>
+                            <StartIndexK>1</StartIndexK>
+                            <CellCountI>1</CellCountI>
+                            <CellCountJ>1</CellCountJ>
+                            <CellCountK>1</CellCountK>
+                        </RicCellRangeUi>
+                    </CellRange>
+                    <ExportFileName></ExportFileName>
+                    <CaseToApply></CaseToApply>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <MaxWellCount>8</MaxWellCount>
+                </RicExportCarfinUi>
+            </ExportCarfin>
+            <ExportCompletionData>
+                <RicExportCompletionDataSettingsUi>
+                    <Folder>C:/gitroot/ResInsight/TestModels/msw-export/output/completion-export</Folder>
+                    <CaseToApply>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0</CaseToApply>
+                    <FileSplit>SPLIT_ON_WELL</FileSplit>
+                    <compdatExport>TRANSMISSIBILITIES</compdatExport>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludeMSW>True </IncludeMSW>
+                    <UseLateralNTG>False </UseLateralNTG>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <IncludeFractures>True </IncludeFractures>
+                    <TransScalingType>False </TransScalingType>
+                    <TransScalingTimeStep>0</TransScalingTimeStep>
+                    <TransScalingWBHPSource>WBHP_SUMMARY</TransScalingWBHPSource>
+                    <TransScalingWBHP>200</TransScalingWBHP>
+                    <ExcludeMainBoreForFishbones>False </ExcludeMainBoreForFishbones>
+                    <ExportDataSourceAsComment>True </ExportDataSourceAsComment>
+                    <ExportWelspec>True </ExportWelspec>
+                    <CompletionWelspecAfterMainBore>True </CompletionWelspecAfterMainBore>
+                    <UseCustomFileName>False </UseCustomFileName>
+                    <CustomFileName></CustomFileName>
+                </RicExportCompletionDataSettingsUi>
+            </ExportCompletionData>
+            <MultipleFractionsData>
+                <RiuCreateMultipleFractionsUi>
+                    <SourceCase></SourceCase>
+                    <MinDistanceFromWellTd>10</MinDistanceFromWellTd>
+                    <MaxFracturesPerWell>10</MaxFracturesPerWell>
+                    <Options/>
+                </RiuCreateMultipleFractionsUi>
+            </MultipleFractionsData>
+            <HoloLenseExportToFolderData>
+                <RicHoloLensExportToFolderUi>
+                    <ViewForExport></ViewForExport>
+                    <ExportFolder></ExportFolder>
+                </RicHoloLensExportToFolderUi>
+            </HoloLenseExportToFolderData>
+            <ExportwellPathsData>
+                <RicExportWellPathsUi>
+                    <ExportFolder></ExportFolder>
+                    <MdStepSize>5</MdStepSize>
+                </RicExportWellPathsUi>
+            </ExportwellPathsData>
+            <ExportLgr>
+                <RicExportLgrUi>
+                    <ExportFolder></ExportFolder>
+                    <CaseToApply></CaseToApply>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFractures>True </IncludeFractures>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <SplitType>LGR_PER_COMPLETION</SplitType>
+                </RicExportLgrUi>
+            </ExportLgr>
+            <ExportSectorModel>
+                <RicExportEclipseInputGridUi>
+                    <ExportGrid>True </ExportGrid>
+                    <ExportGridFilename>GRID.GRDECL</ExportGridFilename>
+                    <ExportInLocalCoords>False </ExportInLocalCoords>
+                    <InvisibleCellActnum>False </InvisibleCellActnum>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>2147483647</MinI>
+                    <MinJ>2147483647</MinJ>
+                    <MinK>2147483647</MinK>
+                    <MaxI>-2147483647</MaxI>
+                    <MaxJ>-2147483647</MaxJ>
+                    <MaxK>-2147483647</MaxK>
+                    <ExportFaults>TO_SINGLE_RESULT_FILE</ExportFaults>
+                    <ExportFaultsFilename>FAULTS.GRDECL</ExportFaultsFilename>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <ExportParams>TO_SEPARATE_RESULT_FILES</ExportParams>
+                    <ExportParamsFilename>RESULTS.GRDECL</ExportParamsFilename>
+                    <ExportMainKeywords></ExportMainKeywords>
+                    <WriteEchoInGrdeclFiles>False </WriteEchoInGrdeclFiles>
+                    <ExportFolder>$PathId_009$</ExportFolder>
+                </RicExportEclipseInputGridUi>
+            </ExportSectorModel>
+            <MockModelSettings>
+                <MockModelSettings>
+                    <CellCountX>100</CellCountX>
+                    <CellCountY>100</CellCountY>
+                    <CellCountZ>10</CellCountZ>
+                    <TotalCellCount>0</TotalCellCount>
+                    <ResultCount>3</ResultCount>
+                    <TimeStepCount>10</TimeStepCount>
+                </MockModelSettings>
+            </MockModelSettings>
+            <CreateEnsembleSurfaceUi>
+                <RicCreateEnsembleSurfaceUi>
+                    <Layers></Layers>
+                    <AutoCreateEnsembleSurfaces>False </AutoCreateEnsembleSurfaces>
+                    <MinLayer>0</MinLayer>
+                    <MaxLayer>0</MaxLayer>
+                </RicCreateEnsembleSurfaceUi>
+            </CreateEnsembleSurfaceUi>
+            <CreateEnsembleWellLogUi>
+                <RicCreateEnsembleWellLogUi>
+                    <AutoCreateEnsembleWellLogs>True </AutoCreateEnsembleWellLogs>
+                    <TimeStep>0</TimeStep>
+                    <WellPathSource>FILE</WellPathSource>
+                    <WellPath></WellPath>
+                    <WellFilePath></WellFilePath>
+                    <SelectedProperties></SelectedProperties>
+                </RicCreateEnsembleWellLogUi>
+            </CreateEnsembleWellLogUi>
+            <ExportSectorModelUi>
+                <RicExportSectorModelUi>
+                    <ExportFolder>$PathId_009$</ExportFolder>
+                    <ExportDeckName></ExportDeckName>
+                    <PorvMultiplier>1000000</PorvMultiplier>
+                    <BoundaryCondition>OPERNUM_OPERATER</BoundaryCondition>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>1</MinI>
+                    <MinJ>1</MinJ>
+                    <MinK>1</MinK>
+                    <MaxI>1</MaxI>
+                    <MaxJ>1</MaxJ>
+                    <MaxK>1</MaxK>
+                    <RefineGrid>False </RefineGrid>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <BcpropKeywords/>
+                    <KeywordsToRemove>ACTION ACTIONX ACTIONW BOX UDQ </KeywordsToRemove>
+                    <EnablePadding>False </EnablePadding>
+                    <PaddingNzUpper>0</PaddingNzUpper>
+                    <PaddingTopUpper>0</PaddingTopUpper>
+                    <PaddingUpperPorosity>0</PaddingUpperPorosity>
+                    <PaddingUpperEquilnum>1</PaddingUpperEquilnum>
+                    <PaddingNzLower>0</PaddingNzLower>
+                    <PaddingBottomLower>0</PaddingBottomLower>
+                    <PaddingMinThickness>0.1</PaddingMinThickness>
+                    <PaddingFillGaps>False </PaddingFillGaps>
+                    <PaddingMonotonicZcorn>False </PaddingMonotonicZcorn>
+                    <PaddingVerticalPillars>False </PaddingVerticalPillars>
+                    <CreateSimulationJob>False </CreateSimulationJob>
+                    <SimulationJobFolder></SimulationJobFolder>
+                    <SimulationJobName></SimulationJobName>
+                    <StartSimulationJobAfterExport>False </StartSimulationJobAfterExport>
+                    <EclipseCase></EclipseCase>
+                    <EclipseView></EclipseView>
+                </RicExportSectorModelUi>
+            </ExportSectorModelUi>
+        </RimDialogData>
+    </DialogData>
+    <TileMode3DWindow>UNDEFINED</TileMode3DWindow>
+    <TileModePlotWindow>UNDEFINED</TileModePlotWindow>
+    <AutomationSettings>
+        <RimAutomationSettings>
+            <CellSelectionDestination></CellSelectionDestination>
+            <CaseReloadIntervalSeconds>15</CaseReloadIntervalSeconds>
+        </RimAutomationSettings>
+    </AutomationSettings>
+</ResInsightProject>

--- a/docs/diagrams/msw-export/01-overview.md
+++ b/docs/diagrams/msw-export/01-overview.md
@@ -1,0 +1,52 @@
+# MSW Export: High-Level Pipeline Overview
+
+```mermaid
+flowchart TD
+    subgraph RIM["RIM (Project Data Model)"]
+        WP[RimWellPath]
+        MSW[RimMswCompletionParameters]
+        PERF[RimPerforationInterval]
+        VALVE["RimWellPathValve<br/>ICD / ICV / AICD / SICD"]
+        FRAC[RimWellPathFracture]
+        FB[RimFishbones]
+        EC[RimEclipseCase]
+    end
+
+    subgraph GEO["Geometry Extraction"]
+        GCS["generateCellSegments<br/>WellPathCellIntersectionInfo list"]
+        FI["filterIntersections<br/>clip to heel MD"]
+    end
+
+    subgraph BUILD["RicWellPathExportMswGeometryPath<br/>buildMswWellExportData"]
+        MB["buildMainBoreBranchFromGeometry<br/>RicMswBranchBuilder"]
+        VB["buildValveBranchesFromGeometry<br/>RicMswBranchBuilder"]
+        FRB["buildFractureBranchesFromGeometry<br/>RicMswBranchBuilder"]
+        FBB["buildFishbonesBranchesFromGeometry<br/>RicMswBranchBuilder"]
+        LAT["buildLateralBranches<br/>recursive"]
+    end
+
+    subgraph RIG["RIG (Intermediate Export Data)"]
+        WED["RigMswWellExportData<br/>header + branches"]
+        BR["RigMswBranch<br/>branchNumber + segments"]
+        SEG["RigMswSegment<br/>WELSEGS row + intersections + valve"]
+    end
+
+    subgraph COLLECT["collectTableData"]
+        TD["RigMswTableData<br/>flat table rows per well"]
+    end
+
+    subgraph OUTPUT["Output Tables"]
+        WH[WelsegsHeader]
+        WR[WelsegsRow]
+        CR[CompsegsRow]
+        VR["WsegvalvRow / WsegaicdRow / WsegsicdRow"]
+    end
+
+    RIM --> GEO
+    GEO --> BUILD
+    BUILD --> RIG
+    RIG --> COLLECT
+    COLLECT --> OUTPUT
+
+    WED --> BR --> SEG
+```

--- a/docs/diagrams/msw-export/02-data-structures.md
+++ b/docs/diagrams/msw-export/02-data-structures.md
@@ -1,0 +1,130 @@
+# MSW Export: Data Structures
+
+## RIG flat structs (new geometry path output)
+
+```mermaid
+classDiagram
+    class RigMswWellExportData {
+        WelsegsHeader header
+        vector~RigMswBranch~ branches
+    }
+
+    class RigMswBranch {
+        int branchNumber
+        optional~RigMswSegment~ tieInValve
+        vector~RigMswSegment~ segments
+    }
+
+    class RigMswSegment {
+        int segmentNumber
+        int outletSegmentNumber
+        double length
+        double depth
+        optional~double~ diameter
+        optional~double~ roughness
+        string description
+        string sourceWellName
+        vector~RigMswCellIntersection~ intersections
+        optional~WsegvalvRow~ wsegvalvData
+        optional~WsegaicdRow~ wsegaicdData
+        optional~WsegsicdRow~ wsegsicdData
+    }
+
+    class RigMswCellIntersection {
+        size_t i, j, k
+        double distanceStart
+        double distanceEnd
+        string gridName
+    }
+
+    class WelsegsHeader {
+        string well
+        double topDepth
+        double topLength
+        string infoType
+        optional~string~ pressureComponents
+    }
+
+    RigMswWellExportData "1" --> "1" WelsegsHeader
+    RigMswWellExportData "1" --> "*" RigMswBranch
+    RigMswBranch "1" --> "*" RigMswSegment
+    RigMswSegment "1" --> "*" RigMswCellIntersection
+```
+
+## Flat table rows collected into RigMswTableData
+
+```mermaid
+classDiagram
+    class RigMswTableData {
+        string wellName
+        WelsegsHeader welsegsHeader
+        vector~WelsegsRow~ welsegsData
+        vector~CompsegsRow~ compsegsData
+        vector~WsegvalvRow~ wsegvalvData
+        vector~WsegaicdRow~ wsegaicdData
+        vector~WsegsicdRow~ wsegsicdData
+        vector~RigMswBranch~ mswBranches
+    }
+
+    class WelsegsRow {
+        int segment1, segment2
+        int branch
+        int joinSegment
+        double length, depth
+        optional~double~ diameter
+        optional~double~ roughness
+    }
+
+    class CompsegsRow {
+        size_t i, j, k
+        int branch
+        double distanceStart
+        double distanceEnd
+        string gridName
+    }
+
+    class WsegvalvRow {
+        string well
+        int segmentNumber
+        double cv
+        double area
+        optional~string~ status
+    }
+
+    class WsegaicdRow {
+        string well
+        int segment1, segment2
+        double strength
+        double maxAbsRate
+        optional~string~ status
+    }
+
+    class WsegsicdRow {
+        string well
+        int segment1, segment2
+        double strength
+        double maxAbsRate
+        optional~string~ status
+    }
+
+    RigMswTableData "1" --> "*" WelsegsRow
+    RigMswTableData "1" --> "*" CompsegsRow
+    RigMswTableData "1" --> "*" WsegvalvRow
+    RigMswTableData "1" --> "*" WsegaicdRow
+    RigMswTableData "1" --> "*" WsegsicdRow
+```
+
+## RigMswUnifiedData aggregates multiple wells
+
+```mermaid
+classDiagram
+    class RigMswUnifiedData {
+        vector~RigMswTableData~ wellDataList
+        getAllCompsegsRows()
+        getAllWsegvalvRows()
+        getAllWsegaicdRows()
+        getAllWsegsicdRows()
+    }
+
+    RigMswUnifiedData "1" --> "*" RigMswTableData
+```

--- a/docs/diagrams/msw-export/03-build-pipeline.md
+++ b/docs/diagrams/msw-export/03-build-pipeline.md
@@ -1,0 +1,81 @@
+# MSW Export: Detailed Build Pipeline
+
+## buildMswWellExportData — main bore + completions
+
+```mermaid
+flowchart TD
+    ENTRY["buildMswWellExportData<br/>(RimEclipseCase, RimWellPath,<br/>maxSegmentLength, completionType)"]
+
+    ENTRY --> GCS["generateCellSegments<br/>-> WellPathCellIntersectionInfo list"]
+    GCS --> INITMD["computeInitialMeasuredDepth<br/>-> initialMD / initialTVD"]
+    INITMD --> FI["filterIntersections<br/>clip list to heel MD"]
+
+    FI --> HEADER["Build WelsegsHeader<br/>(well name, topLength, topDepth,<br/>infoType, pressureComponents)"]
+
+    FI --> MB["buildMainBoreBranchFromGeometry<br/>-> RigMswBranch (branch 1)"]
+    MB --> CSMAP["fills CellSegmentEntry map<br/>(MD range -> segment number)"]
+
+    CSMAP --> SVALVE["standalone valves from<br/>RimWellPathValve (valveCollection)<br/>-> embed WsegvalvRow on segment"]
+
+    CSMAP --> VB["buildValveBranchesFromGeometry<br/>(ICD/ICV/AICD/SICD inside perforations)<br/>-> vector~RigMswBranch~"]
+
+    CSMAP --> FRB["buildFractureBranchesFromGeometry<br/>(if FRACTURES flag set)<br/>-> vector~RigMswBranch~"]
+
+    CSMAP --> FBB["buildFishbonesBranchesFromGeometry<br/>(if FISHBONES flag set)<br/>-> vector~RigMswBranch~"]
+
+    CSMAP --> LAT["buildLateralBranches (recursive)<br/>for each child RimWellPath with tie-in<br/>-> vector~RigMswBranch~"]
+
+    HEADER & MB & VB & FRB & FBB & LAT --> RESULT["RigMswWellExportData<br/>{ header, branches }"]
+```
+
+## buildLateralBranches — recursive lateral handling
+
+```mermaid
+flowchart TD
+    LAT["buildLateralBranches<br/>(eclipseCase, wellPath, mainGrid,<br/>outletSegNum, completionType)"]
+
+    LAT --> TIEINMD["read tieInMD / tieInTVD<br/>from RimWellPathTieIn"]
+
+    TIEINMD --> TICV{"outletValve<br/>(ICV) active?"}
+    TICV -- yes --> TIEINSEG["build tie-in RigMswSegment<br/>+ WsegvalvRow<br/>-> stored as branch.tieInValve"]
+    TICV -- no --> SKIP[use outletSegNum directly]
+
+    TIEINSEG & SKIP --> GCS2["generateCellSegments<br/>filterIntersections"]
+
+    GCS2 --> MB2["buildMainBoreBranchFromGeometry<br/>-> RigMswBranch (lateral)"]
+    MB2 --> SVALVE2["standalone valves<br/>(valveCollection)"]
+    MB2 --> CSMAP2["CellSegmentEntry map"]
+
+    CSMAP2 --> VB2["buildValveBranchesFromGeometry"]
+    CSMAP2 --> FRB2["buildFractureBranchesFromGeometry"]
+    CSMAP2 --> FBB2["buildFishbonesBranchesFromGeometry"]
+
+    CSMAP2 --> GRANDCHILD["for each grandchild wellPath<br/>buildLateralBranches (recurse)"]
+
+    VB2 & FRB2 & FBB2 & GRANDCHILD --> RESULT2["vector~RigMswBranch~"]
+```
+
+## collectTableData — RigMswWellExportData to RigMswTableData
+
+```mermaid
+flowchart TD
+    INPUT["RigMswWellExportData<br/>{ header, branches }"]
+
+    INPUT --> HROW["setWelsegsHeader<br/>-> WelsegsHeader"]
+
+    INPUT --> LOOP["for each RigMswBranch"]
+    LOOP --> TIEIN{"tieInValve<br/>present?"}
+    TIEIN -- yes --> EMIT0["emitSegment(tieInValve)"]
+    TIEIN --> SEGLOOP["for each RigMswSegment"]
+
+    SEGLOOP --> WROW["addWelsegsRow<br/>(segment, branch, outlet, length, depth)"]
+    SEGLOOP --> CROW["addCompsegsRow per<br/>RigMswCellIntersection<br/>(i,j,k, branch, distStart, distEnd)"]
+    SEGLOOP --> VALVROW{"valve data?"}
+    VALVROW -- wsegvalvData --> VV["addWsegvalvRow"]
+    VALVROW -- wsegaicdData --> VA["addWsegaicdRow"]
+    VALVROW -- wsegsicdData --> VS["addWsegsicdRow"]
+
+    LOOP --> ADDMB["addMswBranch<br/>(store RigMswBranch reference)"]
+
+    HROW & WROW & CROW & VV & VA & VS & ADDMB --> TD["RigMswTableData"]
+```

--- a/docs/diagrams/msw-export/04-fishbones-model.md
+++ b/docs/diagrams/msw-export/04-fishbones-model.md
@@ -1,0 +1,79 @@
+# Fishbones MSW Model
+
+## Well path layout
+
+Each fishbones "sub" position on the main bore spawns one ICD branch and one
+lateral branch per installed tube. All segments belong to `RigMswBranch`
+structs; connectivity is expressed through `outletSegmentNumber`.
+
+```
+Heel (seg 1)
+  |
+  |  Branch 1 — main bore
+  |
+  o--[seg 2]--[seg 3]--[seg 4]--[seg 5]--[seg 6]-- ... --[seg N]-- Toe
+                 |                  |
+             Sub position       Sub position
+                 |                  |
+            [ICD seg]           [ICD seg]        <- Branch 2, 5, ...  (one per sub)
+            (WSEGVALV)          (WSEGVALV)
+             /     \             /     \
+       [lat seg] [lat seg]  [lat seg] [lat seg]  <- Branch 3/4, 6/7, ... (one per lateral)
+       COMPSEGS  COMPSEGS   COMPSEGS  COMPSEGS
+```
+
+## Branch and segment hierarchy
+
+```mermaid
+graph LR
+    classDef mainBore fill:#4a90d9,color:#fff,stroke:#2c6fad
+    classDef icd      fill:#e8a838,color:#fff,stroke:#b07e1e
+    classDef lateral  fill:#5cb85c,color:#fff,stroke:#3d7a3d
+    classDef heel     fill:#888,color:#fff,stroke:#555
+
+    HEEL(["Heel<br/>seg 1"]):::heel
+
+    HEEL --> S2["seg 2"]:::mainBore
+    S2   --> S3["seg 3"]:::mainBore
+    S3   --> S4["seg 4<br/>(sub A position)"]:::mainBore
+    S4   --> S5["seg 5"]:::mainBore
+    S5   --> S6["seg 6<br/>(sub B position)"]:::mainBore
+    S6   --> TOE(["Toe<br/>seg N"]):::mainBore
+
+    S4 --> ICD_A["ICD seg<br/>Branch 2<br/>WSEGVALV"]:::icd
+    ICD_A --> LA1["Lateral 1<br/>Branch 3<br/>COMPSEGS"]:::lateral
+    ICD_A --> LA2["Lateral 2<br/>Branch 4<br/>COMPSEGS"]:::lateral
+
+    S6 --> ICD_B["ICD seg<br/>Branch 5<br/>WSEGVALV"]:::icd
+    ICD_B --> LB1["Lateral 1<br/>Branch 6<br/>COMPSEGS"]:::lateral
+    ICD_B --> LB2["Lateral 2<br/>Branch 7<br/>COMPSEGS"]:::lateral
+```
+
+## Per-sub data structure
+
+```mermaid
+flowchart TD
+    SUB["RimFishbones sub<br/>(subIndex, measuredDepth)"]
+
+    SUB --> ICD_SEG["RigMswSegment — ICD<br/>- segmentNumber = icdSegNum<br/>- outletSegmentNumber = main-bore seg at sub MD<br/>- wsegvalvData: cv, area (from icdCount + orifice diameter)<br/>- intersections: cells closest to sub (COMPSEGS)"]
+
+    ICD_SEG --> LAT_BR["RigMswBranch per lateral<br/>(one branch per installed tube)"]
+
+    LAT_BR --> LAT_SEG["RigMswSegment per grid-cell intersection<br/>- outletSegmentNumber chains along lateral<br/>  (first seg -> icdSegNum)<br/>- diameter = equivalentDiameter<br/>- roughness = openHoleRoughnessFactor<br/>- intersections: COMPSEGS (deduplicated<br/>  against cells already used by ICD or<br/>  other laterals on same sub)"]
+```
+
+## Outlet segment lookup
+
+The ICD segment outlet is found with `findOutletSegmentForMD`:
+
+```
+cellSegMap (built during main-bore pass):
+
+  [startMD ---- midpoint ---- endMD] -> lastSubSegmentNumber
+  [  200.0 ---- 212.5 ----  225.0 ] -> seg 3
+  [  225.0 ---- 237.5 ----  250.0 ] -> seg 4   <- sub A at MD 243 connects here
+  [  250.0 ---- 262.5 ----  275.0 ] -> seg 5
+  [  275.0 ---- 287.5 ----  300.0 ] -> seg 6   <- sub B at MD 290 connects here
+
+Rule: pick the entry whose midpoint is closest to, but not greater than, the sub MD.
+```


### PR DESCRIPTION
## Summary

- Introduce flat data structures (`RigMswSegment`, `RigMswBranch`, `RigMswWellExportData`) in `RigMswSegment.h` as the primary building block for the new MSW export approach, replacing tree traversal with pre-computed branch/segment data
- Add `RicMswBranchBuilder` to build MSW branch data from well path completions (perforations, fishbones, fractures, valves) and `RicWellPathExportMswGeometryPath` for geometry path extraction
- Add unit tests for all new components and test models for multiple laterals, standalone valves, and tie-in custom valve configurations

## Plan
The existing MSW tree export is currently used by ResInsight. The new implementation is used from unit tests and integration tests comparing the generated data from both methods. Further testing is required.

When the simplified export is tested, a lot of code can be removed. The complete MSW tree deriving from `RicMswItem` and `RicMswExportInfo` can be removed. Several computation functions working on these structures can also be removed.

Closes #13794 