### PR TITLE
#7142 Janitor: Remove redundant // Overrides comments in command feat…

### DIFF
--- a/ApplicationLibCode/Commands/PlotBuilderCommands/RicNewSummaryMultiPlotFromDataVectorFeature.h
+++ b/ApplicationLibCode/Commands/PlotBuilderCommands/RicNewSummaryMultiPlotFromDataVectorFeature.h
@@ -30,7 +30,6 @@ class RicNewSummaryMultiPlotFromDataVectorFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicNewPlotAxisPropertiesFeature.h
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicNewPlotAxisPropertiesFeature.h
@@ -28,7 +28,6 @@ class RicNewPlotAxisPropertiesFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;

--- a/Fwk/AppFwk/cafCommandFeatures/AddAndDelete/cafCmdDeleteItemFeature.h
+++ b/Fwk/AppFwk/cafCommandFeatures/AddAndDelete/cafCmdDeleteItemFeature.h
@@ -50,7 +50,6 @@ class CmdDeleteItemFeature : public CmdFeature
 protected:
     CmdExecuteCommand* createExecuteCommand();
 
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;

--- a/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsFeature.h
+++ b/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsFeature.h
@@ -48,7 +48,6 @@ class ToggleItemsFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;

--- a/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsOffFeature.h
+++ b/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsOffFeature.h
@@ -48,7 +48,6 @@ class ToggleItemsOffFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;

--- a/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsOnFeature.h
+++ b/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsOnFeature.h
@@ -48,7 +48,6 @@ class ToggleItemsOnFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;

--- a/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsOnOthersOffFeature.h
+++ b/Fwk/AppFwk/cafCommandFeatures/ToggleCommands/cafToggleItemsOnOthersOffFeature.h
@@ -53,7 +53,6 @@ class ToggleItemsOnOthersOffFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
-    // Overrides
     bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;


### PR DESCRIPTION
…ure headers

The bare "// Overrides" comment is now redundant since the override keyword on each method already conveys the same information. Qualified comments like "// Overrides from BaseClass" carry additional information and are kept.