### PR TITLE
#14061 Reorder user interface for summary/grid ensemble import

### DIFF
--- a/ApplicationExeCode/Resources/ResInsight.qrc
+++ b/ApplicationExeCode/Resources/ResInsight.qrc
@@ -296,6 +296,8 @@
         <file>Cloud.svg</file>
         <file>CloudBlobs.svg</file>
         <file>arrow-swap.svg</file>
+        <file>export.svg</file>
+        <file>import.svg</file>
         <file>inspect.svg</file>
         <file>pin.svg</file>
 		<file>Play.svg</file>

--- a/ApplicationExeCode/Resources/export.svg
+++ b/ApplicationExeCode/Resources/export.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8 1L4 5l.707.707L7 3.414V11h2V3.414l2.293 2.293L12 5 8 1zM2 13h12v2H2v-2z" style="fill: rgb(128, 128, 128);"/></svg>

--- a/ApplicationExeCode/Resources/import.svg
+++ b/ApplicationExeCode/Resources/import.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 1v7.586L4.707 6.293 4 7l4 4 4-4-.707-.707L9 8.586V1H7zM2 13h12v2H2v-2z" style="fill: rgb(128, 128, 128);"/></svg>

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipseCaseNewGroupFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipseCaseNewGroupFeature.cpp
@@ -56,5 +56,6 @@ void RicEclipseCaseNewGroupFeature::onActionTriggered( bool isChecked )
 //--------------------------------------------------------------------------------------------------
 void RicEclipseCaseNewGroupFeature::setupActionLook( QAction* actionToSetup )
 {
+    actionToSetup->setIcon( QIcon( ":/CreateGridCaseGroup16x16.png" ) );
     actionToSetup->setText( "New Grid Case Group" );
 }

--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
@@ -252,5 +252,5 @@ QStringList RicImportEclipseCaseFeature::findPvdFilesToImport( const QStringList
 void RicImportEclipseCaseFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setIcon( QIcon( ":/Case.svg" ) );
-    actionToSetup->setText( "Import Eclipse Case" );
+    actionToSetup->setText( "Import Simulation Grid" );
 }

--- a/ApplicationLibCode/Commands/EclipseCommands/RicNewStatisticsCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicNewStatisticsCaseFeature.cpp
@@ -64,6 +64,7 @@ void RicNewStatisticsCaseFeature::onActionTriggered( bool isChecked )
 void RicNewStatisticsCaseFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setText( "New Statistics Case" );
+    actionToSetup->setIcon( QIcon( ":/Histogram16x16.png" ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp
@@ -75,7 +75,8 @@ RimSummaryEnsemble* RicImportEnsembleFeature::createSummaryEnsemble( std::vector
 void RicImportEnsembleFeature::onActionTriggered( bool isChecked )
 {
     QString pathCacheName = "ENSEMBLE_FILES";
-    auto    result = RicImportSummaryCasesFeature::runRecursiveSummaryCaseFileSearchDialogWithGrouping( "Import Ensemble", pathCacheName );
+    auto    result =
+        RicImportSummaryCasesFeature::runRecursiveSummaryCaseFileSearchDialogWithGrouping( "Custom Summary Ensemble Import", pathCacheName );
     QStringList                      fileNames            = result.files;
     RiaDefines::EnsembleGroupingMode ensembleGroupingMode = result.groupingMode;
     RiaDefines::FileType             fileType             = RicRecursiveFileSearchDialog::mapSummaryFileType( result.fileType );
@@ -215,7 +216,7 @@ RimSummaryEnsemble* RicImportEnsembleFeature::groupSummaryCases( std::vector<Rim
 void RicImportEnsembleFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setIcon( QIcon( ":/SummaryEnsemble.svg" ) );
-    actionToSetup->setText( "Import Ensemble" );
+    actionToSetup->setText( "Custom Summary Ensemble Import..." );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp
@@ -236,5 +236,5 @@ void RicImportGridAndSummaryEnsembleFeature::onActionTriggered( bool isChecked )
 void RicImportGridAndSummaryEnsembleFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setIcon( QIcon( ":/GridAndSummaryEnsemble.svg" ) );
-    actionToSetup->setText( "Grid and Summary Ensemble" );
+    actionToSetup->setText( "Import Grid and Summary Ensemble" );
 }

--- a/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.cpp
@@ -34,6 +34,27 @@ CAF_CMD_SOURCE_INIT( RicNewWellTargetMappingFeature, "RicNewWellTargetMappingFea
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicNewWellTargetMappingFeature::isCommandEnabled() const
+{
+    if ( auto gridEnsembles = caf::selectedObjectsByTypeStrict<RimReservoirGridEnsemble*>(); !gridEnsembles.empty() )
+    {
+        // Computation of well target mappings for individual grids is implemented in RimWellTargetMapping::generateEnsembleStatistics().
+        //
+        // If there is a future need to support well target mappings for ensembles with individual grids, the implementation in
+        // RimWellTargetMapping::generateEnsembleStatistics() will need to be updated, and this check can be removed.
+        //
+        // The main performance reason is the memory consumption of loading all grids in the ensemble into memory at the same time, which is
+        // currently needed in order to compute the well target mapping for ensembles with individual grids. For ensembles with shared grid,
+        // only the shared grid needs to be loaded, which is much more memory efficient.
+
+        return false;
+    }
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicNewWellTargetMappingFeature::onActionTriggered( bool isChecked )
 {
     if ( auto ensembles = caf::selectedObjectsByTypeStrict<RimEclipseCaseEnsemble*>(); !ensembles.empty() )

--- a/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.h
+++ b/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.h
@@ -28,6 +28,7 @@ class RicNewWellTargetMappingFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 private:
+    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -127,7 +127,6 @@
 #include "RimSummaryAddress.h"
 #include "RimSummaryAddressCollection.h"
 #include "RimSummaryCase.h"
-#include "RimSummaryCaseMainCollection.h"
 #include "RimSummaryCurve.h"
 #include "RimSummaryCurveCollection.h"
 #include "RimSummaryMultiPlot.h"
@@ -758,19 +757,6 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         else if ( dynamic_cast<RimEnsembleCurveFilterCollection*>( firstUiItem ) )
         {
             menuBuilder << "RicNewEnsembleCurveFilterFeature";
-        }
-        else if ( dynamic_cast<RimSummaryCaseMainCollection*>( firstUiItem ) )
-        {
-            menuBuilder << "RicImportSummaryCaseFeature";
-            menuBuilder << "RicImportRevealSummaryCaseFeature";
-            menuBuilder << "RicImportStimPlanSummaryCaseFeature";
-            menuBuilder << "RicImportSummaryCasesFeature";
-            menuBuilder << "RicImportSummaryGroupFeature";
-            menuBuilder << "RicImportEnsembleFeature";
-            menuBuilder << "RicNewDerivedEnsembleFeature";
-            menuBuilder << "RicNewDerivedSummaryFeature";
-            menuBuilder << "Separator";
-            menuBuilder << "RicShowSummaryCurveCalculatorFeature";
         }
         else if ( dynamic_cast<RimWellLogChannel*>( firstUiItem ) )
         {

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.h
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.h
@@ -49,7 +49,6 @@ private:
     static void                      createExecuteScriptForCasesFeatureMenu( caf::CmdFeatureMenuBuilder& menuBuilder );
 
     static void appendScriptItems( caf::CmdFeatureMenuBuilder& menuBuilder, RimScriptCollection* scriptCollection );
-    static void appendPlotTemplateItems( caf::CmdFeatureMenuBuilder& menuBuilder, RimPlotTemplateFolderItem* plotTemplateRoot );
 
     static int appendImportMenu( caf::CmdFeatureMenuBuilder& menuBuilder, bool addSeparatorBeforeMenu = false, bool addOsduMenuItem = false );
     static int appendCreateCompletions( caf::CmdFeatureMenuBuilder& menuBuilder, bool addSeparatorBeforeMenu = false );

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
@@ -121,10 +121,13 @@ void RimEclipseCaseCollection::removeCaseFromAllGroups( RimEclipseCase* reservoi
 //--------------------------------------------------------------------------------------------------
 void RimEclipseCaseCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
 {
-    menuBuilder.subMenuStart( "Import" );
+    menuBuilder << "RicImportEclipseCaseFeature";
+    menuBuilder << "RicImportGridAndSummaryEnsembleFeature";
+    menuBuilder << "Separator";
+
+    menuBuilder.subMenuStart( "Other Grid Models", QIcon( ":/Case.svg" ) );
     menuBuilder << importMenuFeatureNames();
     menuBuilder.subMenuEnd();
-    menuBuilder << "RicEclipseCaseNewGroupFeature";
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -197,11 +200,13 @@ void RimEclipseCaseCollection::recomputeStatisticsForAllCaseGroups()
 //--------------------------------------------------------------------------------------------------
 QStringList RimEclipseCaseCollection::importMenuFeatureNames()
 {
-    return { "RicImportEclipseCaseFeature",
-             "RicImportEclipseCasesFeature",
+    return { "RicImportEclipseCasesFeature",
              "RicImportEclipseCaseTimeStepFilterFeature",
+             "Separator",
              "RicImportInputEclipseCaseFeature",
+             "RicImportRoffCaseFeature",
              "Separator",
              "RicCreateGridCaseGroupFromFilesFeature",
-             "RicCreateGridCaseEnsemblesFromFilesFeature" };
+             "RicCreateGridCaseEnsemblesFromFilesFeature",
+             "RicEclipseCaseNewGroupFeature" };
 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
@@ -125,7 +125,7 @@ void RimEclipseCaseCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menu
     menuBuilder << "RicImportGridAndSummaryEnsembleFeature";
     menuBuilder << "Separator";
 
-    menuBuilder.subMenuStart( "Other Grid Models", QIcon( ":/Case.svg" ) );
+    menuBuilder.subMenuStart( "More", QIcon( ":/import.svg" ) );
     menuBuilder << importMenuFeatureNames();
     menuBuilder.subMenuEnd();
 }

--- a/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
@@ -386,6 +386,8 @@ void RimWellTargetMapping::generateCandidates( RimEclipseCase* eclipseCase, bool
 //--------------------------------------------------------------------------------------------------
 void RimWellTargetMapping::generateEnsembleStatistics()
 {
+    // See RicNewWellTargetMappingFeature::isCommandEnabled() for comment on future support for ensembles with varying geometry.
+
     auto ensemble = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>();
     if ( !ensemble ) return;
 
@@ -649,13 +651,11 @@ void RimWellTargetMapping::onGenerateButtonClicked()
     }
     else if ( hasGridEnsembleParent )
     {
-        // For RimReservoirGridEnsemble, generate for first case
-        // Full ensemble statistics support can be added later
-        if ( auto eclipseCase = firstCase() )
-        {
-            bool setTimeStepInView = true;
-            generateCandidates( eclipseCase, setTimeStepInView );
-        }
+        // For RimReservoirGridEnsemble implement two variants, shared grid and individual grids. Individual grids variant will require more
+        // work, and is not currently prioritized, so for now just show a warning if user tries to generate candidates for a
+        // RimReservoirGridEnsemble
+        //
+        // See RicNewWellTargetMappingFeature::isCommandEnabled() for comment on future support for ensembles with varying geometry.
     }
     else if ( auto eclipseCase = firstCase() )
     {

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -53,6 +53,7 @@
 #include "RimSummaryPlot.h"
 #include "RimWellRftPlot.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldReorderCapability.h"
 #include "cafProgressInfo.h"
 
@@ -405,6 +406,31 @@ void RimSummaryCaseMainCollection::loadAllSummaryCaseData()
             sumCase->summaryReader()->createAddressesIfRequired();
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryCaseMainCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicImportSummaryCaseFeature";
+    menuBuilder << "RicImportGridAndSummaryEnsembleFeature";
+    menuBuilder << "RicImportEnsembleFeature";
+
+    menuBuilder << "Separator";
+
+    menuBuilder.subMenuStart( "Other Imports" );
+    menuBuilder << "RicImportRevealSummaryCaseFeature";
+    menuBuilder << "RicImportStimPlanSummaryCaseFeature";
+    menuBuilder << "RicImportSummaryCasesFeature";
+    menuBuilder << "RicImportSummaryGroupFeature";
+    menuBuilder.subMenuEnd();
+
+    menuBuilder << "Separator";
+    menuBuilder << "RicNewDerivedEnsembleFeature";
+    menuBuilder << "RicNewDerivedSummaryFeature";
+    menuBuilder << "Separator";
+    menuBuilder << "RicShowSummaryCurveCalculatorFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -415,15 +415,13 @@ void RimSummaryCaseMainCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& 
 {
     menuBuilder << "RicImportSummaryCaseFeature";
     menuBuilder << "RicImportGridAndSummaryEnsembleFeature";
-    menuBuilder << "RicImportEnsembleFeature";
 
-    menuBuilder << "Separator";
-
-    menuBuilder.subMenuStart( "Other Imports" );
+    menuBuilder.subMenuStart( "More", QIcon( ":/import.svg" ) );
     menuBuilder << "RicImportRevealSummaryCaseFeature";
     menuBuilder << "RicImportStimPlanSummaryCaseFeature";
     menuBuilder << "RicImportSummaryCasesFeature";
     menuBuilder << "RicImportSummaryGroupFeature";
+    menuBuilder << "RicImportEnsembleFeature";
     menuBuilder.subMenuEnd();
 
     menuBuilder << "Separator";

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
@@ -81,6 +81,8 @@ public:
     void updateEnsembleNames();
 
 private:
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+
     void initAfterRead() override;
 
     static void loadSummaryCaseData( const std::vector<RimSummaryCase*>& summaryCases, bool extractStateFromFirstCase );

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -499,10 +499,10 @@ void RiuMainWindow::createMenus()
     fileMenu->addSeparator();
 
     // Import menu actions
-    RiuMenuBarBuildTools::addImportMenuWithActions( this, fileMenu );
+    RiuMenuBarBuildTools::addImportMenuForMainWindow( this, fileMenu );
 
     // Export menu actions
-    QMenu* exportMenu = fileMenu->addMenu( "&Export" );
+    QMenu* exportMenu = fileMenu->addMenu( QIcon( ":/export.svg" ), "&Export" );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
     exportMenu->addAction( m_snapshotAllViewsToFile );
     exportMenu->addAction( cmdFeatureMgr->action( "RicAdvancedSnapshotExportFeature" ) );

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -109,32 +109,23 @@ QMenu* RiuMenuBarBuildTools::createDefaultHelpMenu( QMenuBar* menuBar )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RiuMenuBarBuildTools::addImportMenuWithActions( QObject* parent, QMenu* menu )
+void RiuMenuBarBuildTools::addImportMenuForMainWindow( QObject* parent, QMenu* menu )
 {
     caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
 
     if ( !parent || !menu || !cmdFeatureMgr ) return;
 
-    QMenu* importMenu = menu->addMenu( "&Import" );
+    QMenu* importMenu = menu->addMenu( QIcon( ":/import.svg" ), "&Import" );
 
-    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Eclipse Cases" );
-    caf::CmdFeatureMenuBuilder::appendToMenu( importEclipseMenu, RimEclipseCaseCollection::importMenuFeatureNames() );
-
-    QMenu* importRoffMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Roff Grid Models" );
-    importRoffMenu->addAction( cmdFeatureMgr->action( "RicImportRoffCaseFeature" ) );
-
-    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
 
     importMenu->addSeparator();
-    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
+    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Other Grid Models" );
+    caf::CmdFeatureMenuBuilder::appendToMenu( importEclipseMenu, RimEclipseCaseCollection::importMenuFeatureNames() );
 
     importMenu->addSeparator();
-    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Cases" );
+    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Models" );
     importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseFeature" ) );
     importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseTimeStepFilterFeature" ) );
     importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportElementPropertyFeature" ) );
@@ -148,12 +139,37 @@ void RiuMenuBarBuildTools::addImportMenuWithActions( QObject* parent, QMenu* men
     importWellMenu->addAction( cmdFeatureMgr->action( "RicImportWellMeasurementsFeature" ) );
 
     importMenu->addSeparator();
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportSurfacesFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportSeismicFeature" ) );
+
+    RiuTools::enableAllActionsOnShow( parent, importMenu );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMenuBarBuildTools::addImportMenuForPlotWindow( QObject* parent, QMenu* menu )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+
+    if ( !parent || !menu || !cmdFeatureMgr ) return;
+
+    QMenu* importMenu = menu->addMenu( QIcon( ":/import.svg" ), "&Import" );
+
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
+
+    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
+    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
+
+    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
 
     RiuTools::enableAllActionsOnShow( parent, importMenu );
 }

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -121,7 +121,7 @@ void RiuMenuBarBuildTools::addImportMenuForMainWindow( QObject* parent, QMenu* m
     importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
 
     importMenu->addSeparator();
-    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Other Grid Models" );
+    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/import.svg" ), "More" );
     caf::CmdFeatureMenuBuilder::appendToMenu( importEclipseMenu, RimEclipseCaseCollection::importMenuFeatureNames() );
 
     importMenu->addSeparator();
@@ -157,11 +157,11 @@ void RiuMenuBarBuildTools::addImportMenuForPlotWindow( QObject* parent, QMenu* m
 
     QMenu* importMenu = menu->addMenu( QIcon( ":/import.svg" ), "&Import" );
 
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
-
-    importMenu->addSeparator();
     importMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
-    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
+    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/import.svg" ), "More" );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportRevealSummaryCaseFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportStimPlanSummaryCaseFeature" ) );
     importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
     importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
     importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.h
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.h
@@ -33,7 +33,8 @@ QMenu* createDefaultEditMenu( QMenuBar* menuBar );
 QMenu* createDefaultViewMenu( QMenuBar* menuBar );
 QMenu* createDefaultHelpMenu( QMenuBar* menuBar );
 
-void addImportMenuWithActions( QObject* parent, QMenu* menu );
+void addImportMenuForMainWindow( QObject* parent, QMenu* menu );
+void addImportMenuForPlotWindow( QObject* parent, QMenu* menu );
 void addSaveProjectActions( QMenu* menu );
 void addCloseAndExitActions( QMenu* menu );
 

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -340,10 +340,10 @@ void RiuPlotMainWindow::createMenus()
     fileMenu->addSeparator();
 
     // Import menu actions
-    RiuMenuBarBuildTools::addImportMenuWithActions( this, fileMenu );
+    RiuMenuBarBuildTools::addImportMenuForPlotWindow( this, fileMenu );
 
     // Export menu actions
-    QMenu* exportMenu = fileMenu->addMenu( "&Export" );
+    QMenu* exportMenu = fileMenu->addMenu( QIcon( ":/export.svg" ), "&Export" );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToPdfFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotAllPlotsToFileFeature" ) );

--- a/docs/agents/build.md
+++ b/docs/agents/build.md
@@ -91,6 +91,9 @@ cmake --build --preset x64-relwithdebinfo --target ResInsight
 cmake --build --preset x64-relwithdebinfo --target extract-projectfile-versions
 ```
 
+**Important — use `cmake --build`, not `ninja` directly, when sharing `build/` with Visual Studio:**
+Visual Studio's "Open Folder" CMake integration uses its own bundled ninja (under `Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe`) and writes that path into `CMAKE_MAKE_PROGRAM`. If a CLI shell has a different `ninja.exe` first on `PATH`, invoking `ninja` directly produces a `.ninja_log` whose format the other ninja can't read (`ninja: warning: build log version is too old; starting over`), so both VS and the CLI repeatedly rebuild everything from scratch. `cmake --build build` dispatches to `CMAKE_MAKE_PROGRAM`, guaranteeing the same ninja binary as VS. If a build unexpectedly rebuilds far more than expected, verify with `where ninja` and `grep CMAKE_MAKE_PROGRAM build/CMakeCache.txt`.
+
 ## Build Presets
 
 Available CMake presets in `CMakePresets.json`:


### PR DESCRIPTION
Closes #14061.

## Summary
- Make the combined Grid + Summary Ensemble import easily reachable: surfaced at the top of the File→Import menu (main + plot windows) and as the first entry of the `Grid Models` (RimEclipseCaseCollection) and `Summary Cases` (RimSummaryCaseMainCollection) context menus. Less common imports are grouped under "Other Grid Models" / "Other Imports" submenus.
- Split `RiuMenuBarBuildTools::addImportMenuWithActions` into separate `addImportMenuForMainWindow` and `addImportMenuForPlotWindow` so the plot window can show only summary/ensemble/observed imports.
- Rename "Import Eclipse Case" → "Import Simulation Grid" and prefix the grid+summary ensemble action with "Import".
- Disable the "Create Well Target Mapping" menu action for `RimReservoirGridEnsemble` when `gridMode() == INDIVIDUAL_GRIDS`, with cross-referenced comments in `RicNewWellTargetMappingFeature::isCommandEnabled` and `RimWellTargetMapping::generateEnsembleStatistics` documenting the future-support path.
- Move the `RimSummaryCaseMainCollection` context-menu block out of `RimContextCommandBuilder` into a proper `appendMenuItems` override, and drop an unused `appendPlotTemplateItems` declaration.
- Add icons to "New Statistics Case", "New Grid Case Group", and the top-level Import / Export menus (new `import.svg` / `export.svg` using the project's standard mid-grey).
