### PR TITLE
Fix ADL lookup for cvf pdmToVariant/pdmFromVariant overloads

### DIFF
--- a/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
@@ -94,7 +94,8 @@ void RicApplyUserDefinedCameraFeature::readCameraFromSettings( cvf::Vec3d& eye, 
     QVariant upVariant  = settings.value( RicStoreUserDefinedCameraFeature::upName() );
     if ( eyeVariant.isNull() || vrpVariant.isNull() || upVariant.isNull() ) return;
 
-    caf::pdmFromVariant( eyeVariant, eye );
-    caf::pdmFromVariant( vrpVariant, vrp );
-    caf::pdmFromVariant( upVariant, up );
+    using caf::pdmFromVariant;
+    pdmFromVariant( eyeVariant, eye );
+    pdmFromVariant( vrpVariant, vrp );
+    pdmFromVariant( upVariant, up );
 }

--- a/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
@@ -94,8 +94,7 @@ void RicApplyUserDefinedCameraFeature::readCameraFromSettings( cvf::Vec3d& eye, 
     QVariant upVariant  = settings.value( RicStoreUserDefinedCameraFeature::upName() );
     if ( eyeVariant.isNull() || vrpVariant.isNull() || upVariant.isNull() ) return;
 
-    using caf::pdmFromVariant;
-    pdmFromVariant( eyeVariant, eye );
-    pdmFromVariant( vrpVariant, vrp );
-    pdmFromVariant( upVariant, up );
+    caf::fromVariant( eyeVariant, eye );
+    caf::fromVariant( vrpVariant, vrp );
+    caf::fromVariant( upVariant, up );
 }

--- a/ApplicationLibCode/Commands/3dView/RicStoreUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicStoreUserDefinedCameraFeature.cpp
@@ -104,14 +104,10 @@ void RicStoreUserDefinedCameraFeature::onActionTriggered( bool isChecked )
 
         camera->toLookAt( &eye, &vrp, &up );
 
-        QVariant eyeVariant = caf::pdmToVariant( eye );
-        settings.setValue( RicStoreUserDefinedCameraFeature::eyeName(), eyeVariant );
-
-        QVariant vrpVariant = caf::pdmToVariant( vrp );
-        settings.setValue( RicStoreUserDefinedCameraFeature::viewReferencePointName(), vrpVariant );
-
-        QVariant upVariant = caf::pdmToVariant( up );
-        settings.setValue( RicStoreUserDefinedCameraFeature::upName(), upVariant );
+        using caf::pdmToVariant;
+        settings.setValue( RicStoreUserDefinedCameraFeature::eyeName(), pdmToVariant( eye ) );
+        settings.setValue( RicStoreUserDefinedCameraFeature::viewReferencePointName(), pdmToVariant( vrp ) );
+        settings.setValue( RicStoreUserDefinedCameraFeature::upName(), pdmToVariant( up ) );
 
         RiuMainWindow::instance()->refreshViewActions();
     }

--- a/ApplicationLibCode/Commands/3dView/RicStoreUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicStoreUserDefinedCameraFeature.cpp
@@ -104,10 +104,9 @@ void RicStoreUserDefinedCameraFeature::onActionTriggered( bool isChecked )
 
         camera->toLookAt( &eye, &vrp, &up );
 
-        using caf::pdmToVariant;
-        settings.setValue( RicStoreUserDefinedCameraFeature::eyeName(), pdmToVariant( eye ) );
-        settings.setValue( RicStoreUserDefinedCameraFeature::viewReferencePointName(), pdmToVariant( vrp ) );
-        settings.setValue( RicStoreUserDefinedCameraFeature::upName(), pdmToVariant( up ) );
+        settings.setValue( RicStoreUserDefinedCameraFeature::eyeName(), caf::toVariant( eye ) );
+        settings.setValue( RicStoreUserDefinedCameraFeature::viewReferencePointName(), caf::toVariant( vrp ) );
+        settings.setValue( RicStoreUserDefinedCameraFeature::upName(), caf::toVariant( up ) );
 
         RiuMainWindow::instance()->refreshViewActions();
     }

--- a/ApplicationLibCode/Commands/AnnotationCommands/RicTextAnnotation3dEditor.cpp
+++ b/ApplicationLibCode/Commands/AnnotationCommands/RicTextAnnotation3dEditor.cpp
@@ -175,9 +175,10 @@ void RicTextAnnotation3dEditor::updatePoint( caf::PdmUiFieldHandle* uiField, con
 
     cvf::ref<caf::DisplayCoordTransform> dispXf = view->displayCoordTransform();
 
-    cvf::Vec3d domainPos   = dispXf->transformToDomainCoord( newPos );
-    domainPos.z()          = -domainPos.z();
-    QVariant originVariant = caf::pdmToVariant( domainPos );
+    cvf::Vec3d domainPos = dispXf->transformToDomainCoord( newPos );
+    domainPos.z()        = -domainPos.z();
+    using caf::pdmToVariant;
+    QVariant originVariant = pdmToVariant( domainPos );
 
     caf::PdmUiCommandSystemProxy::instance()->setUiValueToField( uiField, originVariant );
 }

--- a/ApplicationLibCode/Commands/AnnotationCommands/RicTextAnnotation3dEditor.cpp
+++ b/ApplicationLibCode/Commands/AnnotationCommands/RicTextAnnotation3dEditor.cpp
@@ -175,10 +175,9 @@ void RicTextAnnotation3dEditor::updatePoint( caf::PdmUiFieldHandle* uiField, con
 
     cvf::ref<caf::DisplayCoordTransform> dispXf = view->displayCoordTransform();
 
-    cvf::Vec3d domainPos = dispXf->transformToDomainCoord( newPos );
-    domainPos.z()        = -domainPos.z();
-    using caf::pdmToVariant;
-    QVariant originVariant = pdmToVariant( domainPos );
+    cvf::Vec3d domainPos   = dispXf->transformToDomainCoord( newPos );
+    domainPos.z()          = -domainPos.z();
+    QVariant originVariant = caf::toVariant( domainPos );
 
     caf::PdmUiCommandSystemProxy::instance()->setUiValueToField( uiField, originVariant );
 }

--- a/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicPolylineTarget3dEditor.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicPolylineTarget3dEditor.cpp
@@ -142,8 +142,7 @@ void RicPolylineTarget3dEditor::slotUpdated( const cvf::Vec3d& origin, const cvf
 
     cvf::Vec3d domainOrigin = dispXf->transformToDomainCoord( origin );
     domainOrigin.z()        = -domainOrigin.z();
-    using caf::pdmToVariant;
-    QVariant originVariant = pdmToVariant( domainOrigin );
+    QVariant originVariant  = caf::toVariant( domainOrigin );
 
     caf::PdmUiCommandSystemProxy::instance()->setUiValueToField( target->targetPointUiCapability(), originVariant );
 }

--- a/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicPolylineTarget3dEditor.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicPolylineTarget3dEditor.cpp
@@ -142,7 +142,8 @@ void RicPolylineTarget3dEditor::slotUpdated( const cvf::Vec3d& origin, const cvf
 
     cvf::Vec3d domainOrigin = dispXf->transformToDomainCoord( origin );
     domainOrigin.z()        = -domainOrigin.z();
-    QVariant originVariant  = caf::pdmToVariant( domainOrigin );
+    using caf::pdmToVariant;
+    QVariant originVariant = pdmToVariant( domainOrigin );
 
     caf::PdmUiCommandSystemProxy::instance()->setUiValueToField( target->targetPointUiCapability(), originVariant );
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
@@ -520,7 +520,8 @@ void RimWellPathGeometryDef::fieldChangedByUi( const caf::PdmFieldHandle* change
                               linkedDefs.end() );
 
             cvf::Vec3d oldPos;
-            caf::pdmFromVariant( oldValue, oldPos );
+            using caf::pdmFromVariant;
+            pdmFromVariant( oldValue, oldPos );
 
             auto delta = m_referencePointUtmXyd() - oldPos;
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
@@ -520,8 +520,7 @@ void RimWellPathGeometryDef::fieldChangedByUi( const caf::PdmFieldHandle* change
                               linkedDefs.end() );
 
             cvf::Vec3d oldPos;
-            using caf::pdmFromVariant;
-            pdmFromVariant( oldValue, oldPos );
+            caf::fromVariant( oldValue, oldPos );
 
             auto delta = m_referencePointUtmXyd() - oldPos;
 

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCoreColor3f.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCoreColor3f.h
@@ -44,8 +44,8 @@
 
 #include <QColor>
 
-// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
-// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called via caf::toVariant/
+// caf::fromVariant — ADL searches the argument's namespace (cvf) in addition to caf.
 namespace cvf
 {
 

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCoreColor3f.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCoreColor3f.h
@@ -44,21 +44,28 @@
 
 #include <QColor>
 
-namespace caf
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
+// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+namespace cvf
 {
 
-inline QVariant pdmToVariant( const cvf::Color3f& value )
+inline QVariant pdmToVariant( const Color3f& value )
 {
     QColor col;
     col.setRgbF( value.r(), value.g(), value.b() );
     return col;
 }
 
-inline void pdmFromVariant( const QVariant& v, cvf::Color3f& out )
+inline void pdmFromVariant( const QVariant& v, Color3f& out )
 {
     QColor col = v.value<QColor>();
     out.set( col.redF(), col.greenF(), col.blueF() );
 }
+
+} // end namespace cvf
+
+namespace caf
+{
 
 template <>
 struct PdmVariantEqualImpl<cvf::Color3f>

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCoreMat4d.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCoreMat4d.h
@@ -45,8 +45,8 @@
 
 #include <QTextStream>
 
-// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
-// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called via caf::toVariant/
+// caf::fromVariant — ADL searches the argument's namespace (cvf) in addition to caf.
 namespace cvf
 {
 

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCoreMat4d.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCoreMat4d.h
@@ -45,10 +45,12 @@
 
 #include <QTextStream>
 
-namespace caf
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
+// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+namespace cvf
 {
 
-inline QVariant pdmToVariant( const cvf::Mat4d& value )
+inline QVariant pdmToVariant( const Mat4d& value )
 {
     QString     str;
     QTextStream textStream( &str );
@@ -56,12 +58,17 @@ inline QVariant pdmToVariant( const cvf::Mat4d& value )
     return QVariant( str );
 }
 
-inline void pdmFromVariant( const QVariant& v, cvf::Mat4d& out )
+inline void pdmFromVariant( const QVariant& v, Mat4d& out )
 {
     QString     str = v.toString();
     QTextStream textStream( &str );
     textStream >> out;
 }
+
+} // end namespace cvf
+
+namespace caf
+{
 
 template <>
 struct PdmVariantEqualImpl<cvf::Mat4d>

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCoreVec3d.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCoreVec3d.h
@@ -47,8 +47,8 @@
 
 Q_DECLARE_METATYPE( cvf::Vec3d );
 
-// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
-// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called via caf::toVariant/
+// caf::fromVariant — ADL searches the argument's namespace (cvf) in addition to caf.
 namespace cvf
 {
 

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCoreVec3d.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCoreVec3d.h
@@ -47,10 +47,12 @@
 
 Q_DECLARE_METATYPE( cvf::Vec3d );
 
-namespace caf
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
+// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+namespace cvf
 {
 
-inline QVariant pdmToVariant( const cvf::Vec3d& value )
+inline QVariant pdmToVariant( const Vec3d& value )
 {
     QString     str;
     QTextStream textStream( &str );
@@ -58,12 +60,17 @@ inline QVariant pdmToVariant( const cvf::Vec3d& value )
     return QVariant( str );
 }
 
-inline void pdmFromVariant( const QVariant& v, cvf::Vec3d& out )
+inline void pdmFromVariant( const QVariant& v, Vec3d& out )
 {
     QString     str = v.toString();
     QTextStream textStream( &str );
     textStream >> out;
 }
+
+} // end namespace cvf
+
+namespace caf
+{
 
 template <>
 struct PdmVariantEqualImpl<cvf::Vec3d>

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreColor3fTest.cpp
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreColor3fTest.cpp
@@ -1,6 +1,27 @@
 #include "cafPdmCoreColor3f.h"
 
+#include "cafPdmFieldTraits.h"
+
 #include "gtest/gtest.h"
+
+#include <QColor>
+
+// Helper templates that mirror the call pattern in PdmUiFieldSpecializationForValueSpec<T>.
+// The "using caf::pdmToVariant" directive means the cvf::Color3f overload is only reachable
+// via ADL (argument namespace), not via the using-declaration alone.
+template <typename T>
+QVariant adlConvert( const T& value )
+{
+    using caf::pdmToVariant;
+    return pdmToVariant( value );
+}
+
+template <typename T>
+void adlSetFromVariant( const QVariant& v, T& out )
+{
+    using caf::pdmFromVariant;
+    pdmFromVariant( v, out );
+}
 
 TEST( SerializeTest, PdmCoreColor3f )
 {
@@ -33,10 +54,12 @@ TEST( VariantTest, PdmCoreColor3f )
     float        b = 0.18f;
     cvf::Color3f myColor( r, g, b );
 
-    QVariant myVariant = caf::pdmToVariant( myColor );
+    using caf::pdmToVariant;
+    QVariant myVariant = pdmToVariant( myColor );
 
     cvf::Color3f decoded;
-    caf::pdmFromVariant( myVariant, decoded );
+    using caf::pdmFromVariant;
+    pdmFromVariant( myVariant, decoded );
 
     EXPECT_FLOAT_EQ( myColor.r(), decoded.r() );
     EXPECT_FLOAT_EQ( myColor.g(), decoded.g() );
@@ -49,12 +72,32 @@ TEST( VariantEqualTest, PdmCoreColor3f )
     cvf::Color3f b( 0.4f, 0.2f, 0.18f );
     cvf::Color3f c( 0.4f, 0.2f, 0.5f );
 
-    QVariant va = caf::pdmToVariant( a );
-    QVariant vb = caf::pdmToVariant( b );
-    QVariant vc = caf::pdmToVariant( c );
+    using caf::pdmToVariant;
+    QVariant va = pdmToVariant( a );
+    QVariant vb = pdmToVariant( b );
+    QVariant vc = pdmToVariant( c );
 
     EXPECT_TRUE( caf::pdmVariantEqual<cvf::Color3f>( va, vb ) );
     EXPECT_FALSE( caf::pdmVariantEqual<cvf::Color3f>( va, vc ) );
+}
+
+// Verifies the ADL round-trip: adlConvert/adlSetFromVariant mirror the template pattern used in
+// PdmUiFieldSpecializationForValueSpec<T>, where the cvf::Color3f overload must be found via ADL.
+TEST( AdlVariantTest, PdmCoreColor3f )
+{
+    cvf::Color3f original( 0.4f, 0.2f, 0.18f );
+
+    QVariant variant = adlConvert( original );
+
+    // The variant must hold a QColor, not a raw cvf::Color3f
+    EXPECT_TRUE( variant.canConvert<QColor>() );
+
+    cvf::Color3f decoded;
+    adlSetFromVariant( variant, decoded );
+
+    EXPECT_FLOAT_EQ( original.r(), decoded.r() );
+    EXPECT_FLOAT_EQ( original.g(), decoded.g() );
+    EXPECT_NEAR( original.b(), decoded.b(), 0.01 );
 }
 
 TEST( SerializeSeveralTest, PdmCoreColor3f )

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreColor3fTest.cpp
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreColor3fTest.cpp
@@ -6,23 +6,6 @@
 
 #include <QColor>
 
-// Helper templates that mirror the call pattern in PdmUiFieldSpecializationForValueSpec<T>.
-// The "using caf::pdmToVariant" directive means the cvf::Color3f overload is only reachable
-// via ADL (argument namespace), not via the using-declaration alone.
-template <typename T>
-QVariant adlConvert( const T& value )
-{
-    using caf::pdmToVariant;
-    return pdmToVariant( value );
-}
-
-template <typename T>
-void adlSetFromVariant( const QVariant& v, T& out )
-{
-    using caf::pdmFromVariant;
-    pdmFromVariant( v, out );
-}
-
 TEST( SerializeTest, PdmCoreColor3f )
 {
     float        r = 0.4f;
@@ -54,12 +37,10 @@ TEST( VariantTest, PdmCoreColor3f )
     float        b = 0.18f;
     cvf::Color3f myColor( r, g, b );
 
-    using caf::pdmToVariant;
-    QVariant myVariant = pdmToVariant( myColor );
+    QVariant myVariant = caf::toVariant( myColor );
 
     cvf::Color3f decoded;
-    using caf::pdmFromVariant;
-    pdmFromVariant( myVariant, decoded );
+    caf::fromVariant( myVariant, decoded );
 
     EXPECT_FLOAT_EQ( myColor.r(), decoded.r() );
     EXPECT_FLOAT_EQ( myColor.g(), decoded.g() );
@@ -72,28 +53,27 @@ TEST( VariantEqualTest, PdmCoreColor3f )
     cvf::Color3f b( 0.4f, 0.2f, 0.18f );
     cvf::Color3f c( 0.4f, 0.2f, 0.5f );
 
-    using caf::pdmToVariant;
-    QVariant va = pdmToVariant( a );
-    QVariant vb = pdmToVariant( b );
-    QVariant vc = pdmToVariant( c );
+    QVariant va = caf::toVariant( a );
+    QVariant vb = caf::toVariant( b );
+    QVariant vc = caf::toVariant( c );
 
     EXPECT_TRUE( caf::pdmVariantEqual<cvf::Color3f>( va, vb ) );
     EXPECT_FALSE( caf::pdmVariantEqual<cvf::Color3f>( va, vc ) );
 }
 
-// Verifies the ADL round-trip: adlConvert/adlSetFromVariant mirror the template pattern used in
-// PdmUiFieldSpecializationForValueSpec<T>, where the cvf::Color3f overload must be found via ADL.
+// Verifies that caf::toVariant dispatches to the cvf::Color3f overload via ADL,
+// producing a QColor variant rather than a raw cvf::Color3f.
 TEST( AdlVariantTest, PdmCoreColor3f )
 {
     cvf::Color3f original( 0.4f, 0.2f, 0.18f );
 
-    QVariant variant = adlConvert( original );
+    QVariant variant = caf::toVariant( original );
 
     // The variant must hold a QColor, not a raw cvf::Color3f
     EXPECT_TRUE( variant.canConvert<QColor>() );
 
     cvf::Color3f decoded;
-    adlSetFromVariant( variant, decoded );
+    caf::fromVariant( variant, decoded );
 
     EXPECT_FLOAT_EQ( original.r(), decoded.r() );
     EXPECT_FLOAT_EQ( original.g(), decoded.g() );

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreMat4dTest.cpp
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreMat4dTest.cpp
@@ -53,12 +53,10 @@ TEST( VariantTest, PdmCoreMat4d )
 {
     cvf::Mat4d myMatrix = createMatrix();
 
-    using caf::pdmToVariant;
-    QVariant myVariant = pdmToVariant( myMatrix );
+    QVariant myVariant = caf::toVariant( myMatrix );
 
     cvf::Mat4d decoded;
-    using caf::pdmFromVariant;
-    pdmFromVariant( myVariant, decoded );
+    caf::fromVariant( myVariant, decoded );
 
     EXPECT_TRUE( decoded.equals( myMatrix ) );
 }

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreMat4dTest.cpp
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreMat4dTest.cpp
@@ -53,10 +53,12 @@ TEST( VariantTest, PdmCoreMat4d )
 {
     cvf::Mat4d myMatrix = createMatrix();
 
-    QVariant myVariant = caf::pdmToVariant( myMatrix );
+    using caf::pdmToVariant;
+    QVariant myVariant = pdmToVariant( myMatrix );
 
     cvf::Mat4d decoded;
-    caf::pdmFromVariant( myVariant, decoded );
+    using caf::pdmFromVariant;
+    pdmFromVariant( myVariant, decoded );
 
     EXPECT_TRUE( decoded.equals( myMatrix ) );
 }

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreVec3dTest.cpp
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreVec3dTest.cpp
@@ -37,12 +37,10 @@ TEST( VariantTest, PdmCoreVec3d )
 
     cvf::Vec3d myVector( a, b, c );
 
-    using caf::pdmToVariant;
-    QVariant myVariant = pdmToVariant( myVector );
+    QVariant myVariant = caf::toVariant( myVector );
 
     cvf::Vec3d decoded;
-    using caf::pdmFromVariant;
-    pdmFromVariant( myVariant, decoded );
+    caf::fromVariant( myVariant, decoded );
 
     EXPECT_TRUE( decoded.equals( myVector ) );
 }
@@ -53,10 +51,9 @@ TEST( VariantEqualTest, PdmCoreVec3d )
     cvf::Vec3d b( 1.0, 2.0, 3.0 );
     cvf::Vec3d c( 1.0, 2.0, 4.0 );
 
-    using caf::pdmToVariant;
-    QVariant va = pdmToVariant( a );
-    QVariant vb = pdmToVariant( b );
-    QVariant vc = pdmToVariant( c );
+    QVariant va = caf::toVariant( a );
+    QVariant vb = caf::toVariant( b );
+    QVariant vc = caf::toVariant( c );
 
     EXPECT_TRUE( caf::pdmVariantEqual<cvf::Vec3d>( va, vb ) );
     EXPECT_FALSE( caf::pdmVariantEqual<cvf::Vec3d>( va, vc ) );

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreVec3dTest.cpp
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmCvf_UnitTests/cafPdmCoreVec3dTest.cpp
@@ -37,10 +37,12 @@ TEST( VariantTest, PdmCoreVec3d )
 
     cvf::Vec3d myVector( a, b, c );
 
-    QVariant myVariant = caf::pdmToVariant( myVector );
+    using caf::pdmToVariant;
+    QVariant myVariant = pdmToVariant( myVector );
 
     cvf::Vec3d decoded;
-    caf::pdmFromVariant( myVariant, decoded );
+    using caf::pdmFromVariant;
+    pdmFromVariant( myVariant, decoded );
 
     EXPECT_TRUE( decoded.equals( myVector ) );
 }
@@ -51,9 +53,10 @@ TEST( VariantEqualTest, PdmCoreVec3d )
     cvf::Vec3d b( 1.0, 2.0, 3.0 );
     cvf::Vec3d c( 1.0, 2.0, 4.0 );
 
-    QVariant va = caf::pdmToVariant( a );
-    QVariant vb = caf::pdmToVariant( b );
-    QVariant vc = caf::pdmToVariant( c );
+    using caf::pdmToVariant;
+    QVariant va = pdmToVariant( a );
+    QVariant vb = pdmToVariant( b );
+    QVariant vc = pdmToVariant( c );
 
     EXPECT_TRUE( caf::pdmVariantEqual<cvf::Vec3d>( va, vb ) );
     EXPECT_FALSE( caf::pdmVariantEqual<cvf::Vec3d>( va, vc ) );

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmMat3d/cafPdmCoreMat3d.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmMat3d/cafPdmCoreMat3d.h
@@ -45,8 +45,8 @@
 
 #include <QTextStream>
 
-// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
-// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called via caf::toVariant/
+// caf::fromVariant — ADL searches the argument's namespace (cvf) in addition to caf.
 namespace cvf
 {
 

--- a/Fwk/AppFwk/cafPdmCvf/cafPdmMat3d/cafPdmCoreMat3d.h
+++ b/Fwk/AppFwk/cafPdmCvf/cafPdmMat3d/cafPdmCoreMat3d.h
@@ -45,10 +45,12 @@
 
 #include <QTextStream>
 
-namespace caf
+// pdmToVariant/pdmFromVariant in namespace cvf so ADL finds them when called from templates
+// that use "using caf::pdmToVariant" — ADL searches the argument's namespace (cvf), not caf.
+namespace cvf
 {
 
-inline QVariant pdmToVariant( const cvf::Mat3d& value )
+inline QVariant pdmToVariant( const Mat3d& value )
 {
     QString     str;
     QTextStream textStream( &str );
@@ -56,12 +58,17 @@ inline QVariant pdmToVariant( const cvf::Mat3d& value )
     return QVariant( str );
 }
 
-inline void pdmFromVariant( const QVariant& v, cvf::Mat3d& out )
+inline void pdmFromVariant( const QVariant& v, Mat3d& out )
 {
     QString     str = v.toString();
     QTextStream textStream( &str );
     textStream >> out;
 }
+
+} // end namespace cvf
+
+namespace caf
+{
 
 template <>
 struct PdmVariantEqualImpl<cvf::Mat3d>

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldTraits.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldTraits.h
@@ -121,6 +121,29 @@ void pdmFromVariant( const QVariant& v, std::optional<T>& out )
 }
 
 //==================================================================================================
+/// toVariant / fromVariant — public API wrappers
+///
+/// Simple qualified-call entry points that encapsulate the ADL two-step internally.
+/// Prefer these over calling pdmToVariant/pdmFromVariant with a using-declaration at the call site.
+/// Custom types are still extended by adding pdmToVariant/pdmFromVariant overloads in the type's
+/// own namespace; these wrappers just hide that detail from callers.
+//==================================================================================================
+
+template <typename T>
+QVariant toVariant( const T& value )
+{
+    using caf::pdmToVariant;
+    return pdmToVariant( value );
+}
+
+template <typename T>
+void fromVariant( const QVariant& v, T& out )
+{
+    using caf::pdmFromVariant;
+    pdmFromVariant( v, out );
+}
+
+//==================================================================================================
 /// PdmVariantEqualImpl<T>
 ///
 /// Class template used for comparing two QVariants carrying a field value of type T.


### PR DESCRIPTION
Move pdmToVariant/pdmFromVariant overloads for cvf::Color3f, Vec3d, Mat4d, and
Mat3d from namespace caf to namespace cvf. Templates in
cafInternalPdmFieldTypeSpecializations.h use "using caf::pdmToVariant" followed
by an unqualified call, so ADL searches the argument's namespace (cvf). With the
overloads only in caf, the default template was selected, causing cvf::Color3f to
be stored raw in a QVariant instead of as QColor — breaking color field editing
and producing QVariant::save warnings.

Update all explicit caf::pdmToVariant/pdmFromVariant call sites for cvf types in
application code and unit tests to use cvf:: namespace. Add AdlVariantTest to
cafPdmCoreColor3fTest.cpp that exercises the exact template pattern.
