### PR TITLE
#12489 Improve robustness of mean calculators

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaWeightedGeometricMeanCalculator.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaWeightedGeometricMeanCalculator.cpp
@@ -18,8 +18,6 @@
 
 #include "RiaWeightedGeometricMeanCalculator.h"
 
-#include "cvfAssert.h"
-
 #include <cmath>
 
 //--------------------------------------------------------------------------------------------------
@@ -36,7 +34,7 @@ RiaWeightedGeometricMeanCalculator::RiaWeightedGeometricMeanCalculator()
 //--------------------------------------------------------------------------------------------------
 void RiaWeightedGeometricMeanCalculator::addValueAndWeight( double value, double weight )
 {
-    CVF_ASSERT( weight >= 0.0 );
+    if ( weight <= 0.0 ) return;
 
     // This can be a very big number, consider other algorithms if that becomes a problem
     m_aggregatedWeightedValue += ( std::log( value ) * weight );

--- a/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp
@@ -18,8 +18,6 @@
 
 #include "RiaWeightedHarmonicMeanCalculator.h"
 
-#include "cvfAssert.h"
-
 #include <cmath>
 
 //--------------------------------------------------------------------------------------------------
@@ -36,7 +34,7 @@ RiaWeightedHarmonicMeanCalculator::RiaWeightedHarmonicMeanCalculator()
 //--------------------------------------------------------------------------------------------------
 void RiaWeightedHarmonicMeanCalculator::addValueAndWeight( double value, double weight )
 {
-    CVF_ASSERT( weight > 1.0e-12 && std::abs( value ) > 1.0e-12 );
+    if ( weight <= 0.0 || std::abs( value ) < 1.0e-12 ) return;
 
     m_aggregatedWeightedValue += weight / value;
     m_aggregatedWeight += weight;
@@ -51,7 +49,6 @@ double RiaWeightedHarmonicMeanCalculator::weightedMean() const
     {
         return m_aggregatedWeight / m_aggregatedWeightedValue;
     }
-    CVF_ASSERT( false );
     return 0.0;
 }
 

--- a/ApplicationLibCode/Application/Tools/RiaWeightedMeanCalculator.inl
+++ b/ApplicationLibCode/Application/Tools/RiaWeightedMeanCalculator.inl
@@ -16,8 +16,6 @@
 //
 /////////////////////////////////////////////////////////////////////////////////
 
-#include "cvfAssert.h"
-
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -34,7 +32,7 @@ RiaWeightedMeanCalculator<T>::RiaWeightedMeanCalculator()
 template <class T>
 void RiaWeightedMeanCalculator<T>::addValueAndWeight( T value, double weight )
 {
-    CVF_ASSERT( weight >= 0.0 );
+    if ( weight <= 0.0 ) return;
 
     m_aggregatedValue = m_aggregatedValue + value * weight;
     m_aggregatedWeight += weight;
@@ -46,9 +44,7 @@ void RiaWeightedMeanCalculator<T>::addValueAndWeight( T value, double weight )
 template <class T>
 T RiaWeightedMeanCalculator<T>::weightedMean() const
 {
-    bool validWeights = validAggregatedWeight();
-    CVF_TIGHT_ASSERT( validWeights );
-    if ( validWeights )
+    if ( validAggregatedWeight() )
     {
         return m_aggregatedValue * ( 1.0 / m_aggregatedWeight );
     }

--- a/ApplicationLibCode/UnitTests/RiaWeightedGeometricMeanCalculator-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaWeightedGeometricMeanCalculator-Test.cpp
@@ -55,3 +55,31 @@ TEST( RiaWeightedGeometricMeanCalculator, BigValues )
     EXPECT_DOUBLE_EQ( 17.0, calc.aggregatedWeight() );
     EXPECT_NEAR( expectedValue, calc.weightedMean(), 1e-8 );
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaWeightedGeometricMeanCalculator, ZeroWeight )
+{
+    {
+        // Zero weight only - no valid data
+        RiaWeightedGeometricMeanCalculator calc;
+        calc.addValueAndWeight( 5.0, 0.0 );
+        EXPECT_DOUBLE_EQ( 0.0, calc.aggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 0.0, calc.weightedMean() );
+    }
+
+    {
+        // Zero weight mixed with valid data - zero weight is ignored
+        RiaWeightedGeometricMeanCalculator calc;
+        calc.addValueAndWeight( 100.0, 0.0 );
+        calc.addValueAndWeight( 30.0, 1.5 );
+        calc.addValueAndWeight( 60.0, 3.5 );
+        calc.addValueAndWeight( 200.0, 0.0 );
+
+        double expectedValue = std::pow( std::pow( 30.0, 1.5 ) * std::pow( 60.0, 3.5 ), 1 / ( 1.5 + 3.5 ) );
+
+        EXPECT_DOUBLE_EQ( 5.0, calc.aggregatedWeight() );
+        EXPECT_NEAR( expectedValue, calc.weightedMean(), 1e-10 );
+    }
+}

--- a/ApplicationLibCode/UnitTests/RiaWeightedHarmonicMeanCalculator-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaWeightedHarmonicMeanCalculator-Test.cpp
@@ -72,3 +72,57 @@ TEST( RiaWeightedHarmonicMeanCalculator, WeightedValues )
         EXPECT_NEAR( expectedValue, calc.weightedMean(), 1.0e-8 );
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaWeightedHarmonicMeanCalculator, ZeroWeight )
+{
+    {
+        // Zero weight only - no valid data, no crash
+        RiaWeightedHarmonicMeanCalculator calc;
+        calc.addValueAndWeight( 5.0, 0.0 );
+        EXPECT_FALSE( calc.validAggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 0.0, calc.weightedMean() );
+    }
+
+    {
+        // Zero weight mixed with valid data - zero weight is ignored
+        RiaWeightedHarmonicMeanCalculator calc;
+        calc.addValueAndWeight( 100.0, 0.0 );
+        calc.addValueAndWeight( 1.0, 1.0 );
+        calc.addValueAndWeight( 4.0, 1.0 );
+        calc.addValueAndWeight( 4.0, 1.0 );
+        calc.addValueAndWeight( 200.0, 0.0 );
+
+        EXPECT_DOUBLE_EQ( 3.0, calc.aggregatedWeight() );
+        EXPECT_NEAR( 2.0, calc.weightedMean(), 1e-10 );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaWeightedHarmonicMeanCalculator, ZeroValue )
+{
+    // Zero value is skipped (would cause division by zero)
+    RiaWeightedHarmonicMeanCalculator calc;
+    calc.addValueAndWeight( 0.0, 1.0 );
+    calc.addValueAndWeight( 1.0, 1.0 );
+    calc.addValueAndWeight( 4.0, 1.0 );
+    calc.addValueAndWeight( 4.0, 1.0 );
+
+    EXPECT_DOUBLE_EQ( 3.0, calc.aggregatedWeight() );
+    EXPECT_NEAR( 2.0, calc.weightedMean(), 1e-10 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaWeightedHarmonicMeanCalculator, NoValidData )
+{
+    // No valid data added - weightedMean returns 0.0 without asserting
+    RiaWeightedHarmonicMeanCalculator calc;
+    EXPECT_FALSE( calc.validAggregatedWeight() );
+    EXPECT_DOUBLE_EQ( 0.0, calc.weightedMean() );
+}

--- a/ApplicationLibCode/UnitTests/RiaWeightedMean-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaWeightedMean-Test.cpp
@@ -29,3 +29,39 @@ TEST( RiaWeightedMeanCalculator, BasicUsage )
         EXPECT_DOUBLE_EQ( 5.0, calc.weightedMean() );
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaWeightedMeanCalculator, ZeroWeight )
+{
+    {
+        // Zero weight only - no valid data
+        RiaWeightedMeanCalculator<double> calc;
+        calc.addValueAndWeight( 5.0, 0.0 );
+        EXPECT_FALSE( calc.validAggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 0.0, calc.aggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 0.0, calc.weightedMean() );
+    }
+
+    {
+        // Zero weight mixed with valid data - zero weight is ignored
+        RiaWeightedMeanCalculator<double> calc;
+        calc.addValueAndWeight( 100.0, 0.0 );
+        calc.addValueAndWeight( 5.0, 2.0 );
+        calc.addValueAndWeight( 200.0, 0.0 );
+        EXPECT_TRUE( calc.validAggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 2.0, calc.aggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 5.0, calc.weightedMean() );
+    }
+
+    {
+        // Negative weight is also ignored
+        RiaWeightedMeanCalculator<double> calc;
+        calc.addValueAndWeight( 100.0, -1.0 );
+        calc.addValueAndWeight( 5.0, 2.0 );
+        EXPECT_TRUE( calc.validAggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 2.0, calc.aggregatedWeight() );
+        EXPECT_DOUBLE_EQ( 5.0, calc.weightedMean() );
+    }
+}


### PR DESCRIPTION
Replace asserts with early-return guards so zero or negative weights are silently skipped instead of crashing. Add unit tests for zero-weight and zero-value edge cases in all three calculator classes.

Fixes #12489.