### PR TITLE
#13962 GeoMech: Show empty unit string for dimensionless FAULTMOB property

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp
@@ -795,6 +795,11 @@ QString RimGeoMechResultDefinition::currentResultUnits() const
             return "Deg";
         }
 
+        if ( componentName == "FAULTMOB" )
+        {
+            return RiaWellLogUnitTools<double>::noUnitString();
+        }
+
         if ( rigFemResultAddress.normalizeByHydrostaticPressure() )
         {
             return "sg";


### PR DESCRIPTION
## Summary
- FAULTMOB is dimensionless, but the GUI displayed `BAR` as its unit.
- Return an empty unit string for FAULTMOB in `RimGeoMechResultDefinition::currentResultUnits()`.

Fixes #13962