### PR TITLE
Well path: Migrate legacy SSIHUB cache file path to m_filePath

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
@@ -5,8 +5,11 @@
 #include "RifWellPathImporter.h"
 
 #include "RimProject.h"
+#include "RimTools.h"
 
 #include "cafUtils.h"
+
+#include <QFileInfo>
 
 CAF_PDM_SOURCE_INIT( RimFileWellPath, "WellPath" );
 
@@ -38,6 +41,12 @@ RimFileWellPath::RimFileWellPath()
 
     CAF_PDM_InitFieldNoDefault( &m_filePath, "WellPathFilepath", "File Path" );
     m_filePath.uiCapability()->setUiReadOnly( true );
+
+    // Read-only legacy field used to migrate SSIHUB-cached well paths saved before commit
+    // bdb46d9df407878f0016ea2c150f44cc07fef698 removed the cache mechanism. See initAfterRead.
+    CAF_PDM_InitFieldNoDefault( &m_filePathInCache_OBSOLETE, "WellPathFilePathInCache", "File Name" );
+    m_filePathInCache_OBSOLETE.uiCapability()->setUiHidden( true );
+    m_filePathInCache_OBSOLETE.xmlCapability()->setIOWritable( false );
 
     CAF_PDM_InitField( &m_wellPathIndexInFile, "WellPathNumberInFile", -1, "Well Number in File" );
     m_wellPathIndexInFile.uiCapability()->setUiReadOnly( true );
@@ -213,5 +222,23 @@ void RimFileWellPath::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
         {
             RimProject::current()->scheduleCreateDisplayModelAndRedrawAllViews();
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimFileWellPath::initAfterRead()
+{
+    RimWellPath::initAfterRead();
+
+    QString cachedPath = m_filePathInCache_OBSOLETE().path();
+    if ( cachedPath.isEmpty() ) return;
+
+    QString newCacheFileName = RimTools::getCacheRootDirectoryPathFromProject() + "_wellpaths/" + QFileInfo( cachedPath ).fileName();
+
+    if ( caf::Utils::fileExists( newCacheFileName ) )
+    {
+        m_filePath = newCacheFileName;
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.h
@@ -34,6 +34,7 @@ public:
 
 protected:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void initAfterRead() override;
 
 private:
     QString surveyType() { return m_surveyType; }
@@ -42,6 +43,7 @@ private:
     void ensureWellPathStartAtSeaLevel( RigWellPath* wellPath );
 
     caf::PdmField<caf::FilePath> m_filePath;
+    caf::PdmField<caf::FilePath> m_filePathInCache_OBSOLETE; // Legacy SSIHUB cache path, read-only for migration
     caf::PdmField<int>           m_wellPathIndexInFile; // -1 means none.
 
     caf::PdmField<QString> id;


### PR DESCRIPTION
## Summary

- Restores `m_filePathInCache_OBSOLETE` as a read-only PDM field (write disabled) so legacy projects that stored the well path in `WellPathFilePathInCache` can still be loaded.
- In `RimFileWellPath::initAfterRead`, look up the cached file in the current project's cache directory and copy its path into `m_filePath`. Subsequent saves write only `m_filePath`, so the legacy field is dropped after one round-trip.
- Companion to commit bdb46d9, which removed the SSIHUB cache mechanism but left no migration path for older projects.

The changes in this PR is required to make legacy project files work.