### PR TITLE
Optimize vcpkg cache with submodule-aware cache key

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -197,11 +197,16 @@ jobs:
         run: |
           ThirdParty/vcpkg/${{ matrix.config.vcpkg-bootstrap }}
 
+      - name: Get vcpkg submodule SHA
+        id: vcpkg-sha
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD:ThirdParty/vcpkg)" >> $GITHUB_OUTPUT
+
       - name: Restore vcpkg cache
         id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@v3
+        uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           prefix: vcpkg-${{ matrix.config.cxx}}/
           
       - name: Print CMake version

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -41,11 +41,16 @@ jobs:
       - name: vcpkg bootstrap
         run: ThirdParty/vcpkg/bootstrap-vcpkg.sh
   
+      - name: Get vcpkg submodule SHA
+        id: vcpkg-sha
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD:ThirdParty/vcpkg)" >> $GITHUB_OUTPUT
+
       - name: Restore vcpkg cache
         id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@v3
+        uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key: ${{ runner.os }}-clang++-19-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
 
       - name: Create compile commands and run clang-tidy
         # https://clang.llvm.org/extra/doxygen/run-clang-tidy_8py_source.html

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -132,11 +132,16 @@ jobs:
           cd ThirdParty/vcpkg
           ./bootstrap-vcpkg.sh
 
+      - name: Get vcpkg submodule SHA
+        id: vcpkg-sha
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD:ThirdParty/vcpkg)" >> $GITHUB_OUTPUT
+
       - name: Restore vcpkg cache
         id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@v3
+        uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key: ${{ runner.os }}-g++-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           prefix: vcpkg-g++/
 
       - name: Use RHEL8 vcpkg configuration


### PR DESCRIPTION
## Background
Several build jobs have failed recently due to rate limit related to GitHub cache. This is probably related to the large number of cached files by the vcpkg-cache action. This action is now optimized to store a single file for each configuration.

## Summary
- Switch vcpkg cache action from `TAServers/vcpkg-cache@v3` to `CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure` in `ResInsightWithCache.yml`, `clang-tidy.yml`, and `rhel8-unit-tests.yml`.
- Replace `token` input with a composite `cache-key` built from `runner.os`, the compiler, the vcpkg submodule SHA, and a hash of `vcpkg.json`/`vcpkg-configuration.json`.
- Add a step that runs `git rev-parse HEAD:ThirdParty/vcpkg` to capture the submodule commit so the cache is invalidated when the vcpkg submodule pointer is updated.