### PR TITLE
Remove deprecated size_t overloads from RigActiveCellInfo

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -179,7 +179,7 @@ RigMswBranch buildMainBoreBranchFromGeometry( const RimWellPath*                
             if ( overlapEnd > overlapStart )
             {
                 if ( activeCellInfo && cellInfo.globCellIndex < mainGrid->totalCellCount() &&
-                     !activeCellInfo->isActive( cellInfo.globCellIndex ) )
+                     !activeCellInfo->isActive( ReservoirCellIndex( cellInfo.globCellIndex ) ) )
                     continue;
                 if ( auto ci = toMswCellIntersection( cellInfo, mainGrid, overlapStart, overlapEnd ) ) cellCompsegs.push_back( *ci );
             }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicFishbonesTransmissibilityCalculationFeatureImp.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicFishbonesTransmissibilityCalculationFeatureImp.cpp
@@ -62,7 +62,7 @@ std::vector<RigCompletionData> RicFishbonesTransmissibilityCalculationFeatureImp
         size_t                                       globalCellIndex = cellAndWellBoreParts.first;
         const std::vector<WellBorePartForTransCalc>& wellBoreParts   = cellAndWellBoreParts.second;
 
-        bool cellIsActive = activeCellInfo->isActive( globalCellIndex );
+        bool cellIsActive = activeCellInfo->isActive( ReservoirCellIndex( globalCellIndex ) );
         if ( !cellIsActive ) continue;
 
         // Find main bore and number of laterals

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp
@@ -1170,7 +1170,7 @@ std::vector<RigCompletionData>
 
             for ( auto& cell : intersectedCells )
             {
-                bool cellIsActive = activeCellInfo->isActive( cell.globCellIndex );
+                bool cellIsActive = activeCellInfo->isActive( ReservoirCellIndex( cell.globCellIndex ) );
                 if ( !cellIsActive ) continue;
 
                 RigCompletionData completion( wellPath->completionSettings()->wellNameForExport(),
@@ -1313,7 +1313,7 @@ std::pair<double, cvf::Vec2i>
         size_t             gridLocalCellIndex = 0;
         const RigGridBase* grid = mainGrid->gridAndGridLocalIdxFromGlobalCellIdx( intersection.globCellIndex, &gridLocalCellIndex );
 
-        if ( grid->gridId() == gridId && activeCellInfo->isActive( intersection.globCellIndex ) )
+        if ( grid->gridId() == gridId && activeCellInfo->isActive( ReservoirCellIndex( intersection.globCellIndex ) ) )
         {
             size_t i, j, k;
             if ( grid->ijkFromCellIndex( gridLocalCellIndex, &i, &j, &k ) )

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
@@ -737,7 +737,7 @@ double RicWellPathExportMswTableData::computeIntitialMeasuredDepth( const RimEcl
     {
         for ( const WellPathCellIntersectionInfo& intersection : allIntersections )
         {
-            if ( activeCellInfo->isActive( intersection.globCellIndex ) )
+            if ( activeCellInfo->isActive( ReservoirCellIndex( intersection.globCellIndex ) ) )
             {
                 candidateMeasuredDepth = intersection.startMD;
                 break;
@@ -1512,7 +1512,7 @@ std::vector<RigCompletionData>
 
         for ( auto& cell : intersectedCells )
         {
-            bool cellIsActive = activeCellInfo->isActive( cell.globCellIndex );
+            bool cellIsActive = activeCellInfo->isActive( ReservoirCellIndex( cell.globCellIndex ) );
             if ( !cellIsActive ) continue;
 
             RigCompletionData completion( wellPath->completionSettings()->wellNameForExport(),
@@ -1702,7 +1702,8 @@ std::pair<double, double>
 {
     for ( const WellPathCellIntersectionInfo& intersection : wellPathIntersections )
     {
-        if ( intersection.globCellIndex < activeCellInfo->reservoirCellCount() && activeCellInfo->isActive( intersection.globCellIndex ) )
+        if ( intersection.globCellIndex < activeCellInfo->reservoirCellCount() &&
+             activeCellInfo->isActive( ReservoirCellIndex( intersection.globCellIndex ) ) )
         {
             double overlapStart = std::max( startMD, intersection.startMD );
             double overlapEnd   = std::min( endMD, intersection.endMD );

--- a/ApplicationLibCode/Commands/ExportCommands/RicSaveEclipseInputVisibleCellsFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSaveEclipseInputVisibleCellsFeature.cpp
@@ -77,7 +77,7 @@ void RicSaveEclipseInputVisibleCellsFeature::executeCommand( RimEclipseView*    
     values.resize( visibleCells.size() );
     for ( size_t i = 0; i < visibleCells.size(); ++i )
     {
-        if ( activeCellInfo->isActive( i ) )
+        if ( activeCellInfo->isActive( ReservoirCellIndex( i ) ) )
         {
             if ( visibleCells[i] )
             {

--- a/ApplicationLibCode/Commands/RicCreateTemporaryLgrFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCreateTemporaryLgrFeature.cpp
@@ -254,10 +254,10 @@ RigGridBase* RicCreateTemporaryLgrFeature::createLgr( const LgrInfo& lgrInfo, Ri
                     auto   gridCell  = localGrid->cell( cellIndex );
                     if ( gridCell.parentCellIndex() != cvf::UNDEFINED_SIZE_T )
                     {
-                        auto resultIndex = activeInfo->cellResultIndex( gridCell.parentCellIndex() );
-                        if ( resultIndex != cvf::UNDEFINED_SIZE_T )
+                        auto resultIndex = activeInfo->cellResultIndex( ReservoirCellIndex( gridCell.parentCellIndex() ) );
+                        if ( resultIndex.value() != cvf::UNDEFINED_SIZE_T )
                         {
-                            activeInfo->setCellResultIndex( cellIndex + mainGridCellCount, resultIndex );
+                            activeInfo->setCellResultIndex( ReservoirCellIndex( cellIndex + mainGridCellCount ), resultIndex );
                             activeCellCount++;
                         }
                     }

--- a/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
@@ -319,7 +319,7 @@ std::expected<std::vector<double>, std::string> RifEclipseInputFileTools::extrac
 
                 size_t reservoirCellIndex = mainGrid->cellIndexFromIJK( mainI, mainJ, mainK );
 
-                size_t resIndex = activeCells->cellResultIndex( reservoirCellIndex );
+                size_t resIndex = activeCells->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
                 if ( resIndex != cvf::UNDEFINED_SIZE_T )
                 {
                     auto value = resultAcc->cellScalarGlobIdx( reservoirCellIndex );
@@ -404,7 +404,7 @@ std::expected<std::vector<double>, std::string> RifEclipseInputFileTools::extrac
                     {
                         size_t mainI              = min.x() + origI;
                         size_t reservoirCellIndex = mainGrid->cellIndexFromIJK( mainI, mainJ, mainK );
-                        size_t resIndex           = activeCells->cellResultIndex( reservoirCellIndex );
+                        size_t resIndex           = activeCells->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
                         size_t subCountI          = refinement.subcellCount( RigRefinement::DimI, origI );
 
                         double value = ( resIndex != cvf::UNDEFINED_SIZE_T ) ? resultAcc->cellScalarGlobIdx( reservoirCellIndex )

--- a/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
@@ -697,13 +697,13 @@ bool RifEclipseOutputFileTools::assignActiveCellData( std::vector<std::vector<in
         {
             if ( actnumValue == matrixActive || actnumValue == matrixAndFractureActive )
             {
-                activeCellInfo->setCellResultIndex( cellIdx, globalActiveMatrixIndex++ );
+                activeCellInfo->setCellResultIndex( ReservoirCellIndex( cellIdx ), ActiveCellIndex( globalActiveMatrixIndex++ ) );
                 activeMatrixIndex++;
             }
 
             if ( actnumValue == fractureActive || actnumValue == matrixAndFractureActive )
             {
-                fractureActiveCellInfo->setCellResultIndex( cellIdx, globalActiveFractureIndex++ );
+                fractureActiveCellInfo->setCellResultIndex( ReservoirCellIndex( cellIdx ), ActiveCellIndex( globalActiveFractureIndex++ ) );
                 activeFractureIndex++;
             }
 

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -184,13 +184,15 @@ bool RifReaderEclipseOutput::transferGridCellData( RigMainGrid*         mainGrid
         int matrixActiveIndex = ecl_grid_get_active_index1( localEclGrid, gridLocalCellIndex );
         if ( matrixActiveIndex != -1 )
         {
-            activeCellInfo->setCellResultIndex( cellStartIndex + gridLocalCellIndex, matrixActiveStartIndex + matrixActiveIndex );
+            activeCellInfo->setCellResultIndex( ReservoirCellIndex( cellStartIndex + gridLocalCellIndex ),
+                                                ActiveCellIndex( matrixActiveStartIndex + matrixActiveIndex ) );
         }
 
         int fractureActiveIndex = ecl_grid_get_active_fracture_index1( localEclGrid, gridLocalCellIndex );
         if ( fractureActiveIndex != -1 )
         {
-            fractureActiveCellInfo->setCellResultIndex( cellStartIndex + gridLocalCellIndex, fractureActiveStartIndex + fractureActiveIndex );
+            fractureActiveCellInfo->setCellResultIndex( ReservoirCellIndex( cellStartIndex + gridLocalCellIndex ),
+                                                        ActiveCellIndex( fractureActiveStartIndex + fractureActiveIndex ) );
         }
 
         // Parent cell index

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -464,13 +464,15 @@ void RifReaderOpmCommon::transferActiveCells( Opm::EclIO::EGrid&  opmGrid,
         int matrixActiveIndex = active_indexes[opmCellIndex];
         if ( matrixActiveIndex != -1 )
         {
-            activeCellInfo->setCellResultIndex( cellStartIndex + opmCellIndex, matrixActiveStartIndex + matrixActiveIndex );
+            activeCellInfo->setCellResultIndex( ReservoirCellIndex( cellStartIndex + opmCellIndex ),
+                                                ActiveCellIndex( matrixActiveStartIndex + matrixActiveIndex ) );
         }
 
         int fractureActiveIndex = active_frac_indexes[opmCellIndex];
         if ( fractureActiveIndex != -1 )
         {
-            fractureActiveCellInfo->setCellResultIndex( cellStartIndex + opmCellIndex, fractureActiveStartIndex + fractureActiveIndex );
+            fractureActiveCellInfo->setCellResultIndex( ReservoirCellIndex( cellStartIndex + opmCellIndex ),
+                                                        ActiveCellIndex( fractureActiveStartIndex + fractureActiveIndex ) );
         }
     }
 }

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
@@ -228,7 +228,8 @@ bool RifRoffFileTools::openGridFile( const QString& fileName, RigEclipseCaseData
             int matrixActiveIndex = activeCells[gridLocalCellIndex];
             if ( matrixActiveIndex != -1 )
             {
-                activeCellInfo->setCellResultIndex( cellStartIndex + gridLocalCellIndex, matrixActiveIndex );
+                activeCellInfo->setCellResultIndex( ReservoirCellIndex( cellStartIndex + gridLocalCellIndex ),
+                                                    ActiveCellIndex( matrixActiveIndex ) );
             }
 
             cell.setParentCellIndex( cvf::UNDEFINED_SIZE_T );
@@ -710,7 +711,7 @@ bool RifRoffFileTools::appendNewInputPropertyResult( RigEclipseCaseData* caseDat
     size_t cellCount      = mainGrid->cellCount();
     for ( size_t i = 0; i < cellCount; i++ )
     {
-        if ( !activeCellInfo->isActive( mainGrid->reservoirCellIndex( i ) ) )
+        if ( !activeCellInfo->isActive( ReservoirCellIndex( mainGrid->reservoirCellIndex( i ) ) ) )
         {
             values[i] = HUGE_VAL;
         }

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivEclipseIntersectionGrid.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivEclipseIntersectionGrid.cpp
@@ -70,7 +70,7 @@ bool RivEclipseIntersectionGrid::useCell( size_t cellIndex ) const
         if ( m_showInactiveCells )
             return !cell.isInvalid() && ( cell.subGrid() == nullptr );
         else
-            return m_activeCellInfo->isActive( cellIndex ) && ( cell.subGrid() == nullptr );
+            return m_activeCellInfo->isActive( ReservoirCellIndex( cellIndex ) ) && ( cell.subGrid() == nullptr );
     }
     return false;
 }

--- a/ApplicationLibCode/ModelVisualization/RivElementVectorResultPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivElementVectorResultPartMgr.cpp
@@ -168,9 +168,9 @@ void RivElementVectorResultPartMgr::appendDynamicGeometryPartsToModel( cvf::Mode
         for ( int gcIdx = 0; gcIdx < static_cast<int>( mainGrid->totalCellCount() ); ++gcIdx )
         {
             auto& cell = mainGrid->cell( gcIdx );
-            if ( !cell.isInvalid() && activeCellInfo->isActive( gcIdx ) )
+            if ( !cell.isInvalid() && activeCellInfo->isActive( ReservoirCellIndex( gcIdx ) ) )
             {
-                size_t resultIdx = activeCellInfo->cellResultIndex( gcIdx );
+                size_t resultIdx = activeCellInfo->cellResultIndex( ReservoirCellIndex( gcIdx ) ).value();
                 if ( result->vectorView() == RimElementVectorResult::VectorView::PER_FACE )
                 {
                     for ( int dir = 0; dir < static_cast<int>( directions.size() ); dir++ )

--- a/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp
@@ -629,7 +629,7 @@ void RivReservoirViewPartMgr::computeNativeVisibility( cvf::UByteArray*         
     {
         const RigCell& cell               = grid->cell( cellIndex );
         size_t         reservoirCellIndex = grid->reservoirCellIndex( cellIndex );
-        bool           isCellActive       = activeCellInfo->isActive( reservoirCellIndex );
+        bool           isCellActive       = activeCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) );
 
         if ( ( !invalidCellsIsVisible && cell.isInvalid() ) || ( !inactiveCellsIsVisible && !isCellActive ) ||
              ( !activeCellsIsVisible && isCellActive ) || ( *cellIsInWellStatuses )[cellIndex] )

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
@@ -656,7 +656,7 @@ void RimFlowCharacteristicsPlot::onLoadDataAndUpdate()
 
                 for ( size_t i = 0; i < visibleCells.size(); ++i )
                 {
-                    size_t cellIndex = activeCellInfo->cellResultIndex( i );
+                    size_t cellIndex = activeCellInfo->cellResultIndex( ReservoirCellIndex( i ) ).value();
                     if ( cellIndex != cvf::UNDEFINED_SIZE_T )
                     {
                         visibleActiveCells[cellIndex] = visibleCells[i];

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimFlowDiagSolution.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimFlowDiagSolution.cpp
@@ -202,7 +202,8 @@ std::map<std::string, std::vector<int>> RimFlowDiagSolution::allTracerActiveCell
                         RigGridBase* grid               = mainGrid->gridByIndex( wrp.gridIndex() );
                         size_t       reservoirCellIndex = grid->reservoirCellIndex( wrp.cellIndex() );
 
-                        int cellActiveIndex = static_cast<int>( activeCellInfo->cellResultIndex( reservoirCellIndex ) );
+                        int cellActiveIndex =
+                            static_cast<int>( activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value() );
 
                         if ( useInjectors == isInjectorWell )
                         {

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/CellFilters/RimPlotCellPropertyFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/CellFilters/RimPlotCellPropertyFilter.cpp
@@ -188,12 +188,12 @@ void RimPlotCellPropertyFilter::updateCellVisibilityFromFilter( size_t timeStepI
 
         for ( size_t reservoirCellIndex = 0; reservoirCellIndex < totalReservoirCellCount; ++reservoirCellIndex )
         {
-            if ( !actCellInfo->isActive( reservoirCellIndex ) ) continue;
+            if ( !actCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) ) continue;
 
             cellResultIndex = reservoirCellIndex;
             if ( isUsingGlobalActiveIndex )
             {
-                cellResultIndex = actCellInfo->cellResultIndex( reservoirCellIndex );
+                cellResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
             }
 
             if ( cellResultIndex != cvf::UNDEFINED_SIZE_T && cellResultIndex < cellResultValues.size() )

--- a/ApplicationLibCode/ProjectDataModel/RimCornerPointCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCornerPointCase.cpp
@@ -292,7 +292,8 @@ void RimCornerPointCase::buildGrid( RigEclipseCaseData&       eclipseCaseData,
         int matrixActiveIndex = activeCells[gridLocalCellIndex];
         if ( matrixActiveIndex != -1 )
         {
-            activeCellInfo->setCellResultIndex( cellStartIndex + gridLocalCellIndex, matrixActiveIndex );
+            activeCellInfo->setCellResultIndex( ReservoirCellIndex( cellStartIndex + gridLocalCellIndex ),
+                                                ActiveCellIndex( matrixActiveIndex ) );
         }
 
         cell.setParentCellIndex( cvf::UNDEFINED_SIZE_T );

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
@@ -1083,7 +1083,7 @@ bool RimEclipseCase::openReservoirCase()
             std::vector<size_t> reservoirCellIndices;
             for ( size_t i = 0; i < mainGrid->cellCount(); i++ )
             {
-                if ( activeCellInfo->isActive( i ) )
+                if ( activeCellInfo->isActive( ReservoirCellIndex( i ) ) )
                 {
                     reservoirCellIndices.push_back( i );
                 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp
@@ -220,7 +220,7 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
 
                     if ( visibility.notNull() && !visibility->val( reservoirCellIndex ) ) continue;
 
-                    if ( destinationActiveCellInfo->isActive( reservoirCellIndex ) )
+                    if ( destinationActiveCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
                         // Extract the cell values from each of the cases and assemble them into one vector
 
@@ -232,7 +232,8 @@ void RimEclipseStatisticsCaseEvaluator::evaluateForResults( const QList<ResSpec>
                             // Replace huge_val with zero in the statistical computation for the following case
                             if ( m_useZeroAsInactiveCellValue || resultName.toUpper() == "ACTNUM" )
                             {
-                                if ( unionActiveCells && unionActiveCells->isActive( reservoirCellIndex ) && val == HUGE_VAL )
+                                if ( unionActiveCells && unionActiveCells->isActive( ReservoirCellIndex( reservoirCellIndex ) ) &&
+                                     val == HUGE_VAL )
                                 {
                                     val = 0.0;
                                 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -1866,7 +1866,7 @@ void RimEclipseView::calculateVisibleWellCellsIncFence( cvf::UByteArray* visible
                                     size_t fenceCellIndex     = grid->cellIndexFromIJK( *pI, *pJ, *pK );
                                     size_t reservoirCellIndex = grid->reservoirCellIndex( fenceCellIndex );
 
-                                    if ( activeCellInfo && activeCellInfo->isActive( reservoirCellIndex ) )
+                                    if ( activeCellInfo && activeCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                                     {
                                         ( *visibleCells )[fenceCellIndex] = true;
                                     }

--- a/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
@@ -310,7 +310,7 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
                     if ( caseCollection->reservoirs[caseIdx]
                              ->eclipseCaseData()
                              ->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL )
-                             ->isActive( reservoirCellIndex ) )
+                             ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
                         activeM[gridLocalCellIndex] = 1;
                     }
@@ -321,7 +321,7 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
                     if ( caseCollection->reservoirs[caseIdx]
                              ->eclipseCaseData()
                              ->activeCellInfo( RiaDefines::PorosityModelType::FRACTURE_MODEL )
-                             ->isActive( reservoirCellIndex ) )
+                             ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
                         activeF[gridLocalCellIndex] = 1;
                     }
@@ -338,13 +338,15 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
 
             if ( activeM[gridLocalCellIndex] != 0 )
             {
-                m_unionOfMatrixActiveCells->setCellResultIndex( reservoirCellIndex, globalActiveMatrixIndex++ );
+                m_unionOfMatrixActiveCells->setCellResultIndex( ReservoirCellIndex( reservoirCellIndex ),
+                                                                ActiveCellIndex( globalActiveMatrixIndex++ ) );
                 activeMatrixIndex++;
             }
 
             if ( activeF[gridLocalCellIndex] != 0 )
             {
-                m_unionOfFractureActiveCells->setCellResultIndex( reservoirCellIndex, globalActiveFractureIndex++ );
+                m_unionOfFractureActiveCells->setCellResultIndex( ReservoirCellIndex( reservoirCellIndex ),
+                                                                  ActiveCellIndex( globalActiveFractureIndex++ ) );
                 activeFractureIndex++;
             }
         }

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -397,7 +397,7 @@ void RimReservoirGridEnsemble::computeUnionOfActiveCells()
                     if ( m_caseCollection->reservoirs[caseIdx]
                              ->eclipseCaseData()
                              ->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL )
-                             ->isActive( reservoirCellIndex ) )
+                             ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
                         activeM[gridLocalCellIndex] = 1;
                     }
@@ -408,7 +408,7 @@ void RimReservoirGridEnsemble::computeUnionOfActiveCells()
                     if ( m_caseCollection->reservoirs[caseIdx]
                              ->eclipseCaseData()
                              ->activeCellInfo( RiaDefines::PorosityModelType::FRACTURE_MODEL )
-                             ->isActive( reservoirCellIndex ) )
+                             ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
                         activeF[gridLocalCellIndex] = 1;
                     }
@@ -425,13 +425,15 @@ void RimReservoirGridEnsemble::computeUnionOfActiveCells()
 
             if ( activeM[gridLocalCellIndex] != 0 )
             {
-                m_unionOfMatrixActiveCells->setCellResultIndex( reservoirCellIndex, globalActiveMatrixIndex++ );
+                m_unionOfMatrixActiveCells->setCellResultIndex( ReservoirCellIndex( reservoirCellIndex ),
+                                                                ActiveCellIndex( globalActiveMatrixIndex++ ) );
                 activeMatrixIndex++;
             }
 
             if ( activeF[gridLocalCellIndex] != 0 )
             {
-                m_unionOfFractureActiveCells->setCellResultIndex( reservoirCellIndex, globalActiveFractureIndex++ );
+                m_unionOfFractureActiveCells->setCellResultIndex( ReservoirCellIndex( reservoirCellIndex ),
+                                                                  ActiveCellIndex( globalActiveFractureIndex++ ) );
                 activeFractureIndex++;
             }
         }

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp
@@ -239,7 +239,7 @@ void RimSimWellInView::wellHeadTopBottomPosition( int frameIndex, cvf::Vec3d* to
         k                         = 0;
 
         size_t topActiveCellIndex = rigReservoir->mainGrid()->cellIndexFromIJK( i, j, k );
-        while ( k < kIndexWellHeadCell && !rimReservoirView->currentActiveCellInfo()->isActive( topActiveCellIndex ) )
+        while ( k < kIndexWellHeadCell && !rimReservoirView->currentActiveCellInfo()->isActive( ReservoirCellIndex( topActiveCellIndex ) ) )
         {
             k++;
             topActiveCellIndex = rigReservoir->mainGrid()->cellIndexFromIJK( i, j, k );

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelPressureCalculator.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelPressureCalculator.cpp
@@ -536,9 +536,9 @@ bool RimStimPlanModelPressureCalculator::buildPressureTablesPerEqlNum( const Rim
 
     for ( size_t cellIndex = 0; cellIndex < eqlNumCellCount; cellIndex++ )
     {
-        size_t resultIdx         = eqlNumActiveCellInfo->cellResultIndex( cellIndex );
+        size_t resultIdx         = eqlNumActiveCellInfo->cellResultIndex( ReservoirCellIndex( cellIndex ) ).value();
         int    eqlNum            = static_cast<int>( eqlNumValues[resultIdx] );
-        size_t pressureResultIdx = pressureActiveCellInfo->cellResultIndex( cellIndex );
+        size_t pressureResultIdx = pressureActiveCellInfo->cellResultIndex( ReservoirCellIndex( cellIndex ) ).value();
         double pressure          = pressureValues[pressureResultIdx];
         if ( presentEqlNums.count( eqlNum ) > 0 && !std::isinf( pressure ) )
         {

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelWellLogCalculator.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelWellLogCalculator.cpp
@@ -799,7 +799,7 @@ bool RimStimPlanModelWellLogCalculator::replaceMissingValuesWithOtherKLayer( Ria
                     while ( !isFound && neighborK >= minK && neighborK <= maxK )
                     {
                         size_t neighborCellIdx = mainGrid->cellIndexFromIJK( i, j, neighborK );
-                        size_t resultIdx       = activeCellInfo->cellResultIndex( neighborCellIdx );
+                        size_t resultIdx       = activeCellInfo->cellResultIndex( ReservoirCellIndex( neighborCellIdx ) ).value();
 
                         if ( neighborCellIdx != cvf::UNDEFINED_SIZE_T && resultIdx < cellValues.size() )
                         {

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimGridCaseSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimGridCaseSurface.cpp
@@ -315,7 +315,7 @@ void RimGridCaseSurface::extractGridDataUsingFourVerticesPerCell()
 
                 bool skipInactiveCells = !m_includeInactiveCells();
                 if ( m_watertight ) skipInactiveCells = false;
-                if ( skipInactiveCells && activeCells && !activeCells->isActive( currentCellIndex ) ) continue;
+                if ( skipInactiveCells && activeCells && !activeCells->isActive( ReservoirCellIndex( currentCellIndex ) ) ) continue;
 
                 std::array<cvf::Vec3d, 8> currentCornerVerts = grid->cellCornerVertices( currentCellIndex );
 

--- a/ApplicationLibCode/ReservoirDataModel/Completions/RigEclipseToStimPlanCellTransmissibilityCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Completions/RigEclipseToStimPlanCellTransmissibilityCalculator.cpp
@@ -280,7 +280,7 @@ void RigEclipseToStimPlanCellTransmissibilityCalculator::calculateStimPlanCellsM
             const RigCell& cell                   = mainGrid->cell( reservoirCellIndex );
             size_t         mainGridReservoirIndex = cell.mainGridCellIndex();
 
-            if ( !activeCellInfo->isActive( mainGridReservoirIndex ) )
+            if ( !activeCellInfo->isActive( ReservoirCellIndex( mainGridReservoirIndex ) ) )
             {
                 isActive = false;
             }

--- a/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp
@@ -162,7 +162,7 @@ std::map<size_t, double> RigTransmissibilityCondenser::scaleMatrixToFracTransByM
                 if ( jt->first.m_cellIndexSpace == CellAddress::ECLIPSE )
                 {
                     size_t globalMatrixCellIdx = jt->first.m_globalCellIdx;
-                    size_t eclipseResultIndex  = actCellInfo->cellResultIndex( globalMatrixCellIdx );
+                    size_t eclipseResultIndex  = actCellInfo->cellResultIndex( ReservoirCellIndex( globalMatrixCellIdx ) ).value();
                     CVF_ASSERT( eclipseResultIndex < currentMatrixPressures.size() );
                     double unsignedDeltaPressure = std::abs( currentMatrixPressures[eclipseResultIndex] - currentWellPressure );
                     double nonZeroDeltaPressure  = std::max( epsilonDeltaPressure, unsignedDeltaPressure );
@@ -182,7 +182,7 @@ std::map<size_t, double> RigTransmissibilityCondenser::scaleMatrixToFracTransByM
                 if ( jt->first.m_cellIndexSpace == CellAddress::ECLIPSE )
                 {
                     size_t globalMatrixCellIdx = jt->first.m_globalCellIdx;
-                    size_t eclipseResultIndex  = actCellInfo->cellResultIndex( globalMatrixCellIdx );
+                    size_t eclipseResultIndex  = actCellInfo->cellResultIndex( ReservoirCellIndex( globalMatrixCellIdx ) ).value();
                     CVF_ASSERT( eclipseResultIndex < currentMatrixPressures.size() );
 
                     originalLumpedMatrixToFractureTrans[globalMatrixCellIdx] += jt->second;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
@@ -326,7 +326,7 @@ double RigEclipseContourMapProjection::getParameterWeightForCell( size_t cellRes
 //--------------------------------------------------------------------------------------------------
 size_t RigEclipseContourMapProjection::gridResultIndex( size_t globalCellIdx ) const
 {
-    if ( m_useActiveCellInfo ) return m_activeCellInfo->cellResultIndex( globalCellIdx );
+    if ( m_useActiveCellInfo ) return m_activeCellInfo->cellResultIndex( ReservoirCellIndex( globalCellIdx ) ).value();
 
     return globalCellIdx;
 }
@@ -338,7 +338,7 @@ bool RigEclipseContourMapProjection::isCellActive( size_t globalCellIdx ) const
 {
     if ( m_useActiveCellInfo && m_activeCellInfo != nullptr )
     {
-        return m_activeCellInfo->isActive( globalCellIdx );
+        return m_activeCellInfo->isActive( ReservoirCellIndex( globalCellIdx ) );
     }
 
     return true;

--- a/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigActiveCellsResultAccessor.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigActiveCellsResultAccessor.cpp
@@ -41,7 +41,7 @@ double RigActiveCellsResultAccessor::cellScalar( size_t gridLocalCellIndex ) con
     if ( m_reservoirResultValues == nullptr || m_reservoirResultValues->empty() ) return HUGE_VAL;
 
     size_t reservoirCellIndex = m_grid->reservoirCellIndex( gridLocalCellIndex );
-    size_t resultValueIndex   = m_activeCellInfo->cellResultIndex( reservoirCellIndex );
+    size_t resultValueIndex   = m_activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
     if ( resultValueIndex == cvf::UNDEFINED_SIZE_T ) return HUGE_VAL;
 
     if ( resultValueIndex < m_reservoirResultValues->size() ) return m_reservoirResultValues->at( resultValueIndex );
@@ -67,7 +67,7 @@ double RigActiveCellsResultAccessor::cellScalarGlobIdx( size_t reservoirCellInde
 {
     if ( m_reservoirResultValues == nullptr || m_reservoirResultValues->empty() ) return HUGE_VAL;
 
-    size_t resultValueIndex = m_activeCellInfo->cellResultIndex( reservoirCellIndex );
+    size_t resultValueIndex = m_activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
     if ( resultValueIndex == cvf::UNDEFINED_SIZE_T ) return HUGE_VAL;
 
     if ( resultValueIndex < m_reservoirResultValues->size() ) return m_reservoirResultValues->at( resultValueIndex );

--- a/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigDepthResultAccessor.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigDepthResultAccessor.cpp
@@ -62,7 +62,7 @@ std::vector<double> RigDepthResultAccessor::resultValues( RigEclipseCaseData*   
                 size_t tmpCellIdx = grid->cellIndexFromIJK( i, j, k );
                 double tmpVal     = 0.0;
 
-                if ( !activeCellInfo->isActive( tmpCellIdx ) )
+                if ( !activeCellInfo->isActive( ReservoirCellIndex( tmpCellIdx ) ) )
                 {
                     tmpVal = nan;
                 }

--- a/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigCellVolumeResultCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigCellVolumeResultCalculator.cpp
@@ -76,7 +76,7 @@ void RigCellVolumeResultCalculator::calculate( const RigEclipseResultAddress& re
     for ( int nativeResvCellIndex = 0; nativeResvCellIndex < static_cast<int>( m_resultsData->m_ownerMainGrid->totalCellCount() );
           nativeResvCellIndex++ )
     {
-        size_t resultIndex = m_resultsData->activeCellInfo()->cellResultIndex( nativeResvCellIndex );
+        size_t resultIndex = m_resultsData->activeCellInfo()->cellResultIndex( ReservoirCellIndex( nativeResvCellIndex ) ).value();
         if ( ( resultIndex != cvf::UNDEFINED_SIZE_T ) && ( resultIndex < cellResultCount ) )
         {
             const RigCell& cell = m_resultsData->m_ownerMainGrid->cell( nativeResvCellIndex );

--- a/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigCellsWithNncsCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigCellsWithNncsCalculator.cpp
@@ -83,7 +83,7 @@ void RigCellsWithNncsCalculator::calculate( const RigEclipseResultAddress& resVa
 
     for ( auto reservoirCellIndex : uniqueReservoirIndices )
     {
-        size_t resultIndex        = m_resultsData->activeCellInfo()->cellResultIndex( reservoirCellIndex );
+        size_t resultIndex        = m_resultsData->activeCellInfo()->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
         resultValues[resultIndex] = 1.0;
     }
 }

--- a/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigOilVolumeResultCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigOilVolumeResultCalculator.cpp
@@ -77,7 +77,7 @@ void RigOilVolumeResultCalculator::calculate( const RigEclipseResultAddress& res
         for ( int nativeResvCellIndex = 0; nativeResvCellIndex < static_cast<int>( m_resultsData->m_ownerMainGrid->totalCellCount() );
               nativeResvCellIndex++ )
         {
-            size_t resultIndex = m_resultsData->activeCellInfo()->cellResultIndex( nativeResvCellIndex );
+            size_t resultIndex = m_resultsData->activeCellInfo()->cellResultIndex( ReservoirCellIndex( nativeResvCellIndex ) ).value();
             if ( resultIndex != cvf::UNDEFINED_SIZE_T )
             {
                 if ( resultIndex < soilResults.size() && resultIndex < cellVolumeResults.size() )

--- a/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigPorvSoilSgasResultCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigPorvSoilSgasResultCalculator.cpp
@@ -132,7 +132,7 @@ void RigPorvSoilSgasResultCalculator::calculate( const RigEclipseResultAddress& 
         for ( int nativeResvCellIndex = 0; nativeResvCellIndex < static_cast<int>( m_resultsData->m_ownerMainGrid->totalCellCount() );
               nativeResvCellIndex++ )
         {
-            size_t resultIndex = m_resultsData->activeCellInfo()->cellResultIndex( nativeResvCellIndex );
+            size_t resultIndex = m_resultsData->activeCellInfo()->cellResultIndex( ReservoirCellIndex( nativeResvCellIndex ) ).value();
             if ( resultIndex != cvf::UNDEFINED_SIZE_T )
             {
                 size_t idx1             = res1ActiveOnly ? resultIndex : nativeResvCellIndex;

--- a/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.cpp
@@ -62,14 +62,6 @@ bool RigActiveCellInfo::isActive( ReservoirCellIndex reservoirCellIndex ) const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RigActiveCellInfo::isActive( size_t reservoirCellIndex ) const
-{
-    return isActive( ReservoirCellIndex( reservoirCellIndex ) );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 ActiveCellIndex RigActiveCellInfo::cellResultIndex( ReservoirCellIndex reservoirCellIndex ) const
 {
     CVF_TIGHT_ASSERT( reservoirCellIndex.value() < m_reservoirCellToActiveCell.size() );
@@ -80,27 +72,11 @@ ActiveCellIndex RigActiveCellInfo::cellResultIndex( ReservoirCellIndex reservoir
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-size_t RigActiveCellInfo::cellResultIndex( size_t reservoirCellIndex ) const
-{
-    return cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void RigActiveCellInfo::setCellResultIndex( ReservoirCellIndex reservoirCellIndex, ActiveCellIndex reservoirCellResultIndex )
 {
     CVF_TIGHT_ASSERT( reservoirCellResultIndex.value() < m_reservoirCellToActiveCell.size() );
 
     m_reservoirCellToActiveCell[reservoirCellIndex.value()] = reservoirCellResultIndex;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RigActiveCellInfo::setCellResultIndex( size_t reservoirCellIndex, size_t reservoirCellResultIndex )
-{
-    setCellResultIndex( ReservoirCellIndex( reservoirCellIndex ), ActiveCellIndex( reservoirCellResultIndex ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigActiveCellInfo.h
@@ -43,10 +43,6 @@ public:
     void                            setCellResultIndex( ReservoirCellIndex reservoirCellIndex, ActiveCellIndex globalResultCellIndex );
     std::vector<ReservoirCellIndex> activeReservoirCellIndices() const;
 
-    [[deprecated( "Use ReservoirCellIndex overload" )]] bool   isActive( size_t reservoirCellIndex ) const;
-    [[deprecated( "Use ReservoirCellIndex overload" )]] size_t cellResultIndex( size_t reservoirCellIndex ) const;
-    [[deprecated( "Use ReservoirCellIndex overload" )]] void setCellResultIndex( size_t reservoirCellIndex, size_t globalResultCellIndex );
-
     void   setGridCount( size_t gridCount );
     void   setGridActiveCellCounts( size_t gridIndex, size_t activeCellCount );
     size_t gridActiveCellCounts( size_t gridIndex ) const;

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultCalculator.cpp
@@ -186,7 +186,7 @@ bool RigCaseCellResultCalculator::computeDifference( RigEclipseCaseData*        
             for ( long localGridCellIdx = 0; localGridCellIdx < static_cast<long>( grid->cellCount() ); localGridCellIdx++ )
             {
                 size_t reservoirCellIndex = grid->reservoirCellIndex( localGridCellIdx );
-                if ( activeCellInfo->isActive( reservoirCellIndex ) )
+                if ( activeCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                 {
                     double sourceVal = sourceResultAccessor->cellScalar( localGridCellIdx );
                     double baseVal   = baseResultAccessor->cellScalar( localGridCellIdx );
@@ -291,7 +291,7 @@ bool RigCaseCellResultCalculator::computeDivideByCellFaceArea( RigMainGrid*     
             for ( int localGridCellIdx = 0; localGridCellIdx < static_cast<int>( grid->cellCount() ); localGridCellIdx++ )
             {
                 const size_t reservoirCellIndex = grid->reservoirCellIndex( localGridCellIdx );
-                if ( activeCellInfo->isActive( reservoirCellIndex ) )
+                if ( activeCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                 {
                     double sourceVal = sourceResultAccessor->cellScalar( localGridCellIdx );
 

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -50,6 +50,7 @@
 #include "RigStatisticsDataCache.h"
 #include "RigStatisticsMath.h"
 #include "RigSwatResultCalculator.h"
+#include "RigTypeSafeIndex.h"
 
 #include "RimCompletionCellIntersectionCalc.h"
 #include "RimEclipseCase.h"
@@ -908,7 +909,7 @@ const std::vector<double>* RigCaseCellResultsData::getResultIndexableStaticResul
 
         for ( size_t globalCellIndex = 0; globalCellIndex < reservoirCellCount; globalCellIndex++ )
         {
-            size_t resultIdx = actCellInfo->cellResultIndex( globalCellIndex );
+            size_t resultIdx = actCellInfo->cellResultIndex( ReservoirCellIndex( globalCellIndex ) ).value();
             if ( resultIdx != cvf::UNDEFINED_SIZE_T )
             {
                 activeCellsResultsTempContainer[resultIdx] = porvResults->at( globalCellIndex );
@@ -1959,7 +1960,7 @@ void RigCaseCellResultsData::computeDepthRelatedResults()
         const RigCell& cell = m_ownerMainGrid->cell( cellIdx );
         if ( cell.isInvalid() ) continue;
 
-        size_t resultIndex = activeCellInfo()->cellResultIndex( cellIdx );
+        size_t resultIndex = activeCellInfo()->cellResultIndex( ReservoirCellIndex( cellIdx ) ).value();
         if ( resultIndex == cvf::UNDEFINED_SIZE_T ) continue;
         if ( resultIndex >= actCellCount ) continue;
 
@@ -2118,7 +2119,7 @@ size_t directReservoirCellIndex( const RigActiveCellInfo* activeCellinfo, size_t
 
 size_t reservoirActiveCellIndex( const RigActiveCellInfo* activeCellinfo, size_t reservoirCellIndex )
 {
-    return activeCellinfo->cellResultIndex( reservoirCellIndex );
+    return activeCellinfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
 }
 } // namespace RigTransmissibilityCalcTools
 
@@ -3031,8 +3032,8 @@ void RigCaseCellResultsData::assignValuesToTemporaryLgrs( const QString& resultN
                 size_t mainGridCellIndex  = cell.mainGridCellIndex();
                 size_t reservoirCellIndex = grid->reservoirCellIndex( localCellIdx );
 
-                size_t mainGridCellResultIndex = m_activeCellInfo->cellResultIndex( mainGridCellIndex );
-                size_t cellResultIndex         = m_activeCellInfo->cellResultIndex( reservoirCellIndex );
+                size_t mainGridCellResultIndex = m_activeCellInfo->cellResultIndex( ReservoirCellIndex( mainGridCellIndex ) ).value();
+                size_t cellResultIndex         = m_activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
 
                 if ( mainGridCellResultIndex != cvf::UNDEFINED_SIZE_T && cellResultIndex != cvf::UNDEFINED_SIZE_T )
                 {

--- a/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
@@ -170,8 +170,8 @@ RigConnectionContainer RigCellFaceGeometryTools::computeOtherNncs( const RigMain
             bool atLeastOneCellActive = true;
             if ( !includeInactiveCells && activeCellInfo && activeCellInfo->reservoirActiveCellCount() > 0u )
             {
-                atLeastOneCellActive = activeCellInfo->isActive( f.m_nativeReservoirCellIndex ) ||
-                                       activeCellInfo->isActive( f.m_oppositeReservoirCellIndex );
+                atLeastOneCellActive = activeCellInfo->isActive( ReservoirCellIndex( f.m_nativeReservoirCellIndex ) ) ||
+                                       activeCellInfo->isActive( ReservoirCellIndex( f.m_oppositeReservoirCellIndex ) );
             }
 
             if ( atLeastOneCellActive ) activeFaceIndices.push_back( faceIdx );

--- a/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.cpp
@@ -438,12 +438,12 @@ void RigEclipseCaseData::computeActiveCellIJKBBox()
 
             if ( !m_mainGrid->isCellValid( i, j, k ) ) continue;
 
-            if ( m_activeCellInfo->isActive( idx ) )
+            if ( m_activeCellInfo->isActive( ReservoirCellIndex( idx ) ) )
             {
                 matrixModelActiveBB.add( i, j, k );
             }
 
-            if ( m_fractureActiveCellInfo->isActive( idx ) )
+            if ( m_fractureActiveCellInfo->isActive( ReservoirCellIndex( idx ) ) )
             {
                 fractureModelActiveBB.add( i, j, k );
             }
@@ -666,7 +666,7 @@ void RigEclipseCaseData::computeActiveCellsGeometryBoundingBoxSlow()
         {
             for ( size_t i = 0; i < m_mainGrid->cellCount(); i++ )
             {
-                if ( activeInfos[acIdx]->isActive( i ) )
+                if ( activeInfos[acIdx]->isActive( ReservoirCellIndex( i ) ) )
                 {
                     std::array<cvf::Vec3d, 8> hexCorners = m_mainGrid->cellCornerVertices( i );
                     for ( const auto& corner : hexCorners )
@@ -756,7 +756,8 @@ void RigEclipseCaseData::computeActiveCellsGeometryBoundingBoxOptimized()
                 {
                     size_t globalCellIndex = localGrid->reservoirCellIndex( localCellIndex );
 
-                    if ( globalCellIndex < activeInfos[acIdx]->reservoirCellCount() && activeInfos[acIdx]->isActive( globalCellIndex ) )
+                    if ( globalCellIndex < activeInfos[acIdx]->reservoirCellCount() &&
+                         activeInfos[acIdx]->isActive( ReservoirCellIndex( globalCellIndex ) ) )
                     {
                         std::array<cvf::Vec3d, 8> hexCorners = localGrid->cellCornerVertices( localCellIndex );
                         for ( const auto& corner : hexCorners )

--- a/ApplicationLibCode/ReservoirDataModel/RigEclipseNativeVisibleCellsStatCalc.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigEclipseNativeVisibleCellsStatCalc.h
@@ -82,7 +82,7 @@ private:
             size_t cellResultIndex = cIdx;
             if ( isUsingGlobalActiveIndex )
             {
-                cellResultIndex = actCellInfo->cellResultIndex( cIdx );
+                cellResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( cIdx ) ).value();
             }
 
             if ( cellResultIndex != cvf::UNDEFINED_SIZE_T && cellResultIndex < values.size() )

--- a/ApplicationLibCode/ReservoirDataModel/RigFlowDiagVisibleCellsStatCalc.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigFlowDiagVisibleCellsStatCalc.h
@@ -68,7 +68,7 @@ private:
         {
             if ( !( *m_cellVisibilities )[cIdx] ) continue;
 
-            size_t cellResultIndex = actCellInfo->cellResultIndex( cIdx );
+            size_t cellResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( cIdx ) ).value();
 
             if ( cellResultIndex != cvf::UNDEFINED_SIZE_T ) accumulator.addValue( ( *values )[cellResultIndex] );
         }

--- a/ApplicationLibCode/ReservoirDataModel/RigGridExportAdapter.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigGridExportAdapter.cpp
@@ -242,7 +242,7 @@ bool RigGridExportAdapter::isCellActive( size_t i, size_t j, size_t k ) const
     size_t originalCellIndex = m_mainGrid->cellIndexFromIJK( mapping.originalI, mapping.originalJ, mapping.originalK );
 
     // Check if original cell is active
-    bool isActive = m_activeCellInfo->isActive( originalCellIndex );
+    bool isActive = m_activeCellInfo->isActive( ReservoirCellIndex( originalCellIndex ) );
 
     // Apply visibility override if present
     if ( isActive && m_cellVisibilityOverride )

--- a/ApplicationLibCode/ReservoirDataModel/RigGriddedPart3d.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigGriddedPart3d.cpp
@@ -723,7 +723,7 @@ void RigGriddedPart3d::postProcessElementSets( const RigMainGrid* mainGrid, cons
         {
             cellIdx = mainGrid->findReservoirCellIndexFromPoint( p );
 
-            bActive = ( cellIdx != cvf::UNDEFINED_SIZE_T ) && ( cellInfo->isActive( cellIdx ) );
+            bActive = ( cellIdx != cvf::UNDEFINED_SIZE_T ) && ( cellInfo->isActive( ReservoirCellIndex( cellIdx ) ) );
             if ( bActive ) break;
         }
 
@@ -772,7 +772,7 @@ void RigGriddedPart3d::updateElementSet( ElementSets              elSet,
                 {
                     cellIdx = mainGrid->findReservoirCellIndexFromPoint( p );
 
-                    if ( ( cellIdx != cvf::UNDEFINED_SIZE_T ) && ( cellInfo->isActive( cellIdx ) ) )
+                    if ( ( cellIdx != cvf::UNDEFINED_SIZE_T ) && ( cellInfo->isActive( ReservoirCellIndex( cellIdx ) ) ) )
                     {
                         bStop = true;
                         break;

--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -562,7 +562,7 @@ void RigMainGrid::addUnNamedFaultFaces( int                               gcIdx,
                 hostGrid = gridAndGridLocalIdxFromGlobalCellIdx( gcIdx, &gridLocalCellIndex );
 
                 hostGrid->ijkFromCellIndex( gridLocalCellIndex, &i, &j, &k );
-                isCellActive = activeCellInfo->isActive( gcIdx );
+                isCellActive = activeCellInfo->isActive( ReservoirCellIndex( gcIdx ) );
 
                 firstNO_FAULTFaceForCell = false;
             }
@@ -578,7 +578,7 @@ void RigMainGrid::addUnNamedFaultFaces( int                               gcIdx,
                 continue;
             }
 
-            bool isNeighborCellActive = activeCellInfo->isActive( neighborReservoirCellIdx );
+            bool isNeighborCellActive = activeCellInfo->isActive( ReservoirCellIndex( neighborReservoirCellIdx ) );
 
             double tolerance = 1e-6;
 

--- a/ApplicationLibCode/ReservoirDataModel/RigNumberOfFloodedPoreVolumesCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigNumberOfFloodedPoreVolumesCalculator.cpp
@@ -304,10 +304,10 @@ void RigNumberOfFloodedPoreVolumesCalculator::distributeNNCflow( const RigConnec
         double        connectionValue = flowrateNNC->at( connectionIndex );
 
         size_t cell1Index       = connection.c1GlobIdx();
-        size_t cell1ResultIndex = actCellInfo->cellResultIndex( cell1Index );
+        size_t cell1ResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( cell1Index ) ).value();
 
         size_t cell2Index       = connection.c2GlobIdx();
-        size_t cell2ResultIndex = actCellInfo->cellResultIndex( cell2Index );
+        size_t cell2ResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( cell2Index ) ).value();
 
         if ( connectionValue > 0 )
         {
@@ -337,13 +337,13 @@ void RigNumberOfFloodedPoreVolumesCalculator::distributeNeighbourCellFlow( RigMa
 
     for ( size_t globalCellIndex = 0; globalCellIndex < mainGrid->totalCellCount(); globalCellIndex++ )
     {
-        if ( !actCellInfo->isActive( globalCellIndex ) ) continue;
+        if ( !actCellInfo->isActive( ReservoirCellIndex( globalCellIndex ) ) ) continue;
 
         const RigCell& cell               = mainGrid->cell( globalCellIndex );
         RigGridBase*   hostGrid           = cell.hostGrid();
         size_t         gridLocalCellIndex = cell.gridLocalCellIndex();
 
-        size_t cellResultIndex = actCellInfo->cellResultIndex( globalCellIndex );
+        size_t cellResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( globalCellIndex ) ).value();
 
         size_t i, j, k;
         hostGrid->ijkFromCellIndex( gridLocalCellIndex, &i, &j, &k );
@@ -352,9 +352,10 @@ void RigNumberOfFloodedPoreVolumesCalculator::distributeNeighbourCellFlow( RigMa
         {
             size_t gridLocalCellIndexPosINeighbour = hostGrid->cellIndexFromIJK( i + 1, j, k );
             size_t reservoirCellIndexPosINeighbour = hostGrid->reservoirCellIndex( gridLocalCellIndexPosINeighbour );
-            size_t cellResultIndexPosINeighbour    = actCellInfo->cellResultIndex( reservoirCellIndexPosINeighbour );
+            size_t cellResultIndexPosINeighbour =
+                actCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndexPosINeighbour ) ).value();
 
-            if ( !actCellInfo->isActive( reservoirCellIndexPosINeighbour ) ) continue;
+            if ( !actCellInfo->isActive( ReservoirCellIndex( reservoirCellIndexPosINeighbour ) ) ) continue;
 
             if ( hostGrid->cell( gridLocalCellIndexPosINeighbour ).subGrid() != nullptr )
             {
@@ -380,9 +381,10 @@ void RigNumberOfFloodedPoreVolumesCalculator::distributeNeighbourCellFlow( RigMa
         {
             size_t gridLocalCellIndexPosJNeighbour = hostGrid->cellIndexFromIJK( i, j + 1, k );
             size_t reservoirCellIndexPosJNeighbour = hostGrid->reservoirCellIndex( gridLocalCellIndexPosJNeighbour );
-            size_t cellResultIndexPosJNeighbour    = actCellInfo->cellResultIndex( reservoirCellIndexPosJNeighbour );
+            size_t cellResultIndexPosJNeighbour =
+                actCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndexPosJNeighbour ) ).value();
 
-            if ( !actCellInfo->isActive( reservoirCellIndexPosJNeighbour ) ) continue;
+            if ( !actCellInfo->isActive( ReservoirCellIndex( reservoirCellIndexPosJNeighbour ) ) ) continue;
 
             if ( hostGrid->cell( gridLocalCellIndexPosJNeighbour ).subGrid() != nullptr )
             {
@@ -408,9 +410,10 @@ void RigNumberOfFloodedPoreVolumesCalculator::distributeNeighbourCellFlow( RigMa
         {
             size_t gridLocalCellIndexPosKNeighbour = hostGrid->cellIndexFromIJK( i, j, k + 1 );
             size_t reservoirCellIndexPosKNeighbour = hostGrid->reservoirCellIndex( gridLocalCellIndexPosKNeighbour );
-            size_t cellResultIndexPosKNeighbour    = actCellInfo->cellResultIndex( reservoirCellIndexPosKNeighbour );
+            size_t cellResultIndexPosKNeighbour =
+                actCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndexPosKNeighbour ) ).value();
 
-            if ( !actCellInfo->isActive( reservoirCellIndexPosKNeighbour ) ) continue;
+            if ( !actCellInfo->isActive( ReservoirCellIndex( reservoirCellIndexPosKNeighbour ) ) ) continue;
 
             if ( hostGrid->cell( gridLocalCellIndexPosKNeighbour ).subGrid() != nullptr )
             {

--- a/ApplicationLibCode/ReservoirDataModel/RigReservoirBuilder.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigReservoirBuilder.cpp
@@ -144,7 +144,7 @@ void RigReservoirBuilder::createGridsAndCells( RigEclipseCaseData* eclipseCase )
     activeCellInfo->setReservoirCellCount( eclipseCase->mainGrid()->totalCellCount() );
     for ( size_t i = 0; i < eclipseCase->mainGrid()->totalCellCount(); i++ )
     {
-        activeCellInfo->setCellResultIndex( i, i );
+        activeCellInfo->setCellResultIndex( ReservoirCellIndex( i ), ActiveCellIndex( i ) );
     }
 
     activeCellInfo->setGridCount( 1 );

--- a/ApplicationLibCode/ReservoirDataModel/RigResultModifier.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigResultModifier.h
@@ -72,7 +72,7 @@ public:
     void setCellScalar( size_t gridLocalCellIndex, double scalarValue ) override
     {
         size_t reservoirCellIndex = m_grid->reservoirCellIndex( gridLocalCellIndex );
-        size_t resultValueIndex   = m_activeCellInfo->cellResultIndex( reservoirCellIndex );
+        size_t resultValueIndex   = m_activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
 
         CVF_TIGHT_ASSERT( m_reservoirResultValues != nullptr && resultValueIndex < m_reservoirResultValues->size() );
 

--- a/ApplicationLibCode/ReservoirDataModel/RigWeightedMeanCalc.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigWeightedMeanCalc.cpp
@@ -52,7 +52,7 @@ void RigWeightedMeanCalc::weightedMeanOverCells( const std::vector<double>* weig
             if ( !( *cellVisibilities )[cIdx] ) continue;
         }
 
-        size_t cellResultIndex = actCellInfo->cellResultIndex( cIdx );
+        size_t cellResultIndex = actCellInfo->cellResultIndex( ReservoirCellIndex( cIdx ) ).value();
         if ( cellResultIndex == cvf::UNDEFINED_SIZE_T || cellResultIndex > weights->size() )
         {
             continue;

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigAccWellFlowCalculator.cpp
@@ -41,7 +41,7 @@ size_t RigEclCellIndexCalculator::resultCellIndex( size_t gridIndex, size_t grid
 {
     size_t reservoirCellIndex = m_mainGrid->reservoirCellIndexByGridAndGridLocalCellIndex( gridIndex, gridCellIndex );
 
-    return m_activeCellInfo->cellResultIndex( reservoirCellIndex );
+    return m_activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/SocketInterface/RiaCaseInfoCommands.cpp
+++ b/ApplicationLibCode/SocketInterface/RiaCaseInfoCommands.cpp
@@ -208,7 +208,7 @@ public:
 
         for ( size_t cIdx = 0; cIdx < mainGrid->totalCellCount(); ++cIdx )
         {
-            if ( actCellInfo->isActive( cIdx ) )
+            if ( actCellInfo->isActive( ReservoirCellIndex( cIdx ) ) )
             {
                 auto&        cell = mainGrid->cell( cIdx );
                 RigGridBase* grid = cell.hostGrid();

--- a/ApplicationLibCode/SocketInterface/RiaGeometryCommands.cpp
+++ b/ApplicationLibCode/SocketInterface/RiaGeometryCommands.cpp
@@ -207,7 +207,7 @@ public:
 
             for ( size_t reservoirCellIndex = 0; reservoirCellIndex < mainGrid->totalCellCount(); reservoirCellIndex++ )
             {
-                if ( !actCellInfo->isActive( reservoirCellIndex ) ) continue;
+                if ( !actCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) ) continue;
 
                 cvf::Vec3d center = mainGrid->cell( reservoirCellIndex ).center();
 
@@ -379,7 +379,7 @@ public:
 
                 for ( size_t reservoirCellIndex = 0; reservoirCellIndex < mainGrid->totalCellCount(); reservoirCellIndex++ )
                 {
-                    if ( !actCellInfo->isActive( reservoirCellIndex ) ) continue;
+                    if ( !actCellInfo->isActive( ReservoirCellIndex( reservoirCellIndex ) ) ) continue;
 
                     std::array<cvf::Vec3d, 8> cornerVerts = mainGrid->cellCornerVertices( reservoirCellIndex );
                     doubleValues[valueIndex++]            = getCellCornerWithPositiveDepth( cornerVerts, cornerIndexMapping, coordIdx );

--- a/ApplicationLibCode/SocketInterface/RiaPropertyDataCommands.cpp
+++ b/ApplicationLibCode/SocketInterface/RiaPropertyDataCommands.cpp
@@ -31,6 +31,7 @@
 #include "RigResultAccessorFactory.h"
 #include "RigResultModifier.h"
 #include "RigResultModifierFactory.h"
+#include "RigTypeSafeIndex.h"
 
 #include "RimEclipseCase.h"
 #include "RimEclipseCellColors.h"
@@ -158,7 +159,7 @@ public:
                 std::vector<double>& doubleValues = scalarResultFrames->at( requestedTimesteps[tIdx] );
                 for ( size_t gcIdx = 0; gcIdx < reservoirCellCount; ++gcIdx )
                 {
-                    size_t resultIdx = activeInfo->cellResultIndex( gcIdx );
+                    size_t resultIdx = activeInfo->cellResultIndex( ReservoirCellIndex( gcIdx ) ).value();
                     if ( resultIdx == cvf::UNDEFINED_SIZE_T ) continue;
 
                     if ( resultIdx < doubleValues.size() )

--- a/ApplicationLibCode/UnitTests/RicTransmissibilityCalculator-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicTransmissibilityCalculator-Test.cpp
@@ -184,7 +184,7 @@ static void enableDualPorosity( RigEclipseCaseData* caseData )
     fractureActiveCellInfo->setReservoirCellCount( cellCount );
     for ( size_t i = 0; i < cellCount; i++ )
     {
-        fractureActiveCellInfo->setCellResultIndex( i, i );
+        fractureActiveCellInfo->setCellResultIndex( ReservoirCellIndex( i ), ActiveCellIndex( i ) );
     }
     fractureActiveCellInfo->setGridCount( 1 );
     fractureActiveCellInfo->setGridActiveCellCounts( 0, cellCount );

--- a/ApplicationLibCode/UnitTests/RifEclipseInputFileTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifEclipseInputFileTools-Test.cpp
@@ -773,8 +773,9 @@ TEST( RifEclipseInputFileToolsTest, ExportKeywordsWithRefinement )
             {
                 for ( size_t i = 0; i < originalGrid->cellCountI(); ++i )
                 {
-                    size_t originalCellIndex   = originalGrid->cellIndexFromIJK( i, j, k );
-                    size_t originalResultIndex = originalResultsData->activeCellInfo()->cellResultIndex( originalCellIndex );
+                    size_t originalCellIndex = originalGrid->cellIndexFromIJK( i, j, k );
+                    size_t originalResultIndex =
+                        originalResultsData->activeCellInfo()->cellResultIndex( ReservoirCellIndex( originalCellIndex ) ).value();
 
                     if ( originalResultIndex != cvf::UNDEFINED_SIZE_T && originalResultIndex < originalData.size() )
                     {
@@ -791,7 +792,7 @@ TEST( RifEclipseInputFileToolsTest, ExportKeywordsWithRefinement )
     ASSERT_FALSE( testCell.isUndefined() ) << "Should find at least one active cell with PORO data to test refinement mapping";
 
     size_t originalCellIndex   = originalGrid->cellIndexFromIJK( testCell.x(), testCell.y(), testCell.z() );
-    size_t originalResultIndex = originalResultsData->activeCellInfo()->cellResultIndex( originalCellIndex );
+    size_t originalResultIndex = originalResultsData->activeCellInfo()->cellResultIndex( ReservoirCellIndex( originalCellIndex ) ).value();
     double originalPoroValue   = originalData[originalResultIndex];
 
     // Check all 4 refined cells (2x2x1) that correspond to this original cell

--- a/ApplicationLibCode/UnitTests/RigActiveCellInfo-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigActiveCellInfo-Test.cpp
@@ -37,12 +37,12 @@ TEST( RigActiveCellInfo, BasicTest )
 
     for ( size_t i = 0; i < globalActiveCellCount; i++ )
     {
-        EXPECT_TRUE( rigActiveCellInfo.cellResultIndex( i ) == cvf::UNDEFINED_SIZE_T );
-        EXPECT_FALSE( rigActiveCellInfo.isActive( i ) );
+        EXPECT_TRUE( rigActiveCellInfo.cellResultIndex( ReservoirCellIndex( i ) ).value() == cvf::UNDEFINED_SIZE_T );
+        EXPECT_FALSE( rigActiveCellInfo.isActive( ReservoirCellIndex( i ) ) );
     }
 
-    rigActiveCellInfo.setCellResultIndex( 3, 1 );
-    EXPECT_TRUE( rigActiveCellInfo.cellResultIndex( 3 ) == 1 );
+    rigActiveCellInfo.setCellResultIndex( ReservoirCellIndex( 3 ), ActiveCellIndex( 1 ) );
+    EXPECT_TRUE( rigActiveCellInfo.cellResultIndex( ReservoirCellIndex( 3 ) ).value() == 1 );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UnitTests/RigGridExportAdapter-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigGridExportAdapter-Test.cpp
@@ -216,7 +216,7 @@ TEST( RigGridExportAdapterTest, CellActivity )
                 size_t origJ          = min.y() + j;
                 size_t origK          = min.z() + k;
                 size_t mainIndex      = mainGrid->cellIndexFromIJK( origI, origJ, origK );
-                bool   expectedActive = activeCellInfo->isActive( mainIndex );
+                bool   expectedActive = activeCellInfo->isActive( ReservoirCellIndex( mainIndex ) );
 
                 EXPECT_EQ( expectedActive, adapterActive ) << "Activity mismatch at (" << i << "," << j << "," << k << ")";
             }

--- a/ApplicationLibCode/UnitTests/opm-flowdiagnostics-Test.cpp
+++ b/ApplicationLibCode/UnitTests/opm-flowdiagnostics-Test.cpp
@@ -62,9 +62,9 @@ TEST( FlowDiagnosticsTest, calculateRelPermCurves_Oil_in_Oil_Gas )
 
         // Convert grid index to active cell index
         auto activeCellInfo = eclipseCaseData->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
-        if ( activeCellInfo->isActive( gridIndex ) )
+        if ( activeCellInfo->isActive( ReservoirCellIndex( gridIndex ) ) )
         {
-            gridLocalActiveCellIndex = activeCellInfo->cellResultIndex( gridIndex );
+            gridLocalActiveCellIndex = activeCellInfo->cellResultIndex( ReservoirCellIndex( gridIndex ) ).value();
         }
         else
         {

--- a/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotUpdater.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotUpdater.cpp
@@ -119,7 +119,7 @@ size_t mapToActiveCellIndex( const RigEclipseCaseData* eclipseCaseData, size_t g
         CVF_ASSERT( activeCellInfo );
 
         const size_t reservoirCellIndex = grid->reservoirCellIndex( gridLocalCellIndex );
-        const size_t activeCellIndex    = activeCellInfo->cellResultIndex( reservoirCellIndex );
+        const size_t activeCellIndex    = activeCellInfo->cellResultIndex( ReservoirCellIndex( reservoirCellIndex ) ).value();
 
         return activeCellIndex;
     }

--- a/GrpcInterface/RiaGrpcActiveCellInfoStateHandler.cpp
+++ b/GrpcInterface/RiaGrpcActiveCellInfoStateHandler.cpp
@@ -102,7 +102,7 @@ grpc::Status RiaGrpcActiveCellInfoStateHandler::assignNextActiveCellInfoData( ri
     while ( m_currentCellIdx < reservoirCells.size() )
     {
         size_t cellIdxToTry = m_currentCellIdx++;
-        if ( m_activeCellInfo->isActive( cellIdxToTry ) )
+        if ( m_activeCellInfo->isActive( ReservoirCellIndex( cellIdxToTry ) ) )
         {
             assignCellInfoData( cellInfo, reservoirCells, cellIdxToTry );
             return grpc::Status::OK;
@@ -231,7 +231,7 @@ grpc::Status RiaGrpcActiveCellInfoStateHandler::assignNextActiveCellCenter( rips
     while ( m_currentCellIdx < reservoirCells.size() )
     {
         size_t cellIdxToTry = m_currentCellIdx++;
-        if ( m_activeCellInfo->isActive( cellIdxToTry ) )
+        if ( m_activeCellInfo->isActive( ReservoirCellIndex( cellIdxToTry ) ) )
         {
             assignCellCenter( cellCenter, reservoirCells, cellIdxToTry );
             return grpc::Status::OK;
@@ -296,7 +296,7 @@ Status RiaGrpcActiveCellInfoStateHandler::assignNextActiveCellCorners( rips::Cel
     while ( m_currentCellIdx < reservoirCells.size() )
     {
         size_t cellIdxToTry = m_currentCellIdx++;
-        if ( m_activeCellInfo->isActive( cellIdxToTry ) )
+        if ( m_activeCellInfo->isActive( ReservoirCellIndex( cellIdxToTry ) ) )
         {
             assignCellCorners( cellCorners, reservoirCells, cellIdxToTry );
             return grpc::Status::OK;

--- a/GrpcInterface/RiaGrpcPropertiesService.cpp
+++ b/GrpcInterface/RiaGrpcPropertiesService.cpp
@@ -270,7 +270,8 @@ protected:
             size_t              reservoirCellCount = activeCellInfo->reservoirCellCount();
             for ( size_t cellIdx = 0; cellIdx < reservoirCellCount; cellIdx++ )
             {
-                size_t activeCellIdx = caseData->activeCellInfo( m_porosityModel )->cellResultIndex( cellIdx );
+                size_t activeCellIdx =
+                    caseData->activeCellInfo( m_porosityModel )->cellResultIndex( ReservoirCellIndex( cellIdx ) ).value();
                 if ( activeCellIdx != cvf::UNDEFINED_SIZE_T )
                     activeCellResultValues[activeCellIdx] = ( *m_resultValues )[cellIdx];
             }


### PR DESCRIPTION
Migrate all callers to use type-safe ReservoirCellIndex and ActiveCellIndex wrappers, then remove the deprecated isActive(size_t), cellResultIndex(size_t), and setCellResultIndex(size_t, size_t) methods.