### PR TITLE
#14054 Telemetry: Remove cleartext username from OpenTelemetry reporting

### DIFF
--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp
@@ -293,15 +293,15 @@ void RiaOpenTelemetryManager::reportEventAsync( const std::string& eventName, co
     }
 
     // Create mutable copy and add hashed username if configured (privacy-preserving for regular events)
-    // Note: crash events already have real username added in reportCrash()
+    // Note: crash events already have hashed username added in reportCrash()
     std::map<std::string, std::string> enrichedAttributes = attributes;
 
     if ( !isCrashEvent )
     {
         std::lock_guard<std::mutex> configLock( m_configMutex );
-        if ( !m_username.empty() )
+        if ( !m_userHash.empty() )
         {
-            enrichedAttributes["user.hash"] = hashUsername( m_username );
+            enrichedAttributes["user.hash"] = m_userHash;
         }
 
         addOsInfo( enrichedAttributes );
@@ -388,12 +388,12 @@ void RiaOpenTelemetryManager::reportCrash( int signalCode, const std::stacktrace
     // Add system information
     addOsInfo( attributes );
 
-    // Add real username for crash reports (not hashed - needed for debugging critical issues)
+    // Add hashed username so crashes can be grouped per user without revealing the cleartext name.
     {
         std::lock_guard<std::mutex> lock( m_configMutex );
-        if ( !m_username.empty() )
+        if ( !m_userHash.empty() )
         {
-            attributes["user.name"] = m_username;
+            attributes["user.hash"] = m_userHash;
         }
     }
 
@@ -451,9 +451,9 @@ void RiaOpenTelemetryManager::setErrorCallback( ErrorCallback callback )
 //--------------------------------------------------------------------------------------------------
 void RiaOpenTelemetryManager::setUsername( const std::string& username )
 {
+    // Hash at the boundary so the cleartext username is never retained in memory.
     std::lock_guard<std::mutex> lock( m_configMutex );
-    // Store original username - will be hashed for regular events but kept plain for crash reports
-    m_username = username;
+    m_userHash = hashUsername( username );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.h
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.h
@@ -172,7 +172,7 @@ private:
     size_t      m_maxQueueSize{ 10000 };
     bool        m_backpressureEnabled{ true };
     size_t      m_memoryThresholdMB{ 50 };
-    std::string m_username;
+    std::string m_userHash;
 
     // Error handling
     ErrorCallback                         m_errorCallback;


### PR DESCRIPTION
Closes #14054. Hash the username at the boundary in setUsername() and store only the SHA-256 digest in m_userHash, so the cleartext value is never retained in memory. Crash reports now send the same user.hash attribute as regular events instead of the cleartext user.name, preserving per-user grouping without revealing identity.