### PR TITLE
#13940 Fracture export: Guard transmissibility condenser against inte…

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp
@@ -333,7 +333,9 @@ void RigTransmissibilityCondenser::calculateCondensedTransmissibilities()
         totalEquationCount = currentEqIdx;
     }
 
-    CAF_ASSERT( idxToFirstExternalEquation != -1 );
+    // Guard against neighbor sets that contain only internal cells: there is nothing to condense
+    // into, so leave m_externalCellAddrSet / m_condensedTransmissibilities empty.
+    if ( idxToFirstExternalEquation == -1 ) return;
 
     using namespace Eigen;
 


### PR DESCRIPTION
…rnal-only neighbor sets

Replace the fatal CAF_ASSERT in calculateCondensedTransmissibilities() with an early return when no external cells are present. The fracture export pipeline now yields no completions for such fractures instead of aborting the process.

Fixes #13940.