### PR TITLE
#13944 Build: Make find_package imported targets globally visible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ endif()
 include(CheckCSourceCompiles)
 include(FetchContent)
 
+# Make imported targets from find_package() visible across directory scopes.
+# Required so Qt 6.10's __qt_internal_walk_libs can resolve Qt:: targets that
+# subdirectory CMakeLists.txt files pull in via their own find_package().
+set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE)
+
 project(ResInsight)
 
 # Include common settings


### PR DESCRIPTION
## Summary
- Set `CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE` at the top of `CMakeLists.txt` so imported targets created by `find_package()` calls in subdirectories (`qwt`, `cafPdmXml`, `cafUserInterface`, etc.) are visible at the consumer's directory scope.
- Silences Qt 6.10 `__qt_internal_walk_libs` warnings about `OpenGLWidgets`, `Xml` and `Svg` targets being "mentioned as a dependency ... but not declared" during finalization of executables like `ResInsight-tests`, `cafPdmXml_UnitTests` and `cafPdmScripting_UnitTests`.
- Keeps the per-module `find_package` pattern (best practice for self-contained subprojects) instead of pushing every transitive Qt component into the top-level call.

Fixes #13944.