### PR TITLE
Replace PdmUiPushButtonEditor fields with dynamic buttons

### DIFF
--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
@@ -52,7 +52,6 @@
 #include "RiuTools.h"
 
 #include "cafPdmUiComboBoxEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 
 #include <QInputDialog>
 #include <QMessageBox>
@@ -84,26 +83,12 @@ std::vector<T> toVector( const std::set<T>& set );
 //--------------------------------------------------------------------------------------------------
 RicSummaryPlotEditorUi::RicSummaryPlotEditorUi()
     : m_plotContainer( nullptr )
+    , m_closeButtonPressed( false )
 {
     CAF_PDM_InitFieldNoDefault( &m_targetPlot, "TargetPlot", "Target Plot" );
 
     m_previewPlot = std::make_unique<RimSummaryPlot>();
     m_previewPlot->setLegendPosition( RiuPlotWidget::Legend::TOP );
-
-    CAF_PDM_InitFieldNoDefault( &m_applyButtonField, "ApplySelection", "" );
-    m_applyButtonField = false;
-    m_applyButtonField.uiCapability()->setUiEditorTypeName( caf::PdmUiPushButtonEditor::uiEditorTypeName() );
-    m_applyButtonField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::LabelPosition::HIDDEN );
-
-    CAF_PDM_InitFieldNoDefault( &m_closeButtonField, "Close", "" );
-    m_closeButtonField = false;
-    m_closeButtonField.uiCapability()->setUiEditorTypeName( caf::PdmUiPushButtonEditor::uiEditorTypeName() );
-    m_closeButtonField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::LabelPosition::HIDDEN );
-
-    CAF_PDM_InitFieldNoDefault( &m_okButtonField, "OK", "" );
-    m_okButtonField = false;
-    m_okButtonField.uiCapability()->setUiEditorTypeName( caf::PdmUiPushButtonEditor::uiEditorTypeName() );
-    m_okButtonField.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::LabelPosition::HIDDEN );
 
     m_summaryCurveSelectionEditor = std::make_unique<RiuSummaryVectorSelectionWidgetCreator>();
 
@@ -187,7 +172,7 @@ QWidget* RicSummaryPlotEditorUi::addressSelectionWidget( QWidget* parent )
 //--------------------------------------------------------------------------------------------------
 bool RicSummaryPlotEditorUi::isCloseButtonPressed() const
 {
-    return m_closeButtonField();
+    return m_closeButtonPressed;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -195,7 +180,7 @@ bool RicSummaryPlotEditorUi::isCloseButtonPressed() const
 //--------------------------------------------------------------------------------------------------
 void RicSummaryPlotEditorUi::clearCloseButton()
 {
-    m_closeButtonField = false;
+    m_closeButtonPressed = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -203,33 +188,6 @@ void RicSummaryPlotEditorUi::clearCloseButton()
 //--------------------------------------------------------------------------------------------------
 void RicSummaryPlotEditorUi::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
-    if ( changedField == &m_applyButtonField || changedField == &m_okButtonField )
-    {
-        if ( m_targetPlot == nullptr )
-        {
-            createNewPlot();
-        }
-
-        updateTargetPlot();
-
-        if ( changedField == &m_okButtonField )
-        {
-            m_closeButtonField = true;
-
-            RiuPlotMainWindowTools::showPlotMainWindow();
-            RiuPlotMainWindowTools::selectAsCurrentItem( m_targetPlot );
-            RiuPlotMainWindowTools::setExpanded( m_targetPlot );
-        }
-
-        m_applyButtonField = false;
-        m_okButtonField    = false;
-
-        caf::PdmField<bool>* field = dynamic_cast<caf::PdmField<bool>*>( m_targetPlot->uiCapability()->objectToggleField() );
-        field->setValueWithFieldChanged( true );
-
-        RiuPlotMainWindow* mainPlotWindow = RiaGuiApplication::instance()->mainPlotWindow();
-        mainPlotWindow->updateMultiPlotToolBar();
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -260,9 +218,15 @@ QList<caf::PdmOptionItemInfo> RicSummaryPlotEditorUi::calculateValueOptions( con
 void RicSummaryPlotEditorUi::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
     uiOrdering.add( &m_targetPlot );
-    uiOrdering.add( &m_okButtonField );
-    uiOrdering.add( &m_applyButtonField );
-    uiOrdering.add( &m_closeButtonField );
+    uiOrdering.addNewButton( "OK", [this]() { onOkButtonClicked(); } );
+    uiOrdering.addNewButton( "Apply", [this]() { onApplyButtonClicked(); }, { .newRow = false } );
+    uiOrdering.addNewButton( "Cancel",
+                             [this]()
+                             {
+                                 m_closeButtonPressed = true;
+                                 uiCapability()->updateConnectedEditors();
+                             },
+                             { .newRow = false } );
 
     uiOrdering.skipRemainingFields( true );
 
@@ -499,31 +463,7 @@ void RicSummaryPlotEditorUi::updatePreviewCurvesFromCurveDefinitions( const std:
 //--------------------------------------------------------------------------------------------------
 void RicSummaryPlotEditorUi::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( &m_applyButtonField == field )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "Apply";
-        }
-    }
-    else if ( &m_closeButtonField == field )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "Cancel";
-        }
-    }
-    else if ( &m_okButtonField == field )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "OK";
-        }
-    }
-    else if ( &m_targetPlot == field )
+    if ( &m_targetPlot == field )
     {
         caf::PdmUiComboBoxEditorAttribute* attrib = dynamic_cast<caf::PdmUiComboBoxEditorAttribute*>( attribute );
         if ( attrib )
@@ -789,6 +729,44 @@ void RicSummaryPlotEditorUi::setInitialCurveVisibility( const RimSummaryPlot* ta
             curveSet->showCurves( false );
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicSummaryPlotEditorUi::onOkButtonClicked()
+{
+    if ( m_targetPlot == nullptr ) createNewPlot();
+    updateTargetPlot();
+
+    m_closeButtonPressed = true;
+
+    RiuPlotMainWindowTools::showPlotMainWindow();
+    RiuPlotMainWindowTools::selectAsCurrentItem( m_targetPlot );
+    RiuPlotMainWindowTools::setExpanded( m_targetPlot );
+
+    caf::PdmField<bool>* field = dynamic_cast<caf::PdmField<bool>*>( m_targetPlot->uiCapability()->objectToggleField() );
+    if ( field ) field->setValueWithFieldChanged( true );
+
+    RiuPlotMainWindow* mainPlotWindow = RiaGuiApplication::instance()->mainPlotWindow();
+    mainPlotWindow->updateMultiPlotToolBar();
+
+    uiCapability()->updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicSummaryPlotEditorUi::onApplyButtonClicked()
+{
+    if ( m_targetPlot == nullptr ) createNewPlot();
+    updateTargetPlot();
+
+    caf::PdmField<bool>* field = dynamic_cast<caf::PdmField<bool>*>( m_targetPlot->uiCapability()->objectToggleField() );
+    if ( field ) field->setValueWithFieldChanged( true );
+
+    RiuPlotMainWindow* mainPlotWindow = RiaGuiApplication::instance()->mainPlotWindow();
+    mainPlotWindow->updateMultiPlotToolBar();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.h
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.h
@@ -98,14 +98,15 @@ private:
     void selectionEditorFieldChanged();
     void setInitialCurveVisibility( const RimSummaryPlot* targetPlot );
 
+    void onOkButtonClicked();
+    void onApplyButtonClicked();
+
 private:
     caf::PdmPtrField<RimSummaryPlot*> m_targetPlot;
 
     std::unique_ptr<RimSummaryPlot> m_previewPlot;
 
-    caf::PdmField<bool> m_okButtonField;
-    caf::PdmField<bool> m_applyButtonField;
-    caf::PdmField<bool> m_closeButtonField;
+    bool m_closeButtonPressed;
 
     std::unique_ptr<RiuSummaryVectorSelectionWidgetCreator> m_summaryCurveSelectionEditor;
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
@@ -41,9 +41,9 @@
 #include "RiuSummaryVectorSelectionDialog.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
+#include "cafPdmUiButton.h"
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiToolButtonEditor.h"
 
 #include "qwt_plot.h"
@@ -66,10 +66,6 @@ RimAbstractCorrelationPlot::RimAbstractCorrelationPlot()
 
     CAF_PDM_InitFieldNoDefault( &m_dataSources, "AnalysisPlotData", "" );
     m_dataSources.uiCapability()->setUiTreeChildrenHidden( true );
-
-    CAF_PDM_InitFieldNoDefault( &m_pushButtonSelectSummaryAddress, "SelectAddress", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_pushButtonSelectSummaryAddress );
-    m_pushButtonSelectSummaryAddress = false;
 
     CAF_PDM_InitFieldNoDefault( &m_timeStepFilter, "TimeStepFilter", "Available Time Steps" );
 
@@ -139,40 +135,7 @@ void RimAbstractCorrelationPlot::setTimeStep( std::time_t timeStep )
 void RimAbstractCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
     RimPlot::fieldChangedByUi( changedField, oldValue, newValue );
-    if ( changedField == &m_pushButtonSelectSummaryAddress )
-    {
-        RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
-
-        if ( m_selectMultipleVectors )
-        {
-            dlg.enableMultiSelect( true );
-        }
-
-        dlg.hideSummaryCases();
-        dlg.setCurveSelection( curveDefinitions() );
-
-        if ( dlg.exec() == QDialog::Accepted )
-        {
-            auto curveSelection = dlg.curveSelection();
-            if ( !curveSelection.empty() )
-            {
-                std::vector<RiaSummaryCurveDefinition> summaryVectorDefinitions = dlg.curveSelection();
-                m_dataSources.deleteChildren();
-                for ( const RiaSummaryCurveDefinition& vectorDef : summaryVectorDefinitions )
-                {
-                    auto plotEntry = new RimAnalysisPlotDataEntry();
-                    plotEntry->setFromCurveDefinition( vectorDef );
-                    m_dataSources.push_back( plotEntry );
-                }
-                connectAllCaseSignals();
-                loadDataAndUpdate();
-                updateConnectedEditors();
-            }
-        }
-
-        m_pushButtonSelectSummaryAddress = false;
-    }
-    else if ( changedField == &m_timeStep )
+    if ( changedField == &m_timeStep )
     {
         loadDataAndUpdate();
         updateConnectedEditors();
@@ -234,11 +197,6 @@ void RimAbstractCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* ch
 //--------------------------------------------------------------------------------------------------
 void RimAbstractCorrelationPlot::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-    if ( attrib )
-    {
-        attrib->m_buttonText = "...";
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -751,7 +709,9 @@ void RimAbstractCorrelationPlot::appendDataSourceFields( QString uiConfigName, c
     m_selectedVarsUiField = selectedVectorNamesText();
 
     curveDataGroup->add( &m_selectedVarsUiField );
-    curveDataGroup->add( &m_pushButtonSelectSummaryAddress, { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
+    curveDataGroup->addNewButton( "...",
+                                  [this]() { onSelectVariablesButtonClicked(); },
+                                  { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
     curveDataGroup->add( &m_timeStepFilter );
     curveDataGroup->add( &m_timeStep );
     curveDataGroup->add( &m_useCaseFilter );
@@ -801,4 +761,39 @@ void RimAbstractCorrelationPlot::connectCurveFilterSignals()
 void RimAbstractCorrelationPlot::onFilterSourceChanged( const caf::SignalEmitter* emitter )
 {
     if ( m_useCaseFilter() ) loadDataAndUpdate();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimAbstractCorrelationPlot::onSelectVariablesButtonClicked()
+{
+    RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
+
+    if ( m_selectMultipleVectors )
+    {
+        dlg.enableMultiSelect( true );
+    }
+
+    dlg.hideSummaryCases();
+    dlg.setCurveSelection( curveDefinitions() );
+
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+        auto curveSelection = dlg.curveSelection();
+        if ( !curveSelection.empty() )
+        {
+            std::vector<RiaSummaryCurveDefinition> summaryVectorDefinitions = dlg.curveSelection();
+            m_dataSources.deleteChildren();
+            for ( const RiaSummaryCurveDefinition& vectorDef : summaryVectorDefinitions )
+            {
+                auto plotEntry = new RimAnalysisPlotDataEntry();
+                plotEntry->setFromCurveDefinition( vectorDef );
+                m_dataSources.push_back( plotEntry );
+            }
+            connectAllCaseSignals();
+            loadDataAndUpdate();
+            updateConnectedEditors();
+        }
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
@@ -130,6 +130,7 @@ private:
     void connectAllCaseSignals();
     void connectCurveFilterSignals();
     void onFilterSourceChanged( const caf::SignalEmitter* emitter );
+    void onSelectVariablesButtonClicked();
 
     RiaSummaryCurveDefinitionAnalyser* getOrCreateSelectedCurveDefAnalyser() const;
 
@@ -140,7 +141,6 @@ protected:
     bool m_selectMultipleVectors;
 
     caf::PdmField<QString>            m_selectedVarsUiField;
-    caf::PdmField<bool>               m_pushButtonSelectSummaryAddress;
     caf::PdmField<TimeStepFilterEnum> m_timeStepFilter;
     caf::PdmField<QDateTime>          m_timeStep;
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
@@ -258,8 +258,6 @@ void RimCorrelationMatrixPlot::fieldChangedByUi( const caf::PdmFieldHandle* chan
 {
     RimAbstractCorrelationPlot::fieldChangedByUi( changedField, oldValue, newValue );
 
-    bool sendSelectedSignal = false;
-
     if ( changedField == &m_showAbsoluteValues || changedField == &m_sortByValues || changedField == &m_sortByAbsoluteValues ||
          changedField == &m_showOnlyTopNCorrelations || changedField == &m_topNFilterCount ||
          changedField == &m_excludeParametersWithoutVariation || changedField == &m_selectedParametersList )
@@ -271,16 +269,7 @@ void RimCorrelationMatrixPlot::fieldChangedByUi( const caf::PdmFieldHandle* chan
         updateLegend();
         loadDataAndUpdate();
         updateConnectedEditors();
-        sendSelectedSignal = true;
-    }
 
-    if ( changedField == &m_pushButtonSelectSummaryAddress )
-    {
-        sendSelectedSignal = true;
-    }
-
-    if ( sendSelectedSignal )
-    {
         auto curves     = curveDefinitions();
         auto parameters = m_selectedParametersList();
         if ( !curves.empty() && !parameters.empty() )

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
@@ -46,8 +46,8 @@
 #include "RiuMatrixPlotWidget.h"
 #include "RiuTools.h"
 
+#include "cafPdmUiButton.h"
 #include "cafPdmUiComboBoxEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiToolButtonEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
@@ -157,8 +157,6 @@ RimWellConnectivityTable::RimWellConnectivityTable()
     CAF_PDM_InitField( &m_timeStepCount, "TimeStepCount", m_initialNumberOfTimeSteps, "Number of Time Steps" );
     CAF_PDM_InitFieldNoDefault( &m_excludeTimeSteps, "ExcludeTimeSteps", "" );
     m_excludeTimeSteps.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
-    CAF_PDM_InitFieldNoDefault( &m_applyTimeStepSelections, "ApplyTimeStepSelections", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelLeft( &m_applyTimeStepSelections );
 
     // Producer/Injector tracer configuration
     CAF_PDM_InitFieldNoDefault( &m_selectedProducerTracersUiField, "SelectedProducerTracers", "Producer Tracers" );
@@ -169,8 +167,6 @@ RimWellConnectivityTable::RimWellConnectivityTable()
     m_syncSelectedInjectorsFromProducerSelection.uiCapability()->setUiEditorTypeName( caf::PdmUiToolButtonEditor::uiEditorTypeName() );
     CAF_PDM_InitField( &m_syncSelectedProducersFromInjectorSelection, "SyncSelectedInjProd", false, "<- Synch Communicators" );
     m_syncSelectedProducersFromInjectorSelection.uiCapability()->setUiEditorTypeName( caf::PdmUiToolButtonEditor::uiEditorTypeName() );
-    CAF_PDM_InitFieldNoDefault( &m_applySelectedInectorProducerTracers, "ApplySelectedInectorProducerTracers", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelLeft( &m_applySelectedInectorProducerTracers );
 
     // Table settings
     CAF_PDM_InitField( &m_showValueLabels, "ShowValueLabels", false, "Show Value Labels" );
@@ -402,11 +398,6 @@ void RimWellConnectivityTable::fieldChangedByUi( const caf::PdmFieldHandle* chan
             setWellSelectionFromViewFilter();
         }
     }
-    else if ( changedField == &m_applyTimeStepSelections || changedField == &m_applySelectedInectorProducerTracers )
-    {
-        // For time step range - depends on apply buttons to prevent unwanted loading of large amount of data
-        onLoadDataAndUpdate();
-    }
     else if ( changedField == &m_timeStepCount && m_timeStepFilterMode == TimeStepRangeFilterMode::TIME_STEP_COUNT )
     {
         m_excludeTimeSteps.setValue( {} );
@@ -492,7 +483,8 @@ void RimWellConnectivityTable::defineUiOrdering( QString uiConfigName, caf::PdmU
         caf::PdmUiGroup& excludeTimeStepGroup = *flowDiagConfigGroup.addNewGroup( "Exclude Time Steps" );
         excludeTimeStepGroup.add( &m_excludeTimeSteps );
         excludeTimeStepGroup.setCollapsedByDefault();
-        flowDiagConfigGroup.add( &m_applyTimeStepSelections );
+        // For time step range - depends on apply button to prevent unwanted loading of large amount of data
+        flowDiagConfigGroup.addNewButton( "Apply", [this]() { onLoadDataAndUpdate(); } );
     }
 
     caf::PdmUiGroup* selectionGroup = uiOrdering.addNewGroup( "Tracer Selection" );
@@ -503,7 +495,8 @@ void RimWellConnectivityTable::defineUiOrdering( QString uiConfigName, caf::PdmU
     injectorGroup->add( &m_selectedInjectorTracersUiField );
     injectorGroup->add( &m_syncSelectedProducersFromInjectorSelection );
 
-    selectionGroup->add( &m_applySelectedInectorProducerTracers );
+    // For tracer selection - depends on apply button to prevent unwanted loading of large amount of data
+    selectionGroup->addNewButton( "Apply", [this]() { onLoadDataAndUpdate(); } );
 
     caf::PdmUiGroup* tableSettingsGroup = uiOrdering.addNewGroup( "Table Settings" );
     tableSettingsGroup->add( &m_showValueLabels );
@@ -527,14 +520,6 @@ void RimWellConnectivityTable::defineUiOrdering( QString uiConfigName, caf::PdmU
 //--------------------------------------------------------------------------------------------------
 void RimWellConnectivityTable::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_applyTimeStepSelections || field == &m_applySelectedInectorProducerTracers )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "Apply";
-        }
-    }
     if ( field == &m_selectedTimeStep || field == &m_selectedFromTimeStep || field == &m_selectedToTimeStep )
     {
         RiuTools::enableUpDownArrowsForComboBox( attribute );

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.h
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.h
@@ -184,7 +184,6 @@ private:
     caf::PdmField<caf::AppEnum<TimeStepRangeFilterMode>> m_timeStepFilterMode;
     caf::PdmField<int>                                   m_timeStepCount;
     caf::PdmField<std::vector<QDateTime>>                m_excludeTimeSteps;
-    caf::PdmField<bool>                                  m_applyTimeStepSelections;
 
     caf::PdmChildField<RimRegularLegendConfig*> m_legendConfig;
 
@@ -192,7 +191,6 @@ private:
     caf::PdmField<std::vector<QString>> m_selectedProducerTracersUiField;
     caf::PdmField<bool>                 m_syncSelectedProducersFromInjectorSelection;
     caf::PdmField<bool>                 m_syncSelectedInjectorsFromProducerSelection;
-    caf::PdmField<bool>                 m_applySelectedInectorProducerTracers;
 
     caf::PdmField<RimRegularLegendConfig::MappingEnum> m_mappingType;
     caf::PdmField<caf::AppEnum<RangeType>>             m_rangeType;

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.cpp
@@ -33,8 +33,8 @@
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmFieldScriptingCapabilityCvfVec3d.h"
 #include "cafPdmObjectScriptingCapability.h"
+#include "cafPdmUiButton.h"
 #include "cafPdmUiColorEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeAttributes.h"
 
 CAF_PDM_SOURCE_INIT( RimPolygon, "Polygon", "RimPolygon" );
@@ -50,9 +50,6 @@ RimPolygon::RimPolygon()
 
     CAF_PDM_InitField( &m_isReadOnly, "IsReadOnly", false, "Read Only" );
     CAF_PDM_InitScriptableFieldWithScriptKeywordNoDefault( &m_pointsInDomainCoords, "PointsInDomainCoords", "Coordinates", "Points" );
-
-    CAF_PDM_InitField( &m_editPolygonButton, "EditPolygonButton", false, "Edit" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_editPolygonButton );
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_appearance, "Appearance", "Appearance" );
     m_appearance = new RimPolygonAppearance;
@@ -177,7 +174,12 @@ void RimPolygon::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiO
 {
     uiOrdering.add( nameField() );
     uiOrdering.add( &m_isReadOnly );
-    uiOrdering.add( &m_editPolygonButton );
+    uiOrdering.addNewButton( m_isReadOnly() ? "Select in Active View" : "Edit in Active View",
+                             [this]()
+                             {
+                                 auto activeView = RiaApplication::instance()->activeReservoirView();
+                                 RimPolygonTools::activate3dEditOfPolygonInView( this, activeView );
+                             } );
 
     auto groupPoints = uiOrdering.addNewGroup( "Points" );
     groupPoints->setCollapsedByDefault();
@@ -199,14 +201,6 @@ void RimPolygon::fieldChangedByUi( const caf::PdmFieldHandle* changedField, cons
         coordinatesChanged.send();
     }
 
-    if ( changedField == &m_editPolygonButton )
-    {
-        auto activeView = RiaApplication::instance()->activeReservoirView();
-        RimPolygonTools::activate3dEditOfPolygonInView( this, activeView );
-
-        m_editPolygonButton = false;
-        return;
-    }
     objectChanged.send();
 }
 
@@ -216,27 +210,6 @@ void RimPolygon::fieldChangedByUi( const caf::PdmFieldHandle* changedField, cons
 void RimPolygon::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
 {
     objectChanged.send();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimPolygon::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_editPolygonButton )
-    {
-        if ( auto attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute ) )
-        {
-            if ( m_isReadOnly() )
-            {
-                attrib->m_buttonText = "Select in Active View";
-            }
-            else
-            {
-                attrib->m_buttonText = "Edit in Active View";
-            }
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.h
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.h
@@ -73,11 +73,9 @@ private:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
 private:
     caf::PdmField<bool>                       m_isReadOnly;
-    caf::PdmField<bool>                       m_editPolygonButton;
     caf::PdmField<std::vector<cvf::Vec3d>>    m_pointsInDomainCoords;
     caf::PdmChildField<RimPolygonAppearance*> m_appearance;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimTimeStepFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimTimeStepFilter.cpp
@@ -31,9 +31,9 @@
 #include "RimReloadCaseTools.h"
 #include "RimReservoirCellResultsStorage.h"
 
+#include "cafPdmUiButton.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 
 #include <QDateTime>
 
@@ -87,9 +87,6 @@ RimTimeStepFilter::RimTimeStepFilter()
 
     CAF_PDM_InitField( &m_readOnlyLastFrame, "OnlyLastFrame", false, "Load Only Last Frame Of Each Time Step" );
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_readOnlyLastFrame );
-
-    CAF_PDM_InitFieldNoDefault( &m_applyReloadOfCase, "ApplyReloadOfCase", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelLeft( &m_applyReloadOfCase );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -283,22 +280,6 @@ void RimTimeStepFilter::fieldChangedByUi( const caf::PdmFieldHandle* changedFiel
 {
     RimEclipseResultCase* rimEclipseResultCase = parentEclipseResultCase();
     RimGeoMechCase*       rimGeoMechCase       = parentGeoMechCase();
-    if ( changedField == &m_applyReloadOfCase )
-    {
-        updateFilteredTimeStepsFromUi();
-
-        if ( rimEclipseResultCase )
-        {
-            RimReloadCaseTools::reloadEclipseGrid( rimEclipseResultCase );
-        }
-        else if ( rimGeoMechCase )
-        {
-            rimGeoMechCase->reloadDataAndUpdate();
-        }
-
-        return;
-    }
-
     if ( changedField == &m_filterType || changedField == &m_firstTimeStep || changedField == &m_lastTimeStep || changedField == &m_interval )
     {
         m_filteredTimeStepsUi = filteredTimeStepIndicesFromUi();
@@ -349,15 +330,7 @@ QList<caf::PdmOptionItemInfo> RimTimeStepFilter::calculateValueOptions( const ca
 //--------------------------------------------------------------------------------------------------
 void RimTimeStepFilter::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_applyReloadOfCase )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "Reload Case";
-        }
-    }
-    else if ( field == &m_interval )
+    if ( field == &m_interval )
     {
         caf::PdmUiLineEditorAttribute* attrib = dynamic_cast<caf::PdmUiLineEditorAttribute*>( attribute );
         if ( attrib )
@@ -457,7 +430,7 @@ void RimTimeStepFilter::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderi
 
     if ( caseLoaded )
     {
-        uiOrdering.add( &m_applyReloadOfCase );
+        uiOrdering.addNewButton( "Reload Case", [this]() { onReloadCaseButtonClicked(); } );
     }
 
     updateFieldVisibility();
@@ -537,5 +510,25 @@ void RimTimeStepFilter::timeStepOptions( QList<caf::PdmOptionItemInfo>&         
             options.push_back(
                 caf::PdmOptionItemInfo( RiaQDateTimeTools::toStringUsingApplicationLocale( dateTime, dateFormatString ), dateTime ) );
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimTimeStepFilter::onReloadCaseButtonClicked()
+{
+    updateFilteredTimeStepsFromUi();
+
+    auto rimEclipseResultCase = parentEclipseResultCase();
+    auto rimGeoMechCase       = parentGeoMechCase();
+
+    if ( rimEclipseResultCase )
+    {
+        RimReloadCaseTools::reloadEclipseGrid( rimEclipseResultCase );
+    }
+    else if ( rimGeoMechCase )
+    {
+        rimGeoMechCase->reloadDataAndUpdate();
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/RimTimeStepFilter.h
+++ b/ApplicationLibCode/ProjectDataModel/RimTimeStepFilter.h
@@ -89,6 +89,8 @@ private:
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
+    void onReloadCaseButtonClicked();
+
 private:
     caf::PdmField<caf::AppEnum<TimeStepFilterTypeEnum>> m_filterType;
 
@@ -97,7 +99,6 @@ private:
     caf::PdmField<int>                  m_firstTimeStep;
     caf::PdmField<int>                  m_lastTimeStep;
     caf::PdmField<int>                  m_interval;
-    caf::PdmField<bool>                 m_applyReloadOfCase;
     caf::PdmField<QString>              m_dateFormat;
     caf::PdmField<std::vector<QString>> m_timeStepNamesFromFile;
     caf::PdmField<bool>                 m_readOnlyLastFrame;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.cpp
@@ -30,8 +30,8 @@
 #include "RimSummaryCaseMainCollection.h"
 #include "RimSummaryEnsemble.h"
 
+#include "cafPdmUiButton.h"
 #include "cafPdmUiCheckBoxEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 
 #include <QDateTime>
@@ -68,9 +68,6 @@ RimDeltaSummaryEnsemble::RimDeltaSummaryEnsemble()
     m_ensemble2.uiCapability()->setAutoAddingOptionFromValue( false );
 
     CAF_PDM_InitFieldNoDefault( &m_operator, "Operator", "Operator" );
-
-    CAF_PDM_InitField( &m_swapEnsemblesButton, "SwapEnsembles", false, "SwapEnsembles" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_swapEnsemblesButton );
 
     CAF_PDM_InitField( &m_caseCount, "CaseCount", QString( "" ), "Matching Cases" );
     m_caseCount.uiCapability()->setUiReadOnly( true );
@@ -350,7 +347,7 @@ void RimDeltaSummaryEnsemble::defineUiOrdering( QString uiConfigName, caf::PdmUi
     caseGroup->add( &m_ensemble1 );
     caseGroup->add( &m_operator );
     caseGroup->add( &m_ensemble2 );
-    caseGroup->add( &m_swapEnsemblesButton );
+    caseGroup->addNewButton( "Swap Ensembles", [this]() { onSwapEnsemblesButtonClicked(); } );
 
     caseGroup->add( &m_useFixedTimeStep );
     if ( m_useFixedTimeStep() != RimDeltaSummaryEnsemble::FixedTimeStepMode::FIXED_TIME_STEP_NONE )
@@ -388,17 +385,6 @@ void RimDeltaSummaryEnsemble::fieldChangedByUi( const caf::PdmFieldHandle* chang
         doUpdateCases = true;
         doShowDialog  = false;
     }
-    else if ( changedField == &m_swapEnsemblesButton )
-    {
-        m_swapEnsemblesButton = false;
-        auto temp             = m_ensemble1();
-        m_ensemble1           = m_ensemble2();
-        m_ensemble2           = temp;
-
-        doUpdate      = true;
-        doUpdateCases = true;
-        doShowDialog  = false;
-    }
 
     if ( doUpdate )
     {
@@ -430,14 +416,6 @@ void RimDeltaSummaryEnsemble::fieldChangedByUi( const caf::PdmFieldHandle* chang
 //--------------------------------------------------------------------------------------------------
 void RimDeltaSummaryEnsemble::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_swapEnsemblesButton )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "Swap Ensembles";
-        }
-    }
     if ( &m_fixedTimeStepIndex == field )
     {
         auto a = dynamic_cast<caf::PdmUiTreeSelectionEditorAttribute*>( attribute );
@@ -620,4 +598,24 @@ std::vector<RimSummaryEnsemble*> RimDeltaSummaryEnsemble::allEnsembles() const
         ensembles.push_back( ensemble );
     }
     return ensembles;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimDeltaSummaryEnsemble::onSwapEnsemblesButtonClicked()
+{
+    auto temp   = m_ensemble1();
+    m_ensemble1 = m_ensemble2();
+    m_ensemble2 = temp;
+
+    RiaSummaryTools::updateSummaryEnsembleNames();
+    createDerivedEnsembleCases();
+    updateConnectedEditors();
+    updateReferringCurveSetsZoomAll();
+
+    for ( auto referring : findReferringEnsembles() )
+    {
+        referring->updateReferringCurveSetsZoomAll();
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimDeltaSummaryEnsemble.h
@@ -74,6 +74,8 @@ private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
+    void onSwapEnsemblesButtonClicked();
+
     void                              setAllCasesNotInUse();
     void                              deleteCasesNoInUse();
     RimDeltaSummaryCase*              firstCaseNotInUse();
@@ -93,7 +95,6 @@ private:
     caf::PdmPtrField<RimSummaryEnsemble*>               m_ensemble1;
     caf::PdmPtrField<RimSummaryEnsemble*>               m_ensemble2;
     caf::PdmField<caf::AppEnum<DerivedSummaryOperator>> m_operator;
-    caf::PdmField<bool>                                 m_swapEnsemblesButton;
     caf::PdmField<QString>                              m_caseCount;
     caf::PdmField<bool>                                 m_matchOnParameters;
     caf::PdmField<bool>                                 m_discardMissingOrIncompleteRealizations;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.cpp
@@ -38,9 +38,9 @@
 #include "RiuSummaryVectorSelectionDialog.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
+#include "cafPdmUiButton.h"
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiTreeSelectionEditor.h"
 #include "cafPdmUiValueRangeEditor.h"
 
@@ -95,10 +95,6 @@ RimEnsembleCurveFilter::RimEnsembleCurveFilter()
 
     CAF_PDM_InitFieldNoDefault( &m_objectiveValuesSummaryAddresses, "ObjectiveSummaryAddress", "Summary Address" );
     m_objectiveValuesSummaryAddresses.uiCapability()->setUiTreeChildrenHidden( true );
-
-    CAF_PDM_InitFieldNoDefault( &m_objectiveValuesSelectSummaryAddressPushButton, "SelectObjectiveSummaryAddress", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_objectiveValuesSelectSummaryAddressPushButton );
-    m_objectiveValuesSelectSummaryAddressPushButton = false;
 
     CAF_PDM_InitFieldNoDefault( &m_objectiveFunction, "ObjectiveFunction", "Objective Function" );
     m_objectiveFunction = new RimObjectiveFunction();
@@ -418,39 +414,6 @@ void RimEnsembleCurveFilter::fieldChangedByUi( const caf::PdmFieldHandle* change
             curveSet->filterCollection()->updateConnectedEditors();
         }
     }
-    else if ( changedField == &m_objectiveValuesSelectSummaryAddressPushButton )
-    {
-        RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
-        RimObjectiveFunctionTools::configureDialogForObjectiveFunctions( &dlg );
-        RimSummaryEnsemble* candidateEnsemble = parentCurveSet()->summaryEnsemble();
-
-        std::vector<RifEclipseSummaryAddress> candidateAddresses;
-        for ( auto address : m_objectiveValuesSummaryAddresses().childrenByType() )
-        {
-            candidateAddresses.push_back( address->address() );
-        }
-
-        dlg.setEnsembleAndAddresses( candidateEnsemble, candidateAddresses );
-
-        if ( dlg.exec() == QDialog::Accepted )
-        {
-            auto curveSelection = dlg.curveSelection();
-            if ( !curveSelection.empty() )
-            {
-                m_objectiveValuesSummaryAddresses.deleteChildren();
-                for ( auto address : curveSelection )
-                {
-                    RimSummaryAddress* summaryAddress = new RimSummaryAddress();
-                    summaryAddress->setAddress( address.summaryAddressY() );
-                    m_objectiveValuesSummaryAddresses.push_back( summaryAddress );
-                }
-                loadDataAndUpdate();
-            }
-        }
-
-        m_objectiveValuesSelectSummaryAddressPushButton = false;
-    }
-
     parentCurveSet()->updateFilterLegend();
 }
 
@@ -526,7 +489,9 @@ void RimEnsembleCurveFilter::defineUiOrdering( QString uiConfigName, caf::PdmUiO
     else if ( m_filterMode() == FilterMode::OBJECTIVE_FUNCTION )
     {
         uiOrdering.add( &m_objectiveValuesSummaryAddressesUiField );
-        uiOrdering.add( &m_objectiveValuesSelectSummaryAddressPushButton, { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
+        uiOrdering.addNewButton( "...",
+                                 [this]() { onObjectiveFunctionSelectionButtonClicked(); },
+                                 { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
         {
             auto equationGroup = uiOrdering.addNewGroup( "Equation" );
             m_objectiveFunction->uiOrdering( "", *equationGroup );
@@ -573,14 +538,7 @@ void RimEnsembleCurveFilter::defineUiOrdering( QString uiConfigName, caf::PdmUiO
 //--------------------------------------------------------------------------------------------------
 void RimEnsembleCurveFilter::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_objectiveValuesSelectSummaryAddressPushButton )
-    {
-        if ( auto attr = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute ) )
-        {
-            attr->m_buttonText = "...";
-        }
-    }
-    else if ( field == &m_valueRange )
+    if ( field == &m_valueRange )
     {
         if ( auto attr = dynamic_cast<caf::PdmUiDoubleSliderEditorAttribute*>( attribute ) )
         {
@@ -879,4 +837,38 @@ RigEnsembleParameter RimEnsembleCurveFilter::selectedEnsembleParameter() const
     auto curveSet = parentCurveSet();
     auto ensemble = curveSet ? curveSet->summaryEnsemble() : nullptr;
     return ensemble ? ensemble->ensembleParameter( m_ensembleParameterName ) : RigEnsembleParameter();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEnsembleCurveFilter::onObjectiveFunctionSelectionButtonClicked()
+{
+    RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
+    RimObjectiveFunctionTools::configureDialogForObjectiveFunctions( &dlg );
+    RimSummaryEnsemble* candidateEnsemble = parentCurveSet()->summaryEnsemble();
+
+    std::vector<RifEclipseSummaryAddress> candidateAddresses;
+    for ( auto address : m_objectiveValuesSummaryAddresses().childrenByType() )
+    {
+        candidateAddresses.push_back( address->address() );
+    }
+
+    dlg.setEnsembleAndAddresses( candidateEnsemble, candidateAddresses );
+
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+        auto curveSelection = dlg.curveSelection();
+        if ( !curveSelection.empty() )
+        {
+            m_objectiveValuesSummaryAddresses.deleteChildren();
+            for ( auto address : curveSelection )
+            {
+                RimSummaryAddress* summaryAddress = new RimSummaryAddress();
+                summaryAddress->setAddress( address.summaryAddressY() );
+                m_objectiveValuesSummaryAddresses.push_back( summaryAddress );
+            }
+            loadDataAndUpdate();
+        }
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.h
@@ -88,6 +88,7 @@ private:
     void                 initAfterRead() override;
 
     void onObjectionFunctionChanged( const caf::SignalEmitter* emitter );
+    void onObjectiveFunctionSelectionButtonClicked();
 
     RimEnsembleCurveFilterCollection* parentCurveFilterCollection() const;
     void                              updateMaxMinAndDefaultValues( bool forceDefault );
@@ -104,7 +105,6 @@ private:
 
     caf::PdmChildArrayField<RimSummaryAddress*>   m_objectiveValuesSummaryAddresses;
     caf::PdmField<QString>                        m_objectiveValuesSummaryAddressesUiField;
-    caf::PdmField<bool>                           m_objectiveValuesSelectSummaryAddressPushButton;
     caf::PdmChildField<RimObjectiveFunction*>     m_objectiveFunction;
     caf::PdmPtrField<RimCustomObjectiveFunction*> m_customObjectiveFunction;
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilterCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilterCollection.cpp
@@ -24,8 +24,8 @@
 
 #include "RiuTextContentFrame.h"
 
-#include <cafPdmUiPushButtonEditor.h>
-#include <cafPdmUiTreeOrdering.h>
+#include "cafPdmUiButton.h"
+#include "cafPdmUiTreeOrdering.h"
 
 CAF_PDM_SOURCE_INIT( RimEnsembleCurveFilterCollection, "RimEnsembleCurveFilterCollection" );
 
@@ -41,10 +41,6 @@ RimEnsembleCurveFilterCollection::RimEnsembleCurveFilterCollection()
     CAF_PDM_InitFieldNoDefault( &m_filters, "CurveFilters", "" );
     m_filters.uiCapability()->setUiTreeChildrenHidden( true );
     m_filters.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::LabelPosition::HIDDEN );
-
-    CAF_PDM_InitFieldNoDefault( &m_newFilterButton, "NewEnsembleFilter", "New Filter" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_newFilterButton );
-    m_newFilterButton = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -111,14 +107,6 @@ void RimEnsembleCurveFilterCollection::fieldChangedByUi( const caf::PdmFieldHand
     {
         curveSet->updateAllCurves();
     }
-    else if ( changedField == &m_newFilterButton )
-    {
-        m_newFilterButton = false;
-
-        addFilter();
-        updateConnectedEditors();
-        curveSet->updateAllCurves();
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -128,7 +116,7 @@ void RimEnsembleCurveFilterCollection::defineUiOrdering( QString uiConfigName, c
 {
     caf::PdmUiGroup* group = uiOrdering.addNewGroup( "Filters" );
 
-    group->add( &m_newFilterButton );
+    group->addNewButton( "Add Ensemble Curve Filter", [this]() { onAddFilterButtonClicked(); } );
 
     for ( auto& filter : m_filters )
     {
@@ -202,13 +190,6 @@ void RimEnsembleCurveFilterCollection::defineEditorAttribute( const caf::PdmFiel
                                                               QString                    uiConfigName,
                                                               caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_newFilterButton )
-    {
-        caf::PdmUiPushButtonEditorAttribute* attr = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( !attr ) return;
-
-        attr->m_buttonText = "Add Ensemble Curve Filter";
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -272,4 +253,17 @@ void RimEnsembleCurveFilterCollection::onChildDeleted( caf::PdmChildArrayFieldHa
 
     RimEnsembleCurveSet* curveSet = firstAncestorOrThisOfType<RimEnsembleCurveSet>();
     if ( curveSet ) curveSet->updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEnsembleCurveFilterCollection::onAddFilterButtonClicked()
+{
+    addFilter();
+    updateConnectedEditors();
+    if ( auto curveSet = firstAncestorOrThisOfType<RimEnsembleCurveSet>() )
+    {
+        curveSet->updateAllCurves();
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilterCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilterCollection.h
@@ -51,6 +51,8 @@ private:
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+
+    void onAddFilterButtonClicked();
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName /* = "" */ ) override;
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
@@ -61,5 +63,4 @@ private:
 private:
     caf::PdmField<bool>                              m_active;
     caf::PdmChildArrayField<RimEnsembleCurveFilter*> m_filters;
-    caf::PdmField<bool>                              m_newFilterButton;
 };

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp
@@ -68,12 +68,12 @@
 
 #include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmObject.h"
+#include "cafPdmUiButton.h"
 #include "cafPdmUiColorEditor.h"
 #include "cafPdmUiDateEditor.h"
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiItem.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiSliderEditor.h"
 #include "cafPdmUiTreeAttributes.h"
 #include "cafPdmUiTreeOrdering.h"
@@ -135,10 +135,6 @@ RimEnsembleCurveSet::RimEnsembleCurveSet()
     m_yValuesSummaryAddress.uiCapability()->setUiTreeChildrenHidden( true );
     m_yValuesSummaryAddress = new RimSummaryAddress;
 
-    CAF_PDM_InitFieldNoDefault( &m_yPushButtonSelectSummaryAddress, "SelectAddress", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_yPushButtonSelectSummaryAddress );
-    m_yPushButtonSelectSummaryAddress = false;
-
     CAF_PDM_InitFieldNoDefault( &m_resampling, "Resampling", "Resampling" );
 
     // X Axis
@@ -184,10 +180,6 @@ RimEnsembleCurveSet::RimEnsembleCurveSet()
 
     CAF_PDM_InitFieldNoDefault( &m_objectiveValuesSummaryAddresses, "ObjectiveSummaryAddress", "Summary Address" );
     m_objectiveValuesSummaryAddresses.uiCapability()->setUiTreeChildrenHidden( true );
-
-    CAF_PDM_InitFieldNoDefault( &m_objectiveValuesSelectSummaryAddressPushButton, "SelectObjectiveSummaryAddress", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_objectiveValuesSelectSummaryAddressPushButton );
-    m_objectiveValuesSelectSummaryAddressPushButton = false;
 
     CAF_PDM_InitFieldNoDefault( &m_customObjectiveFunction, "CustomObjectiveFunction", "Objective Function" );
     m_customObjectiveFunction.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
@@ -1053,77 +1045,6 @@ void RimEnsembleCurveSet::fieldChangedByUi( const caf::PdmFieldHandle* changedFi
     {
         updateTextInPlot = true;
     }
-    else if ( changedField == &m_yPushButtonSelectSummaryAddress )
-    {
-        RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
-        RimSummaryEnsemble*             candidateEnsemble = m_yValuesSummaryEnsemble();
-        RifEclipseSummaryAddress        candicateAddress  = m_yValuesSummaryAddress->address();
-
-        dlg.hideSummaryCases();
-        dlg.setEnsembleAndAddress( candidateEnsemble, candicateAddress );
-
-        if ( dlg.exec() == QDialog::Accepted )
-        {
-            auto curveSelection = dlg.curveSelection();
-            if ( !curveSelection.empty() )
-            {
-                m_yValuesSummaryEnsemble = curveSelection[0].ensemble();
-                m_yValuesSummaryAddress->setAddress( curveSelection[0].summaryAddressY() );
-
-                loadDataAndUpdate( true );
-
-                plot->updateAxes();
-
-                if ( auto multiPlot = firstAncestorOrThisOfType<RimSummaryMultiPlot>() )
-                {
-                    multiPlot->updatePlotTitles();
-                }
-                else
-                {
-                    plot->updatePlotTitle();
-                }
-
-                plot->updateConnectedEditors();
-
-                RiuPlotMainWindow* mainPlotWindow = RiaGuiApplication::instance()->mainPlotWindow();
-                mainPlotWindow->updateMultiPlotToolBar();
-            }
-        }
-
-        m_yPushButtonSelectSummaryAddress = false;
-    }
-    else if ( changedField == &m_objectiveValuesSelectSummaryAddressPushButton )
-    {
-        RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
-        RimObjectiveFunctionTools::configureDialogForObjectiveFunctions( &dlg );
-        RimSummaryEnsemble* candidateEnsemble = m_yValuesSummaryEnsemble();
-
-        std::vector<RifEclipseSummaryAddress> candidateAddresses;
-        for ( auto address : m_objectiveValuesSummaryAddresses().childrenByType() )
-        {
-            candidateAddresses.push_back( address->address() );
-        }
-
-        dlg.setEnsembleAndAddresses( candidateEnsemble, candidateAddresses );
-
-        if ( dlg.exec() == QDialog::Accepted )
-        {
-            auto curveSelection = dlg.curveSelection();
-            if ( !curveSelection.empty() )
-            {
-                m_objectiveValuesSummaryAddresses.deleteChildren();
-                for ( auto address : curveSelection )
-                {
-                    RimSummaryAddress* summaryAddress = new RimSummaryAddress();
-                    summaryAddress->setAddress( address.summaryAddressY() );
-                    m_objectiveValuesSummaryAddresses.push_back( summaryAddress );
-                }
-                loadDataAndUpdate( true );
-            }
-        }
-
-        m_objectiveValuesSelectSummaryAddressPushButton = false;
-    }
     else if ( changedField == &m_customObjectiveFunction )
     {
         if ( m_customObjectiveFunction() )
@@ -1226,7 +1147,9 @@ void RimEnsembleCurveSet::defineUiOrdering( QString uiConfigName, caf::PdmUiOrde
         caf::PdmUiGroup* curveDataGroup = uiOrdering.addNewGroup( "Summary Vector" );
         curveDataGroup->add( &m_yValuesSummaryEnsemble );
         curveDataGroup->add( &m_yValuesSummaryAddressUiField );
-        curveDataGroup->add( &m_yPushButtonSelectSummaryAddress, { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
+        curveDataGroup->addNewButton( "...",
+                                      [this]() { onYValuesSummaryAddressButtonClicked(); },
+                                      { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
 
         if ( !isXAxisSummaryVector() )
         {
@@ -1432,8 +1355,9 @@ void RimEnsembleCurveSet::appendColorGroup( caf::PdmUiOrdering& uiOrdering )
         if ( m_colorMode == ColorMode::BY_OBJECTIVE_FUNCTION )
         {
             colorsGroup->add( &m_objectiveValuesSummaryAddressesUiField );
-            colorsGroup->add( &m_objectiveValuesSelectSummaryAddressPushButton,
-                              { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
+            colorsGroup->addNewButton( "...",
+                                       [this]() { onObjectiveValuesSummaryAddressesButtonClicked(); },
+                                       { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
 
             {
                 auto equationGroup = colorsGroup->addNewGroup( "Equation" );
@@ -1521,11 +1445,6 @@ caf::PdmFieldHandle* RimEnsembleCurveSet::objectToggleField()
 //--------------------------------------------------------------------------------------------------
 void RimEnsembleCurveSet::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( auto* attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute ) )
-    {
-        attrib->m_buttonText = "...";
-    }
-
     if ( field == &m_minTimeSliderPosition || field == &m_maxTimeSliderPosition )
     {
         if ( auto* myAttr = dynamic_cast<caf::PdmUiSliderEditorAttribute*>( attribute ) )
@@ -2917,5 +2836,83 @@ void RimEnsembleCurveSet::recreatePlotCurveForLegend( RimSummaryPlot* plot )
                                                  RiaColorTools::toQColor( m_mainEnsembleColor() ) );
         m_plotCurveForLegendText->attachToPlot( plot->plotWidget() );
         updateEnsembleLegendItem();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEnsembleCurveSet::onYValuesSummaryAddressButtonClicked()
+{
+    RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
+    RimSummaryEnsemble*             candidateEnsemble = m_yValuesSummaryEnsemble();
+    RifEclipseSummaryAddress        candicateAddress  = m_yValuesSummaryAddress->address();
+
+    dlg.hideSummaryCases();
+    dlg.setEnsembleAndAddress( candidateEnsemble, candicateAddress );
+
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+        auto curveSelection = dlg.curveSelection();
+        if ( !curveSelection.empty() )
+        {
+            m_yValuesSummaryEnsemble = curveSelection[0].ensemble();
+            m_yValuesSummaryAddress->setAddress( curveSelection[0].summaryAddressY() );
+
+            loadDataAndUpdate( true );
+
+            if ( auto plot = firstAncestorOrThisOfType<RimSummaryPlot>() )
+            {
+                plot->updateAxes();
+
+                if ( auto multiPlot = firstAncestorOrThisOfType<RimSummaryMultiPlot>() )
+                {
+                    multiPlot->updatePlotTitles();
+                }
+                else
+                {
+                    plot->updatePlotTitle();
+                }
+
+                plot->updateConnectedEditors();
+            }
+
+            RiuPlotMainWindow* mainPlotWindow = RiaGuiApplication::instance()->mainPlotWindow();
+            mainPlotWindow->updateMultiPlotToolBar();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEnsembleCurveSet::onObjectiveValuesSummaryAddressesButtonClicked()
+{
+    RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
+    RimObjectiveFunctionTools::configureDialogForObjectiveFunctions( &dlg );
+    RimSummaryEnsemble* candidateEnsemble = m_yValuesSummaryEnsemble();
+
+    std::vector<RifEclipseSummaryAddress> candidateAddresses;
+    for ( auto address : m_objectiveValuesSummaryAddresses().childrenByType() )
+    {
+        candidateAddresses.push_back( address->address() );
+    }
+
+    dlg.setEnsembleAndAddresses( candidateEnsemble, candidateAddresses );
+
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+        auto curveSelection = dlg.curveSelection();
+        if ( !curveSelection.empty() )
+        {
+            m_objectiveValuesSummaryAddresses.deleteChildren();
+            for ( auto address : curveSelection )
+            {
+                RimSummaryAddress* summaryAddress = new RimSummaryAddress();
+                summaryAddress->setAddress( address.summaryAddressY() );
+                m_objectiveValuesSummaryAddresses.push_back( summaryAddress );
+            }
+            loadDataAndUpdate( true );
+        }
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.h
@@ -237,6 +237,9 @@ private:
     void onObjectiveFunctionChanged( const caf::SignalEmitter* emitter );
     void onCustomObjectiveFunctionChanged( const caf::SignalEmitter* emitter );
 
+    void onYValuesSummaryAddressButtonClicked();
+    void onObjectiveValuesSummaryAddressesButtonClicked();
+
     void computeRealizationColor();
     void onColorTagClicked( const SignalEmitter* emitter, size_t index );
 
@@ -260,7 +263,6 @@ private:
     caf::PdmPtrField<RimSummaryEnsemble*>         m_yValuesSummaryEnsemble;
     caf::PdmChildField<RimSummaryAddress*>        m_yValuesSummaryAddress;
     caf::PdmField<RifEclipseSummaryAddress>       m_yValuesSummaryAddressUiField;
-    caf::PdmField<bool>                           m_yPushButtonSelectSummaryAddress;
     caf::PdmField<RiaDefines::DateTimePeriodEnum> m_resampling;
 
     caf::PdmField<caf::AppEnum<RiaDefines::HorizontalAxisType>> m_xAxisType;
@@ -285,7 +287,6 @@ private:
 
     caf::PdmChildArrayField<RimSummaryAddress*>   m_objectiveValuesSummaryAddresses;
     caf::PdmField<QString>                        m_objectiveValuesSummaryAddressesUiField;
-    caf::PdmField<bool>                           m_objectiveValuesSelectSummaryAddressPushButton;
     caf::PdmPtrField<RimCustomObjectiveFunction*> m_customObjectiveFunction;
     caf::PdmField<int>                            m_minTimeSliderPosition;
     caf::PdmField<int>                            m_maxTimeSliderPosition;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressSelector.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressSelector.cpp
@@ -34,8 +34,8 @@
 
 #include "RiuSummaryVectorSelectionDialog.h"
 
+#include "cafPdmUiButton.h"
 #include "cafPdmUiLineEditor.h"
-#include "cafPdmUiPushButtonEditor.h"
 
 CAF_PDM_SOURCE_INIT( RimSummaryAddressSelector, "RimSummaryAddressSelector" );
 
@@ -65,10 +65,6 @@ RimSummaryAddressSelector::RimSummaryAddressSelector()
 
     CAF_PDM_InitFieldNoDefault( &m_summaryAddress, "SummaryAddress", "Summary Address" );
     m_summaryAddress.uiCapability()->setUiTreeChildrenHidden( true );
-
-    CAF_PDM_InitFieldNoDefault( &m_pushButtonSelectSummaryAddress, "SelectAddress", "" );
-    caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_pushButtonSelectSummaryAddress );
-    m_pushButtonSelectSummaryAddress = false;
 
     CAF_PDM_InitFieldNoDefault( &m_plotAxisProperties, "PlotAxisProperties", "Axis" );
 
@@ -194,37 +190,7 @@ RimPlotAxisPropertiesInterface* RimSummaryAddressSelector::plotAxisProperties() 
 //--------------------------------------------------------------------------------------------------
 void RimSummaryAddressSelector::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
-    if ( changedField == &m_pushButtonSelectSummaryAddress )
-    {
-        RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
-
-        if ( isEnsemble() )
-        {
-            dlg.hideSummaryCases();
-            dlg.setEnsembleAndAddress( m_summaryCaseCollection(), m_summaryAddress->address() );
-        }
-        else
-        {
-            dlg.hideEnsembles();
-            dlg.setCaseAndAddress( m_summaryCase(), m_summaryAddress->address() );
-        }
-
-        if ( dlg.exec() == QDialog::Accepted )
-        {
-            auto curveSelection = dlg.curveSelection();
-            if ( !curveSelection.empty() )
-            {
-                m_summaryCase           = curveSelection[0].summaryCaseY();
-                m_summaryCaseCollection = curveSelection[0].ensemble();
-                auto addr               = curveSelection[0].summaryAddressY();
-                m_summaryAddress->setAddress( addr );
-                m_summaryAddressUiField = addr;
-            }
-        }
-
-        m_pushButtonSelectSummaryAddress = false;
-    }
-    else if ( changedField == &m_summaryAddressUiField )
+    if ( changedField == &m_summaryAddressUiField )
     {
         m_summaryAddress->setAddress( m_summaryAddressUiField() );
     }
@@ -361,7 +327,9 @@ void RimSummaryAddressSelector::defineUiOrdering( QString uiConfigName, caf::Pdm
     m_summaryAddressUiField = m_summaryAddress->address();
 
     uiOrdering.add( &m_summaryAddressUiField, { .newRow = true, .totalColumnSpan = 2, .leftLabelColumnSpan = 1 } );
-    uiOrdering.add( &m_pushButtonSelectSummaryAddress, { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
+    uiOrdering.addNewButton( "...",
+                             [this]() { onSummaryAddressButtonClicked(); },
+                             { .newRow = false, .totalColumnSpan = 1, .leftLabelColumnSpan = 0 } );
 
     if ( m_showResampling )
     {
@@ -381,14 +349,6 @@ void RimSummaryAddressSelector::defineUiOrdering( QString uiConfigName, caf::Pdm
 //--------------------------------------------------------------------------------------------------
 void RimSummaryAddressSelector::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( &m_pushButtonSelectSummaryAddress == field )
-    {
-        auto attrib = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( attrib )
-        {
-            attrib->m_buttonText = "...";
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -397,4 +357,38 @@ void RimSummaryAddressSelector::defineEditorAttribute( const caf::PdmFieldHandle
 bool RimSummaryAddressSelector::isEnsemble() const
 {
     return m_summaryCaseCollection() != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryAddressSelector::onSummaryAddressButtonClicked()
+{
+    RiuSummaryVectorSelectionDialog dlg( RiaGuiApplication::widgetToUseAsParent() );
+
+    if ( isEnsemble() )
+    {
+        dlg.hideSummaryCases();
+        dlg.setEnsembleAndAddress( m_summaryCaseCollection(), m_summaryAddress->address() );
+    }
+    else
+    {
+        dlg.hideEnsembles();
+        dlg.setCaseAndAddress( m_summaryCase(), m_summaryAddress->address() );
+    }
+
+    if ( dlg.exec() == QDialog::Accepted )
+    {
+        auto curveSelection = dlg.curveSelection();
+        if ( !curveSelection.empty() )
+        {
+            m_summaryCase           = curveSelection[0].summaryCaseY();
+            m_summaryCaseCollection = curveSelection[0].ensemble();
+            auto addr               = curveSelection[0].summaryAddressY();
+            m_summaryAddress->setAddress( addr );
+            m_summaryAddressUiField = addr;
+        }
+    }
+
+    addressChanged.send();
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressSelector.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryAddressSelector.h
@@ -70,13 +70,13 @@ private:
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
     bool isEnsemble() const;
+    void onSummaryAddressButtonClicked();
 
 private:
     caf::PdmPtrField<RimSummaryCase*>                 m_summaryCase;
     caf::PdmPtrField<RimSummaryEnsemble*>             m_summaryCaseCollection;
     caf::PdmChildField<RimSummaryAddress*>            m_summaryAddress;
     caf::PdmProxyValueField<RifEclipseSummaryAddress> m_summaryAddressUiField;
-    caf::PdmField<bool>                               m_pushButtonSelectSummaryAddress;
     caf::PdmPtrField<RimPlotAxisPropertiesInterface*> m_plotAxisProperties;
     caf::PdmField<RiaDefines::DateTimePeriodEnum>     m_resamplingPeriod;
 


### PR DESCRIPTION
Replace boolean push button fields used as UI triggers with dynamic buttons
added via addNewButton in defineUiOrdering, removing unnecessary field
boilerplate across multiple classes.
