### PR TITLE
#4529 Remove nextValidId fields and calculate on the fly

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.cpp
@@ -34,6 +34,8 @@
 #include "cafPdmObject.h"
 #include "cafPdmObjectScriptingCapability.h"
 
+#include <algorithm>
+
 CAF_PDM_SOURCE_INIT( RimFractureTemplateCollection, "FractureTemplateCollection", "FractureDefinitionCollection" );
 
 //--------------------------------------------------------------------------------------------------
@@ -50,8 +52,9 @@ RimFractureTemplateCollection::RimFractureTemplateCollection()
 
     CAF_PDM_InitFieldNoDefault( &m_fractureDefinitions, "FractureDefinitions", "" );
 
-    CAF_PDM_InitField( &m_nextValidFractureTemplateId, "NextValidFractureTemplateId", 0, "" );
-    m_nextValidFractureTemplateId.uiCapability()->setUiHidden( true );
+    CAF_PDM_InitField( &m_nextValidFractureTemplateId_OBSOLETE, "NextValidFractureTemplateId", 0, "" );
+    m_nextValidFractureTemplateId_OBSOLETE.xmlCapability()->setIOWritable( false );
+    m_nextValidFractureTemplateId_OBSOLETE.uiCapability()->setUiHidden( true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -288,10 +291,12 @@ void RimFractureTemplateCollection::initAfterRead()
 //--------------------------------------------------------------------------------------------------
 int RimFractureTemplateCollection::nextFractureTemplateId()
 {
-    int newId                     = m_nextValidFractureTemplateId;
-    m_nextValidFractureTemplateId = m_nextValidFractureTemplateId + 1;
-
-    return newId;
+    int nextValidId = 0;
+    for ( const auto& templ : m_fractureDefinitions )
+    {
+        nextValidId = std::max( nextValidId, templ->id() + 1 );
+    }
+    return nextValidId;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.h
@@ -69,6 +69,5 @@ private:
 
     caf::PdmChildArrayField<RimFractureTemplate*>              m_fractureDefinitions;
     caf::PdmField<caf::AppEnum<RiaDefines::EclipseUnitSystem>> m_defaultUnitsForFracTemplates;
-    caf::PdmField<int> m_nextValidFractureTemplateId; // Unique fracture template ID within a project, used to identify
-                                                      // a fracture template
+    caf::PdmField<int>                                         m_nextValidFractureTemplateId_OBSOLETE;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -119,12 +119,6 @@ CAF_PDM_SOURCE_INIT( RimProject, "ResInsightProject" );
 ///
 //--------------------------------------------------------------------------------------------------
 RimProject::RimProject()
-    : m_nextValidCaseId( 0 )
-    , m_nextValidCaseGroupId( 0 )
-    , m_nextValidViewId( -1 )
-    , m_nextValidPlotId( -1 )
-    , m_nextValidSummaryCaseId( 1 )
-    , m_nextValidEnsembleId( 1 )
 {
     CAF_PDM_InitScriptableObjectWithNameAndComment( "Project", "", "", "", "Project", "The ResInsight Project" );
 
@@ -279,13 +273,6 @@ void RimProject::close()
     mainWindowTreeViewStates         = "";
     plotWindowCurrentModelIndexPaths = "";
     plotWindowTreeViewStates         = "";
-
-    m_nextValidCaseId        = 0;
-    m_nextValidCaseGroupId   = 0;
-    m_nextValidViewId        = -1;
-    m_nextValidPlotId        = -1;
-    m_nextValidSummaryCaseId = 1;
-    m_nextValidEnsembleId    = 1;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -588,12 +575,13 @@ void RimProject::assignCaseIdToSummaryCase( RimSummaryCase* summaryCase )
 {
     if ( summaryCase )
     {
+        int nextValidId = 1;
         for ( RimSummaryCase* s : allSummaryCases() )
         {
-            m_nextValidSummaryCaseId = std::max( m_nextValidSummaryCaseId, s->caseId() + 1 );
+            nextValidId = std::max( nextValidId, s->caseId() + 1 );
         }
 
-        summaryCase->setCaseId( m_nextValidSummaryCaseId++ );
+        summaryCase->setCaseId( nextValidId );
     }
 }
 
@@ -604,12 +592,13 @@ void RimProject::assignIdToEnsemble( RimSummaryEnsemble* summaryCaseCollection )
 {
     if ( summaryCaseCollection )
     {
+        int nextValidId = 1;
         for ( RimSummaryEnsemble* ensemble : summaryEnsembles() )
         {
-            m_nextValidEnsembleId = std::max( m_nextValidEnsembleId, ensemble->ensembleId() + 1 );
+            nextValidId = std::max( nextValidId, ensemble->ensembleId() + 1 );
         }
 
-        summaryCaseCollection->setEnsembleId( m_nextValidEnsembleId );
+        summaryCaseCollection->setEnsembleId( nextValidId );
     }
 }
 
@@ -688,13 +677,13 @@ void RimProject::assignCaseIdToCase( RimCase* reservoirCase )
 {
     if ( reservoirCase )
     {
-        std::vector<RimCase*> cases = descendantsIncludingThisOfType<RimCase>();
-        for ( RimCase* rimCase : cases )
+        int nextValidId = 0;
+        for ( RimCase* rimCase : descendantsIncludingThisOfType<RimCase>() )
         {
-            m_nextValidCaseId = std::max( m_nextValidCaseId, rimCase->caseId() + 1 );
+            nextValidId = std::max( nextValidId, rimCase->caseId() + 1 );
         }
 
-        reservoirCase->setCaseId( m_nextValidCaseId++ );
+        reservoirCase->setCaseId( nextValidId );
     }
 }
 
@@ -705,14 +694,14 @@ void RimProject::assignIdToCaseGroup( RimIdenticalGridCaseGroup* caseGroup )
 {
     if ( caseGroup )
     {
-        std::vector<RimIdenticalGridCaseGroup*> identicalCaseGroups = descendantsIncludingThisOfType<RimIdenticalGridCaseGroup>();
+        int nextValidId = 0;
 
-        for ( RimIdenticalGridCaseGroup* existingCaseGroup : identicalCaseGroups )
+        for ( RimIdenticalGridCaseGroup* existingCaseGroup : descendantsIncludingThisOfType<RimIdenticalGridCaseGroup>() )
         {
-            m_nextValidCaseGroupId = std::max( m_nextValidCaseGroupId, existingCaseGroup->groupId() + 1 );
+            nextValidId = std::max( nextValidId, existingCaseGroup->groupId() + 1 );
         }
 
-        caseGroup->groupId = m_nextValidCaseGroupId++;
+        caseGroup->groupId = nextValidId;
     }
 }
 
@@ -723,20 +712,19 @@ void RimProject::assignIdToCaseGroup( RimReservoirGridEnsemble* gridEnsemble )
 {
     if ( gridEnsemble )
     {
-        std::vector<RimIdenticalGridCaseGroup*> identicalCaseGroups = descendantsIncludingThisOfType<RimIdenticalGridCaseGroup>();
-        std::vector<RimReservoirGridEnsemble*>  gridEnsembles       = descendantsIncludingThisOfType<RimReservoirGridEnsemble>();
+        int nextValidId = 0;
 
-        for ( RimIdenticalGridCaseGroup* existingCaseGroup : identicalCaseGroups )
+        for ( RimIdenticalGridCaseGroup* existingCaseGroup : descendantsIncludingThisOfType<RimIdenticalGridCaseGroup>() )
         {
-            m_nextValidCaseGroupId = std::max( m_nextValidCaseGroupId, existingCaseGroup->groupId() + 1 );
+            nextValidId = std::max( nextValidId, existingCaseGroup->groupId() + 1 );
         }
 
-        for ( RimReservoirGridEnsemble* existingEnsemble : gridEnsembles )
+        for ( RimReservoirGridEnsemble* existingEnsemble : descendantsIncludingThisOfType<RimReservoirGridEnsemble>() )
         {
-            m_nextValidCaseGroupId = std::max( m_nextValidCaseGroupId, existingEnsemble->groupId() + 1 );
+            nextValidId = std::max( nextValidId, existingEnsemble->groupId() + 1 );
         }
 
-        gridEnsemble->setGroupId( m_nextValidCaseGroupId++ );
+        gridEnsemble->setGroupId( nextValidId );
     }
 }
 
@@ -747,17 +735,13 @@ void RimProject::assignViewIdToView( Rim3dView* view )
 {
     if ( view )
     {
-        if ( m_nextValidViewId < 0 )
+        int nextValidId = 0;
+        for ( Rim3dView* existingView : descendantsIncludingThisOfType<Rim3dView>() )
         {
-            std::vector<Rim3dView*> views = descendantsIncludingThisOfType<Rim3dView>();
-
-            for ( Rim3dView* existingView : views )
-            {
-                m_nextValidViewId = std::max( m_nextValidViewId, existingView->id() + 1 );
-            }
+            nextValidId = std::max( nextValidId, existingView->id() + 1 );
         }
 
-        view->setId( m_nextValidViewId++ );
+        view->setId( nextValidId );
     }
 }
 
@@ -768,17 +752,13 @@ void RimProject::assignPlotIdToPlotWindow( RimPlotWindow* plotWindow )
 {
     if ( plotWindow )
     {
-        if ( m_nextValidPlotId < 0 )
+        int nextValidId = 0;
+        for ( RimPlotWindow* existingPlotWindow : descendantsIncludingThisOfType<RimPlotWindow>() )
         {
-            std::vector<RimPlotWindow*> plotWindows = descendantsIncludingThisOfType<RimPlotWindow>();
-
-            for ( RimPlotWindow* existingPlotWindow : plotWindows )
-            {
-                m_nextValidPlotId = std::max( m_nextValidPlotId, existingPlotWindow->id() + 1 );
-            }
+            nextValidId = std::max( nextValidId, existingPlotWindow->id() + 1 );
         }
 
-        plotWindow->setId( m_nextValidPlotId++ );
+        plotWindow->setId( nextValidId );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimProject.h
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.h
@@ -228,13 +228,6 @@ private:
     caf::PdmField<caf::AppEnum<RiaDefines::WindowTileMode>> m_subWindowsTileMode3DWindow;
     caf::PdmField<caf::AppEnum<RiaDefines::WindowTileMode>> m_subWindowsTileModePlotWindow;
 
-    int m_nextValidCaseId;
-    int m_nextValidCaseGroupId;
-    int m_nextValidViewId;
-    int m_nextValidPlotId;
-    int m_nextValidSummaryCaseId;
-    int m_nextValidEnsembleId;
-
     caf::PdmChildArrayField<RimEclipseCase*>            casesObsolete; // obsolete
     caf::PdmChildArrayField<RimIdenticalGridCaseGroup*> caseGroupsObsolete; // obsolete
 };

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelTemplateCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelTemplateCollection.cpp
@@ -21,13 +21,14 @@
 #include "RimCase.h"
 #include "RimEclipseCase.h"
 #include "RimEclipseView.h"
-#include "RimFracture.h"
 #include "RimProject.h"
 #include "RimStimPlanModelTemplate.h"
 
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObject.h"
 #include "cafPdmObjectScriptingCapability.h"
+
+#include <algorithm>
 
 CAF_PDM_SOURCE_INIT( RimStimPlanModelTemplateCollection, "StimPlanModelTemplateCollection" );
 
@@ -40,8 +41,9 @@ RimStimPlanModelTemplateCollection::RimStimPlanModelTemplateCollection()
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_stimPlanModelTemplates, "StimPlanModelTemplates", "StimPlan Model Templates" );
 
-    CAF_PDM_InitField( &m_nextValidId, "NextValidId", 0, "" );
-    m_nextValidId.uiCapability()->setUiHidden( true );
+    CAF_PDM_InitField( &m_nextValidId_OBSOLETE, "NextValidId", 0, "" );
+    m_nextValidId_OBSOLETE.xmlCapability()->setIOWritable( false );
+    m_nextValidId_OBSOLETE.uiCapability()->setUiHidden( true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -106,10 +108,12 @@ void RimStimPlanModelTemplateCollection::initAfterRead()
 //--------------------------------------------------------------------------------------------------
 int RimStimPlanModelTemplateCollection::nextFractureTemplateId()
 {
-    int newId     = m_nextValidId;
-    m_nextValidId = m_nextValidId + 1;
-
-    return newId;
+    int nextValidId = 0;
+    for ( const auto& templ : m_stimPlanModelTemplates )
+    {
+        nextValidId = std::max( nextValidId, templ->id() + 1 );
+    }
+    return nextValidId;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelTemplateCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelTemplateCollection.h
@@ -50,5 +50,5 @@ private:
     int nextFractureTemplateId();
 
     caf::PdmChildArrayField<RimStimPlanModelTemplate*> m_stimPlanModelTemplates;
-    caf::PdmField<int>                                 m_nextValidId; // Unique fracture template ID within a project
+    caf::PdmField<int>                                 m_nextValidId_OBSOLETE;
 };


### PR DESCRIPTION
Remove cached next-valid-ID member variables and compute them on demand by scanning existing objects, following the pattern already used by RimUserDefinedCalculationCollection. This eliminates unnecessary state and potential corruption risks.

Fixes #4529.