### PR TITLE
Expose snapshot size to gRPC / rips clients

### DIFF
--- a/ApplicationLibCode/CommandFileInterface/CMakeLists_files.cmake
+++ b/ApplicationLibCode/CommandFileInterface/CMakeLists_files.cmake
@@ -15,6 +15,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetExportFolder.h
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetMainWindowSize.h
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetPlotWindowSize.h
+    ${CMAKE_CURRENT_LIST_DIR}/RicfSetSnapshotSize.h
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetStartDir.h
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetTimeStep.h
     ${CMAKE_CURRENT_LIST_DIR}/RicfScaleFractureTemplate.h
@@ -55,6 +56,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetExportFolder.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetMainWindowSize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetPlotWindowSize.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicfSetSnapshotSize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetStartDir.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicfSetTimeStep.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicfScaleFractureTemplate.cpp

--- a/ApplicationLibCode/CommandFileInterface/RicfSetSnapshotSize.cpp
+++ b/ApplicationLibCode/CommandFileInterface/RicfSetSnapshotSize.cpp
@@ -1,0 +1,80 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicfSetSnapshotSize.h"
+
+#include "RiaGuiApplication.h"
+#include "RiuMainWindow.h"
+#include "RiuMainWindowTools.h"
+#include "RiuPlotMainWindow.h"
+
+#include "cafPdmFieldScriptingCapability.h"
+
+#include <QApplication>
+
+CAF_PDM_SOURCE_INIT( RicfSetSnapshotSize, "setSnapshotSize" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RicfSetSnapshotSize::RicfSetSnapshotSize()
+{
+    CAF_PDM_InitScriptableField( &m_height, "height", -1, "Height" );
+    CAF_PDM_InitScriptableField( &m_width, "width", -1, "Width" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::PdmScriptResponse RicfSetSnapshotSize::execute()
+{
+    if ( m_width() <= 0 || m_height() <= 0 )
+    {
+        return caf::PdmScriptResponse( caf::PdmScriptResponse::COMMAND_ERROR, "setSnapshotSize: width and height must both be > 0" );
+    }
+
+    RiaGuiApplication* guiApp = RiaGuiApplication::instance();
+    if ( !guiApp )
+    {
+        return caf::PdmScriptResponse( caf::PdmScriptResponse::COMMAND_ERROR, "Need GUI ResInsight to set snapshot size" );
+    }
+
+    // Resize plot sub-windows so plot snapshots render at the requested size.
+    // This is the same helper --snapshotsize uses in the CLI dispatch path.
+    // Note: for the inner plot widget to also be resized (and not just the
+    // outer multi-plot wrapper), the caller must have invoked
+    // set_plot_window_size first so the plots are realized inside MDI
+    // sub-windows. Without that, only the wrapper resizes and the qwt
+    // canvas stays anchored at its initial geometry.
+    if ( auto* plotMainWindow = guiApp->mainPlotWindow() )
+    {
+        RiuMainWindowTools::setWindowSizeOnWidgetsInMdiWindows( plotMainWindow, m_width(), m_height() );
+    }
+
+    // Mirror --snapshotsize behavior for 3D views as well.
+    if ( auto* mainWindow = guiApp->mainWindow() )
+    {
+        RiuMainWindowTools::setFixedWindowSizeFor3dViews( mainWindow, m_width(), m_height() );
+    }
+
+    // Let the resize events propagate before the caller's next gRPC
+    // request (typically export_snapshot) renders the widget.
+    QApplication::processEvents();
+
+    return caf::PdmScriptResponse();
+}

--- a/ApplicationLibCode/CommandFileInterface/RicfSetSnapshotSize.h
+++ b/ApplicationLibCode/CommandFileInterface/RicfSetSnapshotSize.h
@@ -1,0 +1,42 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026- Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RicfCommandObject.h"
+
+#include "cafPdmField.h"
+
+//==================================================================================================
+//
+//
+//
+//==================================================================================================
+class RicfSetSnapshotSize : public RicfCommandObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RicfSetSnapshotSize();
+
+    caf::PdmScriptResponse execute() override;
+
+private:
+    caf::PdmField<int> m_height;
+    caf::PdmField<int> m_width;
+};

--- a/GrpcInterface/GrpcProtos/Commands.proto
+++ b/GrpcInterface/GrpcProtos/Commands.proto
@@ -338,6 +338,7 @@ message CommandParams {
     SetWindowSizeParams setPlotWindowSize = 37;
     ExportContourMapToTextRequest exportContourMapToText = 38;
     SaveProjectRequest saveProject = 39;
+    SetWindowSizeParams setSnapshotSize = 40;
   }
 }
 

--- a/GrpcInterface/Python/rips/PythonExamples/export_and_plotting/headless_plot_export.py
+++ b/GrpcInterface/Python/rips/PythonExamples/export_and_plotting/headless_plot_export.py
@@ -26,6 +26,12 @@ summary_plot_collection.new_summary_plot(
     summary_cases=[summary_case], address="WOPR:A*;WOPR:B*"
 )
 
+# Resize the plot sub-windows so the exported PNGs come out at the
+# requested resolution. Without this, the offscreen layout engine picks
+# its own (typically small) geometry and snapshots ignore the --size
+# launch parameter.
+resinsight.set_snapshot_size(1200, 1000)
+
 plots = resinsight.project.plots()
 for plot in plots:
     plot.export_snapshot()

--- a/GrpcInterface/Python/rips/instance.py
+++ b/GrpcInterface/Python/rips/instance.py
@@ -561,6 +561,42 @@ class Instance:
             )
         )
 
+    def set_snapshot_size(self, width: int, height: int):
+        """
+        Set the size used for snapshot export of plots and 3D views.
+
+        Affects subsequent calls to ``export_snapshot`` /
+        ``export_snapshots``. Equivalent to the ``--snapshotsize`` CLI
+        flag. Must be called after at least one plot window has been
+        created (otherwise there is nothing to resize).
+
+        Unlike :meth:`set_plot_window_size`, which only resizes the
+        outer plot main window, this method un-maximizes and resizes
+        each MDI sub-window so the actual plot widget is rendered at
+        the requested dimensions.
+
+        Recommended call order for a filled snapshot:
+
+        1. :meth:`set_plot_window_size` *before* creating plots, so the
+           plots are realized inside MDI sub-windows.
+        2. Create the plot(s).
+        3. ``project.plots()`` to fetch the plot to export. This can
+           re-tile the MDI sub-windows back to their defaults, so call
+           ``set_snapshot_size`` *after* it, not before.
+        4. ``set_snapshot_size(width, height)``.
+        5. ``plot.export_snapshot(...)``.
+
+        **Parameters**::
+
+            Parameter | Description      | Type
+            --------- | ---------------- | -----
+            width     | Width in pixels  | Integer
+            height    | Height in pixels | Integer
+        """
+        return self.__execute_command(
+            setSnapshotSize=Commands_pb2.SetWindowSizeParams(width=width, height=height)
+        )
+
     def major_version(self) -> int:
         """Get an integer with the major version number"""
         return int(self.__version_message().major_version)


### PR DESCRIPTION
Adds a `setSnapshotSize(width, height)` scripting command so Python clients can request a specific snapshot resolution before exporting, instead of being stuck with whatever geometry Qt happens to give the plot widget.

**Motivation:** snapshots exported over gRPC (`Instance.export_snapshots`, `PlotWindow.export_snapshot`) render at the plot widget's current size. In offscreen mode that is typically much smaller than expected, because `set_plot_window_size` only resizes the outer `RiuPlotMainWindow` and leaves the MDI sub-windows at their original layout geometry. The `--snapshotsize` CLI flag already works around this via `RiuMainWindowTools::setWindowSizeOnWidgetsInMdiWindows`, but that helper had no scripting binding — so headless, rips-driven export had no way to control the output resolution.

#### Add `setSnapshotSize` gRPC command (commit 1)

- New **`RicfSetSnapshotSize`** scriptable command in `ApplicationLibCode/CommandFileInterface/`, registered in `CMakeLists_files.cmake`.
- Wraps the same **`RiuMainWindowTools::setWindowSizeOnWidgetsInMdiWindows`** helper the `--snapshotsize` CLI flag uses, and also resizes 3D views via **`setFixedWindowSizeFor3dViews`**, mirroring `RiaGuiApplication`.
- **Validates** `width`/`height > 0`, returning a clear `COMMAND_ERROR` otherwise.
- New `setSnapshotSize` entry in the `CommandParams` oneof in `Commands.proto` (tag 40); dispatch is automatic via the reflection-based command service, so no `RiaGrpcCommandService` change is needed.
- A code comment documents the prerequisite: the caller must invoke `set_plot_window_size` first so the plots are realized inside MDI sub-windows; otherwise only the outer wrapper resizes and the inner qwt canvas stays anchored at its initial geometry.

#### Add `Instance.set_snapshot_size` to the rips Python client (commit 2)

- New `Instance.set_snapshot_size(width, height)` wrapper mirroring the existing `set_plot_window_size` shape.
- Docstring spells out the **recommended call order** for a filled snapshot: `set_plot_window_size` before creating plots → create plots → `project.plots()` → `set_snapshot_size` → `export_snapshot`. (`project.plots()` can re-tile the MDI sub-windows back to defaults, so `set_snapshot_size` must come after it.)
- Updates the `headless_plot_export` example to demonstrate the call.

#### Notes

- This PR pairs with #14041 (the `CODE_HEAD_FILES` CMake typo fix). Both are needed to actually build with `-DRESINSIGHT_ENABLE_GRPC=ON`; building this branch alone without #14041 hits the `undefined reference to vtable for RiaGrpcConsoleApplication` link error.
- The new `setSnapshotSize` oneof tag (40) is purely additive — older `rips` clients are unaffected.

#### Test plan

- [x] `setSnapshotSize` rejects `width`/`height <= 0` with `FAILED_PRECONDITION`.
- [x] Headless export (`-platform offscreen`) after `set_plot_window_size` + `set_snapshot_size(W, H)` produces a `W x H` PNG with the plot filling the canvas (verified at 1600×1000 and 1000×800).
- [ ] CI passes.
