### PR TITLE
#13994 QuickAccess: Fix re-entrant UI update crash when adding property filter

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/QuickAccess/RimQuickAccessCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/QuickAccess/RimQuickAccessCollection.cpp
@@ -212,7 +212,8 @@ void RimQuickAccessCollection::deleteMarkedObjects()
 
         for ( auto group : toBeDeleted )
         {
-            deleteItem( group );
+            m_items.removeChild( group );
+            delete group;
         }
     }
 }
@@ -243,7 +244,7 @@ RimFieldQuickAccessGroup* RimQuickAccessCollection::findOrCreateGroup( caf::PdmO
     auto group = new RimFieldQuickAccessGroup();
     group->setName( groupName );
     group->setOwnerView( parentView );
-    addItem( group );
+    m_items.push_back( group );
 
     return group;
 }


### PR DESCRIPTION
Fixes #13994.

Crash on adding a property filter caused by a re-entrant `updateUi()` call inside `RimQuickAccessCollection`. A secondary use-after-free existed where a newly-created empty group was deleted before `addFields()` could populate it.

**Root cause chain:**
`findOrCreateGroup` → `addItem(group)` → `updateConnectedEditors()` → `defineUiOrdering` → `deleteMarkedObjects` → `deleteItem(group)` → `updateConnectedEditors()` → `CAF_ASSERT(!m_isConfiguringUi)` → abort

## Changes

- **`findOrCreateGroup`**: Replace `addItem(group)` with `m_items.push_back(group)` — defers the UI update, preventing the newly-created empty group from being deleted before its fields are added
- **`addQuickAccessFields` / `addQuickAccessField`**: Explicitly call `updateConnectedEditors()` at the end, after all fields have been added to their groups
- **`deleteMarkedObjects`**: Replace `deleteItem(group)` with `m_items.removeChild(group); delete group;` — removes empty groups without triggering a re-entrant `updateConnectedEditors()` from within `defineUiOrdering`