### PR TITLE
#13992 Hide production disks for wells filtered out by "Wells Through…

### DIFF
--- a/ApplicationLibCode/ModelVisualization/RivWellDiskPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellDiskPartMgr.cpp
@@ -461,7 +461,7 @@ void RivWellDiskPartMgr::appendDynamicGeometryPartsToModel( cvf::ModelBasicList*
     if ( m_rimWell.isNull() ) return;
     if ( !viewWithSettings() ) return;
 
-    if ( !m_rimWell->isWellDiskVisible() ) return;
+    if ( !m_rimWell->isWellDiskVisible( frameIndex ) ) return;
     if ( !m_rimWell->isValidDisk() ) return;
 
     buildWellDiskParts( frameIndex, displayXf );

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp
@@ -650,7 +650,7 @@ size_t RimSimWellInView::resultWellIndex() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-bool RimSimWellInView::isWellDiskVisible() const
+bool RimSimWellInView::isWellDiskVisible( size_t frameIndex ) const
 {
     const auto reservoirView = firstAncestorOrThisOfType<RimEclipseView>();
 
@@ -663,6 +663,14 @@ bool RimSimWellInView::isWellDiskVisible() const
     if ( !showWell() ) return false;
 
     if ( !showWellDisks() ) return false;
+
+    if ( reservoirView->intersectionCollection()->hasActiveIntersectionForSimulationWell( this ) ) return true;
+
+    if ( reservoirView->wellCollection()->showWellsIntersectingVisibleCells() &&
+         ( reservoirView->cellFilterCollection()->hasActiveFilters() || reservoirView->propertyFilterCollection()->hasActiveFilters() ) )
+    {
+        return intersectsDynamicWellCellsFilteredCells( frameIndex );
+    }
 
     return true;
 }

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInView.h
@@ -57,7 +57,7 @@ public:
     const RigSimWellData* simWellData() const;
     size_t                resultWellIndex() const;
 
-    bool isWellDiskVisible() const;
+    bool isWellDiskVisible( size_t frameIndex ) const;
     bool isWellCellsVisible() const;
     bool isWellPipeVisible( size_t frameIndex ) const;
     bool isWellSpheresVisible( size_t frameIndex ) const;

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
@@ -880,11 +880,14 @@ void RimSimWellInViewCollection::scaleWellDisks()
 //--------------------------------------------------------------------------------------------------
 void RimSimWellInViewCollection::scaleWellDisksFromConfig( const RimWellDiskConfig& wellDiskConfig )
 {
+    if ( !m_reservoirView ) return;
+    size_t frameIndex = static_cast<size_t>( m_reservoirView->currentTimeStep() );
+
     double minValue = std::numeric_limits<double>::max();
     double maxValue = -minValue;
     for ( RimSimWellInView* w : wells )
     {
-        if ( !w->isWellDiskVisible() ) continue;
+        if ( !w->isWellDiskVisible( frameIndex ) ) continue;
 
         bool   isOk  = true;
         double value = w->calculateInjectionProductionFractions( wellDiskConfig, &isOk );


### PR DESCRIPTION
… Visible Cells Only"

Production disks were drawn for wells that the visible-cells filter hides, because RimSimWellInView::isWellDiskVisible() never consulted the showWellsIntersectingVisibleCells toggle.

Add a frameIndex parameter and the same active-intersection / visible- cells filter logic that isWellPipeVisible already uses, and update the two call sites to pass the current frame.

Fixes #13992.