### PR TITLE
#3284 Mohr's Circle: fix off-by-one in IJK display

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuMohrsCirclePlot.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMohrsCirclePlot.cpp
@@ -233,11 +233,12 @@ void RiuMohrsCirclePlot::addOrUpdateMohrCircleCurves( const MohrsCirclesInfo& mo
             QString textBuilder;
             textBuilder.append( QString( "<b>FOS</b>: %1, " ).arg( QString::number( mohrsCirclesInfo.factorOfSafety, 'f', 2 ) ) );
 
+            auto ijk1 = mohrsCirclesInfo.ijk.toOneBased();
             textBuilder.append( QString( "<b>Element Id</b>: %1, <b>ijk</b>[%2, %3, %4]," )
                                     .arg( mohrsCirclesInfo.elmId )
-                                    .arg( mohrsCirclesInfo.i )
-                                    .arg( mohrsCirclesInfo.j )
-                                    .arg( mohrsCirclesInfo.k ) );
+                                    .arg( ijk1.x() )
+                                    .arg( ijk1.y() )
+                                    .arg( ijk1.z() ) );
 
             textBuilder.append( QString( "<b>&sigma;<sub>1</sub></b>: %1, " ).arg( principals[0] ) );
             textBuilder.append( QString( "<b>&sigma;<sub>2</sub></b>: %1, " ).arg( principals[1] ) );
@@ -408,8 +409,14 @@ bool RiuMohrsCirclePlot::addOrUpdateCurves( const RimGeoMechResultDefinition* ge
     {
         int elmId = femPart->elmId( elmIndex );
 
-        MohrsCirclesInfo
-            mohrsCircle( principals, gridIndex, elmIndex, elmId, i, j, k, geomResDef, calculateFOS( principals, frictionAngleDeg, cohesion ), color );
+        MohrsCirclesInfo mohrsCircle( principals,
+                                      gridIndex,
+                                      elmIndex,
+                                      elmId,
+                                      caf::VecIjk0( i, j, k ),
+                                      geomResDef,
+                                      calculateFOS( principals, frictionAngleDeg, cohesion ),
+                                      color );
 
         m_mohrsCiclesInfos.push_back( mohrsCircle );
 

--- a/ApplicationLibCode/UserInterface/RiuMohrsCirclePlot.h
+++ b/ApplicationLibCode/UserInterface/RiuMohrsCirclePlot.h
@@ -21,6 +21,7 @@
 #include "RiuDockedQwtPlot.h"
 
 #include "cafTensor3.h"
+#include "cafVecIjk.h"
 #include "cvfColor3.h"
 
 #include <array>
@@ -60,9 +61,7 @@ private:
                           size_t                            gridIndex,
                           size_t                            elmIndex,
                           int                               elmId,
-                          size_t                            i,
-                          size_t                            j,
-                          size_t                            k,
+                          caf::VecIjk0                      ijk,
                           const RimGeoMechResultDefinition* geomResDef,
                           double                            factorOfSafety,
                           cvf::Color3ub                     color )
@@ -70,9 +69,7 @@ private:
             , gridIndex( gridIndex )
             , elmIndex( elmIndex )
             , elmId( elmId )
-            , i( i )
-            , j( j )
-            , k( k )
+            , ijk( ijk )
             , geomResDef( geomResDef )
             , factorOfSafety( factorOfSafety )
             , color( color )
@@ -83,7 +80,7 @@ private:
         size_t                            gridIndex;
         size_t                            elmIndex;
         int                               elmId;
-        size_t                            i, j, k;
+        caf::VecIjk0                      ijk;
         const RimGeoMechResultDefinition* geomResDef;
         double                            factorOfSafety;
         cvf::Color3ub                     color;


### PR DESCRIPTION
Use caf::VecIjk0 in MohrsCirclesInfo and convert to VecIjk1 for display, matching the 1-based indexing used in the 3D view.

Fixes #3284.