### PR TITLE
#14022 DataFilter: Restore category options for case-level property f…

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimDataFilterCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimDataFilterCollection.cpp
@@ -22,6 +22,7 @@
 #include "RimCellRangeFilter.h"
 #include "RimCombinedFilter.h"
 #include "RimEclipsePropertyFilter.h"
+#include "RimEclipseResultDefinition.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldScriptingCapability.h"
@@ -123,6 +124,23 @@ bool RimDataFilterCollection::hasActiveFilters() const
         if ( filter && filter->isFilterEnabled() ) return true;
     }
     return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Populate per-filter caches that depend on case data (e.g. the formation-name category list for
+/// property filters). PDM's initAfterRead runs during XML deserialization, before the grid and
+/// formation names are loaded, so categories cannot be resolved there. Without this pass a saved
+/// FORMATION_NAMES selection has its value preserved but no options list to render against — the
+/// selection only appears after the user toggles the filter (which routes through fieldChangedByUi
+/// → computeResultValueRange). See OPM/ResInsight#14022.
+//--------------------------------------------------------------------------------------------------
+void RimDataFilterCollection::loadAndInitializeFilters()
+{
+    for ( auto* propertyFilter : descendantsIncludingThisOfType<RimEclipsePropertyFilter>() )
+    {
+        propertyFilter->resultDefinition()->loadResult();
+        propertyFilter->computeResultValueRange();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimDataFilterCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimDataFilterCollection.h
@@ -58,6 +58,8 @@ public:
 
     bool hasActiveFilters() const;
 
+    void loadAndInitializeFilters();
+
 protected:
     void onItemsChanged() override;
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -1256,6 +1256,11 @@ void RimEclipseView::onLoadDataAndUpdate()
 
     m_propertyFilterCollection()->loadAndInitializePropertyFilters();
 
+    if ( auto* dataFilters = eclipseCase()->dataFilterCollection() )
+    {
+        dataFilters->loadAndInitializeFilters();
+    }
+
     faultCollection()->synchronizeFaults();
 
     m_wellCollection->scaleWellDisks();


### PR DESCRIPTION
…ilters on project load

The case-level RimDataFilterCollection lacked an equivalent of RimEclipsePropertyFilterCollection::loadAndInitializePropertyFilters, so a saved FORMATION_NAMES selection had its value preserved on reload but no category options list to render against. The selection only appeared after the user toggled the filter, which routes through fieldChangedByUi and rebuilds the category cache. Add loadAndInitializeFilters and invoke it from RimEclipseView::onLoadDataAndUpdate, once openReservoirCase has loaded the grid and active formation names.

Fixes #14022.