### PR TITLE
MSW Export: Add preference for improved MSW data structures

### DIFF
--- a/ApplicationLibCode/Application/RiaPreferences.cpp
+++ b/ApplicationLibCode/Application/RiaPreferences.cpp
@@ -211,6 +211,12 @@ RiaPreferences::RiaPreferences()
     CAF_PDM_InitField( &m_useUndoRedo, "useUndoRedo", false, "Enable Undo/Redo for Property Editor changes" );
     caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_useUndoRedo );
 
+    CAF_PDM_InitField( &m_useImprovedMswDataStructures,
+                       "useImprovedMswDataStructures",
+                       false,
+                       "Use Improved MSW Data Structures" + RiaDefines::betaFeaturePostfix() );
+    caf::PdmUiNativeCheckBoxEditor::configureFieldForEditor( &m_useImprovedMswDataStructures );
+
     CAF_PDM_InitFieldNoDefault( &m_plotTemplateFolders, "plotTemplateFolders", "Plot Template Folder(s)" );
     m_plotTemplateFolders.uiCapability()->setUiEditorTypeName( caf::PdmUiFilePathEditor::uiEditorTypeName() );
     CAF_PDM_InitField( &m_maxPlotTemplateFoldersDepth, "MaxPlotTemplateFoldersDepth", 2, "Maximum Plot Template Folder Search Depth" );
@@ -391,6 +397,7 @@ void RiaPreferences::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering&
         otherGroup->setCollapsedByDefault();
         otherGroup->add( &holoLensDisableCertificateVerification );
         otherGroup->add( &m_useUndoRedo );
+        otherGroup->add( &m_useImprovedMswDataStructures );
 
         caf::PdmUiGroup* importExportGroup = uiOrdering.addNewGroup( "Import and Export" );
         importExportGroup->setCollapsedByDefault();
@@ -715,6 +722,14 @@ QStringList RiaPreferences::tabNames()
 bool RiaPreferences::useUndoRedo() const
 {
     return m_useUndoRedo();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiaPreferences::useImprovedMswDataStructures() const
+{
+    return m_useImprovedMswDataStructures();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaPreferences.h
+++ b/ApplicationLibCode/Application/RiaPreferences.h
@@ -73,6 +73,8 @@ public:
 
     bool useUndoRedo() const;
 
+    bool useImprovedMswDataStructures() const;
+
     const QString& dateFormat() const;
     const QString& timeFormat() const;
     QString
@@ -182,6 +184,7 @@ private:
     caf::PdmField<QString> m_timeFormat;
 
     caf::PdmField<bool> m_useUndoRedo;
+    caf::PdmField<bool> m_useImprovedMswDataStructures;
 
     caf::PdmField<caf::AppEnum<RiaDefines::ThemeEnum>> m_guiTheme;
 

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicPerforationCellFilterEvaluator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicPerforationCellFilterEvaluator.cpp
@@ -57,6 +57,12 @@ bool RicPerforationCellFilterEvaluator::includesGlobalCell( size_t globalCellInd
 
     const RigMainGrid* mainGrid = m_eclipseCase->eclipseCaseData()->mainGrid();
 
+    if ( globalCellIndex >= mainGrid->totalCellCount() )
+    {
+        ++m_rejectedCellCount;
+        return false;
+    }
+
     size_t             localCellIndex = 0;
     const RigGridBase* localGrid      = mainGrid->gridAndGridLocalIdxFromGlobalCellIdx( globalCellIndex, &localCellIndex );
     if ( !localGrid )

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
@@ -19,6 +19,7 @@
 #include "RicWellPathExportMswTableData.h"
 
 #include "RiaLogging.h"
+#include "RiaPreferences.h"
 #include "RiaQStringFormatter.h"
 
 #include "MswExport/RicWellPathExportMswGeometryPath.h"
@@ -71,28 +72,27 @@ std::expected<RigMswTableData, std::string>
                                                              CompletionType                  completionType,
                                                              const std::optional<QDateTime>& exportDate )
 {
-    bool exportAsTree = true; // This can be made configurable if needed, but for now we will always export as tree structure to preserve
-                              // the hierarchy of the well path segments and completions
-
-    if ( exportAsTree )
+    // Data prcessing for MSW has improved. Currently, there exist two code paths for extracting MSW data. The preference for using the
+    // legacy code path is controlled by the "Use Improved MSW Data Structures" preference (General tab, Other group).
+    bool useLegacy = !RiaPreferences::current()->useImprovedMswDataStructures();
+    if ( useLegacy )
     {
-        return extractSingleWellMswDataTree( eclipseCase, wellPath, exportCompletionsAfterMainBoreSegments, completionType, exportDate );
+        return extractSingleWellMsw_Legacy( eclipseCase, wellPath, exportCompletionsAfterMainBoreSegments, completionType, exportDate );
     }
     else
     {
-        return extractSingleWellMswDataGeometry( eclipseCase, wellPath, exportCompletionsAfterMainBoreSegments, completionType, exportDate );
+        return extractSingleWellMsw( eclipseCase, wellPath, exportCompletionsAfterMainBoreSegments, completionType, exportDate );
     }
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::expected<RigMswTableData, std::string>
-    RicWellPathExportMswTableData::extractSingleWellMswDataGeometry( RimEclipseCase*                 eclipseCase,
-                                                                     RimWellPath*                    wellPath,
-                                                                     bool                            exportCompletionsAfterMainBoreSegments,
-                                                                     CompletionType                  completionType,
-                                                                     const std::optional<QDateTime>& exportDate )
+std::expected<RigMswTableData, std::string> RicWellPathExportMswTableData::extractSingleWellMsw( RimEclipseCase* eclipseCase,
+                                                                                                 RimWellPath*    wellPath,
+                                                                                                 bool exportCompletionsAfterMainBoreSegments,
+                                                                                                 CompletionType completionType,
+                                                                                                 const std::optional<QDateTime>& exportDate )
 {
     if ( !eclipseCase || !wellPath || eclipseCase->eclipseCaseData() == nullptr )
         return std::unexpected( "Invalid eclipse case or well path provided" );
@@ -116,11 +116,11 @@ std::expected<RigMswTableData, std::string>
 ///
 //--------------------------------------------------------------------------------------------------
 std::expected<RigMswTableData, std::string>
-    RicWellPathExportMswTableData::extractSingleWellMswDataTree( RimEclipseCase*                 eclipseCase,
-                                                                 RimWellPath*                    wellPath,
-                                                                 bool                            exportCompletionsAfterMainBoreSegments,
-                                                                 CompletionType                  completionType,
-                                                                 const std::optional<QDateTime>& exportDate )
+    RicWellPathExportMswTableData::extractSingleWellMsw_Legacy( RimEclipseCase*                 eclipseCase,
+                                                                RimWellPath*                    wellPath,
+                                                                bool                            exportCompletionsAfterMainBoreSegments,
+                                                                CompletionType                  completionType,
+                                                                const std::optional<QDateTime>& exportDate )
 {
     if ( !eclipseCase || !wellPath || eclipseCase->eclipseCaseData() == nullptr )
     {

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.h
@@ -70,18 +70,17 @@ public:
                                                                                  CompletionType completionType = CompletionType::ALL,
                                                                                  const std::optional<QDateTime>& exportDate = std::nullopt );
 
-    static std::expected<RigMswTableData, std::string> extractSingleWellMswDataTree( RimEclipseCase* eclipseCase,
-                                                                                     RimWellPath*    wellPath,
-                                                                                     bool exportCompletionsAfterMainBoreSegments = true,
-                                                                                     CompletionType completionType = CompletionType::ALL,
-                                                                                     const std::optional<QDateTime>& exportDate = std::nullopt );
+    static std::expected<RigMswTableData, std::string> extractSingleWellMsw_Legacy( RimEclipseCase* eclipseCase,
+                                                                                    RimWellPath*    wellPath,
+                                                                                    bool exportCompletionsAfterMainBoreSegments = true,
+                                                                                    CompletionType completionType = CompletionType::ALL,
+                                                                                    const std::optional<QDateTime>& exportDate = std::nullopt );
 
-    static std::expected<RigMswTableData, std::string>
-        extractSingleWellMswDataGeometry( RimEclipseCase*                 eclipseCase,
-                                          RimWellPath*                    wellPath,
-                                          bool                            exportCompletionsAfterMainBoreSegments = true,
-                                          CompletionType                  completionType                         = CompletionType::ALL,
-                                          const std::optional<QDateTime>& exportDate                             = std::nullopt );
+    static std::expected<RigMswTableData, std::string> extractSingleWellMsw( RimEclipseCase* eclipseCase,
+                                                                             RimWellPath*    wellPath,
+                                                                             bool            exportCompletionsAfterMainBoreSegments = true,
+                                                                             CompletionType  completionType = CompletionType::ALL,
+                                                                             const std::optional<QDateTime>& exportDate = std::nullopt );
 
     static CompletionType convertFromExportSettings( const class RicExportCompletionDataSettingsUi& settings );
 

--- a/ApplicationLibCode/UnitTests/RicWellPathExportMswTableData-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicWellPathExportMswTableData-Test.cpp
@@ -100,7 +100,7 @@ std::vector<std::tuple<size_t, size_t, size_t, std::string>> extractSortedCells(
 // Parameterized integration tests: Tree mode vs Geometry mode for all MSW project files.
 //
 // The test loads a ResInsight project file, extracts well MSW data using both the tree-based
-// (extractSingleWellMswDataTree) and geometry-based (extractSingleWellMswDataGeometry)
+// (extractSingleWellMsw_Legacy) and geometry-based (extractSingleWellMsw)
 // algorithms, and verifies that both produce equivalent results for every well path:
 //
 //   - The same set of reservoir cells in COMPSEGS (sorted {i,j,k,gridName} tuples)
@@ -155,8 +155,8 @@ TEST_P( MswTreeVsGeometryTest, CompareTreeAndGeometryModes )
 
         if ( !wellPath->isTopLevelWellPath() ) continue;
 
-        auto treeResult     = RicWellPathExportMswTableData::extractSingleWellMswDataTree( eclipseCase, wellPath );
-        auto geometryResult = RicWellPathExportMswTableData::extractSingleWellMswDataGeometry( eclipseCase, wellPath );
+        auto treeResult     = RicWellPathExportMswTableData::extractSingleWellMsw_Legacy( eclipseCase, wellPath );
+        auto geometryResult = RicWellPathExportMswTableData::extractSingleWellMsw( eclipseCase, wellPath );
 
         // If one mode fails, the other should fail too (no MSW data for this well path).
         if ( !treeResult.has_value() && !geometryResult.has_value() )


### PR DESCRIPTION
Adds a 'Use Improved MSW Data Structures [BETA]' checkbox to the Other group of the General preferences tab. The preference selects the code path used in RicWellPathExportMswTableData::extractSingleWellMswData; when off (default) the existing tree-based extraction is used, when on the geometry-based extraction is used. The extraction methods are renamed accordingly (extractSingleWellMsw_Legacy and extractSingleWellMsw). Also includes an out-of-range global cell index guard in RicPerforationCellFilterEvaluator::includesGlobalCell to avoid undefined behavior in release builds where the underlying CVF_ASSERT is compiled out.