### PR TITLE
#13982 Python: Generate StrEnum classes for AppEnum-typed fields

### DIFF
--- a/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp
@@ -149,6 +149,128 @@ QString caf::PdmPythonGenerator::generate( PdmObjectFactory* factory, std::vecto
     std::map<QString, QString>                                        classCommentsGenerated;
     std::set<QString>                                                 dataTypesInChildFields;
 
+    // Bookkeeping for AppEnum-typed fields. Each unique C++ AppEnum type (keyed by its xml
+    // dataTypeName, which is typeid().name() and therefore unique per type) gets one Python
+    // StrEnum class. Names are derived from the script field name to stay readable.
+    struct EnumClassDef
+    {
+        QString                                  className;
+        std::vector<std::pair<QString, QString>> members; // (memberName, originalText), in declaration order
+        std::map<QString, QString>               memberNameByText;
+    };
+    std::map<QString, EnumClassDef> enumDefByDataTypeName;
+    std::map<QString, QString>      enumClassNameByDataTypeName;
+    // Seed with names that are already bound at module scope in the generated file (imports
+    // and module-level functions) so a generated enum cannot shadow them.
+    std::set<QString> usedEnumClassNames = { "PdmObjectBase",
+                                             "PdmObject_pb2",
+                                             "grpc",
+                                             "StrEnum",
+                                             "Optional",
+                                             "Dict",
+                                             "List",
+                                             "Tuple",
+                                             "Type",
+                                             "class_dict",
+                                             "class_from_keyword" };
+    for ( std::shared_ptr<PdmObject> object : dummyObjects )
+    {
+        QString scriptClassName =
+            PdmObjectScriptingCapabilityRegister::scriptClassNameFromClassKeyword( object->classKeyword() );
+        if ( scriptClassName.isEmpty() ) scriptClassName = object->classKeyword();
+        usedEnumClassNames.insert( scriptClassName );
+    }
+
+    auto sanitizeEnumMemberName = []( const QString& text ) -> QString
+    {
+        // Python identifiers must start with a letter or underscore and may only contain
+        // letters, digits, and underscores. Some AppEnum texts (e.g. "R-G", "None") violate
+        // these rules — coerce them into valid identifiers without changing the wire value.
+        static const std::set<QString> pythonKeywords = { "False",  "None",     "True",  "and",    "as",       "assert",
+                                                          "async",  "await",    "break", "class",  "continue", "def",
+                                                          "del",    "elif",     "else",  "except", "finally",  "for",
+                                                          "from",   "global",   "if",    "import", "in",       "is",
+                                                          "lambda", "nonlocal", "not",   "or",     "pass",     "raise",
+                                                          "return", "try",      "while", "with",   "yield",    "match",
+                                                          "case" };
+        QString                        s;
+        for ( QChar ch : text )
+        {
+            if ( ch.isLetterOrNumber() || ch == '_' )
+                s += ch;
+            else
+                s += '_';
+        }
+        if ( s.isEmpty() ) s = "_";
+        if ( s[0].isDigit() ) s = "_" + s;
+        if ( pythonKeywords.count( s ) ) s += "_";
+        return s;
+    };
+
+    auto enumClassNameForField = [&]( PdmFieldHandle* field, PdmAbstractFieldScriptingCapability* scriptability ) -> QString
+    {
+        QStringList enumTexts = scriptability->enumScriptTexts();
+        if ( enumTexts.empty() ) return QString();
+
+        QString dataTypeName = field->capability<PdmXmlFieldHandle>()->dataTypeName();
+        auto    cached       = enumClassNameByDataTypeName.find( dataTypeName );
+        if ( cached != enumClassNameByDataTypeName.end() ) return cached->second;
+
+        QString baseName = snakeToCamelCase( camelToSnakeCase( scriptability->scriptFieldName() ) );
+        if ( baseName.isEmpty() ) baseName = "Enum";
+
+        QString candidate = baseName;
+        int     suffix    = 1;
+        while ( usedEnumClassNames.count( candidate ) )
+        {
+            candidate = baseName + QString::number( ++suffix );
+        }
+
+        EnumClassDef def;
+        def.className = candidate;
+        std::set<QString> usedMemberNames;
+        for ( const QString& text : enumTexts )
+        {
+            QString memberName   = sanitizeEnumMemberName( text );
+            int     memberSuffix = 1;
+            QString unique       = memberName;
+            while ( usedMemberNames.count( unique ) )
+            {
+                unique = memberName + QString( "_%1" ).arg( ++memberSuffix );
+            }
+            usedMemberNames.insert( unique );
+            def.members.push_back( { unique, text } );
+            def.memberNameByText[text] = unique;
+        }
+
+        enumClassNameByDataTypeName[dataTypeName] = candidate;
+        enumDefByDataTypeName[dataTypeName]       = def;
+        usedEnumClassNames.insert( candidate );
+        return candidate;
+    };
+
+    auto enumDefaultValueExpression =
+        [&]( PdmFieldHandle* field, const QString& enumClassName, const QString& quotedDefault ) -> QString
+    {
+        // The existing getDefaultValue() returns the AppEnum text wrapped in double quotes (because
+        // dataTypeString reports "str" for enum fields). Convert "MATRIX_MODEL" -> EnumName.MATRIX_MODEL.
+        // If the default isn't a quoted string (e.g. the literal None for fields with no default),
+        // leave it unchanged.
+        if ( !quotedDefault.startsWith( '"' ) || !quotedDefault.endsWith( '"' ) || quotedDefault.size() < 2 )
+        {
+            return quotedDefault;
+        }
+        QString stripped = quotedDefault.mid( 1, quotedDefault.size() - 2 );
+        if ( stripped.isEmpty() ) return quotedDefault;
+
+        QString dataTypeName = field->capability<PdmXmlFieldHandle>()->dataTypeName();
+        auto    it           = enumDefByDataTypeName.find( dataTypeName );
+        QString memberName   = ( it != enumDefByDataTypeName.end() && it->second.memberNameByText.count( stripped ) )
+                                   ? it->second.memberNameByText.at( stripped )
+                                   : sanitizeEnumMemberName( stripped );
+        return QString( "%1.%2" ).arg( enumClassName ).arg( memberName );
+    };
+
     // First generate all attributes and comments to go into each object
     for ( std::shared_ptr<PdmObject> object : dummyObjects )
     {
@@ -262,6 +384,13 @@ QString caf::PdmPythonGenerator::generate( PdmObjectFactory* factory, std::vecto
                                     // TODO: Consider using PdmField<std::optional<T>> for optional fields instead of
                                     // using the default value to manipulate the type
                                     dataType = QString( "Optional[%1]" ).arg( dataType );
+                                }
+
+                                QString enumClassName = enumClassNameForField( field, scriptability );
+                                if ( !enumClassName.isEmpty() )
+                                {
+                                    dataType     = enumClassName;
+                                    defaultValue = enumDefaultValueExpression( field, enumClassName, defaultValue );
                                 }
 
                                 QString fieldCode =
@@ -393,6 +522,13 @@ QString caf::PdmPythonGenerator::generate( PdmObjectFactory* factory, std::vecto
                         commentOrEnumDescription = "One of [" + enumTexts.join( ", " ) + "]";
                     }
 
+                    QString enumClassName = enumClassNameForField( field, scriptability );
+                    if ( !enumClassName.isEmpty() )
+                    {
+                        dataType     = enumClassName;
+                        defaultValue = enumDefaultValueExpression( field, enumClassName, defaultValue );
+                    }
+
                     inputArgumentStrings.push_back(
                         QString( "%1: %2=%3" ).arg( argumentName ).arg( dataType ).arg( defaultValue ) );
                     outputArgumentStrings.push_back( QString( "%1=%1" ).arg( argumentName ) );
@@ -444,8 +580,25 @@ QString caf::PdmPythonGenerator::generate( PdmObjectFactory* factory, std::vecto
     out << "from rips.pdmobject import PdmObjectBase\n";
     out << "import PdmObject_pb2\n";
     out << "import grpc\n";
+    out << "from enum import StrEnum\n";
     out << "from typing import Optional, Dict, List, Tuple, Type\n";
     out << "\n";
+
+    // Emit enum classes sorted by name for stable diffs across regenerations.
+    std::map<QString, const EnumClassDef*> enumDefByClassName;
+    for ( const auto& [dataTypeName, def] : enumDefByDataTypeName )
+    {
+        enumDefByClassName[def.className] = &def;
+    }
+    for ( const auto& [enumClassName, def] : enumDefByClassName )
+    {
+        out << QString( "class %1(StrEnum):\n" ).arg( enumClassName );
+        for ( const auto& [memberName, originalText] : def->members )
+        {
+            out << QString( "    %1 = \"%2\"\n" ).arg( memberName ).arg( originalText );
+        }
+        out << "\n";
+    }
 
     for ( std::shared_ptr<PdmObject> object : dummyObjects )
     {
@@ -629,6 +782,19 @@ QString PdmPythonGenerator::camelToSnakeCase( const QString& camelString )
     snake_case.replace( re1, "\\1_\\2" );
     snake_case.replace( re2, "\\1_\\2" );
     return snake_case.toLower();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString PdmPythonGenerator::snakeToCamelCase( const QString& snakeString )
+{
+    QString camel;
+    for ( const QString& part : snakeString.split( '_', Qt::SkipEmptyParts ) )
+    {
+        camel += part.left( 1 ).toUpper() + part.mid( 1 ).toLower();
+    }
+    return camel;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.h
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.h
@@ -51,6 +51,7 @@ class PdmPythonGenerator : public PdmCodeGenerator
 public:
     QString        generate( PdmObjectFactory* factory, std::vector<QString>& errorMessages ) const override;
     static QString camelToSnakeCase( const QString& camelString );
+    static QString snakeToCamelCase( const QString& snakeString );
     static QString dataTypeString( const PdmFieldHandle* field, bool useStrForUnknownDataTypes );
 
     static QString pythonifyDataValue( const QString& dataValue );

--- a/GrpcInterface/Python/rips/PythonExamples/basic_operations/all_cases.py
+++ b/GrpcInterface/Python/rips/PythonExamples/basic_operations/all_cases.py
@@ -8,32 +8,32 @@ import rips
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    # Get a list of all cases
-    cases = resinsight.project.cases()
 
-    print("Got " + str(len(cases)) + " cases: ")
-    for case in cases:
-        print("Case id: " + str(case.id))
-        print("Case name: " + case.name)
-        print("Case type: " + case.__class__.__name__)
-        print("Case file name: " + case.file_path)
-        print("Case reservoir bounding box:", case.reservoir_boundingbox())
+# Get a list of all cases
+cases = resinsight.project.cases()
 
-        timesteps = case.time_steps()
-        for t in timesteps:
-            print("Year: " + str(t.year))
-            print("Month: " + str(t.month))
+print("Got " + str(len(cases)) + " cases: ")
+for case in cases:
+    print("Case id: " + str(case.id))
+    print("Case name: " + case.name)
+    print("Case type: " + case.__class__.__name__)
+    print("Case file name: " + case.file_path)
+    print("Case reservoir bounding box:", case.reservoir_boundingbox())
 
-        if isinstance(case, rips.EclipseCase):
-            print("Getting coarsening info for case: ", case.name, case.id)
-            coarsening_info = case.coarsening_info()
-            if coarsening_info:
-                print("Coarsening information:")
+    timesteps = case.time_steps()
+    for t in timesteps:
+        print("Year: " + str(t.year))
+        print("Month: " + str(t.month))
 
-            for c in coarsening_info:
-                print(
-                    "[{}, {}, {}] - [{}, {}, {}]".format(
-                        c.min.x, c.min.y, c.min.z, c.max.x, c.max.y, c.max.z
-                    )
+    if isinstance(case, rips.EclipseCase):
+        print("Getting coarsening info for case: ", case.name, case.id)
+        coarsening_info = case.coarsening_info()
+        if coarsening_info:
+            print("Coarsening information:")
+
+        for c in coarsening_info:
+            print(
+                "[{}, {}, {}] - [{}, {}, {}]".format(
+                    c.min.x, c.min.y, c.min.z, c.max.x, c.max.y, c.max.z
                 )
+            )

--- a/GrpcInterface/Python/rips/PythonExamples/basic_operations/error_handling.py
+++ b/GrpcInterface/Python/rips/PythonExamples/basic_operations/error_handling.py
@@ -40,12 +40,14 @@ except rips.RipsError as e:
 
 case = resinsight.project.case(case_id=0)
 if case is not None:
-    results = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+    results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", 0)
     active_cell_count = len(results)
 
     # Send the results back to ResInsight inside try / except construct
     try:
-        case.set_active_cell_property(results, "GENERATED", "POROAPPENDED", 0)
+        case.set_active_cell_property(
+            results, rips.PropertyType.GENERATED, "POROAPPENDED", 0
+        )
         print("Everything went well as expected")
     except Exception as e:  # Match any exception, but it should not happen
         print("Ooops!", e)
@@ -55,7 +57,9 @@ if case is not None:
 
     # This time we should get a rips.RipsError exception.
     try:
-        case.set_active_cell_property(results, "GENERATED", "POROAPPENDED", 0)
+        case.set_active_cell_property(
+            results, rips.PropertyType.GENERATED, "POROAPPENDED", 0
+        )
         print("Everything went well??")
     except rips.RipsError as e:
         print("Server Exception Received: ", e)
@@ -68,7 +72,9 @@ if case is not None:
     case.chunk_size = active_cell_count
 
     try:
-        case.set_active_cell_property(results, "GENERATED", "POROAPPENDED", 0)
+        case.set_active_cell_property(
+            results, rips.PropertyType.GENERATED, "POROAPPENDED", 0
+        )
         print("Everything went well??")
     except rips.RipsError as e:
         print("Got unexpected server exception", e, "This should not happen now")

--- a/GrpcInterface/Python/rips/PythonExamples/basic_operations/instance_example.py
+++ b/GrpcInterface/Python/rips/PythonExamples/basic_operations/instance_example.py
@@ -3,9 +3,8 @@
 #######################################
 import rips
 
-resinsight = rips.Instance.find()
-
-if resinsight is None:
-    print("ERROR: could not find ResInsight")
-else:
+try:
+    resinsight = rips.Instance.find()
     print("Successfully connected to ResInsight")
+except rips.RipsError as e:
+    print(f"ERROR: could not find ResInsight: {e}")

--- a/GrpcInterface/Python/rips/PythonExamples/basic_operations/selected_cases.py
+++ b/GrpcInterface/Python/rips/PythonExamples/basic_operations/selected_cases.py
@@ -14,5 +14,5 @@ if resinsight is not None:
     print("Got " + str(len(cases)) + " cases: ")
     for case in cases:
         print(case.name)
-        for property in case.available_properties("DYNAMIC_NATIVE"):
+        for property in case.available_properties(rips.PropertyType.DYNAMIC_NATIVE):
             print(property)

--- a/GrpcInterface/Python/rips/PythonExamples/basic_operations/selected_cases.py
+++ b/GrpcInterface/Python/rips/PythonExamples/basic_operations/selected_cases.py
@@ -8,11 +8,10 @@
 import rips
 
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    cases = resinsight.project.selected_cases()
+cases = resinsight.project.selected_cases()
 
-    print("Got " + str(len(cases)) + " cases: ")
-    for case in cases:
-        print(case.name)
-        for property in case.available_properties(rips.PropertyType.DYNAMIC_NATIVE):
-            print(property)
+print("Got " + str(len(cases)) + " cases: ")
+for case in cases:
+    print(case.name)
+    for property in case.available_properties(rips.PropertyType.DYNAMIC_NATIVE):
+        print(property)

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/case_grid_group.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/case_grid_group.py
@@ -21,4 +21,4 @@ case_group = resinsight.project.create_grid_case_group(case_paths=case_paths)
 case_group.compute_statistics()
 
 view = case_group.views()[0]
-view.apply_cell_result("DYNAMIC_NATIVE", "PRESSURE_DEV")
+view.apply_cell_result(rips.ResultType.DYNAMIC_NATIVE, "PRESSURE_DEV")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/case_grid_group_generated_results.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/case_grid_group_generated_results.py
@@ -24,11 +24,11 @@ print("Got " + str(len(cases)) + " cases: ")
 
 for case in cases:
     time_step_info = case.time_steps()
-    porv_results = case.active_cell_property("STATIC_NATIVE", "PORV", 0)
+    porv_results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORV", 0)
 
     for time_step_index in range(0, len(time_step_info)):
         pressure_results = case.active_cell_property(
-            "DYNAMIC_NATIVE", "PRESSURE", time_step_index
+            rips.PropertyType.DYNAMIC_NATIVE, "PRESSURE", time_step_index
         )
 
         results = []
@@ -37,7 +37,7 @@ for case in cases:
 
         # set the computed values in the case
         case.set_active_cell_property(
-            results, "GENERATED", "PRESSURE_PORV", time_step_index
+            results, rips.PropertyType.GENERATED, "PRESSURE_PORV", time_step_index
         )
 
     print(
@@ -49,9 +49,9 @@ for case in cases:
 
 print("Transferred all results back to ResInsight")
 
-# one of "GENERATED", "DYNAMIC_NATIVE", "STATIC_NATIVE", "IMPORTED"
+# Pick a value from rips.ResultType (e.g. GENERATED, DYNAMIC_NATIVE, STATIC_NATIVE).
 # https://api.resinsight.org/en/main/rips.html#result-definition
-property_type = "GENERATED"
+property_type = rips.ResultType.GENERATED
 
 property_name = "PRESSURE_PORV"
 

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/compute_avg_poro_for_region.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/compute_avg_poro_for_region.py
@@ -16,8 +16,10 @@ for case in cases:
     sum_poro = 0.0
     cell_cout = 0
 
-    eqlnum = case.active_cell_property("STATIC_NATIVE", "EQLNUM", time_step)
-    poro = case.active_cell_property("STATIC_NATIVE", "PORO", time_step)
+    eqlnum = case.active_cell_property(
+        rips.PropertyType.STATIC_NATIVE, "EQLNUM", time_step
+    )
+    poro = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", time_step)
     if len(eqlnum) != len(poro):
         print("Size of eqlnum and poro is not identical.")
         break

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/export_corner_point_grid.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/export_corner_point_grid.py
@@ -34,9 +34,10 @@ def validate_grid_dimensions(coord_array, zcorn_array, actnum_array, nx, ny, nz)
 
 
 def main():
-    # Connect to ResInsight
-    resinsight = rips.Instance.find()
-    if resinsight is None:
+    # Connect to ResInsight, launching it if no existing instance is found.
+    try:
+        resinsight = rips.Instance.find()
+    except rips.RipsError:
         print("Starting ResInsight...")
         resinsight = rips.Instance.launch(console=True)
 

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/fault_distance.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/fault_distance.py
@@ -5,8 +5,6 @@
 import rips
 
 resinsight = rips.Instance.find()
-if resinsight is None:
-    exit(1)
 
 cases = resinsight.project.cases()
 if len(cases) == 0:

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/import_case_properties.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/import_case_properties.py
@@ -37,7 +37,7 @@ roff_case = resinsight.project.load_case(roff_case_path)
 
 # PORO and EQLNUM should not be among available properties yet
 print("Available properties:")
-for prop in roff_case.available_properties("INPUT_PROPERTY"):
+for prop in roff_case.available_properties(rips.PropertyType.INPUT_PROPERTY):
     print(prop)
 
 # Import properties with file paths
@@ -58,5 +58,5 @@ for name in imported_names.values:
 
 # PORO and EQLNUM should now be among available properties
 print("Available properties:")
-for prop in roff_case.available_properties("INPUT_PROPERTY"):
+for prop in roff_case.available_properties(rips.PropertyType.INPUT_PROPERTY):
     print(prop)

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/input_prop_test_async.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/input_prop_test_async.py
@@ -24,18 +24,25 @@ start = time.time()
 case = resinsight.project.cases()[0]
 
 # Get a generator for the poro results. The generator will provide a chunk each time it is iterated
-poro_chunks = case.active_cell_property_async("STATIC_NATIVE", "PORO", 0)
+poro_chunks = case.active_cell_property_async(
+    rips.PropertyType.STATIC_NATIVE, "PORO", 0
+)
 # Get a generator for the permx results. The generator will provide a chunk each time it is iterated
-permx_chunks = case.active_cell_property_async("STATIC_NATIVE", "PERMX", 0)
+permx_chunks = case.active_cell_property_async(
+    rips.PropertyType.STATIC_NATIVE, "PERMX", 0
+)
 
 # Send back the result with the result provided by a generator object.
 # Iterating the result generator will cause the script to read from the poro and permx generators
 # And return the result of each iteration
 case.set_active_cell_property_async(
-    create_result(poro_chunks, permx_chunks), "GENERATED", "POROPERMXAS", 0
+    create_result(poro_chunks, permx_chunks),
+    rips.PropertyType.GENERATED,
+    "POROPERMXAS",
+    0,
 )
 
 end = time.time()
 print("Time elapsed: ", end - start)
 print("Transferred all results back")
-view = case.views()[0].apply_cell_result("GENERATED", "POROPERMXAS")
+view = case.views()[0].apply_cell_result(rips.ResultType.GENERATED, "POROPERMXAS")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/input_prop_test_sync.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/input_prop_test_sync.py
@@ -2,6 +2,11 @@
 # This example generates a derived property in an synchronous manner
 # Meaning it completes reading each result before calculating the derived result
 # See InputPropTestAsync for how to do this asynchronously instead.
+#
+# Property/porosity/result types accept either a typed enum
+# (rips.PropertyType.STATIC_NATIVE) or a plain string ("STATIC_NATIVE"). This
+# example uses the string form; see input_prop_test_async.py for the typed-enum
+# form.
 ########################################################################################
 import rips
 import time
@@ -12,9 +17,9 @@ start = time.time()
 case = resinsight.project.cases()[0]
 
 # Read poro result into list
-poro_results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", 0)
+poro_results = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
 # Read permx result into list
-permx_results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PERMX", 0)
+permx_results = case.active_cell_property("STATIC_NATIVE", "PERMX", 0)
 
 # Generate output result
 results = []
@@ -23,9 +28,7 @@ for poro, permx in zip(poro_results, permx_results):
 
 try:
     # Send back output result
-    case.set_active_cell_property(
-        results, rips.PropertyType.GENERATED, "POROPERMXSY", 0
-    )
+    case.set_active_cell_property(results, "GENERATED", "POROPERMXSY", 0)
 except grpc.RpcError as e:
     print("Exception Received: ", e)
 
@@ -34,4 +37,4 @@ end = time.time()
 print("Time elapsed: ", end - start)
 print("Transferred all results back")
 
-view = case.views()[0].apply_cell_result(rips.ResultType.GENERATED, "POROPERMXSY")
+view = case.views()[0].apply_cell_result("GENERATED", "POROPERMXSY")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/input_prop_test_sync.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/input_prop_test_sync.py
@@ -12,9 +12,9 @@ start = time.time()
 case = resinsight.project.cases()[0]
 
 # Read poro result into list
-poro_results = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+poro_results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", 0)
 # Read permx result into list
-permx_results = case.active_cell_property("STATIC_NATIVE", "PERMX", 0)
+permx_results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PERMX", 0)
 
 # Generate output result
 results = []
@@ -23,7 +23,9 @@ for poro, permx in zip(poro_results, permx_results):
 
 try:
     # Send back output result
-    case.set_active_cell_property(results, "GENERATED", "POROPERMXSY", 0)
+    case.set_active_cell_property(
+        results, rips.PropertyType.GENERATED, "POROPERMXSY", 0
+    )
 except grpc.RpcError as e:
     print("Exception Received: ", e)
 
@@ -32,4 +34,4 @@ end = time.time()
 print("Time elapsed: ", end - start)
 print("Transferred all results back")
 
-view = case.views()[0].apply_cell_result("GENERATED", "POROPERMXSY")
+view = case.views()[0].apply_cell_result(rips.ResultType.GENERATED, "POROPERMXSY")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/polygon_region_from_project.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/polygon_region_from_project.py
@@ -34,9 +34,6 @@ def point_in_polygon_2d(px, py, polygon_xy):
 
 
 resinsight = rips.Instance.find()
-if resinsight is None:
-    print("No ResInsight instance found")
-    exit()
 
 cases = resinsight.project.cases()
 if not cases:

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/polygon_region_from_project.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/polygon_region_from_project.py
@@ -85,7 +85,9 @@ for cell_idx, cell_center in enumerate(cell_centers):
 # Step 3: Create a Generated result that stores the unique integer region value
 # for every active cell. Cells not covered by any polygon receive value 0.
 property_name = "POLYGON_REGION"
-case.set_active_cell_property(region_values, "GENERATED", property_name, 0)
+case.set_active_cell_property(
+    region_values, rips.PropertyType.GENERATED, property_name, 0
+)
 
 print(f"Generated property '{property_name}' created successfully")
 for i, polygon in enumerate(polygons):
@@ -97,5 +99,7 @@ print(f"  Unassigned (no polygon): {unassigned} cells")
 
 # Apply the generated result in the view to visualize the regions
 view = case.views()[0] if case.views() else case.create_view()
-view.apply_cell_result(result_type="GENERATED", result_variable=property_name)
+view.apply_cell_result(
+    result_type=rips.ResultType.GENERATED, result_variable=property_name
+)
 print(f"Applied '{property_name}' cell result to view")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/result_aliases.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/result_aliases.py
@@ -37,7 +37,7 @@ roff_case = resinsight.project.load_case(roff_case_path)
 
 # Print all available properties
 print("Results on file:")
-for prop in roff_case.available_properties("STATIC_NATIVE"):
+for prop in roff_case.available_properties(rips.PropertyType.STATIC_NATIVE):
     print(prop)
 
 # The name "DYBDE" should point to the "DEPTH" result
@@ -48,11 +48,11 @@ roff_case.add_result_alias("BOTTOM", "PERMX")
 
 # Print all available properties, now with two additional props
 print("Results including aliases:")
-for prop in roff_case.available_properties("STATIC_NATIVE"):
+for prop in roff_case.available_properties(rips.PropertyType.STATIC_NATIVE):
     print(prop)
 
-real_result = roff_case.grid_property("STATIC_NATIVE", "BOTTOM", 0)
-alias_result = roff_case.grid_property("STATIC_NATIVE", "PERMX", 0)
+real_result = roff_case.grid_property(rips.PropertyType.STATIC_NATIVE, "BOTTOM", 0)
+alias_result = roff_case.grid_property(rips.PropertyType.STATIC_NATIVE, "PERMX", 0)
 
 if real_result[40] == alias_result[40]:
     print("Result values at index 40 match!")
@@ -62,10 +62,10 @@ roff_case.clear_result_aliases()
 
 # Print all available properties, now just the original ones
 print("Original results:")
-for prop in roff_case.available_properties("STATIC_NATIVE"):
+for prop in roff_case.available_properties(rips.PropertyType.STATIC_NATIVE):
     print(prop)
 
 try:
-    alias_result = roff_case.grid_property("STATIC_NATIVE", "PERMX", 0)
+    alias_result = roff_case.grid_property(rips.PropertyType.STATIC_NATIVE, "PERMX", 0)
 except Exception:
     print("Result PERMX no longer exists!")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/selected_cells.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/selected_cells.py
@@ -6,63 +6,62 @@
 import rips
 
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    cases = resinsight.project.cases()
+cases = resinsight.project.cases()
 
-    print("Got " + str(len(cases)) + " cases: ")
-    for case in cases:
-        print(case.name)
-        cells = case.selected_cells()
-        print("Found " + str(len(cells)) + " selected cells")
+print("Got " + str(len(cases)) + " cases: ")
+for case in cases:
+    print(case.name)
+    cells = case.selected_cells()
+    print("Found " + str(len(cells)) + " selected cells")
 
-        time_step_info = case.time_steps()
+    time_step_info = case.time_steps()
 
-        for idx, cell in enumerate(cells):
+    for idx, cell in enumerate(cells):
+        print(
+            "Selected cell: [{}, {}, {}] grid: {}".format(
+                cell.ijk.i + 1, cell.ijk.j + 1, cell.ijk.k + 1, cell.grid_index
+            )
+        )
+
+        # Get the grid and dimensions
+        grid = case.grids()[cell.grid_index]
+        dimensions = grid.dimensions()
+
+        # Map ijk to cell index
+        cell_index = (
+            dimensions.i * dimensions.j * cell.ijk.k
+            + dimensions.i * cell.ijk.j
+            + cell.ijk.i
+        )
+
+        # Print the cell center
+        cell_centers = grid.cell_centers()
+        cell_center = cell_centers[cell_index]
+        print(
+            "Cell center: [{}, {}, {}]".format(
+                cell_center.x, cell_center.y, cell_center.z
+            )
+        )
+
+        # Print the cell corners
+        cell_corners = grid.cell_corners()[cell_index]
+        print("Cell corners:")
+        print("c0:\n" + str(cell_corners.c0))
+        print("c1:\n" + str(cell_corners.c1))
+        print("c2:\n" + str(cell_corners.c2))
+        print("c3:\n" + str(cell_corners.c3))
+        print("c4:\n" + str(cell_corners.c4))
+        print("c5:\n" + str(cell_corners.c5))
+        print("c6:\n" + str(cell_corners.c6))
+        print("c7:\n" + str(cell_corners.c7))
+
+        for tidx, timestep in enumerate(time_step_info):
+            # Read the full SOIL result for time step
+            soil_results = case.selected_cell_property(
+                rips.PropertyType.DYNAMIC_NATIVE, "SOIL", tidx
+            )
             print(
-                "Selected cell: [{}, {}, {}] grid: {}".format(
-                    cell.ijk.i + 1, cell.ijk.j + 1, cell.ijk.k + 1, cell.grid_index
+                "SOIL: {} ({}.{}.{})".format(
+                    soil_results[idx], timestep.year, timestep.month, timestep.day
                 )
             )
-
-            # Get the grid and dimensions
-            grid = case.grids()[cell.grid_index]
-            dimensions = grid.dimensions()
-
-            # Map ijk to cell index
-            cell_index = (
-                dimensions.i * dimensions.j * cell.ijk.k
-                + dimensions.i * cell.ijk.j
-                + cell.ijk.i
-            )
-
-            # Print the cell center
-            cell_centers = grid.cell_centers()
-            cell_center = cell_centers[cell_index]
-            print(
-                "Cell center: [{}, {}, {}]".format(
-                    cell_center.x, cell_center.y, cell_center.z
-                )
-            )
-
-            # Print the cell corners
-            cell_corners = grid.cell_corners()[cell_index]
-            print("Cell corners:")
-            print("c0:\n" + str(cell_corners.c0))
-            print("c1:\n" + str(cell_corners.c1))
-            print("c2:\n" + str(cell_corners.c2))
-            print("c3:\n" + str(cell_corners.c3))
-            print("c4:\n" + str(cell_corners.c4))
-            print("c5:\n" + str(cell_corners.c5))
-            print("c6:\n" + str(cell_corners.c6))
-            print("c7:\n" + str(cell_corners.c7))
-
-            for tidx, timestep in enumerate(time_step_info):
-                # Read the full SOIL result for time step
-                soil_results = case.selected_cell_property(
-                    rips.PropertyType.DYNAMIC_NATIVE, "SOIL", tidx
-                )
-                print(
-                    "SOIL: {} ({}.{}.{})".format(
-                        soil_results[idx], timestep.year, timestep.month, timestep.day
-                    )
-                )

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/selected_cells.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/selected_cells.py
@@ -59,7 +59,7 @@ if resinsight is not None:
             for tidx, timestep in enumerate(time_step_info):
                 # Read the full SOIL result for time step
                 soil_results = case.selected_cell_property(
-                    "DYNAMIC_NATIVE", "SOIL", tidx
+                    rips.PropertyType.DYNAMIC_NATIVE, "SOIL", tidx
                 )
                 print(
                     "SOIL: {} ({}.{}.{})".format(

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_cell_result.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_cell_result.py
@@ -6,4 +6,4 @@ import rips
 resinsight = rips.Instance.find()
 
 view = resinsight.project.views()[0]
-view.apply_cell_result(result_type="STATIC_NATIVE", result_variable="DX")
+view.apply_cell_result(result_type=rips.ResultType.STATIC_NATIVE, result_variable="DX")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_active_cell_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_active_cell_property.py
@@ -2,9 +2,9 @@
 # This script creates a discrete (integer) property for all active
 # cells in the first case in the project.
 #
-# Passing data_type="INTEGER" flags the property as discrete regardless
-# of the property name (previously this required the name to end with
-# "NUM").
+# Passing data_type=rips.PropertyDataType.INTEGER flags the property as
+# discrete regardless of the property name (previously this required the
+# name to end with "NUM").
 ######################################################################
 import rips
 
@@ -13,12 +13,16 @@ resinsight = rips.Instance.find()
 case = resinsight.project.case(case_id=0)
 
 # Derive a discrete region id from a continuous property.
-poro = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+poro = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", 0)
 region_ids = [int(value * 100) % 4 for value in poro]
 
 print("Applying discrete values to active cells")
 case.set_active_cell_property(
-    region_ids, "GENERATED", "MY_REGION", 0, data_type="INTEGER"
+    region_ids,
+    rips.PropertyType.GENERATED,
+    "MY_REGION",
+    0,
+    data_type=rips.PropertyDataType.INTEGER,
 )
 
 # Bind integer values to text labels so the legend shows names instead of numbers.

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
@@ -4,8 +4,9 @@
 #
 # A discrete property is visualized with a category legend, in contrast
 # to the continuous legend used for floating point properties. Passing
-# data_type="INTEGER" flags the property as discrete regardless of the
-# property name (previously this required the name to end with "NUM").
+# data_type=rips.PropertyDataType.INTEGER flags the property as discrete
+# regardless of the property name (previously this required the name to
+# end with "NUM").
 ######################################################################
 import rips
 
@@ -22,7 +23,13 @@ for i in range(0, grid_cell_count):
     values.append(i % 4)
 
 print("Applying discrete values to main grid")
-case.set_grid_property(values, "STATIC_NATIVE", "MY_REGION", 0, data_type="INTEGER")
+case.set_grid_property(
+    values,
+    rips.PropertyType.STATIC_NATIVE,
+    "MY_REGION",
+    0,
+    data_type=rips.PropertyDataType.INTEGER,
+)
 
 # Bind integer values to text labels so the legend shows names instead of numbers.
 # Colors are optional — values without a color get an auto-assigned palette color.

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_grid_properties.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_grid_properties.py
@@ -22,9 +22,9 @@ property_data_index = grid.property_data_index_from_ijk(31, 53, 21)
 values[property_data_index] = 1.5
 
 print("Applying values to main grid")
-case.set_grid_property(values, "STATIC_NATIVE", "MY_DATA", 0)
+case.set_grid_property(values, rips.PropertyType.STATIC_NATIVE, "MY_DATA", 0)
 
-values_from_ri = case.grid_property("STATIC_NATIVE", "MY_DATA", 0)
+values_from_ri = case.grid_property(rips.PropertyType.STATIC_NATIVE, "MY_DATA", 0)
 assert values[property_data_index] == values_from_ri[property_data_index]
 
 # Get LGR grid as grid index 1
@@ -37,5 +37,5 @@ for i in range(0, grid_cell_count):
     values.append(i % 3 * 0.75)
 
 print("Applying values to LGR grid")
-case.set_grid_property(values, "STATIC_NATIVE", "MY_DATA", 0, 1)
-values_from_ri = case.grid_property("STATIC_NATIVE", "MY_DATA", 0, 1)
+case.set_grid_property(values, rips.PropertyType.STATIC_NATIVE, "MY_DATA", 0, 1)
+values_from_ri = case.grid_property(rips.PropertyType.STATIC_NATIVE, "MY_DATA", 0, 1)

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_average_async.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_average_async.py
@@ -19,7 +19,9 @@ averages = []
 for i in range(0, len(timeSteps)):
     # Get the results from time step i asynchronously
     # It actually returns a generator object almost immediately
-    result_chunks = case.active_cell_property_async("DYNAMIC_NATIVE", "SOIL", i)
+    result_chunks = case.active_cell_property_async(
+        rips.PropertyType.DYNAMIC_NATIVE, "SOIL", i
+    )
     mysum = 0.0
     count = 0
     # Loop through and append the average. each time we loop resultChunks

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_average_sync.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_average_sync.py
@@ -17,7 +17,7 @@ time_steps = case.time_steps()
 averages = []
 for i in range(0, len(time_steps)):
     # Get a list of all the results for time step i
-    results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", i)
+    results = case.active_cell_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", i)
     mysum = sum(results)
     averages.append(mysum / len(results))
 

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_average_sync.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_average_sync.py
@@ -1,5 +1,9 @@
 ###########################################################################################
 # This example will synchronously calculate the average value for SOIL for all time steps
+#
+# Property/porosity types accept either a typed enum (rips.PropertyType.DYNAMIC_NATIVE) or
+# a plain string ("DYNAMIC_NATIVE"). This example uses the string form; see
+# soil_average_async.py for the typed-enum form.
 ###########################################################################################
 import rips
 import time
@@ -17,7 +21,7 @@ time_steps = case.time_steps()
 averages = []
 for i in range(0, len(time_steps)):
     # Get a list of all the results for time step i
-    results = case.active_cell_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", i)
+    results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", i)
     mysum = sum(results)
     averages.append(mysum / len(results))
 

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_porv_async.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_porv_async.py
@@ -23,7 +23,9 @@ case = resinsight.project.cases()[0]
 timeStepInfo = case.time_steps()
 
 # Get a generator for the porv results. The generator will provide a chunk each time it is iterated
-porv_chunks = case.active_cell_property_async("STATIC_NATIVE", "PORV", 0)
+porv_chunks = case.active_cell_property_async(
+    rips.PropertyType.STATIC_NATIVE, "PORV", 0
+)
 
 # Read the static result into an array, so we don't have to transfer it for each iteration
 # Note we use the async method even if we synchronise here, because we need the values chunked
@@ -34,12 +36,14 @@ for porv_chunk in porv_chunks:
 
 for i in range(0, len(timeStepInfo)):
     # Get a generator object for the SOIL property for time step i
-    soil_chunks = case.active_cell_property_async("DYNAMIC_NATIVE", "SOIL", i)
+    soil_chunks = case.active_cell_property_async(
+        rips.PropertyType.DYNAMIC_NATIVE, "SOIL", i
+    )
     # Create the generator object for the SOIL * PORV derived result
     result_generator = create_result(soil_chunks, iter(porv_array))
     # Send back the result asynchronously with a generator object
     case.set_active_cell_property_async(
-        result_generator, "GENERATED", "SOILPORVAsync", i
+        result_generator, rips.PropertyType.GENERATED, "SOILPORVAsync", i
     )
 
 end = time.time()
@@ -47,4 +51,4 @@ print("Time elapsed: ", end - start)
 
 print("Transferred all results back")
 
-view = case.views()[0].apply_cell_result("GENERATED", "SOILPORVAsync")
+view = case.views()[0].apply_cell_result(rips.ResultType.GENERATED, "SOILPORVAsync")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_porv_sync.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/soil_porv_sync.py
@@ -10,12 +10,14 @@ start = time.time()
 case = resinsight.project.cases()[0]
 
 # Read the full porv result
-porv_results = case.active_cell_property("STATIC_NATIVE", "PORV", 0)
+porv_results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORV", 0)
 time_step_info = case.time_steps()
 
 for i in range(0, len(time_step_info)):
     # Read the full SOIl result for time step i
-    soil_results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", i)
+    soil_results = case.active_cell_property(
+        rips.PropertyType.DYNAMIC_NATIVE, "SOIL", i
+    )
 
     # Generate the result by looping through both lists in order
     results = []
@@ -23,11 +25,13 @@ for i in range(0, len(time_step_info)):
         results.append(soil * porv)
 
     # Send back result
-    case.set_active_cell_property(results, "GENERATED", "SOILPORVSync", i)
+    case.set_active_cell_property(
+        results, rips.PropertyType.GENERATED, "SOILPORVSync", i
+    )
 
 end = time.time()
 print("Time elapsed: ", end - start)
 
 print("Transferred all results back")
 
-view = case.views()[0].apply_cell_result("GENERATED", "SOILPORVSync")
+view = case.views()[0].apply_cell_result(rips.ResultType.GENERATED, "SOILPORVSync")

--- a/GrpcInterface/Python/rips/PythonExamples/export_and_plotting/export_snapshots.py
+++ b/GrpcInterface/Python/rips/PythonExamples/export_and_plotting/export_snapshots.py
@@ -38,7 +38,7 @@ for case in cases:
     for view in case.views():
         for property in property_list:
             view.apply_cell_result(
-                result_type="DYNAMIC_NATIVE", result_variable=property
+                result_type=rips.ResultType.DYNAMIC_NATIVE, result_variable=property
             )
         for time_step in range(0, len(time_steps), 10):
             view.set_time_step(time_step=time_step)

--- a/GrpcInterface/Python/rips/PythonExamples/instance_and_project_management/command_example.py
+++ b/GrpcInterface/Python/rips/PythonExamples/instance_and_project_management/command_example.py
@@ -26,7 +26,9 @@ view2 = view1.clone()
 view1.set_time_step(time_step=2)
 
 # Set cell result to SOIL
-view1.apply_cell_result(result_type="DYNAMIC_NATIVE", result_variable="SOIL")
+view1.apply_cell_result(
+    result_type=rips.ResultType.DYNAMIC_NATIVE, result_variable="SOIL"
+)
 
 
 # Create a temporary directory which will disappear at the end of this script

--- a/GrpcInterface/Python/rips/PythonExamples/instance_and_project_management/launch_load_case_snapshot_exit.py
+++ b/GrpcInterface/Python/rips/PythonExamples/instance_and_project_management/launch_load_case_snapshot_exit.py
@@ -27,7 +27,9 @@ view1 = case.views()[0]
 view1.set_time_step(time_step=2)
 
 # Set cell result to SOIL
-view1.apply_cell_result(result_type="DYNAMIC_NATIVE", result_variable="SOIL")
+view1.apply_cell_result(
+    result_type=rips.ResultType.DYNAMIC_NATIVE, result_variable="SOIL"
+)
 
 # Set export folder for snapshots and properties
 resinsight.set_export_folder(export_type="SNAPSHOTS", path="e:/temp")

--- a/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/create_polygon.py
+++ b/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/create_polygon.py
@@ -8,42 +8,42 @@ import rips
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    # Get a list of all cases
-    cases = resinsight.project.cases()
 
-    for c in cases:
-        print("Case name: " + c.name)
+# Get a list of all cases
+cases = resinsight.project.cases()
 
-        # create a polygon which is same a the bounding box in x and y.
-        # depth is set to middle of the bounding box
-        bbox = c.reservoir_boundingbox()
-        depth = bbox.max_z - ((bbox.max_z - bbox.min_z) / 2.0)
+for c in cases:
+    print("Case name: " + c.name)
 
-        coordinates = []
-        coordinates.append([bbox.min_x, bbox.min_y, depth])
-        coordinates.append([bbox.max_x, bbox.min_y, depth])
-        coordinates.append([bbox.max_x, bbox.max_y, depth])
-        coordinates.append([bbox.min_x, bbox.max_y, depth])
+    # create a polygon which is same a the bounding box in x and y.
+    # depth is set to middle of the bounding box
+    bbox = c.reservoir_boundingbox()
+    depth = bbox.max_z - ((bbox.max_z - bbox.min_z) / 2.0)
 
-        polygon_collection = resinsight.project.descendants(rips.PolygonCollection)[0]
-        p = polygon_collection.create_polygon(
-            name="{} bounding box".format(c.name), coordinates=coordinates
-        )
-        print("Coordinates for {}:".format(p.name))
-        for coord in p.coordinates:
-            print(coord)
+    coordinates = []
+    coordinates.append([bbox.min_x, bbox.min_y, depth])
+    coordinates.append([bbox.max_x, bbox.min_y, depth])
+    coordinates.append([bbox.max_x, bbox.max_y, depth])
+    coordinates.append([bbox.min_x, bbox.max_y, depth])
 
-        # Customize appearance
-        appearance = p.appearance()
-        if appearance is not None:
-            appearance.line_color = "#ff0000"
-            appearance.line_thickness = 5
-            appearance.show_spheres = True
-            appearance.sphere_color = "#0000ff"
-            appearance.update()
-            print(
-                "Appearance updated: line_color={}, line_thickness={}".format(
-                    appearance.line_color, appearance.line_thickness
-                )
+    polygon_collection = resinsight.project.descendants(rips.PolygonCollection)[0]
+    p = polygon_collection.create_polygon(
+        name="{} bounding box".format(c.name), coordinates=coordinates
+    )
+    print("Coordinates for {}:".format(p.name))
+    for coord in p.coordinates:
+        print(coord)
+
+    # Customize appearance
+    appearance = p.appearance()
+    if appearance is not None:
+        appearance.line_color = "#ff0000"
+        appearance.line_thickness = 5
+        appearance.show_spheres = True
+        appearance.sphere_color = "#0000ff"
+        appearance.update()
+        print(
+            "Appearance updated: line_color={}, line_thickness={}".format(
+                appearance.line_color, appearance.line_thickness
             )
+        )

--- a/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/create_regular_surface.py
+++ b/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/create_regular_surface.py
@@ -34,58 +34,56 @@ resinsight = rips.Instance.find()
 
 project = resinsight.project
 
+# Get a list of all cases
+cases = resinsight.project.cases()
 
-if resinsight is not None:
-    # Get a list of all cases
-    cases = resinsight.project.cases()
+for c in cases:
+    bbox = c.reservoir_boundingbox()
+    depth = bbox.max_z - ((bbox.max_z - bbox.min_z) / 2.0)
 
-    for c in cases:
-        bbox = c.reservoir_boundingbox()
-        depth = bbox.max_z - ((bbox.max_z - bbox.min_z) / 2.0)
+    origin_x = bbox.min_x
+    origin_y = bbox.min_y
 
-        origin_x = bbox.min_x
-        origin_y = bbox.min_y
+    name = "{} surface".format(c.name)
 
-        name = "{} surface".format(c.name)
+    nx = 200
+    ny = 100
 
-        nx = 200
-        ny = 100
+    increment_x = (bbox.max_x - bbox.min_x) / float(nx)
+    increment_y = (bbox.max_y - bbox.min_y) / float(ny)
 
-        increment_x = (bbox.max_x - bbox.min_x) / float(nx)
-        increment_y = (bbox.max_y - bbox.min_y) / float(ny)
+    surface_collection = resinsight.project.descendants(rips.SurfaceCollection)[0]
 
-        surface_collection = resinsight.project.descendants(rips.SurfaceCollection)[0]
+    # Create a surface at a given depth
+    s = surface_collection.new_regular_surface(
+        name=name,
+        origin_x=origin_x,
+        origin_y=origin_y,
+        depth=-depth,
+        nx=nx,
+        ny=ny,
+        increment_x=increment_x,
+        increment_y=increment_y,
+    )
 
-        # Create a surface at a given depth
-        s = surface_collection.new_regular_surface(
-            name=name,
-            origin_x=origin_x,
-            origin_y=origin_y,
-            depth=-depth,
-            nx=nx,
-            ny=ny,
-            increment_x=increment_x,
-            increment_y=increment_y,
-        )
+    # Rotate the resulting surface
+    s.rotation = 45.0
+    s.update()
 
-        # Rotate the resulting surface
-        s.rotation = 45.0
-        s.update()
+    # Add one property
+    s.set_property("first_property", create_x_surface(nx, ny))
 
-        # Add one property
-        s.set_property("first_property", create_x_surface(nx, ny))
+    # Add a wave surface
+    s.set_property("wave", create_wave_surface(nx, ny))
 
-        # Add a wave surface
-        s.set_property("wave", create_wave_surface(nx, ny))
+    wave_values = s.get_property("wave")
+    print(
+        f"Retrieved {len(wave_values)} wave property values, min={min(wave_values):.2f}, max={max(wave_values):.2f}"
+    )
 
-        wave_values = s.get_property("wave")
-        print(
-            f"Retrieved {len(wave_values)} wave property values, min={min(wave_values):.2f}, max={max(wave_values):.2f}"
-        )
+    # List available properties
+    props = s.available_properties()
+    print(f"Available properties: {props}")
 
-        # List available properties
-        props = s.available_properties()
-        print(f"Available properties: {props}")
-
-        # Use the wave as depth for the surface
-        s.set_property_as_depth("wave")
+    # Use the wave as depth for the surface
+    s.set_property_as_depth("wave")

--- a/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/view_example.py
+++ b/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/view_example.py
@@ -8,23 +8,21 @@ import rips
 # Connect to ResInsight instance
 resinsight = rips.Instance.find()
 
-# Check if connection worked
-if resinsight is not None:
-    # Get a list of all cases
-    cases = resinsight.project.cases()
-    for case in cases:
-        # Get a list of all views
-        views = case.views()
-        for view in views:
-            # Set some parameters for the view
-            view.show_grid_box = not view.show_grid_box
-            view.background_color = "#3388AA"
-            # Update the view in ResInsight
-            view.update()
-        # Clone the first view
-        new_view = views[0].clone()
-        new_view.background_color = "#FFAA33"
-        new_view.update()
-        view.show_grid_box = False
-        view.set_visible(False)
+# Get a list of all cases
+cases = resinsight.project.cases()
+for case in cases:
+    # Get a list of all views
+    views = case.views()
+    for view in views:
+        # Set some parameters for the view
+        view.show_grid_box = not view.show_grid_box
+        view.background_color = "#3388AA"
+        # Update the view in ResInsight
         view.update()
+    # Clone the first view
+    new_view = views[0].clone()
+    new_view.background_color = "#FFAA33"
+    new_view.update()
+    view.show_grid_box = False
+    view.set_visible(False)
+    view.update()

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/accumulated_perforation_length.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/accumulated_perforation_length.py
@@ -11,8 +11,6 @@ import sys
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is None:
-    sys.exit("ResInsight is not running. Please start ResInsight and try again.")
 
 # Get a list of all wells
 cases = resinsight.project.cases()

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/all_simulation_wells.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/all_simulation_wells.py
@@ -8,29 +8,29 @@ import rips
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    # Get a list of all wells
-    cases = resinsight.project.cases()
 
-    for case in cases:
-        print("Case id: " + str(case.id))
-        print("Case name: " + case.name)
+# Get a list of all wells
+cases = resinsight.project.cases()
 
-        timesteps = case.time_steps()
-        sim_wells = case.simulation_wells()
-        for sim_well in sim_wells:
-            print("Simulation well: " + sim_well.name)
+for case in cases:
+    print("Case id: " + str(case.id))
+    print("Case name: " + case.name)
 
-            for tidx, timestep in enumerate(timesteps):
-                status = sim_well.status(tidx)
-                cells = sim_well.cells(tidx)
-                print(
-                    "timestep: "
-                    + str(tidx)
-                    + " type: "
-                    + status.well_type
-                    + " open: "
-                    + str(status.is_open)
-                    + " cells:"
-                    + str(len(cells))
-                )
+    timesteps = case.time_steps()
+    sim_wells = case.simulation_wells()
+    for sim_well in sim_wells:
+        print("Simulation well: " + sim_well.name)
+
+        for tidx, timestep in enumerate(timesteps):
+            status = sim_well.status(tidx)
+            cells = sim_well.cells(tidx)
+            print(
+                "timestep: "
+                + str(tidx)
+                + " type: "
+                + status.well_type
+                + " open: "
+                + str(status.is_open)
+                + " cells:"
+                + str(len(cells))
+            )

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/all_wells.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/all_wells.py
@@ -8,10 +8,10 @@ import rips
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    # Get a list of all wells
-    wells = resinsight.project.well_paths()
 
-    print("Got " + str(len(wells)) + " wells: ")
-    for well in wells:
-        print("Well name: " + well.name)
+# Get a list of all wells
+wells = resinsight.project.well_paths()
+
+print("Got " + str(len(wells)) + " wells: ")
+for well in wells:
+    print("Well name: " + well.name)

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/append_lateral_to_well.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/append_lateral_to_well.py
@@ -1,8 +1,6 @@
 import rips
 
 resinsight = rips.Instance.find()
-if resinsight is None:
-    raise RuntimeError("No running ResInsight instance found on the expected ports.")
 
 # Create a modeled well path and add well path targets
 # The coordinates are based on the Norne case

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/completion_data.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/completion_data.py
@@ -17,8 +17,6 @@ def fieldValueOrDefaultText(grpc_object, optional_field_name: str):
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is None:
-    exit(1)
 
 # Get a list of all wells
 wells = resinsight.project.well_paths()

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/create_and_export_stim_plan_model.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/create_and_export_stim_plan_model.py
@@ -45,14 +45,14 @@ print("Overburden: ", stim_plan_model_template.overburden_formation)
 
 # Set eclipse result for facies definition
 eclipse_result = stim_plan_model_template.facies_properties().facies_definition()
-eclipse_result.result_type = "INPUT_PROPERTY"
+eclipse_result.result_type = rips.ResultType.INPUT_PROPERTY
 eclipse_result.result_variable = "OPERNUM_1"
 eclipse_result.update()
 
 # Set eclipse result for non-net layers
 non_net_layers = stim_plan_model_template.non_net_layers()
 non_net_layers_result = non_net_layers.facies_definition()
-non_net_layers_result.result_type = "STATIC_NATIVE"
+non_net_layers_result.result_type = rips.ResultType.STATIC_NATIVE
 non_net_layers_result.result_variable = "NTG"
 non_net_layers_result.update()
 non_net_layers.formation = "Not"

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/duplicate_well.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/duplicate_well.py
@@ -9,14 +9,14 @@ import rips
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    # Get a list of all wells
-    wells = resinsight.project.well_paths()
 
-    print("Got " + str(len(wells)) + " wells: ")
-    for well in wells:
-        print("Well name: " + well.name)
+# Get a list of all wells
+wells = resinsight.project.well_paths()
 
-        # will only work for editable well paths (ModeledWellPath)
-        new_well = well.duplicate()
-        print("New Well name: " + new_well.name)
+print("Got " + str(len(wells)) + " wells: ")
+for well in wells:
+    print("Well name: " + well.name)
+
+    # will only work for editable well paths (ModeledWellPath)
+    new_well = well.duplicate()
+    print("New Well name: " + new_well.name)

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/export_well_path_trajectory_with_properties.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/export_well_path_trajectory_with_properties.py
@@ -23,39 +23,39 @@ def print_dictionary(title, data):
 
 # Connect to ResInsight
 resinsight = rips.Instance.find()
-if resinsight is not None:
-    # Get a list of all wells
-    wells = resinsight.project.well_paths()
 
-    # Find the first case
-    cases = resinsight.project.cases()
-    c = cases[0] if len(cases) else None
+# Get a list of all wells
+wells = resinsight.project.well_paths()
 
-    for well in wells:
-        result = well.trajectory_properties(resampling_interval=10.0)
+# Find the first case
+cases = resinsight.project.cases()
+c = cases[0] if len(cases) else None
 
-        if c:
-            # Convert the result data into points
-            positions = [
-                list(coord)
-                for coord in zip(
-                    result["coordinate_x"],
-                    result["coordinate_y"],
-                    result["coordinate_z"],
-                )
-            ]
+for well in wells:
+    result = well.trajectory_properties(resampling_interval=10.0)
 
-            # Extract some properties
-            properties = [
-                (rips.PropertyType.DYNAMIC_NATIVE, "PRESSURE", 0),
-                (rips.PropertyType.STATIC_NATIVE, "FAULTDIST", 0),
-            ]
+    if c:
+        # Convert the result data into points
+        positions = [
+            list(coord)
+            for coord in zip(
+                result["coordinate_x"],
+                result["coordinate_y"],
+                result["coordinate_z"],
+            )
+        ]
 
-            for property_type, property_name, time_step in properties:
-                porosity_model = rips.PorosityModelType.MATRIX_MODEL
-                result[property_name] = c.grid_property_for_positions(
-                    positions, property_type, property_name, time_step, porosity_model
-                )
+        # Extract some properties
+        properties = [
+            (rips.PropertyType.DYNAMIC_NATIVE, "PRESSURE", 0),
+            (rips.PropertyType.STATIC_NATIVE, "FAULTDIST", 0),
+        ]
 
-            title = "Well name: " + well.name
-            print_dictionary(title, result)
+        for property_type, property_name, time_step in properties:
+            porosity_model = rips.PorosityModelType.MATRIX_MODEL
+            result[property_name] = c.grid_property_for_positions(
+                positions, property_type, property_name, time_step, porosity_model
+            )
+
+        title = "Well name: " + well.name
+        print_dictionary(title, result)

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/export_well_path_trajectory_with_properties.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/export_well_path_trajectory_with_properties.py
@@ -47,12 +47,12 @@ if resinsight is not None:
 
             # Extract some properties
             properties = [
-                ("DYNAMIC_NATIVE", "PRESSURE", 0),
-                ("STATIC_NATIVE", "FAULTDIST", 0),
+                (rips.PropertyType.DYNAMIC_NATIVE, "PRESSURE", 0),
+                (rips.PropertyType.STATIC_NATIVE, "FAULTDIST", 0),
             ]
 
             for property_type, property_name, time_step in properties:
-                porosity_model = "MATRIX_MODEL"
+                porosity_model = rips.PorosityModelType.MATRIX_MODEL
                 result[property_name] = c.grid_property_for_positions(
                     positions, property_type, property_name, time_step, porosity_model
                 )

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/generate_ensemble_of_well_logs.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/generate_ensemble_of_well_logs.py
@@ -12,10 +12,10 @@ home_dir = expanduser("~")
 
 
 properties = [
-    ("STATIC_NATIVE", "INDEX_K", 0),
-    ("STATIC_NATIVE", "PORO", 0),
-    ("STATIC_NATIVE", "PERMX", 0),
-    ("DYNAMIC_NATIVE", "PRESSURE", 0),
+    (rips.ResultType.STATIC_NATIVE, "INDEX_K", 0),
+    (rips.ResultType.STATIC_NATIVE, "PORO", 0),
+    (rips.ResultType.STATIC_NATIVE, "PERMX", 0),
+    (rips.ResultType.DYNAMIC_NATIVE, "PRESSURE", 0),
 ]
 
 export_folder = tempfile.mkdtemp()

--- a/GrpcInterface/Python/rips/__init__.py
+++ b/GrpcInterface/Python/rips/__init__.py
@@ -30,6 +30,15 @@ from .surface import RegularSurface as RegularSurface  # noqa: E402
 from . import well_events as well_events  # noqa: F401, E402
 from . import category_mapping as category_mapping  # noqa: F401, E402
 
+# Enums for proto types not visible to the AppEnum auto-generator.
+# PorosityModelType is auto-generated into resinsight_classes (already imported
+# above) and intentionally not re-imported here to avoid a duplicate symbol.
+from .enums import (  # noqa: E402
+    PropertyType as PropertyType,
+    PropertyDataType as PropertyDataType,
+    NNCPropertyType as NNCPropertyType,
+)
+
 __all__: List[str] = []
 for key in class_dict():  # noqa: F405
     __all__.append(key)
@@ -37,5 +46,13 @@ for key in class_dict():  # noqa: F405
 # Add classes not in resinsight_classes
 __all__.append("Grid")
 __all__.append("Instance")
+
+for _enum_name in (
+    "PropertyType",
+    "PropertyDataType",
+    "NNCPropertyType",
+):
+    if _enum_name not in __all__:
+        __all__.append(_enum_name)
 
 __all__.sort()

--- a/GrpcInterface/Python/rips/case.py
+++ b/GrpcInterface/Python/rips/case.py
@@ -37,7 +37,7 @@ result
 
 import grpc
 import uuid
-from typing import List, Tuple
+from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
 
 import Case_pb2
 import Case_pb2_grpc
@@ -73,7 +73,9 @@ import rips.project  # full name import due to circular dependency
 
 
 @add_method(Case)
-def __custom_init__(self, pb2_object, channel):
+def __custom_init__(
+    self, pb2_object: PdmObject_pb2.PdmObject, channel: grpc.Channel
+) -> None:
     self.__case_stub = Case_pb2_grpc.CaseStub(self._channel)
 
     self.__properties_stub = Properties_pb2_grpc.PropertiesStub(self._channel)
@@ -95,12 +97,16 @@ def __grid_count(self) -> int:
 
 
 @add_method(Case)
-def __request(self):
+def __request(self) -> Case_pb2.CaseRequest:
     return Case_pb2.CaseRequest(id=self.id)
 
 
 @add_method(Case)
-def __generate_property_input_iterator(self, values_iterator, parameters):
+def __generate_property_input_iterator(
+    self,
+    values_iterator: Iterable[List[float]],
+    parameters: Properties_pb2.PropertyRequest,
+) -> Iterator[Properties_pb2.PropertyInputChunk]:
     chunk = Properties_pb2.PropertyInputChunk()
     chunk.params.CopyFrom(parameters)
     yield chunk
@@ -112,7 +118,9 @@ def __generate_property_input_iterator(self, values_iterator, parameters):
 
 
 @add_method(Case)
-def __generate_property_input_chunks(self, array, parameters):
+def __generate_property_input_chunks(
+    self, array: List[float], parameters: Properties_pb2.PropertyRequest
+) -> Iterator[Properties_pb2.PropertyInputChunk]:
     index = -1
     while index < len(array):
         chunk = Properties_pb2.PropertyInputChunk()
@@ -161,7 +169,7 @@ def grids(self) -> List[Grid]:
 
 
 @add_method(Case)
-def replace(self, new_grid_file):
+def replace(self, new_grid_file: str) -> None:
     """Replace the current case grid with a new grid loaded from file
 
     Arguments:
@@ -178,7 +186,7 @@ def replace(self, new_grid_file):
 @add_method(Case)
 def cell_count(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-) -> int:
+) -> Case_pb2.CellCount:
     """Get a cell count object containing number of active cells and total number of cells
 
     Arguments:
@@ -207,7 +215,7 @@ def cell_count(
 @add_method(Case)
 def cell_info_for_active_cells_async(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-):
+) -> Iterator[Case_pb2.CellInfoArray]:
     """Get Stream of cell info objects for current case
 
     Arguments:
@@ -229,7 +237,7 @@ def cell_info_for_active_cells_async(
 @add_method(Case)
 def cell_info_for_active_cells(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-):
+) -> List[Case_pb2.CellInfo]:
     """Get list of cell info objects for current case
 
     Arguments:
@@ -269,7 +277,7 @@ def cell_info_for_active_cells(
 
 
 @add_method(Case)
-def time_steps(self):
+def time_steps(self) -> List[Case_pb2.TimeStepDate]:
     """Get a list containing all time steps
 
     The time steps are defined by the class **TimeStepDate**
@@ -291,7 +299,7 @@ def time_steps(self):
 
 
 @add_method(Case)
-def reservoir_boundingbox(self):
+def reservoir_boundingbox(self) -> Case_pb2.BoundingBox:
     """Get the reservoir bounding box
 
     Returns:
@@ -314,7 +322,9 @@ def reservoir_boundingbox(self):
 
 
 @add_method(Case)
-def distance_to_closest_fault(self, x: float, y: float, z: float):
+def distance_to_closest_fault(
+    self, x: float, y: float, z: float
+) -> Tuple[str, float, str]:
     """Find the closest fault to the given point and return the distance, fault name and fault face"""
     request = Case_pb2.ClosestFaultRequest(
         case_request=self.__request(), point=Definitions_pb2.Vec3d(x=x, y=y, z=z)
@@ -336,13 +346,13 @@ def reservoir_depth_range(self) -> Tuple[float, float]:
 
 
 @add_method(Case)
-def days_since_start(self):
+def days_since_start(self) -> List[float]:
     """Get a list of decimal values representing days since the start of the simulation"""
     return self.__case_stub.GetDaysSinceStart(self.__request()).day_decimals
 
 
 @add_method(Case)
-def view(self, view_id):
+def view(self, view_id: int) -> Optional[View]:
     """Get a particular view belonging to a case by providing view id
 
     Arguments:
@@ -360,7 +370,7 @@ def view(self, view_id):
 
 
 @add_method(Case)
-def views(self):
+def views(self) -> List[View]:
     """Get all views of a case
 
     Returns:
@@ -376,7 +386,7 @@ def views(self):
 
 
 @add_method(Case)
-def create_view(self):
+def create_view(self) -> Optional[View]:
     """Create a new view in the current case
 
     Returns:
@@ -390,7 +400,9 @@ def create_view(self):
 
 
 @add_method(Case)
-def export_snapshots_of_all_views(self, prefix="", export_folder=""):
+def export_snapshots_of_all_views(
+    self, prefix: str = "", export_folder: str = ""
+) -> Any:
     """Export snapshots for all views in the case
 
     Arguments:
@@ -412,17 +424,17 @@ def export_snapshots_of_all_views(self, prefix="", export_folder=""):
 @add_method(Case)
 def export_well_path_completions(
     self,
-    time_step,
-    well_path_names,
-    file_split,
-    compdat_export="TRANSMISSIBILITIES",
-    include_perforations=True,
-    include_fishbones=True,
-    fishbones_exclude_main_bore=True,
-    export_welspec=True,
-    export_comments=True,
-    custom_file_name="",
-):
+    time_step: int,
+    well_path_names: Union[str, List[str]],
+    file_split: str,
+    compdat_export: str = "TRANSMISSIBILITIES",
+    include_perforations: bool = True,
+    include_fishbones: bool = True,
+    fishbones_exclude_main_bore: bool = True,
+    export_welspec: bool = True,
+    export_comments: bool = True,
+    custom_file_name: str = "",
+) -> Any:
     """
     Export well path completions for the current case to file
 
@@ -476,7 +488,7 @@ def export_well_path_completions(
 
 
 @add_method(Case)
-def export_msw(self, well_path):
+def export_msw(self, well_path: str) -> Any:
     """
     Export Eclipse Multi-segment-well model to file
 
@@ -491,15 +503,15 @@ def export_msw(self, well_path):
 @add_method(Case)
 def create_multiple_fractures(
     self,
-    template_id,
-    well_path_names,
-    min_dist_from_well_td,
-    max_fractures_per_well,
-    top_layer,
-    base_layer,
-    spacing,
-    action,
-):
+    template_id: int,
+    well_path_names: Union[str, List[str]],
+    min_dist_from_well_td: float,
+    max_fractures_per_well: int,
+    top_layer: int,
+    base_layer: int,
+    spacing: float,
+    action: str,
+) -> Any:
     """
     Create Multiple Fractures in one go
 
@@ -537,13 +549,13 @@ def create_multiple_fractures(
 @add_method(Case)
 def create_lgr_for_completion(
     self,
-    time_step,
-    well_path_names,
-    refinement_i,
-    refinement_j,
-    refinement_k,
-    split_type,
-):
+    time_step: int,
+    well_path_names: Union[str, List[str]],
+    refinement_i: int,
+    refinement_j: int,
+    refinement_k: int,
+    split_type: str,
+) -> Any:
     """
     Create a local grid refinement for the completions on the given well paths
 
@@ -583,7 +595,7 @@ def create_lgr_for_completion(
 
 
 @add_method(Case)
-def create_saturation_pressure_plots(self):
+def create_saturation_pressure_plots(self) -> Any:
     """
     Create saturation pressure plots for the current case
     """
@@ -596,13 +608,13 @@ def create_saturation_pressure_plots(self):
 @add_method(Case)
 def export_flow_characteristics(
     self,
-    time_steps,
-    injectors,
-    producers,
-    file_name,
-    minimum_communication=0.0,
-    aquifer_cell_threshold=0.1,
-):
+    time_steps: Union[int, List[int]],
+    injectors: Union[str, List[str]],
+    producers: Union[str, List[str]],
+    file_name: str,
+    minimum_communication: float = 0.0,
+    aquifer_cell_threshold: float = 0.1,
+) -> Any:
     """Export Flow Characteristics data to text file in CSV format
 
     **Parameters**::
@@ -641,7 +653,7 @@ def available_properties(
     self,
     property_type: PropertyType,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> List[str]:
     """Get a list of available properties
 
     For argument details, see :ref:`Result Definition <result-definition-label>`
@@ -665,10 +677,10 @@ def available_properties(
 def active_cell_property_async(
     self,
     property_type: PropertyType,
-    property_name,
-    time_step,
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> Iterator[Properties_pb2.PropertyChunk]:
     """Get a cell property for all active cells. Async, so returns an iterator. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -698,10 +710,10 @@ def active_cell_property_async(
 def active_cell_property(
     self,
     property_type: PropertyType,
-    property_name,
-    time_step,
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> List[float]:
     """Get a cell property for all active cells. Sync, so returns a list. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -728,10 +740,10 @@ def active_cell_property(
 def selected_cell_property_async(
     self,
     property_type: PropertyType,
-    property_name,
-    time_step,
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> Iterator[Properties_pb2.PropertyChunk]:
     """Get a cell property for all selected cells. Async, so returns an iterator. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -761,10 +773,10 @@ def selected_cell_property_async(
 def selected_cell_property(
     self,
     property_type: PropertyType,
-    property_name,
-    time_step,
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> List[float]:
     """Get a cell property for all selected cells. Sync, so returns a list. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -791,11 +803,11 @@ def selected_cell_property(
 def grid_property_async(
     self,
     property_type: PropertyType,
-    property_name,
-    time_step,
-    grid_index=0,
+    property_name: str,
+    time_step: int,
+    grid_index: int = 0,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> Iterator[Properties_pb2.PropertyChunk]:
     """Get a cell property for all grid cells. Async, so returns an iterator. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -827,11 +839,11 @@ def grid_property_async(
 def grid_property(
     self,
     property_type: PropertyType,
-    property_name,
-    time_step,
-    grid_index=0,
+    property_name: str,
+    time_step: int,
+    grid_index: int = 0,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> List[float]:
     """Get a cell property for all grid cells. Synchronous, so returns a list. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -857,13 +869,13 @@ def grid_property(
 @add_method(Case)
 def set_active_cell_property_async(
     self,
-    values_iterator,
+    values_iterator: Iterable[List[float]],
     property_type: PropertyType,
-    property_name,
-    time_step,
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
     data_type: PropertyDataType = PropertyDataType.FLOAT,
-):
+) -> None:
     """Set cell property for all active cells Async. Takes an iterator to the input values. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -893,13 +905,13 @@ def set_active_cell_property_async(
 @add_method(Case)
 def set_active_cell_property(
     self,
-    values,
+    values: List[float],
     property_type: PropertyType,
-    property_name,
-    time_step,
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
     data_type: PropertyDataType = PropertyDataType.FLOAT,
-):
+) -> None:
     """Set a cell property for all active cells. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -930,14 +942,14 @@ def set_active_cell_property(
 @add_method(Case)
 def set_grid_property(
     self,
-    values,
+    values: List[float],
     property_type: PropertyType,
-    property_name,
-    time_step,
-    grid_index=0,
+    property_name: str,
+    time_step: int,
+    grid_index: int = 0,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
     data_type: PropertyDataType = PropertyDataType.FLOAT,
-):
+) -> None:
     """Set a cell property for all grid cells. For argument details, see :ref:`Result Definition <result-definition-label>`
 
     Arguments:
@@ -970,12 +982,12 @@ def set_grid_property(
 @add_method(Case)
 def export_property(
     self,
-    time_step,
-    property_name,
-    eclipse_keyword=property,
-    undefined_value=0.0,
-    export_file=property,
-):
+    time_step: int,
+    property_name: str,
+    eclipse_keyword: Any = property,
+    undefined_value: float = 0.0,
+    export_file: Any = property,
+) -> Any:
     """Export an Eclipse property
 
     Arguments:
@@ -998,7 +1010,12 @@ def export_property(
 
 
 @add_method(Case)
-def create_well_bore_stability_plot(self, well_path, time_step, parameters=None):
+def create_well_bore_stability_plot(
+    self,
+    well_path: str,
+    time_step: int,
+    parameters: Optional[WbsParameters] = None,
+) -> Optional[WellBoreStabilityPlot]:
     """Create a new well bore stability plot
 
     Arguments:
@@ -1027,7 +1044,9 @@ def create_well_bore_stability_plot(self, well_path, time_step, parameters=None)
 
 
 @add_method(Case)
-def import_formation_names(self, formation_files=None):
+def import_formation_names(
+    self, formation_files: Optional[Union[str, List[str]]] = None
+) -> None:
     """Import formation names into project and apply it to the current case
 
     Arguments:
@@ -1047,7 +1066,7 @@ def import_formation_names(self, formation_files=None):
 
 
 @add_method(Case)
-def simulation_wells(self):
+def simulation_wells(self) -> List[SimulationWell]:
     """Get a list of all simulation wells for a case
 
     Returns:
@@ -1063,7 +1082,7 @@ def simulation_wells(self):
 @add_method(Case)
 def active_cell_centers_async(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-):
+) -> Iterator[Definitions_pb2.CellCenters]:
     """Get a cell centers for all active cells. Async, so returns an iterator
 
     Arguments:
@@ -1083,7 +1102,7 @@ def active_cell_centers_async(
 @add_method(Case)
 def active_cell_centers(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-):
+) -> List[Definitions_pb2.Vec3d]:
     """Get a cell centers for all active cells. Synchronous, so returns a list.
 
     Arguments:
@@ -1103,7 +1122,7 @@ def active_cell_centers(
 @add_method(Case)
 def active_cell_corners_async(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-):
+) -> Iterator[Definitions_pb2.CellCornersArray]:
     """Get a cell corners for all active cells. Async, so returns an iterator
 
     Arguments:
@@ -1123,7 +1142,7 @@ def active_cell_corners_async(
 @add_method(Case)
 def active_cell_corners(
     self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
-):
+) -> List[Definitions_pb2.CellCorners]:
     """Get a cell corners for all active cells. Synchronous, so returns a list.
 
         Arguments:
@@ -1153,7 +1172,7 @@ def active_cell_corners(
 
 
 @add_method(Case)
-def selected_cells_async(self):
+def selected_cells_async(self) -> Iterator[Case_pb2.SelectedCells]:
     """Get the selected cells. Async, so returns an iterator.
 
     Returns:
@@ -1164,7 +1183,7 @@ def selected_cells_async(self):
 
 
 @add_method(Case)
-def selected_cells(self):
+def selected_cells(self) -> List[Case_pb2.SelectedCell]:
     """Get the selected cells. Synchronous, so returns a list.
 
     Returns:
@@ -1179,7 +1198,7 @@ def selected_cells(self):
 
 
 @add_method(Case)
-def coarsening_info(self):
+def coarsening_info(self) -> List[Case_pb2.CoarseningInfo]:
     """Get a coarsening information for all grids in the case.
 
     Returns:
@@ -1190,7 +1209,7 @@ def coarsening_info(self):
 
 
 @add_method(Case)
-def available_nnc_properties(self):
+def available_nnc_properties(self) -> List[NNCProperties_pb2.AvailableNNCProperty]:
     """Get a list of available NNC properties
 
     **NNCConnection class description**::
@@ -1209,7 +1228,7 @@ def available_nnc_properties(self):
 
 
 @add_method(Case)
-def nnc_connections_async(self):
+def nnc_connections_async(self) -> Iterator[NNCProperties_pb2.NNCConnections]:
     """Get the NNC connections. Async, so returns an iterator.
 
     Returns:
@@ -1220,7 +1239,7 @@ def nnc_connections_async(self):
 
 
 @add_method(Case)
-def nnc_connections(self):
+def nnc_connections(self) -> List[NNCProperties_pb2.NNCConnection]:
     """Get the NNC connection. Synchronous, so returns a list.
 
     Returns:
@@ -1235,7 +1254,9 @@ def nnc_connections(self):
 
 
 @add_method(Case)
-def __nnc_connections_values_async(self, property_name, property_type, time_step):
+def __nnc_connections_values_async(
+    self, property_name: str, property_type: int, time_step: int
+) -> Iterator[NNCProperties_pb2.NNCValues]:
     request = NNCProperties_pb2.NNCValuesRequest(
         case_id=self.id,
         property_name=property_name,
@@ -1246,7 +1267,9 @@ def __nnc_connections_values_async(self, property_name, property_type, time_step
 
 
 @add_method(Case)
-def __nnc_values_generator_to_list(self, generator):
+def __nnc_values_generator_to_list(
+    self, generator: Iterable[NNCProperties_pb2.NNCValues]
+) -> List[float]:
     """Converts a NNC values generator to a list."""
     vals = []
     for chunk in generator:
@@ -1256,7 +1279,9 @@ def __nnc_values_generator_to_list(self, generator):
 
 
 @add_method(Case)
-def nnc_connections_static_values_async(self, property_name):
+def nnc_connections_static_values_async(
+    self, property_name: str
+) -> Iterator[NNCProperties_pb2.NNCValues]:
     """Get the static NNC values. Async, so returns an iterator.
 
     Returns:
@@ -1272,7 +1297,7 @@ def nnc_connections_static_values_async(self, property_name):
 
 
 @add_method(Case)
-def nnc_connections_static_values(self, property_name):
+def nnc_connections_static_values(self, property_name: str) -> List[float]:
     """Get the static NNC values.
 
     Returns:
@@ -1285,7 +1310,9 @@ def nnc_connections_static_values(self, property_name):
 
 
 @add_method(Case)
-def nnc_connections_dynamic_values_async(self, property_name, time_step):
+def nnc_connections_dynamic_values_async(
+    self, property_name: str, time_step: int
+) -> Iterator[NNCProperties_pb2.NNCValues]:
     """Get the dynamic NNC values. Async, so returns an iterator.
 
     Returns:
@@ -1301,7 +1328,9 @@ def nnc_connections_dynamic_values_async(self, property_name, time_step):
 
 
 @add_method(Case)
-def nnc_connections_dynamic_values(self, property_name, time_step):
+def nnc_connections_dynamic_values(
+    self, property_name: str, time_step: int
+) -> List[float]:
     """Get the dynamic NNC values.
 
     Returns:
@@ -1314,7 +1343,9 @@ def nnc_connections_dynamic_values(self, property_name, time_step):
 
 
 @add_method(Case)
-def nnc_connections_generated_values_async(self, property_name, time_step):
+def nnc_connections_generated_values_async(
+    self, property_name: str, time_step: int
+) -> Iterator[NNCProperties_pb2.NNCValues]:
     """Get the generated NNC values. Async, so returns an iterator.
 
     Returns:
@@ -1330,7 +1361,9 @@ def nnc_connections_generated_values_async(self, property_name, time_step):
 
 
 @add_method(Case)
-def nnc_connections_generated_values(self, property_name, time_step):
+def nnc_connections_generated_values(
+    self, property_name: str, time_step: int
+) -> List[float]:
     """Get the generated NNC values.
 
     Returns:
@@ -1343,7 +1376,9 @@ def nnc_connections_generated_values(self, property_name, time_step):
 
 
 @add_method(Case)
-def __generate_nnc_property_input_chunks(self, array, parameters):
+def __generate_nnc_property_input_chunks(
+    self, array: List[float], parameters: NNCProperties_pb2.NNCValuesInputRequest
+) -> Iterator[NNCProperties_pb2.NNCValuesChunk]:
     index = -1
     while index < len(array):
         chunk = NNCProperties_pb2.NNCValuesChunk()
@@ -1368,11 +1403,11 @@ def __generate_nnc_property_input_chunks(self, array, parameters):
 @add_method(Case)
 def set_nnc_connections_values(
     self,
-    values,
-    property_name,
-    time_step,
+    values: List[float],
+    property_name: str,
+    time_step: int,
     porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
-):
+) -> None:
     """Set nnc connection values for all connections..
 
     Arguments:

--- a/GrpcInterface/Python/rips/case.py
+++ b/GrpcInterface/Python/rips/case.py
@@ -53,6 +53,7 @@ from .resinsight_classes import (
     Case as Case,
     EclipseCase as EclipseCase,
     GeoMechCase as GeoMechCase,
+    PorosityModelType as PorosityModelType,
     Reservoir as Reservoir,
     WellBoreStabilityPlot as WellBoreStabilityPlot,
     WbsParameters as WbsParameters,
@@ -64,6 +65,10 @@ from .project import Project as Project
 from .pdmobject import add_method
 from .view import View as View
 from .simulation_well import SimulationWell
+from .enums import (
+    PropertyType,
+    PropertyDataType,
+)
 import rips.project  # full name import due to circular dependency
 
 
@@ -171,7 +176,9 @@ def replace(self, new_grid_file):
 
 
 @add_method(Case)
-def cell_count(self, porosity_model: str = "MATRIX_MODEL") -> int:
+def cell_count(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+) -> int:
     """Get a cell count object containing number of active cells and total number of cells
 
     Arguments:
@@ -198,7 +205,9 @@ def cell_count(self, porosity_model: str = "MATRIX_MODEL") -> int:
 
 
 @add_method(Case)
-def cell_info_for_active_cells_async(self, porosity_model: str = "MATRIX_MODEL"):
+def cell_info_for_active_cells_async(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+):
     """Get Stream of cell info objects for current case
 
     Arguments:
@@ -218,7 +227,9 @@ def cell_info_for_active_cells_async(self, porosity_model: str = "MATRIX_MODEL")
 
 
 @add_method(Case)
-def cell_info_for_active_cells(self, porosity_model: str = "MATRIX_MODEL"):
+def cell_info_for_active_cells(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+):
     """Get list of cell info objects for current case
 
     Arguments:
@@ -626,7 +637,11 @@ def export_flow_characteristics(
 
 
 @add_method(Case)
-def available_properties(self, property_type, porosity_model: str = "MATRIX_MODEL"):
+def available_properties(
+    self,
+    property_type: PropertyType,
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
+):
     """Get a list of available properties
 
     For argument details, see :ref:`Result Definition <result-definition-label>`
@@ -648,7 +663,11 @@ def available_properties(self, property_type, porosity_model: str = "MATRIX_MODE
 
 @add_method(Case)
 def active_cell_property_async(
-    self, property_type, property_name, time_step, porosity_model: str = "MATRIX_MODEL"
+    self,
+    property_type: PropertyType,
+    property_name,
+    time_step,
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Get a cell property for all active cells. Async, so returns an iterator. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -677,7 +696,11 @@ def active_cell_property_async(
 
 @add_method(Case)
 def active_cell_property(
-    self, property_type, property_name, time_step, porosity_model: str = "MATRIX_MODEL"
+    self,
+    property_type: PropertyType,
+    property_name,
+    time_step,
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Get a cell property for all active cells. Sync, so returns a list. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -703,7 +726,11 @@ def active_cell_property(
 
 @add_method(Case)
 def selected_cell_property_async(
-    self, property_type, property_name, time_step, porosity_model: str = "MATRIX_MODEL"
+    self,
+    property_type: PropertyType,
+    property_name,
+    time_step,
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Get a cell property for all selected cells. Async, so returns an iterator. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -732,7 +759,11 @@ def selected_cell_property_async(
 
 @add_method(Case)
 def selected_cell_property(
-    self, property_type, property_name, time_step, porosity_model: str = "MATRIX_MODEL"
+    self,
+    property_type: PropertyType,
+    property_name,
+    time_step,
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Get a cell property for all selected cells. Sync, so returns a list. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -759,11 +790,11 @@ def selected_cell_property(
 @add_method(Case)
 def grid_property_async(
     self,
-    property_type,
+    property_type: PropertyType,
     property_name,
     time_step,
     grid_index=0,
-    porosity_model: str = "MATRIX_MODEL",
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Get a cell property for all grid cells. Async, so returns an iterator. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -795,11 +826,11 @@ def grid_property_async(
 @add_method(Case)
 def grid_property(
     self,
-    property_type,
+    property_type: PropertyType,
     property_name,
     time_step,
     grid_index=0,
-    porosity_model: str = "MATRIX_MODEL",
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Get a cell property for all grid cells. Synchronous, so returns a list. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -827,11 +858,11 @@ def grid_property(
 def set_active_cell_property_async(
     self,
     values_iterator,
-    property_type,
+    property_type: PropertyType,
     property_name,
     time_step,
-    porosity_model: str = "MATRIX_MODEL",
-    data_type: str = "FLOAT",
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
+    data_type: PropertyDataType = PropertyDataType.FLOAT,
 ):
     """Set cell property for all active cells Async. Takes an iterator to the input values. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -863,11 +894,11 @@ def set_active_cell_property_async(
 def set_active_cell_property(
     self,
     values,
-    property_type,
+    property_type: PropertyType,
     property_name,
     time_step,
-    porosity_model: str = "MATRIX_MODEL",
-    data_type: str = "FLOAT",
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
+    data_type: PropertyDataType = PropertyDataType.FLOAT,
 ):
     """Set a cell property for all active cells. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -900,12 +931,12 @@ def set_active_cell_property(
 def set_grid_property(
     self,
     values,
-    property_type,
+    property_type: PropertyType,
     property_name,
     time_step,
     grid_index=0,
-    porosity_model: str = "MATRIX_MODEL",
-    data_type: str = "FLOAT",
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
+    data_type: PropertyDataType = PropertyDataType.FLOAT,
 ):
     """Set a cell property for all grid cells. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -1030,7 +1061,9 @@ def simulation_wells(self):
 
 
 @add_method(Case)
-def active_cell_centers_async(self, porosity_model: str = "MATRIX_MODEL"):
+def active_cell_centers_async(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+):
     """Get a cell centers for all active cells. Async, so returns an iterator
 
     Arguments:
@@ -1048,7 +1081,9 @@ def active_cell_centers_async(self, porosity_model: str = "MATRIX_MODEL"):
 
 
 @add_method(Case)
-def active_cell_centers(self, porosity_model: str = "MATRIX_MODEL"):
+def active_cell_centers(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+):
     """Get a cell centers for all active cells. Synchronous, so returns a list.
 
     Arguments:
@@ -1066,7 +1101,9 @@ def active_cell_centers(self, porosity_model: str = "MATRIX_MODEL"):
 
 
 @add_method(Case)
-def active_cell_corners_async(self, porosity_model: str = "MATRIX_MODEL"):
+def active_cell_corners_async(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+):
     """Get a cell corners for all active cells. Async, so returns an iterator
 
     Arguments:
@@ -1084,7 +1121,9 @@ def active_cell_corners_async(self, porosity_model: str = "MATRIX_MODEL"):
 
 
 @add_method(Case)
-def active_cell_corners(self, porosity_model: str = "MATRIX_MODEL"):
+def active_cell_corners(
+    self, porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL
+):
     """Get a cell corners for all active cells. Synchronous, so returns a list.
 
         Arguments:
@@ -1328,7 +1367,11 @@ def __generate_nnc_property_input_chunks(self, array, parameters):
 
 @add_method(Case)
 def set_nnc_connections_values(
-    self, values, property_name, time_step, porosity_model: str = "MATRIX_MODEL"
+    self,
+    values,
+    property_name,
+    time_step,
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ):
     """Set nnc connection values for all connections..
 
@@ -1355,10 +1398,10 @@ def set_nnc_connections_values(
 def grid_property_for_positions(
     self,
     positions: List[List[float]],
-    property_type: str,
+    property_type: PropertyType,
     property_name: str,
     time_step: int,
-    porosity_model: str = "MATRIX_MODEL",
+    porosity_model: PorosityModelType = PorosityModelType.MATRIX_MODEL,
 ) -> List[float]:
     shared_uuid = uuid.uuid4()
     coordinate_x = "{}_{}".format(shared_uuid, "coordinate_x")

--- a/GrpcInterface/Python/rips/enums.py
+++ b/GrpcInterface/Python/rips/enums.py
@@ -1,0 +1,42 @@
+"""Typed enums mirroring the proto enums used by the rips.case API.
+
+These are hand-written counterparts to proto enums defined in ``Properties.proto``
+and ``NNCProperties.proto``. They give users typed, autocompletable enum members
+while remaining wire-compatible with the existing string-based API (``StrEnum``
+members are strings).
+
+Auto-generated ``StrEnum`` classes for ``caf::AppEnum`` scriptable fields live in
+``rips.generated.generated_classes`` and are emitted by ``cafPdmPythonGenerator``.
+``PorosityModelType`` is one of those auto-generated enums and is imported from
+``resinsight_classes``; the enums in this module cover the gRPC-only proto enums
+that the auto-generator does not see.
+"""
+
+from enum import StrEnum
+
+
+# Keep in sync with PropertyType in GrpcInterface/GrpcProtos/Properties.proto
+class PropertyType(StrEnum):
+    DYNAMIC_NATIVE = "DYNAMIC_NATIVE"
+    STATIC_NATIVE = "STATIC_NATIVE"
+    SOURSIMRL = "SOURSIMRL"
+    GENERATED = "GENERATED"
+    INPUT_PROPERTY = "INPUT_PROPERTY"
+    FORMATION_NAMES = "FORMATION_NAMES"
+    FLOW_DIAGNOSTICS = "FLOW_DIAGNOSTICS"
+    INJECTION_FLOODING = "INJECTION_FLOODING"
+    REMOVED = "REMOVED"
+    UNDEFINED = "UNDEFINED"
+
+
+# Keep in sync with PropertyDataType in GrpcInterface/GrpcProtos/Properties.proto
+class PropertyDataType(StrEnum):
+    FLOAT = "FLOAT"
+    INTEGER = "INTEGER"
+
+
+# Keep in sync with NNCPropertyType in GrpcInterface/GrpcProtos/NNCProperties.proto
+class NNCPropertyType(StrEnum):
+    NNC_DYNAMIC = "NNC_DYNAMIC"
+    NNC_STATIC = "NNC_STATIC"
+    NNC_GENERATED = "NNC_GENERATED"

--- a/GrpcInterface/Python/rips/instance.py
+++ b/GrpcInterface/Python/rips/instance.py
@@ -116,7 +116,7 @@ class Instance:
         init_timeout: int = 300,
         command_line_parameters: List[str] = [],
         enable_heartbeat: bool = True,
-    ) -> Optional[Instance]:
+    ) -> Instance:
         """Launch a new Instance of ResInsight. This requires the environment variable
         RESINSIGHT_EXECUTABLE to be set or the parameter resinsight_executable to be provided.
         The RESINSIGHT_GRPC_PORT environment variable can be set to an alternative port number.
@@ -135,7 +135,7 @@ class Instance:
                 server periodically and aborts pending RPCs if it dies. Disable on
                 slow boxes where false positives matter (long GC pauses, debugger).
         Returns:
-            Instance: an instance object if it worked. None if not.
+            Instance: a connected instance object. Raises :class:`RipsError` on failure.
         """
 
         requested_port: int = 50051
@@ -193,29 +193,23 @@ class Instance:
 
             process = subprocess.Popen(parameters)
             pid = process.pid
-            if pid:
-                port = Instance.__read_port_number_from_file(
-                    port_number_file, init_timeout
-                )
-                if port == -1:
-                    # Need to kill the process using PID since there is no GRPC connection to use.
-                    Instance.__kill_process(pid)
-                    raise RipsError("Unable to read port number. Launch failed.")
-                else:
-                    instance = Instance(
-                        port=port,
-                        launched=True,
-                        enable_heartbeat=enable_heartbeat,
-                    )
-                    return instance
-        return None
+            port = Instance.__read_port_number_from_file(port_number_file, init_timeout)
+            if port == -1:
+                # Need to kill the process using PID since there is no GRPC connection to use.
+                Instance.__kill_process(pid)
+                raise RipsError("Unable to read port number. Launch failed.")
+            return Instance(
+                port=port,
+                launched=True,
+                enable_heartbeat=enable_heartbeat,
+            )
 
     @staticmethod
     def find(
         start_port: int = 50051,
         end_port: int = 50071,
         enable_heartbeat: bool = True,
-    ) -> Optional[Instance]:
+    ) -> Instance:
         """Search for an existing Instance of ResInsight by testing ports.
 
         By default we search from port 50051 to 50071 or if the environment

--- a/GrpcInterface/Python/rips/pdmobject.py
+++ b/GrpcInterface/Python/rips/pdmobject.py
@@ -3,6 +3,7 @@
 ResInsight caf::PdmObject connection module
 """
 
+from enum import Enum
 from functools import wraps
 import grpc
 import re
@@ -243,6 +244,8 @@ class PdmObjectBase:
             if value:
                 return "true"
             return "false"
+        if isinstance(value, Enum):
+            return str(value.value)
         if isinstance(value, PdmObjectBase):
             return value.__class__.__name__ + ":" + str(value.address())
         if isinstance(value, list):

--- a/GrpcInterface/Python/rips/tests/test_cases.py
+++ b/GrpcInterface/Python/rips/tests/test_cases.py
@@ -205,7 +205,9 @@ def test_selected_cells(rips_instance, initialize_test):
     time_step_info = case.time_steps()
     for tidx, timestep in enumerate(time_step_info):
         # Try to read for SOIL the time step (will be empty since nothing is selected)
-        soil_results = case.selected_cell_property("DYNAMIC_NATIVE", "SOIL", tidx)
+        soil_results = case.selected_cell_property(
+            rips.PropertyType.DYNAMIC_NATIVE, "SOIL", tidx
+        )
         assert len(soil_results) == 0
 
 
@@ -235,9 +237,9 @@ def test_10k_property_for_positions(rips_instance, initialize_test):
         [3598.62, 5274.48, 4181.96],
     ]
 
-    property_type = "STATIC_NATIVE"
+    property_type = rips.PropertyType.STATIC_NATIVE
     property_name = "DX"
-    porosity_model = "MATRIX_MODEL"
+    porosity_model = rips.PorosityModelType.MATRIX_MODEL
     time_step = 0
     result = case.grid_property_for_positions(
         positions, property_type, property_name, time_step, porosity_model
@@ -258,9 +260,9 @@ def test_10k_property_for_positions_outside_of_model(rips_instance, initialize_t
         [3690.07, 52400.69, 4180.02],
     ]
 
-    property_type = "STATIC_NATIVE"
+    property_type = rips.PropertyType.STATIC_NATIVE
     property_name = "DX"
-    porosity_model = "MATRIX_MODEL"
+    porosity_model = rips.PorosityModelType.MATRIX_MODEL
     time_step = 0
     result = case.grid_property_for_positions(
         positions, property_type, property_name, time_step, porosity_model
@@ -278,9 +280,9 @@ def test_10k_property_for_positions_no_positions(rips_instance, initialize_test)
 
     positions = []
 
-    property_type = "STATIC_NATIVE"
+    property_type = rips.PropertyType.STATIC_NATIVE
     property_name = "DX"
-    porosity_model = "MATRIX_MODEL"
+    porosity_model = rips.PorosityModelType.MATRIX_MODEL
     time_step = 0
     with pytest.raises(rips.RipsError, match="Invalid positions specified"):
         case.grid_property_for_positions(
@@ -298,9 +300,9 @@ def test_10k_property_for_positions_invalid_property_name(
         [3655.67, 5145.34, 4176.63],
     ]
 
-    property_type = "STATIC_NATIVE"
+    property_type = rips.PropertyType.STATIC_NATIVE
     invalid_property_name = "NON_EXISTING_RESULT"
-    porosity_model = "MATRIX_MODEL"
+    porosity_model = rips.PorosityModelType.MATRIX_MODEL
     time_step = 0
     with pytest.raises(rips.RipsError, match="Result property not found."):
         case.grid_property_for_positions(
@@ -320,7 +322,7 @@ def test_10k_property_for_positions_invalid_property_type(
 
     property_type = "NON_EXISTING_PROPERTY_TYPE"
     invalid_property_name = "PRESSURE"
-    porosity_model = "MATRIX_MODEL"
+    porosity_model = rips.PorosityModelType.MATRIX_MODEL
     time_step = 0
     with pytest.raises(rips.RipsError, match="Invalid property type."):
         case.grid_property_for_positions(
@@ -338,9 +340,9 @@ def test_10k_property_for_positions_invalid_time_step(rips_instance, initialize_
         [3655.67, 5145.34, 4176.63],
     ]
 
-    property_type = "DYNAMIC_NATIVE"
+    property_type = rips.PropertyType.DYNAMIC_NATIVE
     property_name = "PRESSURE"
-    porosity_model = "MATRIX_MODEL"
+    porosity_model = rips.PorosityModelType.MATRIX_MODEL
     invalid_time_step = 99
     with pytest.raises(rips.RipsError, match="Invalid time step."):
         case.grid_property_for_positions(
@@ -348,23 +350,37 @@ def test_10k_property_for_positions_invalid_time_step(rips_instance, initialize_
         )
 
 
+def test_10k_grid_property_strenum(rips_instance, initialize_test):
+    case_path = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+    case = rips_instance.project.load_case(path=case_path)
+
+    from_str = case.grid_property("DYNAMIC_NATIVE", "SOIL", 3)
+    from_enum = case.grid_property(
+        rips.PropertyType.DYNAMIC_NATIVE,
+        "SOIL",
+        3,
+        porosity_model=rips.PorosityModelType.MATRIX_MODEL,
+    )
+    assert from_str == from_enum
+
+
 def test_10k_result_alias(rips_instance, initialize_test):
     case_path = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=case_path)
 
-    result_permx = case.grid_property("STATIC_NATIVE", "PERMX", 0)
-    result_soil = case.grid_property("DYNAMIC_NATIVE", "SOIL", 3)
+    result_permx = case.grid_property(rips.PropertyType.STATIC_NATIVE, "PERMX", 0)
+    result_soil = case.grid_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", 3)
 
     case.add_result_alias("PERMX", "PERMW")
     case.add_result_alias("SOIL", "SPOIL")
 
-    result_permw = case.grid_property("STATIC_NATIVE", "PERMW", 0)
+    result_permw = case.grid_property(rips.PropertyType.STATIC_NATIVE, "PERMW", 0)
     assert len(result_permw) == len(result_permx)
 
     for i in range(len(result_permx)):
         assert result_permw[i] == result_permx[i]
 
-    result_spoil = case.grid_property("DYNAMIC_NATIVE", "SPOIL", 3)
+    result_spoil = case.grid_property(rips.PropertyType.DYNAMIC_NATIVE, "SPOIL", 3)
 
     assert len(result_spoil) == len(result_soil)
 
@@ -374,4 +390,4 @@ def test_10k_result_alias(rips_instance, initialize_test):
     case.clear_result_aliases()
 
     with pytest.raises(rips.RipsError, match="No such result"):
-        case.grid_property("DYNAMIC_NATIVE", "SPOIL", 3)
+        case.grid_property(rips.PropertyType.DYNAMIC_NATIVE, "SPOIL", 3)

--- a/GrpcInterface/Python/rips/tests/test_grids.py
+++ b/GrpcInterface/Python/rips/tests/test_grids.py
@@ -80,7 +80,7 @@ def check_reek_grid_box(case: rips.Case):
     total_size = dimensions.i * dimensions.j * dimensions.k
     assert len(cell_centers) == total_size
 
-    poro = case.active_cell_property("INPUT_PROPERTY", "PORO", 0)
+    poro = case.active_cell_property(rips.PropertyType.INPUT_PROPERTY, "PORO", 0)
     assert len(poro) == total_size
     assert math.isclose(min(poro), 0.000928084715269506)
     assert math.isclose(max(poro), 0.351595014333725)
@@ -108,7 +108,7 @@ def verify_load_grid_and_separate_properties(
     case: rips.Reservoir, property_name_and_paths: NameAndPath
 ):
     # Load case without properties
-    available_properties = case.available_properties("INPUT_PROPERTY")
+    available_properties = case.available_properties(rips.PropertyType.INPUT_PROPERTY)
     for [name, _path] in property_name_and_paths.items():
         assert name not in available_properties
 
@@ -120,11 +120,13 @@ def verify_load_grid_and_separate_properties(
     imported = case.import_properties(file_names=list(property_name_and_paths.values()))
     imported_names = imported.values
 
-    available_properties = case.available_properties("INPUT_PROPERTY")
+    available_properties = case.available_properties(rips.PropertyType.INPUT_PROPERTY)
     for [name, _path] in property_name_and_paths.items():
         assert name in available_properties
         assert name in imported_names
-        property_values = case.active_cell_property("INPUT_PROPERTY", name, 0)
+        property_values = case.active_cell_property(
+            rips.PropertyType.INPUT_PROPERTY, name, 0
+        )
         assert len(property_values) == total_size
 
 

--- a/GrpcInterface/Python/rips/tests/test_project.py
+++ b/GrpcInterface/Python/rips/tests/test_project.py
@@ -30,13 +30,15 @@ def test_well_log_plots(rips_instance, initialize_test):
     for plot in plots:
         if isinstance(plot, rips.WellLogPlot):
             assert plot.depth_type == "MEASURED_DEPTH"
+            assert plot.depth_type == rips.DepthType.MEASURED_DEPTH
             well_log_plots.append(plot)
     assert len(well_log_plots) == 2
 
     with tempfile.TemporaryDirectory(prefix="rips") as tmpdirname:
         for well_log_plot in well_log_plots:
-            well_log_plot.depth_type = "TRUE_VERTICAL_DEPTH_RKB"
+            well_log_plot.depth_type = rips.DepthType.TRUE_VERTICAL_DEPTH_RKB
             well_log_plot.update()
+            assert well_log_plot.depth_type == "TRUE_VERTICAL_DEPTH_RKB"
             if rips_instance.is_gui():
                 well_log_plot.export_snapshot(tmpdirname)
             well_log_plot.export_data_as_las(tmpdirname)

--- a/GrpcInterface/Python/rips/tests/test_properties.py
+++ b/GrpcInterface/Python/rips/tests/test_properties.py
@@ -158,6 +158,32 @@ def test_10k_set_integer_grid_property(rips_instance, initialize_test):
         assert expected == int(actual)
 
 
+def test_10k_property_strings(rips_instance, initialize_test):
+    # Backward-compat coverage: the property/porosity/data-type arguments accept
+    # plain strings as an alternative to the typed StrEnum classes. This test
+    # exercises only the string form end-to-end so a future refactor that
+    # accidentally narrows the accepted types would be caught.
+    casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+    case = rips_instance.project.load_case(path=casePath)
+
+    available = case.available_properties("STATIC_NATIVE", "MATRIX_MODEL")
+    assert "PORO" in available
+    assert "PERMX" in available
+
+    poro = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+    assert len(poro) > 0
+
+    grid_poro = case.grid_property("STATIC_NATIVE", "PORO", 0)
+    assert len(grid_poro) > 0
+
+    integer_values = [int(v * 100) for v in poro]
+    case.set_active_cell_property(
+        integer_values, "GENERATED", "MY_STRING_DISCRETE", 0, data_type="INTEGER"
+    )
+    round_trip = case.active_cell_property("GENERATED", "MY_STRING_DISCRETE", 0)
+    assert len(round_trip) == len(integer_values)
+
+
 def test_exportPropertyInView(rips_instance, initialize_test):
     case_path = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(case_path)

--- a/GrpcInterface/Python/rips/tests/test_properties.py
+++ b/GrpcInterface/Python/rips/tests/test_properties.py
@@ -13,7 +13,9 @@ def test_10kAsync(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    resultChunks = case.active_cell_property_async("DYNAMIC_NATIVE", "SOIL", 1)
+    resultChunks = case.active_cell_property_async(
+        rips.PropertyType.DYNAMIC_NATIVE, "SOIL", 1
+    )
     mysum = 0.0
     count = 0
     for chunk in resultChunks:
@@ -29,7 +31,7 @@ def test_10kSync(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", 1)
+    results = case.active_cell_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", 1)
     mysum = sum(results)
     average = mysum / len(results)
     assert mysum == pytest.approx(621.768, abs=0.001)
@@ -41,29 +43,33 @@ def test_10k_set(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", 1)
-    case.set_active_cell_property(results, "GENERATED", "SOIL", 1)
+    results = case.active_cell_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", 1)
+    case.set_active_cell_property(results, rips.PropertyType.GENERATED, "SOIL", 1)
 
 
 def test_10k_set_out_of_bounds(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", 1)
+    results = case.active_cell_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", 1)
     results.append(5.0)
     with pytest.raises(rips.RipsError):
-        assert case.set_active_cell_property(results, "GENERATED", "SOIL", 1)
+        assert case.set_active_cell_property(
+            results, rips.PropertyType.GENERATED, "SOIL", 1
+        )
 
 
 def test_10k_set_out_of_bounds_client(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    results = case.active_cell_property("DYNAMIC_NATIVE", "SOIL", 1)
+    results = case.active_cell_property(rips.PropertyType.DYNAMIC_NATIVE, "SOIL", 1)
     case.chunk_size = len(results)
     results.append(5.0)
     with pytest.raises(IndexError):
-        assert case.set_active_cell_property(results, "GENERATED", "SOIL", 1)
+        assert case.set_active_cell_property(
+            results, rips.PropertyType.GENERATED, "SOIL", 1
+        )
 
 
 def createResult(poroChunks, permxChunks):
@@ -84,16 +90,23 @@ def test_10k_PoroPermX(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    poroChunks = case.active_cell_property_async("STATIC_NATIVE", "PORO", 0)
-    permxChunks = case.active_cell_property_async("STATIC_NATIVE", "PERMX", 0)
-
-    case.set_active_cell_property_async(
-        createResult(poroChunks, permxChunks), "GENERATED", "POROPERMXAS", 0
+    poroChunks = case.active_cell_property_async(
+        rips.PropertyType.STATIC_NATIVE, "PORO", 0
+    )
+    permxChunks = case.active_cell_property_async(
+        rips.PropertyType.STATIC_NATIVE, "PERMX", 0
     )
 
-    poro = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
-    permx = case.active_cell_property("STATIC_NATIVE", "PERMX", 0)
-    poroPermX = case.active_cell_property("GENERATED", "POROPERMXAS", 0)
+    case.set_active_cell_property_async(
+        createResult(poroChunks, permxChunks),
+        rips.PropertyType.GENERATED,
+        "POROPERMXAS",
+        0,
+    )
+
+    poro = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", 0)
+    permx = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PERMX", 0)
+    poroPermX = case.active_cell_property(rips.PropertyType.GENERATED, "POROPERMXAS", 0)
 
     checkResults(poro, permx, poroPermX)
 
@@ -102,16 +115,22 @@ def test_10k_set_integer_active_cell_property(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
-    results = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+    results = case.active_cell_property(rips.PropertyType.STATIC_NATIVE, "PORO", 0)
     integer_values = [int(v * 100) for v in results]
 
     # A name that does not end with "NUM" - only the data_type flag should
     # cause this to be treated as a discrete/category property.
     case.set_active_cell_property(
-        integer_values, "GENERATED", "MY_DISCRETE_ACTIVE", 0, data_type="INTEGER"
+        integer_values,
+        rips.PropertyType.GENERATED,
+        "MY_DISCRETE_ACTIVE",
+        0,
+        data_type=rips.PropertyDataType.INTEGER,
     )
 
-    round_trip = case.active_cell_property("GENERATED", "MY_DISCRETE_ACTIVE", 0)
+    round_trip = case.active_cell_property(
+        rips.PropertyType.GENERATED, "MY_DISCRETE_ACTIVE", 0
+    )
     assert len(round_trip) == len(integer_values)
     for expected, actual in zip(integer_values, round_trip):
         assert expected == int(actual)
@@ -126,10 +145,14 @@ def test_10k_set_integer_grid_property(rips_instance, initialize_test):
     integer_values = [i % 4 for i in range(grid_cell_count)]
 
     case.set_grid_property(
-        integer_values, "GENERATED", "MY_DISCRETE_GRID", 0, data_type="INTEGER"
+        integer_values,
+        rips.PropertyType.GENERATED,
+        "MY_DISCRETE_GRID",
+        0,
+        data_type=rips.PropertyDataType.INTEGER,
     )
 
-    round_trip = case.grid_property("GENERATED", "MY_DISCRETE_GRID", 0)
+    round_trip = case.grid_property(rips.PropertyType.GENERATED, "MY_DISCRETE_GRID", 0)
     assert len(round_trip) == len(integer_values)
     for expected, actual in zip(integer_values, round_trip):
         assert expected == int(actual)

--- a/GrpcInterface/Python/rips/tests/test_well_log_extraction.py
+++ b/GrpcInterface/Python/rips/tests/test_well_log_extraction.py
@@ -26,10 +26,10 @@ def test_10k_well_log_extraction(rips_instance, initialize_test):
     well_path = wells[0]
 
     properties = [
-        ("STATIC_NATIVE", "INDEX_K", 0),
-        ("STATIC_NATIVE", "PORO", 0),
-        ("STATIC_NATIVE", "PERMX", 0),
-        ("DYNAMIC_NATIVE", "PRESSURE", 0),
+        (rips.ResultType.STATIC_NATIVE, "INDEX_K", 0),
+        (rips.ResultType.STATIC_NATIVE, "PORO", 0),
+        (rips.ResultType.STATIC_NATIVE, "PERMX", 0),
+        (rips.ResultType.DYNAMIC_NATIVE, "PRESSURE", 0),
     ]
 
     well_log_plot_collection = rips_instance.project.descendants(

--- a/GrpcInterface/Python/setup.py.cmake
+++ b/GrpcInterface/Python/setup.py.cmake
@@ -20,5 +20,5 @@ setup(
     packages=['rips'],
     package_data={'rips': ['py.typed', '*.py', 'generated/*.py', 'PythonExamples/*.py', 'tests/*.py']},
     install_requires=['grpcio', 'protobuf', 'wheel', 'typing_extensions'],
-    python_requires='>=3.8',
+    python_requires='>=3.11',
 )


### PR DESCRIPTION
Auto-generate enum.StrEnum classes from cafPdmPythonGenerator for every caf::AppEnum-backed scriptable field, deduplicated by C++ AppEnum type. Generated PdmObject attributes and method arguments now reference the typed enum (e.g. self.depth_type: DepthType = DepthType.MEASURED_DEPTH) instead of bare str. Member names are sanitized against Python keywords and identifier rules (None -> None_, R-G -> R_G).

Existing scripts that pass plain strings keep working because StrEnum members are strings; the wire format is unchanged.

Bumps python_requires to >=3.11 (StrEnum). Adds an Enum branch in PdmObjectBase.__convert_to_grpc_value so future IntEnum use is also handled.

Fixes #13982.