### PR TITLE
#13922 PolygonFilter: Guard K index against per-grid cellCountK

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp
@@ -486,6 +486,8 @@ void RimPolygonFilter::updateCellsKIndexEclipse( const std::vector<cvf::Vec3d>& 
 {
     const int gIdx = static_cast<int>( grid->gridIndex() );
 
+    if ( K < 0 || static_cast<size_t>( K ) >= grid->cellCountK() ) return;
+
     std::list<size_t> foundCells;
     const bool        closedPolygon = isPolygonClosed();
     const bool        singlePoint   = ( points.size() == 1 );


### PR DESCRIPTION
The K layer returned by findEclipseKLayer is computed against one grid (usually the main grid), but updateCellsForEclipse then forwards it to every grid including LGRs whose cellCountK can be smaller. Inside updateCellsKIndexEclipse the unguarded cellIndexFromIJKUnguarded call combined with the bounds-unchecked cell() accessor produced an out-of-range cell whose corner indices crashed RigCell::center() and cellCornerVertices.

Fixes #13922.