### PR TITLE
#13977 Viewer: Fix perspective clipping of very small models

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp
@@ -534,13 +534,13 @@ cvf::ref<RifReaderInterface> RimEclipseResultCase::createMockModel( QString mode
             double startY = 0;
             double startZ = 0;
 
-            double widthX = 6000;
-            double widthY = 12000;
-            double widthZ = 500;
+            double widthX = mockModelSettings->extentX;
+            double widthY = mockModelSettings->extentY;
+            double widthZ = mockModelSettings->extentZ;
 
-            // Test code to simulate UTM coordinates
-            double offsetX = 400000;
-            double offsetY = 6000000;
+            // Offset to simulate UTM coordinates
+            double offsetX = mockModelSettings->offsetX;
+            double offsetY = mockModelSettings->offsetY;
             double offsetZ = 0;
 
             mockFileInterface->setWorldCoordinates( cvf::Vec3d( startX + offsetX, startY + offsetY, startZ + offsetZ ),

--- a/ApplicationLibCode/ProjectDataModel/RimMockModelSettings.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMockModelSettings.cpp
@@ -35,6 +35,16 @@ RimMockModelSettings::RimMockModelSettings()
     CAF_PDM_InitFieldNoDefault( &totalCellCount, "TotalCellCount", "Total Cell Count" );
     totalCellCount.uiCapability()->setUiReadOnly( true );
 
+    CAF_PDM_InitField( &extentX, "ExtentX", 6000.0, "Extent X" );
+    extentX.setMinValue( 0.0 );
+    CAF_PDM_InitField( &extentY, "ExtentY", 12000.0, "Extent Y" );
+    extentY.setMinValue( 0.0 );
+    CAF_PDM_InitField( &extentZ, "ExtentZ", 500.0, "Extent Z" );
+    extentZ.setMinValue( 0.0 );
+
+    CAF_PDM_InitField( &offsetX, "OffsetX", 400000.0, "Offset X" );
+    CAF_PDM_InitField( &offsetY, "OffsetY", 6000000.0, "Offset Y" );
+
     CAF_PDM_InitField( &resultCount, "ResultCount", quint64( 3 ), "Result Count" );
     CAF_PDM_InitField( &timeStepCount, "TimeStepCount", quint64( 10 ), "Time Step Count" );
 }
@@ -70,6 +80,15 @@ void RimMockModelSettings::defineUiOrdering( QString uiConfigName, caf::PdmUiOrd
     gridSizeGroup->add( &cellCountY );
     gridSizeGroup->add( &cellCountZ );
     gridSizeGroup->add( &totalCellCount );
+
+    caf::PdmUiGroup* extentGroup = uiOrdering.addNewGroup( "Extent" );
+    extentGroup->add( &extentX );
+    extentGroup->add( &extentY );
+    extentGroup->add( &extentZ );
+
+    caf::PdmUiGroup* offsetGroup = uiOrdering.addNewGroup( "Offset" );
+    offsetGroup->add( &offsetX );
+    offsetGroup->add( &offsetY );
 
     caf::PdmUiGroup* resultGroup = uiOrdering.addNewGroup( "Results" );
     resultGroup->add( &resultCount );

--- a/ApplicationLibCode/ProjectDataModel/RimMockModelSettings.h
+++ b/ApplicationLibCode/ProjectDataModel/RimMockModelSettings.h
@@ -41,6 +41,13 @@ public:
 
     caf::PdmField<quint64> totalCellCount;
 
+    caf::PdmField<double> extentX;
+    caf::PdmField<double> extentY;
+    caf::PdmField<double> extentZ;
+
+    caf::PdmField<double> offsetX;
+    caf::PdmField<double> offsetY;
+
     caf::PdmField<quint64> resultCount;
     caf::PdmField<quint64> timeStepCount;
 

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -577,19 +577,21 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
 
     if ( rendering->camera()->projection() == cvf::Camera::PERSPECTIVE || isOrthoNearPlaneFollowingCamera )
     {
-        // Choose the one furthest from the camera of: 0.8*bbox distance, m_defaultPerspectiveNearPlaneDistance.
-        ( *nearPlaneDist ) = CVF_MAX( m_defaultPerspectiveNearPlaneDistance, 0.8 * minDistEyeToCornerAlongViewDir );
+        // Place the near plane just in front of the closest geometry along the view direction.
+        // Do not floor against m_defaultPerspectiveNearPlaneDistance here: for very small models
+        // the closest corner can be well within that default distance, and clamping would push
+        // the near plane past the model and clip it entirely.
+        ( *nearPlaneDist ) = 0.8 * minDistEyeToCornerAlongViewDir;
 
-        // If the camera is inside (or past) the bounding box, allow the near plane to move
-        // closer to the camera based on the point of interest distance, so zooming into details
-        // does not clip geometry.
+        // If the camera is inside (or past) the bounding box, derive the near plane from the
+        // point of interest distance so zooming into details does not clip geometry.
         if ( minDistEyeToCornerAlongViewDir <= 0 && m_navigationPolicy.notNull() && m_navigationPolicyEnabled )
         {
             double pointOfInterestDist = ( eye - navPointOfinterest ).length();
-            ( *nearPlaneDist )         = CVF_MAX( m_defaultPerspectiveNearPlaneDistance, pointOfInterestDist * 0.1 );
+            ( *nearPlaneDist )         = pointOfInterestDist * 0.1;
         }
 
-        // Guard against the zero nearplane possibility
+        // Guard against the zero/negative nearplane possibility (e.g. camera on a bbox corner).
         if ( ( *nearPlaneDist ) <= 0 ) ( *nearPlaneDist ) = m_defaultPerspectiveNearPlaneDistance;
     }
     else // Orthographic projection. Set to encapsulate the complete boundingbox, possibly setting a negative nearplane


### PR DESCRIPTION
Fixes #13977.

## Summary

- The perspective near plane was hard-floored at `m_defaultPerspectiveNearPlaneDistance = 0.05` via `CVF_MAX`. For very small models (extent ~1.0 or below) the closest bounding-box corner sits within that distance of the eye, so the clamp pushed the near plane past the model and the line-607 fix-up bumped far to `near + 1.0`, leaving the entire model behind near. Parallel projection was unaffected because its near plane scales directly with `minDistEyeToCorner`.
- Drop the floor on both the bbox-corner branch and the inside-bbox branch in `caf::Viewer::calculateNearFarPlanes`. The default value still kicks in via the existing zero/negative guard. The `maxFarNearRatio = 3000` guard continues to protect depth-buffer precision when geometry spans both very close and very distant corners.
- Adds extent (XYZ) and UTM offset (XY) fields to the Customize Mock Model dialog so the bug can be reproduced from `Test → Customized Mock Model` by setting Extent X/Y/Z to e.g. 1.0 and Offset to 0.