### PR TITLE
#13998 Suppress MSVC C4875 deprecation warning from bundled gsl headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,11 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 elseif(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
   set(_HAS_STD_BYTE 0)
+
+  # C4875: non-string-literal argument to [[gsl::suppress]] is deprecated.
+  # Emitted by the bundled ThirdParty/gsl headers on MSVC 14.51+. The upstream
+  # fix (microsoft/GSL PR #1213) is not yet in a tagged release.
+  add_compile_options(/wd4875)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
- Adds `/wd4875` to the global MSVC compile options. 
- MSVC 14.51+ emits C4875 for the non-string-literal `[[gsl::suppress(x)]]` form used in the bundled `ThirdParty/gsl` headers, breaking `/WX` builds. 
- Upstream fix ([microsoft/GSL PR #1213](https://github.com/microsoft/GSL/pull/1243)) is merged but not yet in a tagged release (v4.2.1 was cut before it; v4.2.2 was announced but not yet released).