### PR TITLE
#13967 Completion Export: Apply persisted Flip X/Y axis and clear face-normal cache

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp
@@ -291,6 +291,7 @@ bool RimEclipseResultCase::importGridAndResultMetaData( bool showTimeStepFilter 
         CVF_ASSERT( readerInterface.notNull() );
 
         progInfo.setProgressDescription( "Computing Case Cache" );
+        eclipseCaseData()->mainGrid()->setFlipAxis( m_flipXAxis, m_flipYAxis );
         computeCachedData();
         loadAndSynchronizeInputProperties( false );
 

--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -349,6 +349,9 @@ void RigMainGrid::setFlipAxis( bool flipXAxis, bool flipYAxis )
 
         m_flipXAxis = flipXAxis;
         m_flipYAxis = flipYAxis;
+
+        // Cell face normals flip direction with the geometry, so a cached value computed before the flip is stale.
+        m_isFaceNormalsOutwardsComputed = false;
     }
 }
 

--- a/ApplicationLibCode/UnitTests/RigWellLogExtractor-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogExtractor-Test.cpp
@@ -75,3 +75,110 @@ TEST( RigEclipseWellLogExtractor, ShortWellPathInsideOneCell )
     auto intersections = e->cellIntersectionInfosAlongWellPath();
     EXPECT_FALSE( intersections.empty() );
 }
+
+//--------------------------------------------------------------------------------------------------
+/// Reproduces https://github.com/OPM/ResInsight/issues/13967
+/// A horizontal well crossing several cells must report all the cells it passes through, regardless
+/// of which combination of Flip X / Flip Y has been applied to the grid.
+//--------------------------------------------------------------------------------------------------
+TEST( RigEclipseWellLogExtractor, HorizontalWellAcrossFlippedGrid )
+{
+    auto buildReservoir = []( bool flipX, bool flipY )
+    {
+        cvf::ref<RigEclipseCaseData> reservoir         = new RigEclipseCaseData( nullptr );
+        cvf::ref<RifReaderMockModel> mockFileInterface = new RifReaderMockModel;
+
+        mockFileInterface->setWorldCoordinates( cvf::Vec3d( 10, 10, 10 ), cvf::Vec3d( 20, 20, 20 ) );
+        mockFileInterface->setCellCounts( cvf::Vec3st( 5, 6, 7 ) );
+        mockFileInterface->enableWellData( false );
+        mockFileInterface->open( "", reservoir.p() );
+
+        if ( flipX || flipY ) reservoir->mainGrid()->setFlipAxis( flipX, flipY );
+
+        reservoir->mainGrid()->computeCachedData();
+        return reservoir;
+    };
+
+    auto runWellPath = []( cvf::ref<RigEclipseCaseData> reservoir, bool flipX, bool flipY )
+    {
+        const double            xSign            = flipX ? -1.0 : 1.0;
+        const double            ySign            = flipY ? -1.0 : 1.0;
+        cvf::ref<RigWellPath>   wellPathGeometry = new RigWellPath;
+        std::vector<cvf::Vec3d> wellPathPoints   = { cvf::Vec3d( xSign * 10.5, ySign * 13.0, 15.0 ),
+                                                     cvf::Vec3d( xSign * 19.5, ySign * 13.0, 15.0 ) };
+        std::vector<double>     mdValues         = { 0.0, 9.0 };
+        wellPathGeometry->setWellPathPoints( wellPathPoints, mdValues );
+
+        cvf::ref<RigEclipseWellLogExtractor> e = new RigEclipseWellLogExtractor( reservoir.p(), wellPathGeometry.p(), "" );
+        return e->cellIntersectionInfosAlongWellPath();
+    };
+
+    auto baseline = runWellPath( buildReservoir( false, false ), false, false );
+    EXPECT_GT( baseline.size(), 2u );
+
+    struct FlipCase
+    {
+        bool flipX;
+        bool flipY;
+    };
+    const FlipCase cases[] = { { false, false }, { true, false }, { false, true }, { true, true } };
+
+    for ( const auto& c : cases )
+    {
+        // Freshly-built grid with the requested flip applied before the first lazy cache populates.
+        auto fresh = runWellPath( buildReservoir( c.flipX, c.flipY ), c.flipX, c.flipY );
+        EXPECT_EQ( baseline.size(), fresh.size() ) << "fresh: flipX=" << c.flipX << " flipY=" << c.flipY;
+
+        // Interactive toggle: load un-flipped, populate the face-normal-direction cache, then flip.
+        // The intersection result must still match the freshly-built flipped grid.
+        auto toggled = buildReservoir( false, false );
+        (void)toggled->mainGrid()->isFaceNormalsOutwards();
+        toggled->mainGrid()->setFlipAxis( c.flipX, c.flipY );
+        toggled->mainGrid()->computeCachedData();
+
+        auto toggledCells = runWellPath( toggled, c.flipX, c.flipY );
+        EXPECT_EQ( baseline.size(), toggledCells.size() ) << "toggled: flipX=" << c.flipX << " flipY=" << c.flipY;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// setFlipAxis must actually mirror the grid node coordinates for every combination of Flip X /
+/// Flip Y. Covers the data-level part of https://github.com/OPM/ResInsight/issues/13967 where a
+/// saved flip flag could appear active while the grid was still un-flipped.
+//--------------------------------------------------------------------------------------------------
+TEST( RigMainGrid, SetFlipAxisMirrorsNodeCoordinates )
+{
+    auto checkFlip = []( bool flipX, bool flipY )
+    {
+        cvf::ref<RigEclipseCaseData> reservoir         = new RigEclipseCaseData( nullptr );
+        cvf::ref<RifReaderMockModel> mockFileInterface = new RifReaderMockModel;
+
+        mockFileInterface->setWorldCoordinates( cvf::Vec3d( 100, 200, 300 ), cvf::Vec3d( 110, 210, 310 ) );
+        mockFileInterface->setCellCounts( cvf::Vec3st( 2, 2, 2 ) );
+        mockFileInterface->enableWellData( false );
+        mockFileInterface->open( "", reservoir.p() );
+
+        auto*      mainGrid      = reservoir->mainGrid();
+        const auto originalNodes = mainGrid->nodes();
+        ASSERT_FALSE( originalNodes.empty() );
+
+        mainGrid->setFlipAxis( flipX, flipY );
+
+        const auto& flippedNodes = mainGrid->nodes();
+        ASSERT_EQ( originalNodes.size(), flippedNodes.size() );
+
+        const double xSign = flipX ? -1.0 : 1.0;
+        const double ySign = flipY ? -1.0 : 1.0;
+        for ( size_t i = 0; i < originalNodes.size(); i++ )
+        {
+            EXPECT_DOUBLE_EQ( xSign * originalNodes[i].x(), flippedNodes[i].x() ) << "flipX=" << flipX << " flipY=" << flipY;
+            EXPECT_DOUBLE_EQ( ySign * originalNodes[i].y(), flippedNodes[i].y() ) << "flipX=" << flipX << " flipY=" << flipY;
+            EXPECT_DOUBLE_EQ( originalNodes[i].z(), flippedNodes[i].z() ) << "flipX=" << flipX << " flipY=" << flipY;
+        }
+    };
+
+    checkFlip( false, false );
+    checkFlip( true, false );
+    checkFlip( false, true );
+    checkFlip( true, true );
+}


### PR DESCRIPTION
## Summary

Fixes two related defects around Flip X / Flip Y on Eclipse cases:

- **Closes #13974** — When a project file persisted `FlipXAxis` or `FlipYAxis` as `true`, the flag was restored to the PdmField but never propagated to the grid nodes during `RimEclipseResultCase::importGridAndResultMetaData`. Only the UI change handler applied the flip, so on reload the grid stayed un-flipped while the checkbox appeared active. Fixed by mirroring the call already present in `RimEclipseInputCase` and `RimRoffCase` and invoking `setFlipAxis` before `computeCachedData`.

- **Closes #13967** — `RigMainGrid::isFaceNormalsOutwards` lazily computes whether cell face normals point outward and caches the answer. `setFlipAxis` mirrored the node coordinates without resetting that cache, so any consumer that triggered the lazy computation before the user toggled Flip X/Y kept the stale pre-flip answer. The well-path/cell intersection then inverted the entering/leaving flag the wrong way, causing the proper-pair filter to discard every intermediate cell along a perforation interval - only the start and end cells survived through the well-starts/ends-inside-a-cell fallback. Fixed by resetting `m_isFaceNormalsOutwardsComputed` whenever the flip state actually changes.

Together these two changes restore correct perforation export both for freshly loaded projects with Flip Y persisted and for interactive Flip X/Y toggling.

Unit tests cover all four combinations of Flip X / Flip Y for the data-level node mirroring and for the well-path/cell intersection in both freshly-built and interactive-toggle scenarios.