### PR TITLE
CI: Run RHEL8 unit tests on every push and PR

### DIFF
--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -1,10 +1,16 @@
 name: RHEL8 Unit Tests
 
 on:
+  push:
+  pull_request:
   workflow_dispatch:
   schedule:
     # Nightly at 2am UTC
     - cron: "0 2 * * *"
+
+concurrency:
+  group: rhel8-unit-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Resolves the prebuilt CI image name so it works in forks and upstream alike

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Nightly at 2am UTC
+    # Nightly at 2am UTC 
     - cron: "0 2 * * *"
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add `push` and `pull_request` triggers to the RHEL8 unit tests workflow (now fast thanks to the prebuilt CI Docker image with baked vcpkg/buildcache).
- Keep existing `workflow_dispatch` and nightly schedule.
- Add a concurrency group so superseded runs on the same ref/PR are cancelled, matching the pattern used in `ResInsightWithCache.yml`.