### PR TITLE
WellAllocationPlot: Display connection numbers as 1-based

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -359,7 +359,7 @@ void RimWellAllocationPlot::updateFromWell()
 
         accumulatedWellFlowPlot()->addPlot( plotTrack );
 
-        const std::vector<double>& depthValues =
+        const std::vector<double> depthValues =
             depthType == RiaDefines::DepthType::CONNECTION_NUMBER     ? wfCalculator->connectionNumbersFromTop( brIdx )
             : depthType == RiaDefines::DepthType::PSEUDO_LENGTH       ? wfCalculator->pseudoLengthFromTop( brIdx )
             : depthType == RiaDefines::DepthType::TRUE_VERTICAL_DEPTH ? wfCalculator->trueVerticalDepth( brIdx )
@@ -377,10 +377,12 @@ void RimWellAllocationPlot::updateFromWell()
                     accFlow = ( m_flowType == ACCUMULATED ? wfCalculator->accumulatedTracerFlowPrConnection( tracerName, brIdx )
                                                           : wfCalculator->tracerFlowPrConnection( tracerName, brIdx ) );
 
-                    if ( !accFlow.empty() ) // Add fictitious point to extend the first bar (topmost connection)
+                    if ( !accFlow.empty() )
                     {
+                        // Add a dummy zero connection number at the end to make the curve reach the y-axis when showing in flow rate. The
+                        // lowest connection number is 1.0, so adding a zero value will not cause any issue when showing in accumulated flow.
                         accFlow.push_back( accFlow.back() );
-                        curveDepthValues.push_back( -1.0 );
+                        curveDepthValues.push_back( 0.0 );
                     }
 
                     // Shift the "bars" to make connection number tick at the midpoint of the constant value

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.cpp
@@ -186,9 +186,12 @@ void RigAccWellFlowCalculator::initializePipeBranchesMeasuredDepths()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-const std::vector<double>& RigAccWellFlowCalculator::connectionNumbersFromTop( size_t branchIdx ) const
+std::vector<double> RigAccWellFlowCalculator::connectionNumbersFromTop( size_t branchIdx ) const
 {
-    return m_connectionFlowPrBranch[branchIdx].depthValuesFromTop;
+    std::vector<double> result = m_connectionFlowPrBranch[branchIdx].depthValuesFromTop;
+    for ( double& v : result )
+        v += 1.0;
+    return result;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.h
@@ -81,7 +81,7 @@ public:
                               const std::vector<double>&             pipeBranchMeasuredDepths,
                               bool                                   totalFlowOnly );
 
-    const std::vector<double>& connectionNumbersFromTop( size_t branchIdx ) const;
+    std::vector<double> connectionNumbersFromTop( size_t branchIdx ) const;
     const std::vector<double>& accumulatedTracerFlowPrConnection( const QString& tracerName, size_t branchIdx ) const;
     const std::vector<double>& tracerFlowPrConnection( const QString& tracerName, size_t branchIdx ) const;
 

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.h
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.h
@@ -81,7 +81,7 @@ public:
                               const std::vector<double>&             pipeBranchMeasuredDepths,
                               bool                                   totalFlowOnly );
 
-    std::vector<double> connectionNumbersFromTop( size_t branchIdx ) const;
+    std::vector<double>        connectionNumbersFromTop( size_t branchIdx ) const;
     const std::vector<double>& accumulatedTracerFlowPrConnection( const QString& tracerName, size_t branchIdx ) const;
     const std::vector<double>& tracerFlowPrConnection( const QString& tracerName, size_t branchIdx ) const;
 


### PR DESCRIPTION
connectionNumbersFromTop() now adds 1 to all values so connection numbers are displayed starting from 1 in both the plot and ASCII text report. Also updates the fictitious extension point from -1.0 to 0.0 to be consistent with 1-based numbering.
