### PR TITLE
Correlation Report Plot: click-to-select realization and improved subplot visibility control

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
@@ -645,7 +645,7 @@ void RimCorrelationMatrixPlot::updatePlotTitle()
 {
     if ( m_useAutoPlotTitle )
     {
-        m_description = QString( "Result Vectors vs Parameters at %2" ).arg( timeStepString() );
+        m_description = QString( "Pearson Correlation - %2" ).arg( timeStepString() );
     }
 
     if ( m_plotWidget )

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
@@ -31,7 +31,6 @@
 #include "RimEnsembleStatistics.h"
 #include "RimParameterResultCrossPlot.h"
 #include "RimRegularLegendConfig.h"
-#include "RimSummaryAddressSelector.h"
 #include "RimSummaryEnsemble.h"
 #include "RimSummaryPlot.h"
 #include "RimSummaryTimeAxisProperties.h"
@@ -43,12 +42,14 @@
 #include "RiuPlotWidget.h"
 #include "RiuQwtPlotWidget.h"
 
+#include "DockAreaTitleBar.h"
 #include "DockAreaWidget.h"
 #include "DockManager.h"
 #include "DockWidget.h"
 
 #include "cafAssert.h"
 #include "cafPdmPointer.h"
+#include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 #include "cafSelectionManager.h"
 
@@ -209,10 +210,9 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
     CAF_PDM_InitFieldNoDefault( &m_axisTitleFontSize, "AxisTitleFontSize", "Axis Title Font Size" );
     CAF_PDM_InitFieldNoDefault( &m_axisValueFontSize, "AxisValueFontSize", "Axis Value Font Size" );
 
-    CAF_PDM_InitField( &m_showSummaryPlot, "ShowSummaryPlot", true, "Show Summary Plot" );
+    CAF_PDM_InitField( &m_showDockTitleBars, "ShowDockTitleBars", false, "Show Title Bars" );
+    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_showDockTitleBars );
     CAF_PDM_InitFieldNoDefault( &m_summaryPlot, "SummaryPlot", "Summary Plot" );
-    CAF_PDM_InitFieldNoDefault( &m_summaryAddressSelector, "SummaryAddressSelector", "Summary Vector" );
-
     CAF_PDM_InitField( &m_dockState, "DockState", QString(), "Dock State" );
     m_dockState.uiCapability()->setUiHidden( true );
 
@@ -244,13 +244,6 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
     curveSet->setColor( TRACKING_ANNOTATION_COLOR );
     curveSet->statisticsOptions()->enableCurveLabels( false );
     m_summaryPlot->ensembleCurveSetCollection()->addCurveSet( curveSet );
-
-    m_summaryAddressSelector = new RimSummaryAddressSelector();
-    m_summaryAddressSelector->setShowResampling( false );
-    m_summaryAddressSelector->setShowAxis( false );
-    m_summaryAddressSelector->addressChanged.connect( this, &RimCorrelationReportPlot::onAddressSelectorChanged );
-
-    uiCapability()->setUiTreeChildrenHidden( true );
 
     m_correlationMatrixPlot->matrixCellSelected.connect( this, &RimCorrelationReportPlot::onDataSelection );
     m_correlationPlot->tornadoItemSelected.connect( this, &RimCorrelationReportPlot::onDataSelection );
@@ -398,21 +391,25 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
     }
 
     // Wrap each plot in a dock widget
-    m_matrixDockWidget = new ads::CDockWidget( "Matrix Plot", m_dockManager );
-    m_matrixDockWidget->setWidget( m_correlationMatrixPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
-    m_matrixDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+    auto makeDockWidget = [&]( const QString& title, RimPlotWindow* plot, QWidget* widget ) -> ads::CDockWidget*
+    {
+        auto* dock = new ads::CDockWidget( title, m_dockManager );
+        dock->setWidget( widget, ads::CDockWidget::ForceNoScrollArea );
+        connect( dock,
+                 &ads::CDockWidget::closed,
+                 this,
+                 [this, plot]()
+                 {
+                     plot->setShowWindow( false );
+                     updateConnectedEditors();
+                 } );
+        return dock;
+    };
 
-    m_correlationDockWidget = new ads::CDockWidget( "Correlation Plot", m_dockManager );
-    m_correlationDockWidget->setWidget( m_correlationPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
-    m_correlationDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
-
-    m_crossPlotDockWidget = new ads::CDockWidget( "Cross Plot", m_dockManager );
-    m_crossPlotDockWidget->setWidget( m_parameterResultCrossPlot->viewer(), ads::CDockWidget::ForceNoScrollArea );
-    m_crossPlotDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
-
-    m_summaryDockWidget = new ads::CDockWidget( "Summary Plot", m_dockManager );
-    m_summaryDockWidget->setWidget( m_summaryPlot->plotWidget(), ads::CDockWidget::ForceNoScrollArea );
-    m_summaryDockWidget->setFeature( ads::CDockWidget::DockWidgetClosable, false );
+    m_matrixDockWidget      = makeDockWidget( "Matrix Plot", m_correlationMatrixPlot(), m_correlationMatrixPlot->viewer() );
+    m_correlationDockWidget = makeDockWidget( "Correlation Plot", m_correlationPlot(), m_correlationPlot->viewer() );
+    m_crossPlotDockWidget   = makeDockWidget( "Cross Plot", m_parameterResultCrossPlot(), m_parameterResultCrossPlot->viewer() );
+    m_summaryDockWidget     = makeDockWidget( "Summary Plot", m_summaryPlot(), m_summaryPlot->plotWidget() );
 
     // Disable zoom — clicks are used for time step selection, not zooming
     if ( m_summaryPlot->summaryPlotWidget() ) m_summaryPlot->summaryPlotWidget()->setZoomEnabled( false );
@@ -453,9 +450,15 @@ void RimCorrelationReportPlot::recreatePlotWidgets()
         m_dockManager->addDockWidget( ads::LeftDockWidgetArea, m_matrixDockWidget );
         m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_crossPlotDockWidget, corrArea );
         m_dockManager->addDockWidget( ads::BottomDockWidgetArea, m_summaryDockWidget );
-
-        m_summaryDockWidget->toggleView( m_showSummaryPlot() );
     }
+
+    // Sync initial dock visibility from subplot enabled state
+    m_matrixDockWidget->toggleView( m_correlationMatrixPlot->showWindow() );
+    m_correlationDockWidget->toggleView( m_correlationPlot->showWindow() );
+    m_crossPlotDockWidget->toggleView( m_parameterResultCrossPlot->showWindow() );
+    m_summaryDockWidget->toggleView( m_summaryPlot()->showWindow() );
+
+    updateDockTitleBarsVisibility();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -580,23 +583,17 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
         m_correlationPlot->loadDataAndUpdate();
         m_parameterResultCrossPlot->loadDataAndUpdate();
 
-        if ( m_showSummaryPlot() )
+        if ( m_summaryPlot->showWindow() )
         {
-            if ( !m_summaryAddressSelector->ensemble() )
+            auto curveSets = m_summaryPlot->ensembleCurveSetCollection()->curveSets();
+            if ( !curveSets.empty() && !curveSets[0]->summaryEnsemble() )
             {
                 auto curveDefs = m_correlationMatrixPlot->curveDefinitions();
                 if ( !curveDefs.empty() )
                 {
-                    m_summaryAddressSelector->setEnsemble( curveDefs.front().ensemble() );
-                    m_summaryAddressSelector->setAddress( curveDefs.front().summaryAddressY() );
+                    curveSets[0]->setSummaryEnsemble( curveDefs.front().ensemble() );
+                    curveSets[0]->setSummaryAddressY( curveDefs.front().summaryAddressY() );
                 }
-            }
-
-            auto curveSets = m_summaryPlot->ensembleCurveSetCollection()->curveSets();
-            if ( !curveSets.empty() )
-            {
-                curveSets[0]->setSummaryEnsemble( m_summaryAddressSelector->ensemble() );
-                curveSets[0]->setSummaryAddressY( m_summaryAddressSelector->summaryAddress() );
             }
 
             m_summaryPlot->loadDataAndUpdate();
@@ -626,13 +623,6 @@ void RimCorrelationReportPlot::defineUiOrdering( QString uiConfigName, caf::PdmU
     auto filterGroup = uiOrdering.addNewGroup( "Filter" );
     m_parameterResultCrossPlot->appendFilterFields( *filterGroup );
 
-    auto summaryGroup = uiOrdering.addNewGroup( "Summary Plot" );
-    summaryGroup->add( &m_showSummaryPlot );
-    if ( m_showSummaryPlot() )
-    {
-        m_summaryAddressSelector->uiOrdering( "", *summaryGroup );
-    }
-
     auto plotGroup = uiOrdering.addNewGroup( "Plot Settings" );
     plotGroup->setCollapsedByDefault();
     plotGroup->add( &m_titleFontSize );
@@ -645,8 +635,9 @@ void RimCorrelationReportPlot::defineUiOrdering( QString uiConfigName, caf::PdmU
 
     auto layoutGroup = uiOrdering.addNewGroup( "Dock Layout" );
     layoutGroup->setCollapsedByDefault();
+    layoutGroup->add( &m_showDockTitleBars );
     layoutGroup->addNewButton( "Save as Default Layout", [this]() { onSaveDefaultDockLayout(); } );
-    layoutGroup->addNewButton( "Restore Default Layout", [this]() { onRestoreDefaultDockLayout(); } );
+    layoutGroup->addNewButton( "Restore Default Layout", [this]() { onRestoreDefaultDockLayout(); }, { .newRow = false } );
 
     uiOrdering.skipRemainingFields( true );
 }
@@ -654,11 +645,34 @@ void RimCorrelationReportPlot::defineUiOrdering( QString uiConfigName, caf::PdmU
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::updateDockTitleBarsVisibility()
+{
+    if ( !m_dockManager ) return;
+    for ( auto* area : m_dockManager->openedDockAreas() )
+        area->titleBar()->setVisible( m_showDockTitleBars() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationReportPlot::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName )
+{
+    uiTreeOrdering.add( m_correlationMatrixPlot() );
+    uiTreeOrdering.add( m_correlationPlot() );
+    uiTreeOrdering.add( m_parameterResultCrossPlot() );
+    uiTreeOrdering.add( m_summaryPlot() );
+    uiTreeOrdering.skipRemainingChildren();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
-    if ( changedField == &m_showSummaryPlot && m_summaryDockWidget )
+    if ( changedField == &m_showDockTitleBars )
     {
-        m_summaryDockWidget->toggleView( m_showSummaryPlot() );
+        updateDockTitleBarsVisibility();
+        return;
     }
     loadDataAndUpdate();
 }
@@ -668,6 +682,18 @@ void RimCorrelationReportPlot::fieldChangedByUi( const caf::PdmFieldHandle* chan
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField )
 {
+    // childFieldChangedByUi receives the parent field (the PdmChildField in this class),
+    // not the specific field that changed inside the child. Sync dock visibility unconditionally
+    // so toggling showWindow() in the tree view is always reflected immediately.
+    if ( m_matrixDockWidget && changedChildField == &m_correlationMatrixPlot )
+        m_matrixDockWidget->toggleView( m_correlationMatrixPlot->showWindow() );
+    else if ( m_correlationDockWidget && changedChildField == &m_correlationPlot )
+        m_correlationDockWidget->toggleView( m_correlationPlot->showWindow() );
+    else if ( m_crossPlotDockWidget && changedChildField == &m_parameterResultCrossPlot )
+        m_crossPlotDockWidget->toggleView( m_parameterResultCrossPlot->showWindow() );
+    else if ( m_summaryDockWidget && changedChildField == &m_summaryPlot )
+        m_summaryDockWidget->toggleView( m_summaryPlot->showWindow() );
+
     loadDataAndUpdate();
 }
 
@@ -693,6 +719,18 @@ void RimCorrelationReportPlot::onDataSelection( const caf::SignalEmitter*       
     m_parameterResultCrossPlot->setEnsembleParameter( paramName );
     m_parameterResultCrossPlot->loadDataAndUpdate();
 
+    if ( m_summaryPlot->showWindow() && curveDef.ensemble() )
+    {
+        auto curveSets = m_summaryPlot->ensembleCurveSetCollection()->curveSets();
+        if ( !curveSets.empty() )
+        {
+            curveSets[0]->setSummaryEnsemble( curveDef.ensemble() );
+            curveSets[0]->setSummaryAddressY( curveDef.summaryAddressY() );
+        }
+        m_summaryPlot->loadDataAndUpdate();
+        if ( m_summaryPlot->plotWidget() ) m_summaryPlot->plotWidget()->setPlotTitleEnabled( true );
+    }
+
     updateConnectedEditors();
 }
 
@@ -710,14 +748,6 @@ void RimCorrelationReportPlot::onSummaryPlotMousePressed( double xPlotCoordinate
                                 [clickedTime]( time_t a, time_t b ) { return std::abs( a - clickedTime ) < std::abs( b - clickedTime ); } );
 
     m_correlationMatrixPlot->setTimeStep( *it );
-    loadDataAndUpdate();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimCorrelationReportPlot::onAddressSelectorChanged( const caf::SignalEmitter* )
-{
     loadDataAndUpdate();
 }
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.h
@@ -27,15 +27,12 @@
 #include <QDateTime>
 #include <QObject>
 
-class RimAnalysisPlotDataEntry;
 class RimCorrelationMatrixPlot;
 class RimParameterResultCrossPlot;
 class RimSummaryEnsemble;
 class RimCorrelationPlot;
 class RiaSummaryCurveDefinition;
 class RimSummaryPlot;
-class RimSummaryAddressSelector;
-
 namespace ads
 {
 class CDockManager;
@@ -76,15 +73,16 @@ private:
     void     deleteViewWidget() override;
     void     onLoadDataAndUpdate() override;
     void     defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+    void     defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
     void     fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void     childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
     void     doUpdateLayout() override;
 
     void onDataSelection( const caf::SignalEmitter* emitter, std::pair<QString, RiaSummaryCurveDefinition> parameterAndCurveDef );
     void onSummaryPlotMousePressed( double xPlotCoordinate );
-    void onAddressSelectorChanged( const caf::SignalEmitter* emitter );
     void onSaveDefaultDockLayout();
     void onRestoreDefaultDockLayout();
+    void updateDockTitleBarsVisibility();
 
 private:
     caf::PdmProxyValueField<QString> m_name;
@@ -92,15 +90,14 @@ private:
     caf::PdmChildField<RimCorrelationMatrixPlot*>    m_correlationMatrixPlot;
     caf::PdmChildField<RimCorrelationPlot*>          m_correlationPlot;
     caf::PdmChildField<RimParameterResultCrossPlot*> m_parameterResultCrossPlot;
-    RimFontSizeField                                 m_subTitleFontSize;
-    RimFontSizeField                                 m_labelFontSize;
-    RimFontSizeField                                 m_axisTitleFontSize;
-    RimFontSizeField                                 m_axisValueFontSize;
+    caf::PdmChildField<RimSummaryPlot*>              m_summaryPlot;
 
-    caf::PdmField<bool>                            m_showSummaryPlot;
-    caf::PdmChildField<RimSummaryPlot*>            m_summaryPlot;
-    caf::PdmChildField<RimSummaryAddressSelector*> m_summaryAddressSelector;
+    RimFontSizeField m_subTitleFontSize;
+    RimFontSizeField m_labelFontSize;
+    RimFontSizeField m_axisTitleFontSize;
+    RimFontSizeField m_axisValueFontSize;
 
+    caf::PdmField<bool>    m_showDockTitleBars;
     caf::PdmField<QString> m_dockState;
 
     QWidget*           m_viewWidget            = nullptr;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
@@ -656,7 +656,7 @@ private:
         // Accept if within 3% of the total axis range
         if ( closestCase && minDist < 0.03 * 0.03 )
         {
-            RiuDockWidgetTools::selectItemInTreeView( RiuDockWidgetTools::plotMainWindowDataSourceTreeName(), { closestCase } );
+            RiuDockWidgetTools::selectItemsInTreeView( RiuDockWidgetTools::plotMainWindowDataSourceTreeName(), { closestCase } );
         }
     }
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
@@ -47,9 +47,11 @@
 #include "qwt_plot_curve.h"
 #include "qwt_plot_marker.h"
 #include "qwt_plot_picker.h"
+#include "qwt_scale_map.h"
 #include "qwt_text.h"
 
 #include <QColor>
+#include <QMouseEvent>
 #include <QStringList>
 
 #include <limits>
@@ -597,6 +599,70 @@ protected:
         return QwtText();
     }
 };
+class CurveSelectorFilter : public QObject
+{
+public:
+    CurveSelectorFilter( QwtPlot* plot, RimParameterResultCrossPlot* crossPlot )
+        : QObject( plot->canvas() )
+        , m_plot( plot )
+        , m_crossPlot( crossPlot )
+    {
+        plot->canvas()->installEventFilter( this );
+    }
+
+protected:
+    bool eventFilter( QObject*, QEvent* event ) override
+    {
+        if ( event->type() == QEvent::MouseButtonPress )
+        {
+            auto* mouseEvent = static_cast<QMouseEvent*>( event );
+            if ( mouseEvent->button() == Qt::LeftButton )
+            {
+                selectClosestCase( mouseEvent->pos() );
+            }
+        }
+        return false;
+    }
+
+private:
+    void selectClosestCase( const QPoint& pixelPos )
+    {
+        const auto xMap = m_plot->canvasMap( QwtAxis::XBottom );
+        const auto yMap = m_plot->canvasMap( QwtAxis::YLeft );
+
+        const double clickX = xMap.invTransform( pixelPos.x() );
+        const double clickY = yMap.invTransform( pixelPos.y() );
+
+        // Normalise by axis range to get a dimensionless distance
+        const double xRange = std::abs( xMap.s2() - xMap.s1() );
+        const double yRange = std::abs( yMap.s2() - yMap.s1() );
+        if ( xRange == 0.0 || yRange == 0.0 ) return;
+
+        double          minDist     = std::numeric_limits<double>::max();
+        RimSummaryCase* closestCase = nullptr;
+
+        for ( const auto& [paramValue, summaryValue, summaryCase] : m_crossPlot->createCaseData() )
+        {
+            const double dx   = ( paramValue - clickX ) / xRange;
+            const double dy   = ( summaryValue - clickY ) / yRange;
+            const double dist = dx * dx + dy * dy;
+            if ( dist < minDist )
+            {
+                minDist     = dist;
+                closestCase = summaryCase;
+            }
+        }
+
+        // Accept if within 3% of the total axis range
+        if ( closestCase && minDist < 0.03 * 0.03 )
+        {
+            RiuDockWidgetTools::selectItemInTreeView( RiuDockWidgetTools::plotMainWindowDataSourceTreeName(), { closestCase } );
+        }
+    }
+
+    QwtPlot*                     m_plot      = nullptr;
+    RimParameterResultCrossPlot* m_crossPlot = nullptr;
+};
 } // namespace internal
 
 //--------------------------------------------------------------------------------------------------
@@ -619,6 +685,9 @@ RiuPlotWidget* RimParameterResultCrossPlot::doCreatePlotViewWidget( QWidget* mai
     {
         // Add a curve tracker to display the name of the realization when mouse is close to a sample in the cross plot
         new internal::CurveTracker( m_plotWidget->qwtPlot() );
+
+        // Add a click filter to select the realization in the tree view when a point is clicked
+        new internal::CurveSelectorFilter( m_plotWidget->qwtPlot(), this );
     }
 
     return m_plotWidget;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.h
@@ -42,6 +42,15 @@ public:
     std::vector<RimSummaryCase*> summaryCasesExcludedByFilter() const;
     void                         appendFilterFields( caf::PdmUiOrdering& uiOrdering );
 
+    struct CaseData
+    {
+        double          parameterValue;
+        double          summaryValue;
+        RimSummaryCase* summaryCase;
+    };
+
+    std::vector<CaseData> createCaseData() const;
+
     void detachAllCurves() override;
 
 private:
@@ -62,15 +71,6 @@ private:
     void updateFilterRanges();
 
     QString excludedCasesText() const;
-
-    struct CaseData
-    {
-        double          parameterValue;
-        double          summaryValue;
-        RimSummaryCase* summaryCase;
-    };
-
-    std::vector<CaseData> createCaseData() const;
 
     size_t hashFromCurrentData() const;
     void   writeDataToCache();

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/ObservedDataParser-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/EclipseRftReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicExpressionParser-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiuQwtLinearScaleEngine-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuSummaryVectorDescriptionMap-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FixedWidthDataParser-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigTimeCurveHistoryMerger-Test.cpp

--- a/ApplicationLibCode/UnitTests/RiuQwtLinearScaleEngine-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiuQwtLinearScaleEngine-Test.cpp
@@ -1,0 +1,95 @@
+#include "gtest/gtest.h"
+
+#include "RiuQwtLinearScaleEngine.h"
+
+#include "qwt_scale_div.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiuQwtLinearScaleEngine, DivideScaleWithExplicitIntervals_NormalCase )
+{
+    RiuQwtLinearScaleEngine engine;
+
+    // Range 0..10 with major step 2 and minor step 1
+    QwtScaleDiv scaleDiv = engine.divideScaleWithExplicitIntervals( 0.0, 10.0, 2.0, 1.0 );
+
+    EXPECT_DOUBLE_EQ( scaleDiv.lowerBound(), 0.0 );
+    EXPECT_DOUBLE_EQ( scaleDiv.upperBound(), 10.0 );
+
+    const QList<double>& majorTicks = scaleDiv.ticks( QwtScaleDiv::MajorTick );
+    EXPECT_EQ( majorTicks.size(), 6 ); // 0, 2, 4, 6, 8, 10
+
+    const QList<double>& minorTicks = scaleDiv.ticks( QwtScaleDiv::MinorTick );
+    EXPECT_EQ( minorTicks.size(), 11 ); // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiuQwtLinearScaleEngine, DivideScaleWithExplicitIntervals_ZeroMajorStep )
+{
+    RiuQwtLinearScaleEngine engine;
+
+    // Zero major step should produce no major ticks (guard against division by zero)
+    QwtScaleDiv scaleDiv = engine.divideScaleWithExplicitIntervals( 0.0, 10.0, 0.0, 1.0 );
+
+    const QList<double>& majorTicks = scaleDiv.ticks( QwtScaleDiv::MajorTick );
+    EXPECT_TRUE( majorTicks.isEmpty() );
+
+    // Minor ticks should still be built
+    const QList<double>& minorTicks = scaleDiv.ticks( QwtScaleDiv::MinorTick );
+    EXPECT_FALSE( minorTicks.isEmpty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiuQwtLinearScaleEngine, DivideScaleWithExplicitIntervals_ZeroMinorStep )
+{
+    RiuQwtLinearScaleEngine engine;
+
+    // Zero minor step should produce no minor ticks (guard against division by zero)
+    QwtScaleDiv scaleDiv = engine.divideScaleWithExplicitIntervals( 0.0, 10.0, 2.0, 0.0 );
+
+    const QList<double>& minorTicks = scaleDiv.ticks( QwtScaleDiv::MinorTick );
+    EXPECT_TRUE( minorTicks.isEmpty() );
+
+    // Major ticks should still be built
+    const QList<double>& majorTicks = scaleDiv.ticks( QwtScaleDiv::MajorTick );
+    EXPECT_FALSE( majorTicks.isEmpty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiuQwtLinearScaleEngine, DivideScaleWithExplicitIntervalsAndRange_RangeDiffersFromTickInterval )
+{
+    RiuQwtLinearScaleEngine engine;
+
+    // Ticks cover 0..10, but the displayed range is -2..12
+    QwtScaleDiv scaleDiv = engine.divideScaleWithExplicitIntervalsAndRange( 0.0, 10.0, 2.0, 1.0, -2.0, 12.0 );
+
+    EXPECT_DOUBLE_EQ( scaleDiv.lowerBound(), -2.0 );
+    EXPECT_DOUBLE_EQ( scaleDiv.upperBound(), 12.0 );
+
+    const QList<double>& majorTicks = scaleDiv.ticks( QwtScaleDiv::MajorTick );
+    EXPECT_EQ( majorTicks.size(), 6 ); // 0, 2, 4, 6, 8, 10
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiuQwtLinearScaleEngine, DivideScaleWithExplicitIntervalsAndRange_ZeroStepIntervals )
+{
+    RiuQwtLinearScaleEngine engine;
+
+    // Both step intervals zero — no ticks should be built
+    QwtScaleDiv scaleDiv = engine.divideScaleWithExplicitIntervalsAndRange( 0.0, 10.0, 0.0, 0.0, 0.0, 10.0 );
+
+    const QList<double>& majorTicks = scaleDiv.ticks( QwtScaleDiv::MajorTick );
+    EXPECT_TRUE( majorTicks.isEmpty() );
+
+    const QList<double>& minorTicks = scaleDiv.ticks( QwtScaleDiv::MinorTick );
+    EXPECT_TRUE( minorTicks.isEmpty() );
+}

--- a/ApplicationLibCode/UserInterface/RiuDockWidgetTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuDockWidgetTools.cpp
@@ -447,6 +447,34 @@ std::vector<caf::PdmUiItem*> RiuDockWidgetTools::selectedItemsInTreeView( const 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RiuDockWidgetTools::selectItemInTreeView( const QString& dockWidgetName, const std::vector<const caf::PdmUiItem*>& items )
+{
+    ads::CDockWidget* dockWidget = nullptr;
+    if ( auto mainWindow = RiuMainWindow::instance() )
+    {
+        dockWidget = RiuDockWidgetTools::findDockWidget( mainWindow->dockManager(), dockWidgetName );
+    }
+
+    if ( !dockWidget )
+    {
+        if ( auto plotWindow = RiuPlotMainWindow::instance() )
+        {
+            dockWidget = RiuDockWidgetTools::findDockWidget( plotWindow->dockManager(), dockWidgetName );
+        }
+    }
+
+    if ( dockWidget )
+    {
+        if ( auto tree = dynamic_cast<caf::PdmUiTreeView*>( dockWidget->widget() ) )
+        {
+            tree->selectItems( items );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 QByteArray RiuDockWidgetTools::defaultDockState( const QString& layoutName )
 {
     if ( layoutName == dockState3DEclipseName() )

--- a/ApplicationLibCode/UserInterface/RiuDockWidgetTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuDockWidgetTools.cpp
@@ -447,7 +447,7 @@ std::vector<caf::PdmUiItem*> RiuDockWidgetTools::selectedItemsInTreeView( const 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RiuDockWidgetTools::selectItemInTreeView( const QString& dockWidgetName, const std::vector<const caf::PdmUiItem*>& items )
+void RiuDockWidgetTools::selectItemsInTreeView( const QString& dockWidgetName, const std::vector<const caf::PdmUiItem*>& items )
 {
     ads::CDockWidget* dockWidget = nullptr;
     if ( auto mainWindow = RiuMainWindow::instance() )

--- a/ApplicationLibCode/UserInterface/RiuDockWidgetTools.h
+++ b/ApplicationLibCode/UserInterface/RiuDockWidgetTools.h
@@ -102,7 +102,7 @@ public:
     static QIcon dockIcon( const QString dockWidgetName );
 
     static std::vector<caf::PdmUiItem*> selectedItemsInTreeView( const QString& dockWidgetName );
-    static void selectItemInTreeView( const QString& dockWidgetName, const std::vector<const caf::PdmUiItem*>& items );
+    static void selectItemsInTreeView( const QString& dockWidgetName, const std::vector<const caf::PdmUiItem*>& items );
 
 private:
     static QByteArray defaultEclipseDockState();

--- a/ApplicationLibCode/UserInterface/RiuDockWidgetTools.h
+++ b/ApplicationLibCode/UserInterface/RiuDockWidgetTools.h
@@ -102,6 +102,7 @@ public:
     static QIcon dockIcon( const QString dockWidgetName );
 
     static std::vector<caf::PdmUiItem*> selectedItemsInTreeView( const QString& dockWidgetName );
+    static void selectItemInTreeView( const QString& dockWidgetName, const std::vector<const caf::PdmUiItem*>& items );
 
 private:
     static QByteArray defaultEclipseDockState();

--- a/ApplicationLibCode/UserInterface/RiuQwtLinearScaleEngine.cpp
+++ b/ApplicationLibCode/UserInterface/RiuQwtLinearScaleEngine.cpp
@@ -27,8 +27,21 @@ QwtScaleDiv RiuQwtLinearScaleEngine::divideScaleWithExplicitIntervals( double x1
 {
     QwtInterval   interval( x1, x2 );
     QwtInterval   roundedInterval = align( interval, majorStepInterval );
-    QList<double> majorTicks      = buildMajorTicks( roundedInterval, majorStepInterval );
-    QList<double> minorTicks      = buildMajorTicks( roundedInterval, minorStepInterval );
+    QList<double> majorTicks;
+
+    // Only build major ticks if the interval is non-zero to avoid division by zero
+    if ( majorStepInterval > 0.0 )
+    {
+        majorTicks = buildMajorTicks( roundedInterval, majorStepInterval );
+    }
+
+    QList<double> minorTicks;
+
+    // Only build minor ticks if the interval is non-zero to avoid division by zero
+    if ( minorStepInterval > 0.0 )
+    {
+        minorTicks = buildMajorTicks( roundedInterval, minorStepInterval );
+    }
 
     return QwtScaleDiv( x1, x2, minorTicks, minorTicks, majorTicks );
 }
@@ -44,8 +57,21 @@ QwtScaleDiv RiuQwtLinearScaleEngine::divideScaleWithExplicitIntervalsAndRange( d
                                                                                double rangeEnd )
 {
     QwtInterval   tickInterval( tickStart, tickEnd );
-    QList<double> majorTicks = buildMajorTicks( tickInterval, majorStepInterval );
-    QList<double> minorTicks = buildMajorTicks( tickInterval, minorStepInterval );
+    QList<double> majorTicks;
+
+    // Only build major ticks if the interval is non-zero to avoid division by zero
+    if ( majorStepInterval > 0.0 )
+    {
+        majorTicks = buildMajorTicks( tickInterval, majorStepInterval );
+    }
+
+    QList<double> minorTicks;
+
+    // Only build minor ticks if the interval is non-zero to avoid division by zero
+    if ( minorStepInterval > 0.0 )
+    {
+        minorTicks = buildMajorTicks( tickInterval, minorStepInterval );
+    }
 
     return QwtScaleDiv( rangeStart, rangeEnd, minorTicks, minorTicks, majorTicks );
 }


### PR DESCRIPTION
Closes #13845

## Changes

### Click-to-select realization in Parameter/Result Cross Plot
- Installs a mouse event filter on the cross plot canvas (`CurveSelectorFilter`)
- On left-click, finds the nearest data point using normalised axis-range distance and selects the corresponding `RimSummaryCase` in the plot data source tree view
- Adds `RiuDockWidgetTools::selectItemInTreeView()` helper to locate the tree view dock and drive the selection

### Improved subplot visibility control in Correlation Report Plot
- Exposes the four sub-plots as children in the project tree via `defineUiTreeOrdering`; their eye-icon visibility toggles map to dock show/hide via `childFieldChangedByUi`
- Dock `closed` signal feeds back to `plot->setShowWindow(false)` to keep model and UI in sync
- Adds "Show Title Bars" checkbox (`m_showDockTitleBars`) to the Dock Layout settings group
- Removes `RimSummaryAddressSelector` — the summary plot address is now driven directly from the ensemble curve set
- Renames matrix plot auto-title to "Pearson Correlation – …"