### PR TITLE
Make RimMultiPlot column/row count scriptable via gRPC

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
@@ -61,10 +61,8 @@ RimMultiPlot::RimMultiPlot()
     reorderability->orderChanged.connect( this, &RimMultiPlot::onPlotsReordered );
 
     RiaPreferencesSummary* sumPrefs = RiaPreferencesSummary::current();
-    CAF_PDM_InitFieldNoDefault( &m_columnCount, "NumberOfColumns", "Number of Columns" );
-    m_columnCount = sumPrefs->defaultMultiPlotColumnCount();
-    CAF_PDM_InitFieldNoDefault( &m_rowsPerPage, "RowsPerPage", "Rows per Page" );
-    m_rowsPerPage = sumPrefs->defaultMultiPlotRowCount();
+    CAF_PDM_InitScriptableField( &m_columnCount, "NumberOfColumns", ColumnCountEnum( sumPrefs->defaultMultiPlotColumnCount() ), "Number of Columns" );
+    CAF_PDM_InitScriptableField( &m_rowsPerPage, "RowsPerPage", RowCountEnum( sumPrefs->defaultMultiPlotRowCount() ), "Rows per Page" );
 
     CAF_PDM_InitField( &m_showIndividualPlotTitles, "ShowPlotTitles", true, "Show Sub Plot Titles" );
     CAF_PDM_InitFieldNoDefault( &m_majorTickmarkCount, "MajorTickmarkCount", "Major Tickmark Count" );

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryMultiPlot.cpp
@@ -61,6 +61,7 @@
 #include "RiuSummaryMultiPlotBook.h"
 #include "RiuSummaryVectorSelectionUi.h"
 
+#include "cafPdmObjectScriptingCapability.h"
 #include "cafPdmUiButton.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiComboBoxEditor.h"
@@ -113,7 +114,7 @@ void RimSummaryMultiPlot::clearLayoutInfo()
 //--------------------------------------------------------------------------------------------------
 RimSummaryMultiPlot::RimSummaryMultiPlot()
 {
-    CAF_PDM_InitObject( "Multi Summary Plot", ":/SummaryPlotLight16x16.png" );
+    CAF_PDM_InitScriptableObject( "Multi Summary Plot", ":/SummaryPlotLight16x16.png" );
     setDeletable( true );
 
     CAF_PDM_InitField( &m_autoPlotTitle, "AutoPlotTitle", true, "Auto Plot Title" );

--- a/GrpcInterface/Python/rips/tests/test_summary_multi_plot.py
+++ b/GrpcInterface/Python/rips/tests/test_summary_multi_plot.py
@@ -1,0 +1,56 @@
+import sys
+import os
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../"))
+import rips
+
+import dataroot
+
+
+def _create_summary_multi_plot(rips_instance):
+    """Import a summary case and create one summary plot, returning the
+    newly created RimSummaryMultiPlot wrapper."""
+    case_path = dataroot.PATH + "/flow_diagnostics_test/SIMPLE_SUMMARY2.SMSPEC"
+    summary_case = rips_instance.project.import_summary_case(case_path)
+    assert summary_case.id == 1
+
+    collection = rips_instance.project.descendants(rips.SummaryPlotCollection)[0]
+    collection.new_summary_plot(summary_cases=[summary_case], address="FOPT")
+
+    multi_plots = rips_instance.project.descendants(rips.MultiSummaryPlot)
+    assert len(multi_plots) >= 1
+    return multi_plots[-1]
+
+
+def test_summary_multi_plot_layout_is_scriptable(rips_instance, initialize_test):
+    """The column/row count fields on a summary multi-plot are exposed over
+    gRPC and round-trip through update()."""
+    multi_plot = _create_summary_multi_plot(rips_instance)
+
+    # Fields are readable (default seeded from the Multi Plot Defaults
+    # preference; the exact default is environment dependent).
+    assert multi_plot.number_of_columns in (1, 2, 3, 4)
+    assert multi_plot.rows_per_page in (1, 2, 3, 4)
+
+    # Set, update, and verify the new values are persisted server-side.
+    multi_plot.number_of_columns = 3
+    multi_plot.rows_per_page = 2
+    multi_plot.update()
+
+    refetched = rips_instance.project.descendants(rips.MultiSummaryPlot)[-1]
+    assert refetched.number_of_columns == 3
+    assert refetched.rows_per_page == 2
+
+
+def test_summary_multi_plot_layout_override(rips_instance, initialize_test):
+    """Forcing a 1x1 layout works regardless of the preference default —
+    this is what a headless export uses to get deterministic output."""
+    multi_plot = _create_summary_multi_plot(rips_instance)
+
+    multi_plot.number_of_columns = 1
+    multi_plot.rows_per_page = 1
+    multi_plot.update()
+
+    refetched = rips_instance.project.descendants(rips.MultiSummaryPlot)[-1]
+    assert refetched.number_of_columns == 1
+    assert refetched.rows_per_page == 1


### PR DESCRIPTION
Exposes the multi-plot grid layout (`number_of_columns` / `rows_per_page`) to the `rips` Python client so scripts can set it per multi-plot, instead of silently inheriting the user's interactive preference.

**Motivation:** `RimMultiPlot::m_columnCount` and `m_rowsPerPage` are initialized from `RiaPreferencesSummary` — the user's interactive `Edit → Preferences → Plotting → Multi Plot Defaults` setting, backed by the on-disk preferences file that is **shared between every ResInsight process on the machine**. A headless, rips-driven script had no way to override them, so a preference change made in one interactive session silently altered the output of unrelated scripts. The fields did not surface in the generated Python bindings at all, because they were declared with `CAF_PDM_InitFieldNoDefault` and the containing class `RimSummaryMultiPlot` was registered with the non-scriptable `CAF_PDM_InitObject`.

#### Changes

- **`RimMultiPlot.cpp`** — declare `m_columnCount` / `m_rowsPerPage` with `CAF_PDM_InitScriptableField` (seeding the default from `RiaPreferencesSummary` as before), instead of `CAF_PDM_InitFieldNoDefault`.
- **`RimSummaryMultiPlot.cpp`** — register the class with `CAF_PDM_InitScriptableObject` (was `CAF_PDM_InitObject`) so it appears in the generated bindings, and add the missing `cafPdmObjectScriptingCapability.h` include.

#### Result

The generated `rips` classes now expose `MultiSummaryPlot.number_of_columns` / `.rows_per_page` as int-valued attributes that round-trip through `update()`:

```python
mp = ri.project.descendants(rips.MultiSummaryPlot)[-1]
mp.number_of_columns = 1
mp.rows_per_page = 1
mp.update()
```

This lets a headless export force a deterministic layout (e.g. 1×1) regardless of the user's interactive preference.

#### Scope

Only `RimSummaryMultiPlot` is made scriptable here; `RimMultiPlot` itself and `RimHistogramMultiPlot` keep `CAF_PDM_InitObject`. Coverage can be expanded in a follow-up if other multi-plot types need the same.

#### Notes

- Part of the same GRPC scripting work as #14041 (`CODE_HEAD_FILES` CMake typo fix) and #14042 (snapshot size). Building this branch with `-DRESINSIGHT_ENABLE_GRPC=ON` requires the #14041 fix; it is otherwise independent of #14042 (no file overlap).
- The change is additive to the scriptable surface — existing command files and saved projects load unchanged (`CAF_PDM_InitScriptableField` uses the same serialization as `CAF_PDM_InitFieldNoDefault`, just with extra scripting metadata).

#### Test plan

- [x] `rips` exposes `MultiSummaryPlot.number_of_columns` / `.rows_per_page`; setting + `update()` round-trips (verified 2 → 1).
- [x] Headless export of a summary multi-plot honors a forced 1×1 layout regardless of the on-disk `Multi Plot Defaults` preference.
- [ ] CI passes.
