### PR TITLE
Fix 3D polygon picker start/stop after button migration

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonInView.cpp
@@ -255,6 +255,26 @@ void RimPolygonInView::updatePolygonFromTargets()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimPolygonInView::togglePicking()
+{
+    m_enablePicking = !m_enablePicking;
+
+    updateConnectedEditors();
+
+    // When embedded in a RimPolygonFilter, the property panel and 3D editor are bound to the filter,
+    // not to this polygon-in-view. Ask the owning picker interface to refresh its editors so the
+    // button label updates and the pick event handler is (un)registered.
+    if ( auto owner = firstAncestorOfType<RimPolylinePickerInterface>() )
+    {
+        owner->updateEditorsAndVisualization();
+    }
+
+    updateVisualization();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimPolygonInView::connectSignals()
 {
     if ( m_polygon )
@@ -297,13 +317,7 @@ void RimPolygonInView::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderin
 
     if ( enableEdit )
     {
-        uiOrdering.addNewButton( m_enablePicking ? "Stop Picking Points" : "Start Picking Points",
-                                 [this]()
-                                 {
-                                     m_enablePicking = !m_enablePicking;
-                                     updateConnectedEditors();
-                                     updateVisualization();
-                                 } );
+        uiOrdering.addNewButton( m_enablePicking ? "Stop Picking Points" : "Start Picking Points", [this]() { togglePicking(); } );
         uiOrdering.add( &m_targets );
         uiOrdering.add( &m_handleScalingFactor );
     }
@@ -378,13 +392,7 @@ void RimPolygonInView::defineObjectEditorAttribute( QString uiConfigName, caf::P
 //--------------------------------------------------------------------------------------------------
 void RimPolygonInView::uiOrderingForLocalPolygon( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-    uiOrdering.addNewButton( m_enablePicking ? "Stop Picking Points" : "Start Picking Points",
-                             [this]()
-                             {
-                                 m_enablePicking = !m_enablePicking;
-                                 updateConnectedEditors();
-                                 updateVisualization();
-                             } );
+    uiOrdering.addNewButton( m_enablePicking ? "Stop Picking Points" : "Start Picking Points", [this]() { togglePicking(); } );
     uiOrdering.add( &m_targets );
     uiOrdering.add( &m_handleScalingFactor );
 }

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonInView.h
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonInView.h
@@ -93,6 +93,7 @@ private:
 
     void updatePolygonFromTargets();
     void connectSignals();
+    void togglePicking();
 
 private:
     caf::PdmPtrField<RimPolygon*> m_polygon;


### PR DESCRIPTION
## Summary
- Closes #13894.
- `RimPolygonInView::m_enablePicking` was migrated from a `PdmField<bool>` push button to a `PdmUiButton` callback. With the old field, `RimPolygonFilter::childFieldChangedByUi` ran on every toggle and refreshed the filter's property panel and 3D editor. The callback-based version only called `updateConnectedEditors()` on the polygon-in-view, which has no editors bound to it when the filter owns the property panel and the `RicPolyline3dEditor`. Result: the "Start/Stop Picking Points" button label did not update and the pick event handler was never (un)registered.
- Toggle logic is now in `togglePicking()` which, after flipping the flag, walks up to any ancestor `RimPolylinePickerInterface` (e.g. the filter) and calls `updateEditorsAndVisualization()` so its editors are refreshed.