### PR TITLE
Fix CODE_HEAD_FILES typo so gRPC headers reach MOC

### DIFF
--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -63,7 +63,7 @@ set(CODE_HEADER_FILES RiaMainTools.h)
 set(CODE_SOURCE_FILES RiaMain.cpp RiaMainTools.cpp)
 
 if(RESINSIGHT_ENABLE_GRPC)
-  list(APPEND CODE_HEAD_FILES RiaGrpcConsoleApplication.h
+  list(APPEND CODE_HEADER_FILES RiaGrpcConsoleApplication.h
        RiaGrpcGuiApplication.h
   )
   list(APPEND CODE_SOURCE_FILES RiaGrpcConsoleApplication.cpp


### PR DESCRIPTION
The `if(RESINSIGHT_ENABLE_GRPC)` block in `ApplicationExeCode/CMakeLists.txt` appends the gRPC application headers to a **misnamed variable** `CODE_HEAD_FILES` instead of `CODE_HEADER_FILES` (the variable declared a few lines above). CMake silently creates the unused variable rather than warning, so `RiaGrpcConsoleApplication.h` and `RiaGrpcGuiApplication.h` are never passed to Qt's MOC.

The result is a link failure with `undefined reference to vtable for RiaGrpcConsoleApplication` (and the same for `RiaGrpcGuiApplication`), which blocks **all** `-DRESINSIGHT_ENABLE_GRPC=ON` builds.

This one-line change appends the headers to the correct `CODE_HEADER_FILES` variable so MOC processes them.

#### Test plan

- [x] `-DRESINSIGHT_ENABLE_GRPC=ON` build links cleanly (verified locally; the gRPC `ResInsight` binary builds and the `rips` Python client connects)
- [ ] CI passes (the default non-GRPC build path is unaffected — the renamed variable is only referenced inside the `RESINSIGHT_ENABLE_GRPC` block)
