### PR TITLE
WellAllocationPlot: Fix missing first well connection

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -377,8 +377,7 @@ void RimWellAllocationPlot::updateFromWell()
                     accFlow = ( m_flowType == ACCUMULATED ? wfCalculator->accumulatedTracerFlowPrConnection( tracerName, brIdx )
                                                           : wfCalculator->tracerFlowPrConnection( tracerName, brIdx ) );
 
-                    if ( m_flowType == ACCUMULATED && brIdx == 0 && !accFlow.empty() ) // Add fictitious point to -1
-                                                                                       // for first branch
+                    if ( !accFlow.empty() ) // Add fictitious point to extend the first bar (topmost connection)
                     {
                         accFlow.push_back( accFlow.back() );
                         curveDepthValues.push_back( -1.0 );


### PR DESCRIPTION
- The first well connection was missing from both the plot and the \"Show Plot Data\" ASCII export for all flow types (INFLOW and ACCUMULATED) and all branches
- Root cause: the fictitious depth point (`-1.0`) needed to extend the topmost connection bar was only added for `ACCUMULATED && brIdx == 0`; removed that condition so it applies to all cases

Closes #13405
