### PR TITLE
#13913 Add "Active Wells Only" visibility toggle for simulation wells

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp
@@ -508,6 +508,8 @@ bool RimSimWellInView::isWellPipeVisible( size_t frameIndex ) const
 
     if ( !showWellPipe() ) return false;
 
+    if ( reservoirView->wellCollection()->showOnlyActiveWells() && !simWellData()->isOpen( frameIndex ) ) return false;
+
     if ( reservoirView->intersectionCollection()->hasActiveIntersectionForSimulationWell( this ) ) return true;
 
     if ( reservoirView->wellCollection()->showWellsIntersectingVisibleCells() &&
@@ -548,6 +550,8 @@ bool RimSimWellInView::isWellSpheresVisible( size_t frameIndex ) const
 
     if ( !showWellSpheres() ) return false;
 
+    if ( reservoirView->wellCollection()->showOnlyActiveWells() && !simWellData()->isOpen( frameIndex ) ) return false;
+
     if ( reservoirView->intersectionCollection()->hasActiveIntersectionForSimulationWell( this ) ) return true;
 
     if ( reservoirView->wellCollection()->showWellsIntersectingVisibleCells() && reservoirView->cellFilterCollection()->hasActiveFilters() )
@@ -585,6 +589,8 @@ bool RimSimWellInView::isWellValvesVisible( size_t frameIndex ) const
 
     if ( !reservoirView->wellCollection()->isActive() ) return false;
     if ( !reservoirView->wellCollection()->showValves() ) return false;
+
+    if ( reservoirView->wellCollection()->showOnlyActiveWells() && !simWellData()->isOpen( frameIndex ) ) return false;
 
     if ( reservoirView->intersectionCollection()->hasActiveIntersectionForSimulationWell( this ) ) return true;
 
@@ -663,6 +669,8 @@ bool RimSimWellInView::isWellDiskVisible( size_t frameIndex ) const
     if ( !showWell() ) return false;
 
     if ( !showWellDisks() ) return false;
+
+    if ( reservoirView->wellCollection()->showOnlyActiveWells() && !simWellData()->isOpen( frameIndex ) ) return false;
 
     if ( reservoirView->intersectionCollection()->hasActiveIntersectionForSimulationWell( this ) ) return true;
 

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
@@ -144,6 +144,8 @@ RimSimWellInViewCollection::RimSimWellInViewCollection()
     // CAF_PDM_InitField(&showWellsIntersectingVisibleCells, "ShowWellsIntersectingVisibleCells", false, "Hide Wells
     // Missing Visible Cells");
 
+    CAF_PDM_InitField( &m_showOnlyActiveWells, "ShowOnlyActiveWells", false, "Active Wells Only" );
+
     // Appearance
     CAF_PDM_InitFieldNoDefault( &m_showWellHead, "ShowWellHeadTristate", "Well Head" );
     CAF_PDM_InitFieldNoDefault( &m_showWellLabel, "ShowWellLabelTristate", "Label" );
@@ -404,7 +406,7 @@ void RimSimWellInViewCollection::fieldChangedByUi( const caf::PdmFieldHandle* ch
         }
 
         if ( &isActive == changedField || &m_showWellCells == changedField || &m_showWellCellFence == changedField ||
-             &wellCellFenceType == changedField || &showWellsIntersectingVisibleCells == changedField )
+             &wellCellFenceType == changedField || &showWellsIntersectingVisibleCells == changedField || &m_showOnlyActiveWells == changedField )
         {
             m_reservoirView->scheduleGeometryRegen( VISIBLE_WELL_CELLS );
             m_reservoirView->scheduleCreateDisplayModelAndRedraw();
@@ -611,6 +613,7 @@ void RimSimWellInViewCollection::defineUiOrdering( QString uiConfigName, caf::Pd
     if ( !isContourMap )
     {
         appearanceGroup->add( &showWellsIntersectingVisibleCells );
+        appearanceGroup->add( &m_showOnlyActiveWells );
     }
     appearanceGroup->add( &m_showWellLabel );
     appearanceGroup->add( &m_showWellHead );

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.h
@@ -125,6 +125,7 @@ public:
     bool showWellCells();
 
     bool showWellCommunicationLines() { return m_showWellCommunicationLines(); }
+    bool showOnlyActiveWells() const { return m_showOnlyActiveWells(); }
 
     caf::PdmField<WellFenceEnum> wellCellFenceType;
     caf::PdmField<double>        wellCellTransparencyLevel;
@@ -199,6 +200,7 @@ private:
 
     caf::PdmField<bool> m_showWellValves;
     caf::PdmField<bool> m_showWellCommunicationLines;
+    caf::PdmField<bool> m_showOnlyActiveWells;
 
     // Well Discs
     caf::PdmField<caf::AppEnum<WellDiskPropertyType>>       m_wellDiskPropertyType;


### PR DESCRIPTION
Adds a collection-level checkbox in the simulation well "Visibility" group that hides wells which are not open at the current time step. Mirrors the existing "Wells Through Visible Cells Only" sibling toggle in placement, default (off), and contour-map gating.

The frame-aware predicates isWellPipeVisible, isWellSpheresVisible, isWellValvesVisible and isWellDiskVisible now short-circuit to false when the toggle is on and RigSimWellData::isOpen(frameIndex) is false, placed before the active-intersection bypass so the user's filter is not overridden.

Fixes #13913