### PR TITLE
#14006 CorrelationPlot: Guard against empty time steps in fieldChange…

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
@@ -158,10 +158,16 @@ void RimAbstractCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* ch
             allDateTimes.push_back( dateTime );
         }
 
-        std::vector<int> filteredTimeStepIndices =
-            RimTimeStepFilter::filteredTimeStepIndices( allDateTimes, 0, (int)allDateTimes.size() - 1, m_timeStepFilter(), 1 );
+        if ( !allDateTimes.empty() )
+        {
+            std::vector<int> filteredTimeStepIndices =
+                RimTimeStepFilter::filteredTimeStepIndices( allDateTimes, 0, (int)allDateTimes.size() - 1, m_timeStepFilter(), 1 );
 
-        m_timeStep = allDateTimes[filteredTimeStepIndices.back()];
+            if ( !filteredTimeStepIndices.empty() )
+            {
+                m_timeStep = allDateTimes[filteredTimeStepIndices.back()];
+            }
+        }
 
         updateConnectedEditors();
     }


### PR DESCRIPTION
…dByUi

Changing the time step filter combo box crashed when the plot had no available time steps: filteredTimeStepIndices returned an empty vector and .back() invoked undefined behaviour. Skip the m_timeStep assignment when either allDateTimes or filteredTimeStepIndices is empty.

Fixes #14006.