### PR TITLE
#13126 RiaLogging: Replace .toStdString() idiom with std::format in FileInterface

### DIFF
--- a/ApplicationLibCode/FileInterface/RifColumnBasedUserData.cpp
+++ b/ApplicationLibCode/FileInterface/RifColumnBasedUserData.cpp
@@ -61,7 +61,7 @@ bool RifColumnBasedUserData::parse( const QString& data, QString* errorText )
     m_parser = std::make_unique<RifColumnBasedUserDataParser>( data, errorText );
     if ( !m_parser )
     {
-        RiaLogging::error( QString( "Failed to parse file" ).toStdString() );
+        RiaLogging::error( "Failed to parse file" );
 
         return false;
     }
@@ -157,7 +157,7 @@ void RifColumnBasedUserData::buildTimeStepsAndMappings()
         if ( timeStepsForTable.empty() )
         {
             RiaLogging::warning( std::format( "Failed to find time data for table {}", tableIndex ) );
-            RiaLogging::warning( QString( "No data for this table is imported" ).toStdString() );
+            RiaLogging::warning( "No data for this table is imported" );
 
             return;
         }

--- a/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseInputFileTools.cpp
@@ -489,7 +489,7 @@ void RifEclipseInputFileTools::saveFault( QString                               
     QFile exportFile( completeFilename );
     if ( !exportFile.open( QIODevice::WriteOnly | QIODevice::Text ) )
     {
-        RiaLogging::error( "Could not open the file : " + completeFilename.toStdString() );
+        RiaLogging::error( std::format( "Could not open the file : {}", completeFilename ) );
         return;
     }
 
@@ -1060,7 +1060,7 @@ void RifEclipseInputFileTools::parsePflotranInputFile( const QString& fileName, 
 {
     QStringList gridSectionFilenames;
 
-    RiaLogging::info( "Looking for faults in 'PFLOTRAN' file: " + fileName.toStdString() );
+    RiaLogging::info( std::format( "Looking for faults in 'PFLOTRAN' file: {}", fileName ) );
 
     {
         // Find all referenced grdecl files in a pflotran input file, in the GRID section, example
@@ -1141,7 +1141,7 @@ void RifEclipseInputFileTools::parsePflotranInputFile( const QString& fileName, 
                     parseAndReadFaults( absoluteFilePath, faults );
                     if ( currentFaultCount != faults->size() )
                     {
-                        RiaLogging::info( "Imported faults from " + absoluteFilePath.toStdString() );
+                        RiaLogging::info( std::format( "Imported faults from {}", absoluteFilePath ) );
                     }
                 }
             }

--- a/ApplicationLibCode/FileInterface/RifKeywordVectorUserData.cpp
+++ b/ApplicationLibCode/FileInterface/RifKeywordVectorUserData.cpp
@@ -58,7 +58,7 @@ bool RifKeywordVectorUserData::parse( const QString& data, const QString& custom
     m_parser = std::make_unique<RifKeywordVectorParser>( data );
     if ( !m_parser )
     {
-        RiaLogging::error( QString( "Failed to parse file" ).toStdString() );
+        RiaLogging::error( "Failed to parse file" );
 
         return false;
     }

--- a/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp
@@ -165,11 +165,10 @@ bool RifOpmCommonEclipseSummary::open( const QString& fileName, bool includeRest
         const QString smspecFileNameShort = QFileInfo( smspecFileName ).fileName();
         const QString esmryFileNameShort  = QFileInfo( candidateEsmryFileName ).fileName();
 
-        RiaLogging::warning( QString( " %3 : %1 is older than %2, importing data from newest file %2." )
-                                 .arg( esmryFileNameShort )
-                                 .arg( smspecFileNameShort )
-                                 .arg( root )
-                                 .toStdString() );
+        RiaLogging::warning( std::format( " {2} : {0} is older than {1}, importing data from newest file {1}.",
+                                          esmryFileNameShort,
+                                          smspecFileNameShort,
+                                          root ) );
     }
 
     auto timeBeforeReader = RiaLogging::currentTime();
@@ -217,8 +216,7 @@ std::pair<bool, std::vector<double>> RifOpmCommonEclipseSummary::values( const R
         }
         catch ( const std::exception& e )
         {
-            RiaLogging::warning(
-                QString( "Summary reader failed to load keyword '%1': %2" ).arg( QString::fromStdString( keyword ) ).arg( e.what() ).toStdString() );
+            RiaLogging::warning( std::format( "Summary reader failed to load keyword '{}': {}", keyword, e.what() ) );
             return { false, {} };
         }
         return { true, values };

--- a/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp
@@ -165,10 +165,8 @@ bool RifOpmCommonEclipseSummary::open( const QString& fileName, bool includeRest
         const QString smspecFileNameShort = QFileInfo( smspecFileName ).fileName();
         const QString esmryFileNameShort  = QFileInfo( candidateEsmryFileName ).fileName();
 
-        RiaLogging::warning( std::format( " {2} : {0} is older than {1}, importing data from newest file {1}.",
-                                          esmryFileNameShort,
-                                          smspecFileNameShort,
-                                          root ) );
+        RiaLogging::warning(
+            std::format( " {2} : {0} is older than {1}, importing data from newest file {1}.", esmryFileNameShort, smspecFileNameShort, root ) );
     }
 
     auto timeBeforeReader = RiaLogging::currentTime();

--- a/ApplicationLibCode/FileInterface/RifOpmRadialGridTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmRadialGridTools.cpp
@@ -88,9 +88,8 @@ bool RifOpmRadialGridTools::importCylindricalCoordinates( const std::string& gri
 
             if ( opmMainGrid.is_radial() && opmMainGrid.dimension().at( 1 ) < minimumAngularCellCount )
             {
-                RiaLogging::info( QString( "Radial grid with less than 4 cells in J direction detected, creating refinement : %1" )
-                                      .arg( QString::fromStdString( gridFilePath ) )
-                                      .toStdString() );
+                RiaLogging::info(
+                    std::format( "Radial grid with less than 4 cells in J direction detected, creating refinement : {}", gridFilePath ) );
 
                 int radialRefinement = ( minimumAngularCellCount / opmMainGrid.dimension().at( 1 ) ) + 1;
 
@@ -104,8 +103,7 @@ bool RifOpmRadialGridTools::importCylindricalCoordinates( const std::string& gri
     }
     catch ( ... )
     {
-        RiaLogging::warning(
-            QString( "Failed to open grid case for import of radial coordinates : %1" ).arg( QString::fromStdString( gridFilePath ) ).toStdString() );
+        RiaLogging::warning( std::format( "Failed to open grid case for import of radial coordinates : {}", gridFilePath ) );
     }
 
     return false;
@@ -171,8 +169,7 @@ bool RifOpmRadialGridTools::tryConvertRadialGridToCartesianGrid( const std::stri
     }
     catch ( ... )
     {
-        RiaLogging::warning(
-            QString( "Failed to open grid case for import of radial coordinates : %1" ).arg( QString::fromStdString( gridFilePath ) ).toStdString() );
+        RiaLogging::warning( std::format( "Failed to open grid case for import of radial coordinates : {}", gridFilePath ) );
     }
 
     return true;

--- a/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
@@ -191,8 +191,7 @@ bool RifOpmSummaryTools::isEsmryConversionRequired( const QString& fileName )
         const QString smspecFileNameShort = QFileInfo( smspecFileName ).fileName();
         const QString esmryFileNameShort  = QFileInfo( candidateEsmryFileName ).fileName();
 
-        RiaLogging::debug(
-            std::format( " {2} : {0} is older than {1}, recreating {0}.", esmryFileNameShort, smspecFileNameShort, root ) );
+        RiaLogging::debug( std::format( " {2} : {0} is older than {1}, recreating {0}.", esmryFileNameShort, smspecFileNameShort, root ) );
 
         // Check if we have write permission in the folder
         QFileInfo info( smspecFileName );

--- a/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
@@ -192,17 +192,16 @@ bool RifOpmSummaryTools::isEsmryConversionRequired( const QString& fileName )
         const QString esmryFileNameShort  = QFileInfo( candidateEsmryFileName ).fileName();
 
         RiaLogging::debug(
-            QString( " %3 : %1 is older than %2, recreating %1." ).arg( esmryFileNameShort ).arg( smspecFileNameShort ).arg( root ).toStdString() );
+            std::format( " {2} : {0} is older than {1}, recreating {0}.", esmryFileNameShort, smspecFileNameShort, root ) );
 
         // Check if we have write permission in the folder
         QFileInfo info( smspecFileName );
 
         if ( !info.isWritable() )
         {
-            QString txt = QString( "ESMRY is older than SMSPEC, but export to file %1 failed due to missing write permissions. "
-                                   "Aborting operation." )
-                              .arg( candidateEsmryFileName );
-            RiaLogging::error( txt.toStdString() );
+            RiaLogging::error( std::format( "ESMRY is older than SMSPEC, but export to file {} failed due to missing write permissions. "
+                                            "Aborting operation.",
+                                            candidateEsmryFileName ) );
 
             return false;
         }

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -591,7 +591,8 @@ void RifReaderEclipseOutput::setHdf5FileName( const QString& fileName )
     {
         if ( allTimeSteps().size() != sourSimTimeSteps.size() )
         {
-            RiaLogging::error( std::format( "HDF: Time step count mismatch, Eclipse : {} ; HDF : {} ", allTimeSteps().size(), sourSimTimeSteps.size() ) );
+            RiaLogging::error(
+                std::format( "HDF: Time step count mismatch, Eclipse : {} ; HDF : {} ", allTimeSteps().size(), sourSimTimeSteps.size() ) );
 
             return;
         }
@@ -609,7 +610,8 @@ void RifReaderEclipseOutput::setHdf5FileName( const QString& fileName )
             }
             else
             {
-                RiaLogging::error( std::format( "HDF: Time step count mismatch, Eclipse : {} ; HDF : {} ", timeStepInfos.size(), sourSimTimeSteps.size() ) );
+                RiaLogging::error(
+                    std::format( "HDF: Time step count mismatch, Eclipse : {} ; HDF : {} ", timeStepInfos.size(), sourSimTimeSteps.size() ) );
 
                 // We have less soursim time steps than eclipse time steps
                 isTimeStampsEqual = false;
@@ -1103,8 +1105,9 @@ std::vector<RigEclipseTimeStepInfo> RifReaderEclipseOutput::createFilteredTimeSt
         }
         if ( timeStepsOnFile.size() != reportNumbersOnFile.size() )
         {
-            RiaLogging::error(
-                std::format( "Time step count mismatch: timeStepsOnFile = {}, reportNumbersOnFile = {}", timeStepsOnFile.size(), reportNumbersOnFile.size() ) );
+            RiaLogging::error( std::format( "Time step count mismatch: timeStepsOnFile = {}, reportNumbersOnFile = {}",
+                                            timeStepsOnFile.size(),
+                                            reportNumbersOnFile.size() ) );
             return {};
         }
 

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -591,10 +591,7 @@ void RifReaderEclipseOutput::setHdf5FileName( const QString& fileName )
     {
         if ( allTimeSteps().size() != sourSimTimeSteps.size() )
         {
-            RiaLogging::error( QString( "HDF: Time step count mismatch, Eclipse : %1 ; HDF : %2 " )
-                                   .arg( allTimeSteps().size() )
-                                   .arg( sourSimTimeSteps.size() )
-                                   .toStdString() );
+            RiaLogging::error( std::format( "HDF: Time step count mismatch, Eclipse : {} ; HDF : {} ", allTimeSteps().size(), sourSimTimeSteps.size() ) );
 
             return;
         }
@@ -612,10 +609,7 @@ void RifReaderEclipseOutput::setHdf5FileName( const QString& fileName )
             }
             else
             {
-                RiaLogging::error( QString( "HDF: Time step count mismatch, Eclipse : %1 ; HDF : %2 " )
-                                       .arg( timeStepInfos.size() )
-                                       .arg( sourSimTimeSteps.size() )
-                                       .toStdString() );
+                RiaLogging::error( std::format( "HDF: Time step count mismatch, Eclipse : {} ; HDF : {} ", timeStepInfos.size(), sourSimTimeSteps.size() ) );
 
                 // We have less soursim time steps than eclipse time steps
                 isTimeStampsEqual = false;
@@ -1102,18 +1096,15 @@ std::vector<RigEclipseTimeStepInfo> RifReaderEclipseOutput::createFilteredTimeSt
 
         if ( timeStepsOnFile.size() != daysSinceSimulationStartOnFile.size() )
         {
-            RiaLogging::error( QString( "Time step count mismatch: timeStepsOnFile = %1, daysSinceSimulationStartOnFile = %2" )
-                                   .arg( timeStepsOnFile.size() )
-                                   .arg( daysSinceSimulationStartOnFile.size() )
-                                   .toStdString() );
+            RiaLogging::error( std::format( "Time step count mismatch: timeStepsOnFile = {}, daysSinceSimulationStartOnFile = {}",
+                                            timeStepsOnFile.size(),
+                                            daysSinceSimulationStartOnFile.size() ) );
             return {};
         }
         if ( timeStepsOnFile.size() != reportNumbersOnFile.size() )
         {
-            RiaLogging::error( QString( "Time step count mismatch: timeStepsOnFile = %1, reportNumbersOnFile = %2" )
-                                   .arg( timeStepsOnFile.size() )
-                                   .arg( reportNumbersOnFile.size() )
-                                   .toStdString() );
+            RiaLogging::error(
+                std::format( "Time step count mismatch: timeStepsOnFile = {}, reportNumbersOnFile = {}", timeStepsOnFile.size(), reportNumbersOnFile.size() ) );
             return {};
         }
 

--- a/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderOpmCommon.cpp
@@ -115,7 +115,7 @@ bool RifReaderOpmCommon::open( const QString& fileName, RigEclipseCaseData* ecli
 
         if ( !importGrid( eclipseCaseData->mainGrid(), eclipseCaseData ) )
         {
-            RiaLogging::error( "Failed to open grid file " + fileName.toStdString() );
+            RiaLogging::error( std::format( "Failed to open grid file {}", fileName ) );
 
             return false;
         }

--- a/ApplicationLibCode/FileInterface/RifReaderRegularGridModel.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderRegularGridModel.cpp
@@ -20,6 +20,7 @@
 
 #include "RiaDefines.h"
 #include "RiaLogging.h"
+#include "RiaQStringFormatter.h"
 
 #include "RifEclipseInputFileTools.h"
 #include "RifEclipseInputPropertyLoader.h"
@@ -54,7 +55,7 @@ void RifReaderRegularGridModel::writeCache( const QString& fileName, RimEclipseC
     QFile cacheFile( fileName );
     if ( !cacheFile.open( QIODevice::WriteOnly ) )
     {
-        RiaLogging::error( "Saving project: Can't open the cache file : " + fileName.toStdString() );
+        RiaLogging::error( std::format( "Saving project: Can't open the cache file : {}", fileName ) );
         return;
     }
 
@@ -72,7 +73,7 @@ void RifReaderRegularGridModel::writeCache( const QString& fileName, RimEclipseC
     const bool writeEchoKeywords = false;
     if ( !RifEclipseInputFileTools::exportKeywords( fileName, eclipseCase->eclipseCaseData(), keywords, writeEchoKeywords ) )
     {
-        RiaLogging::error( "Error detected when writing the cache file : " + fileName.toStdString() );
+        RiaLogging::error( std::format( "Error detected when writing the cache file : {}", fileName ) );
     }
 }
 

--- a/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp
@@ -104,10 +104,9 @@ bool RifStimPlanModelGeologicalFrkExporter::writeToFile( RimStimPlanModel* stimP
     // Warn if the generated model has too many layers for StimPlan
     if ( tvd.size() > MAX_STIMPLAN_LAYERS )
     {
-        RiaLogging::warning( QString( "Exporting model with too many layers: %1. Maximum supported number of layers is %2." )
-                                 .arg( tvd.size() )
-                                 .arg( MAX_STIMPLAN_LAYERS )
-                                 .toStdString() );
+        RiaLogging::warning( std::format( "Exporting model with too many layers: {}. Maximum supported number of layers is {}.",
+                                          tvd.size(),
+                                          MAX_STIMPLAN_LAYERS ) );
     }
 
     // Make sure stress gradients are in the valid interval
@@ -320,12 +319,11 @@ void RifStimPlanModelGeologicalFrkExporter::fixupStressGradients( std::vector<do
     {
         if ( stressGradients[i] < minStressGradient || stressGradients[i] > maxStressGradient )
         {
-            RiaLogging::warning( QString( "Found stress gradient outside valid range [%1, %2]. Replacing %3 with default value: %4." )
-                                     .arg( minStressGradient )
-                                     .arg( maxStressGradient )
-                                     .arg( stressGradients[i] )
-                                     .arg( defaultStressGradient )
-                                     .toStdString() );
+            RiaLogging::warning( std::format( "Found stress gradient outside valid range [{}, {}]. Replacing {} with default value: {}.",
+                                              minStressGradient,
+                                              maxStressGradient,
+                                              stressGradients[i],
+                                              defaultStressGradient ) );
 
             stressGradients[i] = defaultStressGradient;
         }
@@ -341,11 +339,8 @@ void RifStimPlanModelGeologicalFrkExporter::fixupLowerBoundary( std::vector<doub
     {
         if ( value < minValue )
         {
-            RiaLogging::warning( QString( "Found %1 outside valid lower boundary (%2). Replacing %3 with default value: %2." )
-                                     .arg( property )
-                                     .arg( minValue )
-                                     .arg( value )
-                                     .toStdString() );
+            RiaLogging::warning(
+                std::format( "Found {0} outside valid lower boundary ({1}). Replacing {2} with default value: {1}.", property, minValue, value ) );
             value = minValue;
         }
     }

--- a/ApplicationLibCode/FileInterface/RifStimPlanXmlReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifStimPlanXmlReader.cpp
@@ -69,10 +69,8 @@ cvf::ref<RigStimPlanFractureDefinition> RifStimPlanXmlReader::readStimPlanXMLFil
         caf::AppEnum<RiaDefines::EclipseUnitSystem> unitSystem = stimPlanFileData->unitSet();
 
         if ( unitSystem != RiaDefines::EclipseUnitSystem::UNITS_UNKNOWN )
-            RiaLogging::info( QString( "Setting unit system for StimPlan fracture template %1 to %2" )
-                                  .arg( stimPlanFileName )
-                                  .arg( unitSystem.uiText() )
-                                  .toStdString() );
+            RiaLogging::info(
+                std::format( "Setting unit system for StimPlan fracture template {} to {}", stimPlanFileName, unitSystem.uiText() ) );
         else
             RiaLogging::error( std::format( "Found invalid units for {}. Unit system not set.", stimPlanFileName ) );
 
@@ -105,7 +103,7 @@ cvf::ref<RigStimPlanFractureDefinition> RifStimPlanXmlReader::readStimPlanXMLFil
     QString parameter;
     QString unit;
 
-    RiaLogging::info( QString( "Properties available in file:" ).toStdString() );
+    RiaLogging::info( "Properties available in file:" );
     int propertiesElementCount = 0;
     while ( !xmlStream2.atEnd() && propertiesElementCount < 2 )
     {
@@ -350,7 +348,7 @@ void RifStimPlanXmlReader::readStimplanGridAndTimesteps( QXmlStreamReader&      
 
     if ( startNegValuesYs > 0 )
     {
-        RiaLogging::error( QString( "Negative depth values detected in XML file" ).toStdString() );
+        RiaLogging::error( "Negative depth values detected in XML file" );
     }
 }
 


### PR DESCRIPTION
## Summary
- Convert surviving `QString(...).arg(...).toStdString()` callsites and `"text " + qstr.toStdString()` concatenations in `ApplicationLibCode/FileInterface/` to `std::format`, leveraging the `std::formatter<QString>` specialization in `RiaQStringFormatter.h`.
- Drop bare `QString("literal").toStdString()` wrappers (literal binds to `std::string_view` directly) and redundant `QString::fromStdString` wrappers around `std::string` args inside `.arg()` chains.
- Single-variable `qstr.toStdString()` callsites with no formatting are intentionally left as-is — replacing them with `std::format("{}", qstr)` is longer, not shorter.

11 files changed, 44 insertions(+), 65 deletions(-).