### PR TITLE
#12106 Polygon: Show coordinates with positive depth in property panel

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.cpp
@@ -20,6 +20,7 @@
 
 #include "RiaApplication.h"
 #include "RiaColorTools.h"
+#include "RiaVec3Tools.h"
 
 #include "RigPolyLinesData.h"
 
@@ -50,6 +51,12 @@ RimPolygon::RimPolygon()
 
     CAF_PDM_InitField( &m_isReadOnly, "IsReadOnly", false, "Read Only" );
     CAF_PDM_InitScriptableFieldWithScriptKeywordNoDefault( &m_pointsInDomainCoords, "PointsInDomainCoords", "Coordinates", "Points" );
+    m_pointsInDomainCoords.uiCapability()->setUiHidden( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_pointsInDomainCoordsForUi, "PointsInDomainCoordsUi", "Coordinates" );
+    m_pointsInDomainCoordsForUi.registerSetMethod( this, &RimPolygon::setPointsInDomainCoordsFromXyd );
+    m_pointsInDomainCoordsForUi.registerGetMethod( this, &RimPolygon::pointsInDomainCoordsXyd );
+    m_pointsInDomainCoordsForUi.xmlCapability()->disableIO();
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_appearance, "Appearance", "Appearance" );
     m_appearance = new RimPolygonAppearance;
@@ -101,6 +108,22 @@ void RimPolygon::setPointsInDomainCoords( const std::vector<cvf::Vec3d>& points 
 std::vector<cvf::Vec3d> RimPolygon::pointsInDomainCoords() const
 {
     return m_pointsInDomainCoords();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<cvf::Vec3d> RimPolygon::pointsInDomainCoordsXyd() const
+{
+    return RiaVec3Tools::invertZSign( m_pointsInDomainCoords() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimPolygon::setPointsInDomainCoordsFromXyd( const std::vector<cvf::Vec3d>& pointsXyd )
+{
+    m_pointsInDomainCoords = RiaVec3Tools::invertZSign( pointsXyd );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -183,9 +206,9 @@ void RimPolygon::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiO
 
     auto groupPoints = uiOrdering.addNewGroup( "Points" );
     groupPoints->setCollapsedByDefault();
-    groupPoints->add( &m_pointsInDomainCoords );
+    groupPoints->add( &m_pointsInDomainCoordsForUi );
 
-    m_pointsInDomainCoords.uiCapability()->setUiReadOnly( m_isReadOnly() );
+    m_pointsInDomainCoordsForUi.uiCapability()->setUiReadOnly( m_isReadOnly() );
 
     auto group = uiOrdering.addNewGroup( "Appearance" );
     m_appearance->uiOrdering( uiConfigName, *group );
@@ -196,7 +219,7 @@ void RimPolygon::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiO
 //--------------------------------------------------------------------------------------------------
 void RimPolygon::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
 {
-    if ( changedField == &m_pointsInDomainCoords )
+    if ( changedField == &m_pointsInDomainCoords || changedField == &m_pointsInDomainCoordsForUi )
     {
         coordinatesChanged.send();
     }

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.h
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.h
@@ -23,6 +23,7 @@
 
 #include "cafPdmChildField.h"
 #include "cafPdmFieldCvfVec3d.h"
+#include "cafPdmProxyValueField.h"
 
 #include "cvfColor3.h"
 #include "cvfVector3.h"
@@ -74,8 +75,12 @@ private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
 
+    std::vector<cvf::Vec3d> pointsInDomainCoordsXyd() const;
+    void                    setPointsInDomainCoordsFromXyd( const std::vector<cvf::Vec3d>& pointsXyd );
+
 private:
-    caf::PdmField<bool>                       m_isReadOnly;
-    caf::PdmField<std::vector<cvf::Vec3d>>    m_pointsInDomainCoords;
-    caf::PdmChildField<RimPolygonAppearance*> m_appearance;
+    caf::PdmField<bool>                              m_isReadOnly;
+    caf::PdmField<std::vector<cvf::Vec3d>>           m_pointsInDomainCoords;
+    caf::PdmProxyValueField<std::vector<cvf::Vec3d>> m_pointsInDomainCoordsForUi;
+    caf::PdmChildField<RimPolygonAppearance*>        m_appearance;
 };


### PR DESCRIPTION
Bind a PdmProxyValueField that inverts the Z sign to the Points group in RimPolygon's property panel, mirroring the pattern already used by RimExtrudedCurveIntersection. The raw m_pointsInDomainCoords field keeps its XYZ semantics, scriptable keyword, and serialization unchanged.

Fixes #12106.