### PR TITLE
Fix GCC warning by specializing PdmVariantEqualImpl for QString

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldTraits.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldTraits.h
@@ -220,6 +220,14 @@ struct PdmVariantEqualImpl<double>
     }
 };
 
+template <>
+struct PdmVariantEqualImpl<QString>
+{
+    // Use toString() instead of value<QString>() to avoid a GCC false-positive
+    // -Wmaybe-uninitialized warning triggered by deep inlining through qvariant_cast.
+    static bool equal( const QVariant& a, const QVariant& b ) { return a.toString() == b.toString(); }
+};
+
 //==================================================================================================
 /// pdmVariantEqual<T> — public API, delegates to PdmVariantEqualImpl<T>
 //==================================================================================================


### PR DESCRIPTION
Compiling on default system on Ubuntu 26.04(gcc15 and Qt6.10.2)  gives a warning multiple times. This is a known false positive on GCC related to deep inlining of `qvariant_cast<QString>` 

Fixed by specializing PdmVariantEqualImpl for QString

```
Building CXX object ApplicationLibCode/CMakeFiles/ApplicationLibCode.dir/ProjectDataModel/Summary/RimSummaryTable.cpp.o
In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/qhashfunctions.h:9,
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/qlist.h:11,
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/QList:1,
                 from /home/builder/gitroot/ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafFontTools.h:38,
                 from /home/builder/gitroot/ResInsight/ApplicationLibCode/ProjectDataModel/Appearance/RimFontSizeField.h:21,
                 from /home/builder/gitroot/ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotWindow.h:20,
                 from /home/builder/gitroot/ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTable.h:21,
                 from /home/builder/gitroot/ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryTable.cpp:19:
In copy constructor ‘QString::QString(const QString&)’,
    inlined from ‘T qvariant_cast(const QVariant&) [with T = QString]’ at /usr/include/x86_64-linux-gnu/qt6/QtCore/qvariant.h:900:27,
    inlined from ‘T QVariant::value() const & [with T = QString]’ at /usr/include/x86_64-linux-gnu/qt6/QtCore/qvariant.h:649:36,
    inlined from ‘static bool caf::PdmVariantEqualImpl<T>::equal(const QVariant&, const QVariant&) [with T = QString]’ at /home/builder/gitroot/ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldTraits.h:158:98,
    inlined from ‘bool caf::pdmVariantEqual(const QVariant&, const QVariant&) [with T = QString]’ at /home/builder/gitroot/ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmFieldTraits.h:230:41,
    inlined from ‘bool caf::PdmFieldUiCap<FieldType>::isQVariantDataEqual(const QVariant&, const QVariant&) const [with FieldType = caf::PdmField<QString>]’ at /home/builder/gitroot/ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:286:67:
/usr/include/x86_64-linux-gnu/qt6/QtCore/qstring.h:1355:51: warning: ‘SR.8812’ may be used uninitialized [-Wmaybe-uninitialized]
 1355 | QString::QString(const QString &other) noexcept : d(other.d)
      |                                                   ^~~~~~~~~~
```