### PR TITLE
#13938 SummaryMultiPlot: Guard against null curve point tracker

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuSummaryQwtPlot.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSummaryQwtPlot.cpp
@@ -292,7 +292,7 @@ RiuPlotWidget* RiuSummaryQwtPlot::plotWidget() const
 //--------------------------------------------------------------------------------------------------
 void RiuSummaryQwtPlot::enableCurvePointTracking( bool enable )
 {
-    m_curvePointTracker->setEnabled( enable );
+    if ( m_curvePointTracker ) m_curvePointTracker->setEnabled( enable );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #13938. `RiuSummaryQwtPlot::enableCurvePointTracking` dereferenced `m_curvePointTracker` (a `QPointer`) without a null check, causing a crash inside `QwtPicker::setEnabled` when the tracker's parent canvas had been destroyed. Reached via `RimSummaryMultiPlot::insertPlot` → `updateReadOutSettings` when adding a default summary plot.

The sibling `setZoomEnabled` already guards its `QPointer` members the same way, so this aligns with the existing pattern in the file.

A follow-up issue (#13942) tracks remaining unguarded `QPointer` dereferences in the same file.