### PR TITLE
CorrelationReportPlot: Replace fixed grid with ADS dock manager and add optional summary plot

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
@@ -662,7 +662,7 @@ void RimCorrelationMatrixPlot::updatePlotTitle()
     if ( m_plotWidget )
     {
         m_plotWidget->setPlotTitle( m_description );
-        m_plotWidget->setPlotTitleEnabled( m_showPlotTitle && !isSubPlot() );
+        m_plotWidget->setPlotTitleEnabled( m_showPlotTitle );
         if ( isMdiWindow() )
         {
             m_plotWidget->setPlotTitleFontSize( titleFontSize() );

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlot.cpp
@@ -268,7 +268,7 @@ void RimCorrelationPlot::updatePlotTitle()
         m_description = QString( "%1, %2 at %3" ).arg( vectorName ).arg( ensemble->name() ).arg( timeStepString() );
     }
     m_plotWidget->setPlotTitle( m_description );
-    m_plotWidget->setPlotTitleEnabled( m_showPlotTitle && !isSubPlot() );
+    m_plotWidget->setPlotTitleEnabled( m_showPlotTitle );
     m_plotWidget->setPlotTitleFontSize( titleFontSize() );
 }
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
@@ -113,15 +113,10 @@ public:
         auto*      timeAxisProps = m_summaryPlot->timeAxisProperties();
         if ( timeAxisProps )
         {
-            if ( m_trackingAnnotation )
-            {
-                timeAxisProps->removeAnnotation( m_trackingAnnotation );
-                m_trackingAnnotation = nullptr;
-            }
+            removeTrackingAnnotation( timeAxisProps );
             auto* anno = RimTimeAxisAnnotation::createTimeAnnotation( timeTValue, TRACKING_ANNOTATION_COLOR );
             anno->setPenStyle( Qt::DashLine );
             timeAxisProps->appendAnnotation( anno );
-            m_trackingAnnotation = anno;
         }
 
         m_summaryPlot->updateAnnotationsInPlotWidget();
@@ -132,22 +127,34 @@ public:
 
     void widgetLeaveEvent( QEvent* ) override
     {
-        if ( m_trackingAnnotation && m_summaryPlot )
+        if ( !m_summaryPlot ) return;
+
+        auto* timeAxisProps = m_summaryPlot->timeAxisProperties();
+        if ( timeAxisProps && removeTrackingAnnotation( timeAxisProps ) )
         {
-            auto* timeAxisProps = m_summaryPlot->timeAxisProperties();
-            if ( timeAxisProps )
-            {
-                timeAxisProps->removeAnnotation( m_trackingAnnotation );
-                m_trackingAnnotation = nullptr;
-            }
             m_summaryPlot->updateAnnotationsInPlotWidget();
             m_summaryPlot->updatePlotWidgetFromAxisRanges();
         }
     }
 
 private:
-    caf::PdmPointer<RimSummaryPlot>                m_summaryPlot;
-    mutable caf::PdmPointer<RimTimeAxisAnnotation> m_trackingAnnotation;
+    static bool removeTrackingAnnotation( RimSummaryTimeAxisProperties* timeAxisProps )
+    {
+        if ( !timeAxisProps ) return false;
+        for ( auto* anno : timeAxisProps->annotations() )
+        {
+            // Identify the tracking annotation by its pen style, which is unique among time axis annotations. This way we don't interfere
+            // with the selected-time annotation, which is also on the time axis.
+            if ( anno->penStyle() == Qt::DashLine )
+            {
+                timeAxisProps->removeAnnotation( dynamic_cast<RimTimeAxisAnnotation*>( anno ) );
+                return true;
+            }
+        }
+        return false;
+    }
+
+    caf::PdmPointer<RimSummaryPlot> m_summaryPlot;
 };
 
 namespace
@@ -280,8 +287,15 @@ QString RimCorrelationReportPlot::description() const
 //--------------------------------------------------------------------------------------------------
 QImage RimCorrelationReportPlot::snapshotWindowContent()
 {
-    if ( m_viewWidget ) return m_viewWidget->grab().toImage();
-    return {};
+    QImage image;
+
+    if ( m_viewWidget )
+    {
+        QPixmap pix = m_viewWidget->grab();
+        image       = pix.toImage();
+    }
+
+    return image;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -580,13 +594,8 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
         m_parameterResultCrossPlot->setAxisValueFontSize( m_axisValueFontSize() );
 
         m_correlationMatrixPlot->loadDataAndUpdate();
-        if ( m_correlationMatrixPlot->viewer() ) m_correlationMatrixPlot->viewer()->setPlotTitleEnabled( true );
-
         m_correlationPlot->loadDataAndUpdate();
-        if ( m_correlationPlot->viewer() ) m_correlationPlot->viewer()->setPlotTitleEnabled( true );
-
         m_parameterResultCrossPlot->loadDataAndUpdate();
-        if ( m_parameterResultCrossPlot->viewer() ) m_parameterResultCrossPlot->viewer()->setPlotTitleEnabled( true );
 
         if ( m_showSummaryPlot() )
         {

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
@@ -20,26 +20,33 @@
 
 #include "RiaPreferences.h"
 #include "RiaQDateTimeTools.h"
+#include "RiaTimeTTools.h"
 #include "Summary/RiaSummaryCurveDefinition.h"
 
 #include "RimCorrelationMatrixPlot.h"
 #include "RimCorrelationPlot.h"
 #include "RimCorrelationPlotCollection.h"
+#include "RimEnsembleCurveSet.h"
+#include "RimEnsembleCurveSetCollection.h"
 #include "RimParameterResultCrossPlot.h"
 #include "RimRegularLegendConfig.h"
+#include "RimSummaryAddressSelector.h"
 #include "RimSummaryEnsemble.h"
+#include "RimSummaryPlot.h"
 
-#include "RiuMultiPlotPage.h"
 #include "RiuPlotWidget.h"
 #include "RiuQwtPlotWidget.h"
+
+#include "DockAreaWidget.h"
+#include "DockManager.h"
+#include "DockWidget.h"
 
 #include "cafAssert.h"
 #include "cafPdmUiTreeOrdering.h"
 
-#include <QDebug>
 #include <QImage>
-#include <QPixmap>
 #include <QStringList>
+#include <QVBoxLayout>
 
 //==================================================================================================
 //
@@ -69,6 +76,13 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
     CAF_PDM_InitFieldNoDefault( &m_axisTitleFontSize, "AxisTitleFontSize", "Axis Title Font Size" );
     CAF_PDM_InitFieldNoDefault( &m_axisValueFontSize, "AxisValueFontSize", "Axis Value Font Size" );
 
+    CAF_PDM_InitField( &m_showSummaryPlot, "ShowSummaryPlot", false, "Show Summary Plot" );
+    CAF_PDM_InitFieldNoDefault( &m_summaryPlot, "SummaryPlot", "Summary Plot" );
+    CAF_PDM_InitFieldNoDefault( &m_summaryAddressSelector, "SummaryAddressSelector", "Summary Vector" );
+
+    CAF_PDM_InitField( &m_dockState, "DockState", QString(), "Dock State" );
+    m_dockState.uiCapability()->setUiHidden( true );
+
     setAsPlotMdiWindow();
 
     m_showWindow      = true;
@@ -82,14 +96,21 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
 
     m_correlationMatrixPlot = new RimCorrelationMatrixPlot;
     m_correlationMatrixPlot->setLegendsVisible( false );
-    m_correlationMatrixPlot->setColSpan( RimPlot::TWO );
-    m_correlationMatrixPlot->setRowSpan( RimPlot::TWO );
 
     m_correlationPlot = new RimCorrelationPlot;
     m_correlationPlot->setLegendsVisible( false );
 
     m_parameterResultCrossPlot = new RimParameterResultCrossPlot;
     m_parameterResultCrossPlot->setLegendsVisible( true );
+
+    m_summaryPlot = new RimSummaryPlot();
+    m_summaryPlot->setLegendsVisible( false );
+    m_summaryPlot->ensembleCurveSetCollection()->addCurveSet( new RimEnsembleCurveSet() );
+
+    m_summaryAddressSelector = new RimSummaryAddressSelector();
+    m_summaryAddressSelector->setShowResampling( false );
+    m_summaryAddressSelector->setShowAxis( false );
+    m_summaryAddressSelector->addressChanged.connect( this, &RimCorrelationReportPlot::onAddressSelectorChanged );
 
     uiCapability()->setUiTreeChildrenHidden( true );
 
@@ -111,7 +132,7 @@ RimCorrelationReportPlot::~RimCorrelationReportPlot()
 //--------------------------------------------------------------------------------------------------
 QWidget* RimCorrelationReportPlot::viewWidget()
 {
-    return m_viewer;
+    return m_dockManager;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -127,16 +148,8 @@ QString RimCorrelationReportPlot::description() const
 //--------------------------------------------------------------------------------------------------
 QImage RimCorrelationReportPlot::snapshotWindowContent()
 {
-    QImage image;
-
-    if ( m_viewer )
-    {
-        QPixmap pix( m_viewer->size() );
-        m_viewer->renderTo( &pix );
-        image = pix.toImage();
-    }
-
-    return image;
+    if ( m_dockManager ) return m_dockManager->grab().toImage();
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -176,14 +189,6 @@ RimCorrelationPlot* RimCorrelationReportPlot::correlationPlot() const
 RimParameterResultCrossPlot* RimCorrelationReportPlot::crossPlot() const
 {
     return m_parameterResultCrossPlot();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-int RimCorrelationReportPlot::columnCount() const
-{
-    return 3;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -243,16 +248,61 @@ QString RimCorrelationReportPlot::createDescription() const
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::recreatePlotWidgets()
 {
-    CAF_ASSERT( m_viewer );
-    m_correlationMatrixPlot->createPlotWidget();
-    m_correlationPlot->createPlotWidget();
-    m_parameterResultCrossPlot->createPlotWidget();
+    CAF_ASSERT( m_dockManager );
 
-    m_viewer->addPlot( m_correlationMatrixPlot->viewer() );
-    m_viewer->addPlot( m_correlationPlot->viewer() );
-    m_viewer->addPlot( m_parameterResultCrossPlot->viewer() );
+    // Create plot widgets
+    m_correlationMatrixPlot->createPlotWidget( m_dockManager );
+    m_correlationPlot->createPlotWidget( m_dockManager );
+    m_parameterResultCrossPlot->createPlotWidget( m_dockManager );
+    m_summaryPlot->createPlotWidget( m_dockManager );
 
-    m_viewer->scheduleUpdate();
+    // Wrap each plot in a dock widget
+    m_matrixDockWidget = new ads::CDockWidget( "Matrix Plot", m_dockManager );
+    m_matrixDockWidget->setWidget( m_correlationMatrixPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
+    m_matrixDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+
+    m_correlationDockWidget = new ads::CDockWidget( "Correlation Plot", m_dockManager );
+    m_correlationDockWidget->setWidget( m_correlationPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
+    m_correlationDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+
+    m_crossPlotDockWidget = new ads::CDockWidget( "Cross Plot", m_dockManager );
+    m_crossPlotDockWidget->setWidget( m_parameterResultCrossPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
+    m_crossPlotDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+
+    m_summaryDockWidget = new ads::CDockWidget( "Summary Plot", m_dockManager );
+    m_summaryDockWidget->setWidget( m_summaryPlot->plotWidget(), ads::CDockWidget::ForceNoScrollArea );
+    m_summaryDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+
+    // Connect summary plot click → time step update
+    auto* summaryWidget = dynamic_cast<RiuQwtPlotWidget*>( m_summaryPlot->plotWidget() );
+    if ( summaryWidget )
+    {
+        connect( summaryWidget, &RiuQwtPlotWidget::plotMousePressedAt, this, &RimCorrelationReportPlot::onSummaryPlotMousePressed );
+    }
+
+    // Restore saved dock state if available; otherwise set up default layout
+    if ( !m_dockState().isEmpty() )
+    {
+        // Add all widgets to the manager first (required before restoreState)
+        m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
+        m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_correlationDockWidget );
+        m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_crossPlotDockWidget );
+        m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_summaryDockWidget );
+        m_dockManager->restoreState( QByteArray::fromBase64( m_dockState().toLatin1() ), 1 );
+    }
+    else
+    {
+        // Default layout: matrix on left, corr top-right, cross bottom-right, summary far right
+        auto* matrixArea = m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
+        auto* corrArea   = m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_correlationDockWidget );
+        auto* crossArea  = m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_crossPlotDockWidget, corrArea );
+        m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_summaryDockWidget, corrArea );
+
+        (void)matrixArea;
+        (void)crossArea;
+
+        m_summaryDockWidget->toggleView( m_showSummaryPlot() );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -263,12 +313,29 @@ void RimCorrelationReportPlot::cleanupBeforeClose()
     m_correlationMatrixPlot->detachAllCurves();
     m_correlationPlot->detachAllCurves();
     m_parameterResultCrossPlot->detachAllCurves();
+    m_summaryPlot->detachAllCurves();
 
-    if ( m_viewer )
+    // Dock widget pointers are owned by the dock manager; nullify them before deletion
+    m_matrixDockWidget      = nullptr;
+    m_correlationDockWidget = nullptr;
+    m_crossPlotDockWidget   = nullptr;
+    m_summaryDockWidget     = nullptr;
+
+    if ( m_dockManager )
     {
-        m_viewer->setParent( nullptr );
-        delete m_viewer;
-        m_viewer = nullptr;
+        delete m_dockManager;
+        m_dockManager = nullptr;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::setupBeforeSave()
+{
+    if ( m_dockManager )
+    {
+        m_dockState = QString::fromLatin1( m_dockManager->saveState( 1 ).toBase64() );
     }
 }
 
@@ -277,9 +344,9 @@ void RimCorrelationReportPlot::cleanupBeforeClose()
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::doRenderWindowContent( QPaintDevice* paintDevice )
 {
-    if ( m_viewer )
+    if ( m_dockManager )
     {
-        m_viewer->renderTo( paintDevice );
+        m_dockManager->render( paintDevice );
     }
 }
 
@@ -288,12 +355,11 @@ void RimCorrelationReportPlot::doRenderWindowContent( QPaintDevice* paintDevice 
 //--------------------------------------------------------------------------------------------------
 QWidget* RimCorrelationReportPlot::createViewWidget( QWidget* mainWindowParent /*= nullptr */ )
 {
-    m_viewer = new RiuMultiPlotPage( this, mainWindowParent );
-    m_viewer->setAutoAlignAxes( false );
-    m_viewer->setPlotTitle( createPlotWindowTitle() );
+    m_dockManager = new ads::CDockManager( mainWindowParent );
+    m_dockManager->setStyleSheet( "ads--CDockSplitter::handle { width: 1px; height: 1px; }" );
     recreatePlotWidgets();
 
-    return m_viewer;
+    return m_dockManager;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -348,10 +414,32 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
         m_parameterResultCrossPlot->setAxisValueFontSize( m_axisValueFontSize() );
 
         m_correlationMatrixPlot->loadDataAndUpdate();
-        m_correlationPlot->loadDataAndUpdate();
-        m_parameterResultCrossPlot->loadDataAndUpdate();
+        if ( m_correlationMatrixPlot->viewer() ) m_correlationMatrixPlot->viewer()->setPlotTitleEnabled( true );
 
-        m_viewer->setPlotTitle( createDescription() );
+        m_correlationPlot->loadDataAndUpdate();
+        if ( m_correlationPlot->viewer() ) m_correlationPlot->viewer()->setPlotTitleEnabled( true );
+
+        m_parameterResultCrossPlot->loadDataAndUpdate();
+        if ( m_parameterResultCrossPlot->viewer() ) m_parameterResultCrossPlot->viewer()->setPlotTitleEnabled( true );
+
+        if ( m_showSummaryPlot() )
+        {
+            if ( !m_summaryAddressSelector->ensemble() )
+            {
+                auto ensembles = m_correlationMatrixPlot->ensembles();
+                if ( !ensembles.empty() ) m_summaryAddressSelector->setEnsemble( *ensembles.begin() );
+            }
+
+            auto curveSets = m_summaryPlot->ensembleCurveSetCollection()->curveSets();
+            if ( !curveSets.empty() )
+            {
+                curveSets[0]->setSummaryEnsemble( m_summaryAddressSelector->ensemble() );
+                curveSets[0]->setSummaryAddressY( m_summaryAddressSelector->summaryAddress() );
+            }
+
+            m_summaryPlot->loadDataAndUpdate();
+            if ( m_summaryPlot->plotWidget() ) m_summaryPlot->plotWidget()->setPlotTitleEnabled( true );
+        }
     }
 
     updateLayout();
@@ -366,6 +454,13 @@ void RimCorrelationReportPlot::defineUiOrdering( QString uiConfigName, caf::PdmU
 
     auto filterGroup = uiOrdering.addNewGroup( "Filter" );
     m_parameterResultCrossPlot->appendFilterFields( *filterGroup );
+
+    auto summaryGroup = uiOrdering.addNewGroup( "Summary Plot" );
+    summaryGroup->add( &m_showSummaryPlot );
+    if ( m_showSummaryPlot() )
+    {
+        m_summaryAddressSelector->uiOrdering( "", *summaryGroup );
+    }
 
     auto plotGroup = uiOrdering.addNewGroup( "Plot Settings" );
     plotGroup->setCollapsedByDefault();
@@ -385,6 +480,10 @@ void RimCorrelationReportPlot::defineUiOrdering( QString uiConfigName, caf::PdmU
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
+    if ( changedField == &m_showSummaryPlot && m_summaryDockWidget )
+    {
+        m_summaryDockWidget->toggleView( m_showSummaryPlot() );
+    }
     loadDataAndUpdate();
 }
 
@@ -401,13 +500,6 @@ void RimCorrelationReportPlot::childFieldChangedByUi( const caf::PdmFieldHandle*
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::doUpdateLayout()
 {
-    if ( m_showWindow && m_viewer )
-    {
-        m_viewer->setTitleFontSizes( titleFontSize(), subTitleFontSize() );
-        m_viewer->setLegendFontSize( legendFontSize() );
-        m_viewer->setAxisFontSizes( axisTitleFontSize(), axisValueFontSize() );
-        m_viewer->setSubTitlesVisible( true );
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -424,10 +516,31 @@ void RimCorrelationReportPlot::onDataSelection( const caf::SignalEmitter*       
     m_parameterResultCrossPlot->setCurveDefinitions( { curveDef } );
     m_parameterResultCrossPlot->setEnsembleParameter( paramName );
     m_parameterResultCrossPlot->loadDataAndUpdate();
-    if ( m_viewer )
-    {
-        m_viewer->updateSubTitles();
-    }
 
     updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::onSummaryPlotMousePressed( double xPlotCoordinate )
+{
+    auto clickedTime    = RiaTimeTTools::fromDouble( xPlotCoordinate );
+    auto availableSteps = m_correlationMatrixPlot->allAvailableTimeSteps();
+    if ( availableSteps.empty() ) return;
+
+    auto it = std::min_element( availableSteps.begin(),
+                                availableSteps.end(),
+                                [clickedTime]( time_t a, time_t b ) { return std::abs( a - clickedTime ) < std::abs( b - clickedTime ); } );
+
+    m_correlationMatrixPlot->setTimeStep( *it );
+    loadDataAndUpdate();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::onAddressSelectorChanged( const caf::SignalEmitter* )
+{
+    loadDataAndUpdate();
 }

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
@@ -38,6 +38,8 @@
 #include "RimTimeAxisAnnotation.h"
 
 #include "RiuInterfaceToViewWindow.h"
+
+#include "RimViewWindow.h"
 #include "RiuPlotWidget.h"
 #include "RiuQwtPlotWidget.h"
 
@@ -62,7 +64,8 @@
 #include <QStringList>
 #include <QVBoxLayout>
 
-static const char* DOCK_LAYOUT_REGISTRY_KEY = "CorrelationReportPlot/defaultDockLayout";
+static const char*        DOCK_LAYOUT_REGISTRY_KEY  = "CorrelationReportPlot/defaultDockLayout";
+static const cvf::Color3f TRACKING_ANNOTATION_COLOR = cvf::Color3f( 0.6f, 0.4f, 0.08f );
 
 //--------------------------------------------------------------------------------------------------
 /// Thin wrapper around CDockManager that implements RiuInterfaceToViewWindow so that
@@ -71,19 +74,19 @@ static const char* DOCK_LAYOUT_REGISTRY_KEY = "CorrelationReportPlot/defaultDock
 class RiuCorrelationReportPlotWidget : public QFrame, public RiuInterfaceToViewWindow
 {
 public:
-    RiuCorrelationReportPlotWidget( RimCorrelationReportPlot* plot, QWidget* parent = nullptr )
+    RiuCorrelationReportPlotWidget( RimViewWindow* viewWindow, QWidget* parent = nullptr )
         : QFrame( parent )
-        , m_plot( plot )
+        , m_viewWindow( viewWindow )
     {
         setLayout( new QVBoxLayout );
         layout()->setContentsMargins( 0, 0, 0, 0 );
         layout()->setSpacing( 0 );
     }
 
-    RimViewWindow* ownerViewWindow() const override { return m_plot; }
+    RimViewWindow* ownerViewWindow() const override { return m_viewWindow; }
 
 private:
-    RimCorrelationReportPlot* m_plot;
+    RimViewWindow* m_viewWindow;
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -115,7 +118,7 @@ public:
                 timeAxisProps->removeAnnotation( m_trackingAnnotation );
                 m_trackingAnnotation = nullptr;
             }
-            auto* anno = RimTimeAxisAnnotation::createTimeAnnotation( timeTValue, cvf::Color3f( 0.6f, 0.4f, 0.08f ) );
+            auto* anno = RimTimeAxisAnnotation::createTimeAnnotation( timeTValue, TRACKING_ANNOTATION_COLOR );
             anno->setPenStyle( Qt::DashLine );
             timeAxisProps->appendAnnotation( anno );
             m_trackingAnnotation = anno;
@@ -152,23 +155,23 @@ namespace
 // Ensures the correlation report plot is selected in CAF whenever a context menu event is dispatched
 // anywhere within the dock manager — so feature availability checks in RiuContextMenuLauncher
 // see the correct item (mirrors what RiuMultiPlotPage::contextMenuEvent did explicitly).
-class ReportPlotContextMenuFilter : public QObject
+class SelectionFixerOnContextMenu : public QObject
 {
 public:
-    ReportPlotContextMenuFilter( RimCorrelationReportPlot* plot, QObject* parent )
+    SelectionFixerOnContextMenu( caf::PdmObject* item, QObject* parent )
         : QObject( parent )
-        , m_plot( plot )
+        , m_item( item )
     {
     }
 
     bool eventFilter( QObject*, QEvent* event ) override
     {
-        if ( event->type() == QEvent::ContextMenu ) caf::SelectionManager::instance()->setSelectedItem( m_plot );
+        if ( event->type() == QEvent::ContextMenu ) caf::SelectionManager::instance()->setSelectedItem( m_item );
         return false; // never consume the event
     }
 
 private:
-    RimCorrelationReportPlot* m_plot;
+    caf::PdmObject* m_item;
 };
 } // namespace
 
@@ -232,8 +235,8 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
 
     auto* curveSet = new RimEnsembleCurveSet();
     curveSet->setColorMode( RimEnsembleCurveSet::ColorMode::SINGLE_COLOR );
-    curveSet->setColor( cvf::Color3f( 0.6f, 0.4f, 0.08f ) );
-    const_cast<RimEnsembleStatistics*>( curveSet->statisticsOptions() )->enableCurveLabels( false );
+    curveSet->setColor( TRACKING_ANNOTATION_COLOR );
+    curveSet->statisticsOptions()->enableCurveLabels( false );
     m_summaryPlot->ensembleCurveSetCollection()->addCurveSet( curveSet );
 
     m_summaryAddressSelector = new RimSummaryAddressSelector();
@@ -385,13 +388,17 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
     m_parameterResultCrossPlot->createPlotWidget( m_dockManager );
     m_summaryPlot->createPlotWidget( m_dockManager );
 
-    // Install selection fixer on each plot widget (runs first due to LIFO filter order), so that
-    // RiuContextMenuLauncher sees the correct CAF selection when building the context menu.
-    auto* filter = new ReportPlotContextMenuFilter( this, m_dockManager );
-    if ( m_correlationMatrixPlot->viewer() ) m_correlationMatrixPlot->viewer()->installEventFilter( filter );
-    if ( m_correlationPlot->viewer() ) m_correlationPlot->viewer()->installEventFilter( filter );
-    if ( m_parameterResultCrossPlot->viewer() ) m_parameterResultCrossPlot->viewer()->installEventFilter( filter );
-    if ( m_summaryPlot->plotWidget() ) m_summaryPlot->plotWidget()->installEventFilter( filter );
+    // Install selection fixer on each plot widget.
+    // Filter runs first (LIFO order) so RiuContextMenuLauncher sees the correct CAF selection.
+    delete m_contextMenuFilter;
+    m_contextMenuFilter = new SelectionFixerOnContextMenu( this, this );
+    for ( RiuPlotWidget* w : std::initializer_list<RiuPlotWidget*>{ m_correlationMatrixPlot->viewer(),
+                                                                    m_correlationPlot->viewer(),
+                                                                    m_parameterResultCrossPlot->viewer(),
+                                                                    m_summaryPlot->plotWidget() } )
+    {
+        if ( w ) w->installEventFilter( m_contextMenuFilter );
+    }
 
     // Wrap each plot in a dock widget
     m_matrixDockWidget = new ads::CDockWidget( "Matrix Plot", m_dockManager );
@@ -409,6 +416,9 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
     m_summaryDockWidget = new ads::CDockWidget( "Summary Plot", m_dockManager );
     m_summaryDockWidget->setWidget( m_summaryPlot->plotWidget(), ads::CDockWidget::ForceNoScrollArea );
     m_summaryDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+
+    // Disable zoom — clicks are used for time step selection, not zooming
+    if ( m_summaryPlot->summaryPlotWidget() ) m_summaryPlot->summaryPlotWidget()->setZoomEnabled( false );
 
     // Connect summary plot click → time step update; add time tracking readout
     auto* summaryWidget = dynamic_cast<RiuQwtPlotWidget*>( m_summaryPlot->plotWidget() );
@@ -440,14 +450,12 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
     }
     else
     {
-        // Hard-coded default: matrix on left, corr top-right, cross bottom-right, summary far right
-        auto* matrixArea = m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
-        auto* corrArea   = m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_correlationDockWidget );
-        auto* crossArea  = m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_crossPlotDockWidget, corrArea );
-        m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_summaryDockWidget, corrArea );
-
-        (void)matrixArea;
-        (void)crossArea;
+        // Hard-coded default: matrix left (full height), corr top-right, cross bottom-right,
+        // summary spanning full width at bottom
+        auto* corrArea = m_dockManager->addDockWidget( ads::CenterDockWidgetArea, m_correlationDockWidget );
+        m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
+        m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_crossPlotDockWidget, corrArea );
+        m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_summaryDockWidget );
 
         m_summaryDockWidget->toggleView( m_showSummaryPlot() );
     }
@@ -607,7 +615,7 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
             auto* timeAxisProps = m_summaryPlot->timeAxisProperties();
             if ( timeAxisProps )
             {
-                timeAxisProps->appendAnnotation( RimTimeAxisAnnotation::createTimeAnnotation( timeStep, cvf::Color3f( 0.6f, 0.4f, 0.08f ) ) );
+                timeAxisProps->appendAnnotation( RimTimeAxisAnnotation::createTimeAnnotation( timeStep, TRACKING_ANNOTATION_COLOR ) );
                 m_summaryPlot->updateAnnotationsInPlotWidget();
             }
         }

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
@@ -28,12 +28,16 @@
 #include "RimCorrelationPlotCollection.h"
 #include "RimEnsembleCurveSet.h"
 #include "RimEnsembleCurveSetCollection.h"
+#include "RimEnsembleStatistics.h"
 #include "RimParameterResultCrossPlot.h"
 #include "RimRegularLegendConfig.h"
 #include "RimSummaryAddressSelector.h"
 #include "RimSummaryEnsemble.h"
 #include "RimSummaryPlot.h"
+#include "RimSummaryTimeAxisProperties.h"
+#include "RimTimeAxisAnnotation.h"
 
+#include "RiuInterfaceToViewWindow.h"
 #include "RiuPlotWidget.h"
 #include "RiuQwtPlotWidget.h"
 
@@ -42,11 +46,131 @@
 #include "DockWidget.h"
 
 #include "cafAssert.h"
+#include "cafPdmPointer.h"
 #include "cafPdmUiTreeOrdering.h"
+#include "cafSelectionManager.h"
 
+#include "qwt_picker_machine.h"
+#include "qwt_plot.h"
+#include "qwt_plot_picker.h"
+#include "qwt_text.h"
+
+#include <QContextMenuEvent>
+#include <QFrame>
 #include <QImage>
+#include <QSettings>
 #include <QStringList>
 #include <QVBoxLayout>
+
+static const char* DOCK_LAYOUT_REGISTRY_KEY = "CorrelationReportPlot/defaultDockLayout";
+
+//--------------------------------------------------------------------------------------------------
+/// Thin wrapper around CDockManager that implements RiuInterfaceToViewWindow so that
+/// activeViewWindow() / viewWindowFromWidget() can resolve the owning RimViewWindow.
+//--------------------------------------------------------------------------------------------------
+class RiuCorrelationReportPlotWidget : public QFrame, public RiuInterfaceToViewWindow
+{
+public:
+    RiuCorrelationReportPlotWidget( RimCorrelationReportPlot* plot, QWidget* parent = nullptr )
+        : QFrame( parent )
+        , m_plot( plot )
+    {
+        setLayout( new QVBoxLayout );
+        layout()->setContentsMargins( 0, 0, 0, 0 );
+        layout()->setSpacing( 0 );
+    }
+
+    RimViewWindow* ownerViewWindow() const override { return m_plot; }
+
+private:
+    RimCorrelationReportPlot* m_plot;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// Local picker for time tracking readout — draws a dashed vertical line following the mouse cursor.
+/// Manages only its own annotation so the static selected-time annotation is preserved.
+//--------------------------------------------------------------------------------------------------
+class TimeReadoutPicker : public QwtPlotPicker
+{
+public:
+    TimeReadoutPicker( RimSummaryPlot* summaryPlot, QwtPlot* plot )
+        : QwtPlotPicker( plot->canvas() )
+        , m_summaryPlot( summaryPlot )
+    {
+        setTrackerMode( QwtPlotPicker::AlwaysOn );
+        plot->canvas()->setMouseTracking( true );
+        setStateMachine( new QwtPickerTrackerMachine );
+    }
+
+    QwtText trackerText( const QPoint& screenPixelCoordinates ) const override
+    {
+        if ( !plot() || !m_summaryPlot ) return {};
+
+        const auto timeTValue    = RiaTimeTTools::fromDouble( invTransform( screenPixelCoordinates ).x() );
+        auto*      timeAxisProps = m_summaryPlot->timeAxisProperties();
+        if ( timeAxisProps )
+        {
+            if ( m_trackingAnnotation )
+            {
+                timeAxisProps->removeAnnotation( m_trackingAnnotation );
+                m_trackingAnnotation = nullptr;
+            }
+            auto* anno = RimTimeAxisAnnotation::createTimeAnnotation( timeTValue, cvf::Color3f( 0.6f, 0.4f, 0.08f ) );
+            anno->setPenStyle( Qt::DashLine );
+            timeAxisProps->appendAnnotation( anno );
+            m_trackingAnnotation = anno;
+        }
+
+        m_summaryPlot->updateAnnotationsInPlotWidget();
+        m_summaryPlot->updatePlotWidgetFromAxisRanges();
+
+        return {};
+    }
+
+    void widgetLeaveEvent( QEvent* ) override
+    {
+        if ( m_trackingAnnotation && m_summaryPlot )
+        {
+            auto* timeAxisProps = m_summaryPlot->timeAxisProperties();
+            if ( timeAxisProps )
+            {
+                timeAxisProps->removeAnnotation( m_trackingAnnotation );
+                m_trackingAnnotation = nullptr;
+            }
+            m_summaryPlot->updateAnnotationsInPlotWidget();
+            m_summaryPlot->updatePlotWidgetFromAxisRanges();
+        }
+    }
+
+private:
+    caf::PdmPointer<RimSummaryPlot>                m_summaryPlot;
+    mutable caf::PdmPointer<RimTimeAxisAnnotation> m_trackingAnnotation;
+};
+
+namespace
+{
+// Ensures the correlation report plot is selected in CAF whenever a context menu event is dispatched
+// anywhere within the dock manager — so feature availability checks in RiuContextMenuLauncher
+// see the correct item (mirrors what RiuMultiPlotPage::contextMenuEvent did explicitly).
+class ReportPlotContextMenuFilter : public QObject
+{
+public:
+    ReportPlotContextMenuFilter( RimCorrelationReportPlot* plot, QObject* parent )
+        : QObject( parent )
+        , m_plot( plot )
+    {
+    }
+
+    bool eventFilter( QObject*, QEvent* event ) override
+    {
+        if ( event->type() == QEvent::ContextMenu ) caf::SelectionManager::instance()->setSelectedItem( m_plot );
+        return false; // never consume the event
+    }
+
+private:
+    RimCorrelationReportPlot* m_plot;
+};
+} // namespace
 
 //==================================================================================================
 //
@@ -76,7 +200,7 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
     CAF_PDM_InitFieldNoDefault( &m_axisTitleFontSize, "AxisTitleFontSize", "Axis Title Font Size" );
     CAF_PDM_InitFieldNoDefault( &m_axisValueFontSize, "AxisValueFontSize", "Axis Value Font Size" );
 
-    CAF_PDM_InitField( &m_showSummaryPlot, "ShowSummaryPlot", false, "Show Summary Plot" );
+    CAF_PDM_InitField( &m_showSummaryPlot, "ShowSummaryPlot", true, "Show Summary Plot" );
     CAF_PDM_InitFieldNoDefault( &m_summaryPlot, "SummaryPlot", "Summary Plot" );
     CAF_PDM_InitFieldNoDefault( &m_summaryAddressSelector, "SummaryAddressSelector", "Summary Vector" );
 
@@ -105,7 +229,12 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
 
     m_summaryPlot = new RimSummaryPlot();
     m_summaryPlot->setLegendsVisible( false );
-    m_summaryPlot->ensembleCurveSetCollection()->addCurveSet( new RimEnsembleCurveSet() );
+
+    auto* curveSet = new RimEnsembleCurveSet();
+    curveSet->setColorMode( RimEnsembleCurveSet::ColorMode::SINGLE_COLOR );
+    curveSet->setColor( cvf::Color3f( 0.6f, 0.4f, 0.08f ) );
+    const_cast<RimEnsembleStatistics*>( curveSet->statisticsOptions() )->enableCurveLabels( false );
+    m_summaryPlot->ensembleCurveSetCollection()->addCurveSet( curveSet );
 
     m_summaryAddressSelector = new RimSummaryAddressSelector();
     m_summaryAddressSelector->setShowResampling( false );
@@ -132,7 +261,7 @@ RimCorrelationReportPlot::~RimCorrelationReportPlot()
 //--------------------------------------------------------------------------------------------------
 QWidget* RimCorrelationReportPlot::viewWidget()
 {
-    return m_dockManager;
+    return m_viewWidget;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -148,7 +277,7 @@ QString RimCorrelationReportPlot::description() const
 //--------------------------------------------------------------------------------------------------
 QImage RimCorrelationReportPlot::snapshotWindowContent()
 {
-    if ( m_dockManager ) return m_dockManager->grab().toImage();
+    if ( m_viewWidget ) return m_viewWidget->grab().toImage();
     return {};
 }
 
@@ -256,6 +385,14 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
     m_parameterResultCrossPlot->createPlotWidget( m_dockManager );
     m_summaryPlot->createPlotWidget( m_dockManager );
 
+    // Install selection fixer on each plot widget (runs first due to LIFO filter order), so that
+    // RiuContextMenuLauncher sees the correct CAF selection when building the context menu.
+    auto* filter = new ReportPlotContextMenuFilter( this, m_dockManager );
+    if ( m_correlationMatrixPlot->viewer() ) m_correlationMatrixPlot->viewer()->installEventFilter( filter );
+    if ( m_correlationPlot->viewer() ) m_correlationPlot->viewer()->installEventFilter( filter );
+    if ( m_parameterResultCrossPlot->viewer() ) m_parameterResultCrossPlot->viewer()->installEventFilter( filter );
+    if ( m_summaryPlot->plotWidget() ) m_summaryPlot->plotWidget()->installEventFilter( filter );
+
     // Wrap each plot in a dock widget
     m_matrixDockWidget = new ads::CDockWidget( "Matrix Plot", m_dockManager );
     m_matrixDockWidget->setWidget( m_correlationMatrixPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
@@ -273,26 +410,37 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
     m_summaryDockWidget->setWidget( m_summaryPlot->plotWidget(), ads::CDockWidget::ForceNoScrollArea );
     m_summaryDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
 
-    // Connect summary plot click → time step update
+    // Connect summary plot click → time step update; add time tracking readout
     auto* summaryWidget = dynamic_cast<RiuQwtPlotWidget*>( m_summaryPlot->plotWidget() );
     if ( summaryWidget )
     {
         connect( summaryWidget, &RiuQwtPlotWidget::plotMousePressedAt, this, &RimCorrelationReportPlot::onSummaryPlotMousePressed );
+        new TimeReadoutPicker( m_summaryPlot(), summaryWidget->qwtPlot() );
     }
 
-    // Restore saved dock state if available; otherwise set up default layout
+    // Restore saved dock state: project state takes priority, then registry default, then hard-coded layout
+    QByteArray stateToRestore;
     if ( !m_dockState().isEmpty() )
+        stateToRestore = QByteArray::fromBase64( m_dockState().toLatin1() );
+    else
+    {
+        QSettings settings;
+        QVariant  v = settings.value( DOCK_LAYOUT_REGISTRY_KEY );
+        if ( v.isValid() ) stateToRestore = v.toByteArray();
+    }
+
+    if ( !stateToRestore.isEmpty() )
     {
         // Add all widgets to the manager first (required before restoreState)
         m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
         m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_correlationDockWidget );
         m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_crossPlotDockWidget );
         m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_summaryDockWidget );
-        m_dockManager->restoreState( QByteArray::fromBase64( m_dockState().toLatin1() ), 1 );
+        m_dockManager->restoreState( stateToRestore, 1 );
     }
     else
     {
-        // Default layout: matrix on left, corr top-right, cross bottom-right, summary far right
+        // Hard-coded default: matrix on left, corr top-right, cross bottom-right, summary far right
         auto* matrixArea = m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
         auto* corrArea   = m_dockManager->addDockWidget( ads::RightDockWidgetArea, m_correlationDockWidget );
         auto* crossArea  = m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_crossPlotDockWidget, corrArea );
@@ -326,6 +474,13 @@ void RimCorrelationReportPlot::cleanupBeforeClose()
         delete m_dockManager;
         m_dockManager = nullptr;
     }
+
+    if ( m_viewWidget )
+    {
+        m_viewWidget->setParent( nullptr );
+        delete m_viewWidget;
+        m_viewWidget = nullptr;
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -344,9 +499,9 @@ void RimCorrelationReportPlot::setupBeforeSave()
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::doRenderWindowContent( QPaintDevice* paintDevice )
 {
-    if ( m_dockManager )
+    if ( m_viewWidget )
     {
-        m_dockManager->render( paintDevice );
+        m_viewWidget->render( paintDevice );
     }
 }
 
@@ -355,11 +510,14 @@ void RimCorrelationReportPlot::doRenderWindowContent( QPaintDevice* paintDevice 
 //--------------------------------------------------------------------------------------------------
 QWidget* RimCorrelationReportPlot::createViewWidget( QWidget* mainWindowParent /*= nullptr */ )
 {
-    m_dockManager = new ads::CDockManager( mainWindowParent );
+    auto* wrapper = new RiuCorrelationReportPlotWidget( this, mainWindowParent );
+    m_viewWidget  = wrapper;
+    m_dockManager = new ads::CDockManager( wrapper );
     m_dockManager->setStyleSheet( "ads--CDockSplitter::handle { width: 1px; height: 1px; }" );
+    wrapper->layout()->addWidget( m_dockManager );
     recreatePlotWidgets();
 
-    return m_dockManager;
+    return m_viewWidget;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -426,8 +584,12 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
         {
             if ( !m_summaryAddressSelector->ensemble() )
             {
-                auto ensembles = m_correlationMatrixPlot->ensembles();
-                if ( !ensembles.empty() ) m_summaryAddressSelector->setEnsemble( *ensembles.begin() );
+                auto curveDefs = m_correlationMatrixPlot->curveDefinitions();
+                if ( !curveDefs.empty() )
+                {
+                    m_summaryAddressSelector->setEnsemble( curveDefs.front().ensemble() );
+                    m_summaryAddressSelector->setAddress( curveDefs.front().summaryAddressY() );
+                }
             }
 
             auto curveSets = m_summaryPlot->ensembleCurveSetCollection()->curveSets();
@@ -439,6 +601,15 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
 
             m_summaryPlot->loadDataAndUpdate();
             if ( m_summaryPlot->plotWidget() ) m_summaryPlot->plotWidget()->setPlotTitleEnabled( true );
+
+            // Add static line for the currently selected time step.
+            // Must be done after loadDataAndUpdate() since that clears all annotations internally.
+            auto* timeAxisProps = m_summaryPlot->timeAxisProperties();
+            if ( timeAxisProps )
+            {
+                timeAxisProps->appendAnnotation( RimTimeAxisAnnotation::createTimeAnnotation( timeStep, cvf::Color3f( 0.6f, 0.4f, 0.08f ) ) );
+                m_summaryPlot->updateAnnotationsInPlotWidget();
+            }
         }
     }
 
@@ -471,6 +642,11 @@ void RimCorrelationReportPlot::defineUiOrdering( QString uiConfigName, caf::PdmU
     plotGroup->add( &m_axisTitleFontSize );
     plotGroup->add( &m_axisValueFontSize );
     m_correlationMatrixPlot->legendConfig()->uiOrdering( "ColorsOnly", *plotGroup );
+
+    auto layoutGroup = uiOrdering.addNewGroup( "Dock Layout" );
+    layoutGroup->setCollapsedByDefault();
+    layoutGroup->addNewButton( "Save as Default Layout", [this]() { onSaveDefaultDockLayout(); } );
+    layoutGroup->addNewButton( "Restore Default Layout", [this]() { onRestoreDefaultDockLayout(); } );
 
     uiOrdering.skipRemainingFields( true );
 }
@@ -543,4 +719,28 @@ void RimCorrelationReportPlot::onSummaryPlotMousePressed( double xPlotCoordinate
 void RimCorrelationReportPlot::onAddressSelectorChanged( const caf::SignalEmitter* )
 {
     loadDataAndUpdate();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::onSaveDefaultDockLayout()
+{
+    if ( m_dockManager )
+    {
+        QSettings settings;
+        settings.setValue( DOCK_LAYOUT_REGISTRY_KEY, m_dockManager->saveState( 1 ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::onRestoreDefaultDockLayout()
+{
+    if ( !m_dockManager ) return;
+
+    QSettings settings;
+    QVariant  v = settings.value( DOCK_LAYOUT_REGISTRY_KEY );
+    if ( v.isValid() ) m_dockManager->restoreState( v.toByteArray(), 1 );
 }

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
@@ -84,6 +84,8 @@ private:
     void onDataSelection( const caf::SignalEmitter* emitter, std::pair<QString, RiaSummaryCurveDefinition> parameterAndCurveDef );
     void onSummaryPlotMousePressed( double xPlotCoordinate );
     void onAddressSelectorChanged( const caf::SignalEmitter* emitter );
+    void onSaveDefaultDockLayout();
+    void onRestoreDefaultDockLayout();
 
 private:
     caf::PdmProxyValueField<QString> m_name;
@@ -102,6 +104,7 @@ private:
 
     caf::PdmField<QString> m_dockState;
 
+    QWidget*           m_viewWidget            = nullptr;
     ads::CDockManager* m_dockManager           = nullptr;
     ads::CDockWidget*  m_matrixDockWidget      = nullptr;
     ads::CDockWidget*  m_correlationDockWidget = nullptr;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
@@ -20,12 +20,12 @@
 #include "RimPlotWindow.h"
 
 #include "cafPdmChildField.h"
+#include "cafPdmField.h"
 #include "cafPdmProxyValueField.h"
 #include "cafPdmPtrField.h"
 
 #include <QDateTime>
 #include <QObject>
-#include <QPointer>
 
 class RimAnalysisPlotDataEntry;
 class RimCorrelationMatrixPlot;
@@ -33,8 +33,14 @@ class RimParameterResultCrossPlot;
 class RimSummaryEnsemble;
 class RimCorrelationPlot;
 class RiaSummaryCurveDefinition;
+class RimSummaryPlot;
+class RimSummaryAddressSelector;
 
-class RiuMultiPlotPage;
+namespace ads
+{
+class CDockManager;
+class CDockWidget;
+} // namespace ads
 
 class RimCorrelationReportPlot : public QObject, public RimPlotWindow
 {
@@ -55,7 +61,6 @@ public:
     RimCorrelationPlot*          correlationPlot() const;
     RimParameterResultCrossPlot* crossPlot() const;
 
-    int columnCount() const override;
     int subTitleFontSize() const;
     int axisTitleFontSize() const;
     int axisValueFontSize() const;
@@ -66,6 +71,7 @@ private:
     void    recreatePlotWidgets();
     void    cleanupBeforeClose();
 
+    void     setupBeforeSave() override;
     void     doRenderWindowContent( QPaintDevice* paintDevice ) override;
     QWidget* createViewWidget( QWidget* mainWindowParent = nullptr ) override;
     void     deleteViewWidget() override;
@@ -76,6 +82,8 @@ private:
     void     doUpdateLayout() override;
 
     void onDataSelection( const caf::SignalEmitter* emitter, std::pair<QString, RiaSummaryCurveDefinition> parameterAndCurveDef );
+    void onSummaryPlotMousePressed( double xPlotCoordinate );
+    void onAddressSelectorChanged( const caf::SignalEmitter* emitter );
 
 private:
     caf::PdmProxyValueField<QString> m_name;
@@ -88,5 +96,15 @@ private:
     RimFontSizeField                                 m_axisTitleFontSize;
     RimFontSizeField                                 m_axisValueFontSize;
 
-    QPointer<RiuMultiPlotPage> m_viewer;
+    caf::PdmField<bool>                            m_showSummaryPlot;
+    caf::PdmChildField<RimSummaryPlot*>            m_summaryPlot;
+    caf::PdmChildField<RimSummaryAddressSelector*> m_summaryAddressSelector;
+
+    caf::PdmField<QString> m_dockState;
+
+    ads::CDockManager* m_dockManager           = nullptr;
+    ads::CDockWidget*  m_matrixDockWidget      = nullptr;
+    ads::CDockWidget*  m_correlationDockWidget = nullptr;
+    ads::CDockWidget*  m_crossPlotDockWidget   = nullptr;
+    ads::CDockWidget*  m_summaryDockWidget     = nullptr;
 };

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
@@ -105,6 +105,7 @@ private:
     caf::PdmField<QString> m_dockState;
 
     QWidget*           m_viewWidget            = nullptr;
+    QObject*           m_contextMenuFilter     = nullptr;
     ads::CDockManager* m_dockManager           = nullptr;
     ads::CDockWidget*  m_matrixDockWidget      = nullptr;
     ads::CDockWidget*  m_correlationDockWidget = nullptr;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
@@ -658,6 +658,6 @@ void RimParameterResultCrossPlot::updatePlotTitle()
             QString( "%1 x %2, %3 at %4" ).arg( vectorName ).arg( m_ensembleParameter ).arg( ensemble->name() ).arg( timeStepString() );
     }
     m_plotWidget->setPlotTitle( m_description );
-    m_plotWidget->setPlotTitleEnabled( m_showPlotTitle && !isSubPlot() );
+    m_plotWidget->setPlotTitleEnabled( m_showPlotTitle );
     m_plotWidget->setPlotTitleFontSize( titleFontSize() );
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
@@ -2589,6 +2589,14 @@ const RimEnsembleStatistics* RimEnsembleCurveSet::statisticsOptions() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RimEnsembleStatistics* RimEnsembleCurveSet::statisticsOptions()
+{
+    return m_statistics();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimEnsembleCurveSet::updateEnsembleLegendItem()
 {
     if ( !m_plotCurveForLegendText ) return;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
@@ -166,6 +166,7 @@ public:
     bool hasPercentileData( int p ) const override;
 
     const RimEnsembleStatistics* statisticsOptions() const;
+    RimEnsembleStatistics*       statisticsOptions();
 
     void appendColorGroup( caf::PdmUiOrdering& uiOrdering );
     void appendOptionItemsForSummaryAddresses( QList<caf::PdmOptionItemInfo>* options, RimSummaryEnsemble* summaryCaseGroup );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -315,6 +315,14 @@ RiuPlotWidget* RimSummaryPlot::plotWidget()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RiuSummaryPlot* RimSummaryPlot::summaryPlotWidget() const
+{
+    return m_summaryPlot;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 QString RimSummaryPlot::asciiDataForPlotExport() const
 {
     return asciiDataForSummaryPlotExport( RiaDefines::DateTimePeriod::YEAR, false );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
@@ -174,12 +174,13 @@ public:
 
     RimSummaryPlotSourceStepping* sourceSteppingObjectForKeyEventHandling() const;
 
-    void           setAutoScaleXEnabled( bool enabled ) override;
-    void           setAutoScaleYEnabled( bool enabled ) override;
-    RiuPlotWidget* plotWidget() override;
-    void           zoomAll() override;
-    void           updatePlotWidgetFromAxisRanges() override;
-    void           updateAxisRangesFromPlotWidget() override;
+    void            setAutoScaleXEnabled( bool enabled ) override;
+    void            setAutoScaleYEnabled( bool enabled ) override;
+    RiuPlotWidget*  plotWidget() override;
+    RiuSummaryPlot* summaryPlotWidget() const;
+    void            zoomAll() override;
+    void            updatePlotWidgetFromAxisRanges() override;
+    void            updateAxisRangesFromPlotWidget() override;
 
     void onAxisSelected( RiuPlotAxis axis, bool toggle ) override;
 

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp
@@ -642,6 +642,8 @@ bool RiuQwtPlotWidget::eventFilter( QObject* watched, QEvent* event )
                     return false;
                 };
 
+                emit plotMousePressedAt( m_plot->canvasMap( QwtAxis::XBottom ).invTransform( mouseEvent->pos().x() ) );
+
                 if ( !hasRecentlyBeenZoomed() )
                 {
                     // Avoid selecting the curve if a zoom operation has been performed recently

--- a/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.h
+++ b/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.h
@@ -179,6 +179,7 @@ signals:
     void onKeyPressEvent( QKeyEvent* event );
     void onWheelEvent( QWheelEvent* event );
     void plotZoomed();
+    void plotMousePressedAt( double xPlotCoordinate );
 
 protected:
     bool eventFilter( QObject* watched, QEvent* event ) override;

--- a/ApplicationLibCode/UserInterface/RiuSummaryPlot.h
+++ b/ApplicationLibCode/UserInterface/RiuSummaryPlot.h
@@ -53,6 +53,7 @@ public:
     virtual RiuPlotWidget* plotWidget() const = 0;
 
     virtual void enableCurvePointTracking( bool enable ) {};
+    virtual void setZoomEnabled( bool enable ) {};
 
 public slots:
     void showContextMenu( QPoint );

--- a/ApplicationLibCode/UserInterface/RiuSummaryQwtPlot.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSummaryQwtPlot.cpp
@@ -298,6 +298,21 @@ void RiuSummaryQwtPlot::enableCurvePointTracking( bool enable )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RiuSummaryQwtPlot::setZoomEnabled( bool enable )
+{
+    if ( m_plotZoomer ) m_plotZoomer->setEnabled( enable );
+    if ( m_wheelZoomer && m_plotWidget && m_plotWidget->qwtPlot() )
+    {
+        if ( enable )
+            m_plotWidget->qwtPlot()->canvas()->installEventFilter( m_wheelZoomer );
+        else
+            m_plotWidget->qwtPlot()->canvas()->removeEventFilter( m_wheelZoomer );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RiuSummaryQwtPlot::clearAnnotationObjects()
 {
     m_annotationTool->detachAllAnnotations();

--- a/ApplicationLibCode/UserInterface/RiuSummaryQwtPlot.h
+++ b/ApplicationLibCode/UserInterface/RiuSummaryQwtPlot.h
@@ -61,6 +61,7 @@ public:
     RiuPlotWidget* plotWidget() const override;
 
     void enableCurvePointTracking( bool enable ) override;
+    void setZoomEnabled( bool enable ) override;
 
 protected:
     void setDefaults();


### PR DESCRIPTION
## Summary

- Replace the fixed 3-column grid layout in `RimCorrelationReportPlot` with an **ADS dock manager**, giving users full flexibility to resize and rearrange the Matrix, Correlation, Cross, and Summary plot panels
- Add an **optional Summary Plot** in the lower row (full width) showing ensemble curves for a selected vector; clicking a time position in the summary plot snaps all correlation plots to the nearest available time step
- Dock layout is **persisted** in the project file (`setupBeforeSave`) and can be saved/restored as a user default via the OS registry
- Time tracking annotation (dashed line) follows the mouse in the summary plot and is removed on mouse leave
- Zoom disabled in the summary plot since clicks are used for time step selection
- Context menu stability fixed by ensuring correct CAF selection before menu build
- Snapshot command fixed by wrapping `CDockManager` in `RiuCorrelationReportPlotWidget` which implements `RiuInterfaceToViewWindow`

Closes #13815