### PR TITLE
Refresh filter tree facade when cell/property filters change

### DIFF
--- a/ApplicationLibCode/Commands/CellFilterCommands/RicCellFilterFeatureTools.h
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicCellFilterFeatureTools.h
@@ -22,9 +22,11 @@
 
 #include "Rim3dView.h"
 #include "RimCase.h"
+#include "RimCellFilter.h"
 #include "RimCellFilterCollection.h"
 #include "RimCombinedFilter.h"
 #include "RimDataFilterCollection.h"
+#include "RimEclipseView.h"
 #include "RimFilterInViewCollection.h"
 #include "RimGridView.h"
 
@@ -42,6 +44,26 @@
 namespace RicCellFilterFeatureTools
 {
 //--------------------------------------------------------------------------------------------------
+/// After creating a new cell filter: select it in the tree, and refresh the per-view filter facade
+/// so the new entry appears immediately. The facade lives on RimEclipseView only, so the refresh
+/// is a no-op for filters created outside an eclipse view (e.g. case-level data filter collection).
+//--------------------------------------------------------------------------------------------------
+inline void selectAndRefreshFilterTree( RimCellFilter* filter )
+{
+    if ( !filter ) return;
+
+    if ( auto* eclipseView = filter->firstAncestorOrThisOfType<RimEclipseView>() )
+    {
+        if ( auto* facade = eclipseView->filterInViewCollection() )
+        {
+            facade->updateConnectedEditors();
+        }
+    }
+
+    Riu3DMainWindowTools::selectAsCurrentItem( filter );
+}
+
+//--------------------------------------------------------------------------------------------------
 /// If a RimCombinedFilter is the current selection, create a new T inside it (configured via init)
 /// and select the result. Returns true when a combined filter was the selection — the caller should
 /// bail out of its own collection-targeted flow.
@@ -57,7 +79,7 @@ bool addNewFilterIfCombinedSelected( Init&& init )
     // need a Rim3dView ancestor here.
     RimCombinedFilter* target  = combined.front();
     T*                 created = target->addNewFilter<T>( std::forward<Init>( init ) );
-    if ( created ) Riu3DMainWindowTools::selectAsCurrentItem( created );
+    selectAndRefreshFilterTree( created );
     return true;
 }
 
@@ -100,7 +122,7 @@ bool addNewFilterToDataCollectionIfSelected( Init&& init )
     auto* created = new T();
     target->addFilter( created );
     std::forward<Init>( init )( created );
-    Riu3DMainWindowTools::selectAsCurrentItem( created );
+    selectAndRefreshFilterTree( created );
     return true;
 }
 } // namespace RicCellFilterFeatureTools

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
@@ -64,10 +64,7 @@ void RicNewCellIndexFilterFeature::onActionTriggered( bool isChecked )
     if ( RimCase* sourceCase = filtColl->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase() )
     {
         RimCellIndexFilter* lastCreatedOrUpdated = filtColl->addNewCellIndexFilter( sourceCase );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilter3dviewFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilter3dviewFeature.cpp
@@ -18,6 +18,8 @@
 
 #include "RicNewPolygonFilter3dviewFeature.h"
 
+#include "RicCellFilterFeatureTools.h"
+
 #include "Polygons/RimPolygonInView.h"
 
 #include "RiaApplication.h"
@@ -49,10 +51,7 @@ void RicNewPolygonFilter3dviewFeature::onActionTriggered( bool isChecked )
     RimCase* sourceCase = viewOrComparisonView->ownerCase();
 
     RimPolygonFilter* lastCreatedOrUpdated = filtColl->addNewPolygonFilter( sourceCase, nullptr );
-    if ( lastCreatedOrUpdated )
-    {
-        Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-    }
+    RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
@@ -100,7 +100,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
         {
             lastItem = addOne( polygon );
         }
-        if ( lastItem ) Riu3DMainWindowTools::selectAsCurrentItem( lastItem );
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastItem );
         return;
     }
 
@@ -117,7 +117,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
             configurePolygonFilter( f, polygon );
             lastItem = f;
         }
-        if ( lastItem ) Riu3DMainWindowTools::selectAsCurrentItem( lastItem );
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastItem );
         return;
     }
 
@@ -141,10 +141,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
         }
     }
 
-    if ( lastItem )
-    {
-        Riu3DMainWindowTools::selectAsCurrentItem( lastItem );
-    }
+    RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastItem );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSlice3dviewFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSlice3dviewFeature.cpp
@@ -18,6 +18,8 @@
 
 #include "RicNewRangeFilterSlice3dviewFeature.h"
 
+#include "RicCellFilterFeatureTools.h"
+
 #include "RiaApplication.h"
 
 #include "RigMainGrid.h"
@@ -101,7 +103,7 @@ void RicNewRangeFilterSlice3dviewFeature::onActionTriggered( bool isChecked )
     RimCellFilter* newFilter = filtColl->addNewCellRangeFilter( sourceCase, gridIndex, direction, sliceStart );
     if ( newFilter )
     {
-        Riu3DMainWindowTools::selectAsCurrentItem( newFilter );
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( newFilter );
         activeView->setSurfaceDrawstyle();
     }
 }

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
@@ -73,10 +73,7 @@ void RicNewRangeFilterSliceFeature::onActionTriggered( bool isChecked )
     {
         int            gridIndex            = 0;
         RimCellFilter* lastCreatedOrUpdated = filterCollection->addNewCellRangeFilter( sourceCase, gridIndex, m_sliceDirection );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
@@ -51,10 +51,7 @@ void RicNewUserDefinedFilterFeature::onActionTriggered( bool isChecked )
     if ( sourceCase )
     {
         RimUserDefinedFilter* lastCreatedOrUpdated = filtColl->addNewUserDefinedFilter( sourceCase );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
@@ -53,10 +53,7 @@ void RicNewUserDefinedIndexFilterFeature::onActionTriggered( bool isChecked )
     if ( sourceCase )
     {
         auto* lastCreatedOrUpdated = filtColl->addNewUserDefinedIndexFilter( sourceCase );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/EclipseCommands/RicAddLinkedEclipsePropertyFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicAddLinkedEclipsePropertyFilterFeature.cpp
@@ -22,6 +22,8 @@
 
 #include "RimEclipsePropertyFilter.h"
 #include "RimEclipsePropertyFilterCollection.h"
+#include "RimEclipseView.h"
+#include "RimFilterInViewCollection.h"
 
 #include "Riu3DMainWindowTools.h"
 
@@ -51,6 +53,10 @@ void RicAddLinkedEclipsePropertyFilterFeature::onActionTriggered( bool isChecked
     {
         auto filter = coll->addFilterLinkedToCellResult();
         coll->updateAllRequiredEditors();
+        if ( auto* view = coll->reservoirView() )
+        {
+            if ( auto* facade = view->filterInViewCollection() ) facade->updateConnectedEditors();
+        }
 
         Riu3DMainWindowTools::setExpanded( filter );
     }

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipseCombinedPropertyFilterNewFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipseCombinedPropertyFilterNewFeature.cpp
@@ -25,6 +25,8 @@
 #include "RimCombinedFilter.h"
 #include "RimDataFilterCollection.h"
 #include "RimEclipsePropertyFilterCollection.h"
+#include "RimEclipseView.h"
+#include "RimFilterInViewCollection.h"
 
 #include "Riu3DMainWindowTools.h"
 
@@ -68,6 +70,10 @@ void RicEclipseCombinedPropertyFilterNewFeature::onActionTriggered( bool isCheck
         RimCombinedFilter* parent  = combined.front();
         RimCombinedFilter* created = parent->addNewFilter<RimCombinedFilter>( []( RimCombinedFilter* ) {} );
         parent->updateConnectedEditors();
+        if ( auto* view = parent->firstAncestorOrThisOfType<RimEclipseView>() )
+        {
+            if ( auto* facade = view->filterInViewCollection() ) facade->updateConnectedEditors();
+        }
         if ( created ) Riu3DMainWindowTools::selectAsCurrentItem( created );
         return;
     }
@@ -86,6 +92,10 @@ void RicEclipseCombinedPropertyFilterNewFeature::onActionTriggered( bool isCheck
 
     RimCombinedFilter* created = target->addNewCombinedFilter();
     target->updateConnectedEditors();
+    if ( auto* view = target->reservoirView() )
+    {
+        if ( auto* facade = view->filterInViewCollection() ) facade->updateConnectedEditors();
+    }
     if ( created )
     {
         Riu3DMainWindowTools::selectAsCurrentItem( created );

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterFeatureImpl.cpp
@@ -82,6 +82,10 @@ void RicEclipsePropertyFilterFeatureImpl::addPropertyFilter( RimEclipsePropertyF
     propertyFilterCollection->reservoirView()->scheduleCreateDisplayModelAndRedraw();
 
     propertyFilterCollection->updateConnectedEditors();
+    if ( auto* facade = propertyFilterCollection->reservoirView()->filterInViewCollection() )
+    {
+        facade->updateConnectedEditors();
+    }
     Riu3DMainWindowTools::selectAsCurrentItem( propertyFilter, false );
 
     propertyFilterCollection->onChildAdded( nullptr );
@@ -105,6 +109,8 @@ RimEclipsePropertyFilter* RicEclipsePropertyFilterFeatureImpl::addPropertyFilter
     {
         view->scheduleGeometryRegen( PROPERTY_FILTERED );
         view->scheduleCreateDisplayModelAndRedraw();
+
+        if ( auto* facade = view->filterInViewCollection() ) facade->updateConnectedEditors();
     }
 
     combined->updateConnectedEditors();
@@ -132,6 +138,10 @@ void RicEclipsePropertyFilterFeatureImpl::insertPropertyFilter( RimEclipseProper
     propertyFilterCollection->reservoirView()->scheduleCreateDisplayModelAndRedraw();
 
     propertyFilterCollection->updateConnectedEditors();
+    if ( auto* facade = propertyFilterCollection->reservoirView()->filterInViewCollection() )
+    {
+        facade->updateConnectedEditors();
+    }
     Riu3DMainWindowTools::selectAsCurrentItem( propertyFilter, false );
 }
 

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterNewExec.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterNewExec.cpp
@@ -23,6 +23,8 @@
 
 #include "RimEclipsePropertyFilter.h"
 #include "RimEclipsePropertyFilterCollection.h"
+#include "RimEclipseView.h"
+#include "RimFilterInViewCollection.h"
 #include "RimGridView.h"
 
 //--------------------------------------------------------------------------------------------------
@@ -66,4 +68,8 @@ void RicEclipsePropertyFilterNewExec::undo()
     m_propertyFilterCollection->propertyFiltersField().erase( m_propertyFilterCollection->propertyFiltersField().size() - 1 );
 
     m_propertyFilterCollection->updateConnectedEditors();
+    if ( auto* facade = m_propertyFilterCollection->reservoirView()->filterInViewCollection() )
+    {
+        facade->updateConnectedEditors();
+    }
 }

--- a/ApplicationLibCode/Commands/FlowCommands/RicShowContributingWellsFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/FlowCommands/RicShowContributingWellsFeatureImpl.cpp
@@ -29,6 +29,7 @@
 #include "RimEclipseResultCase.h"
 #include "RimEclipseView.h"
 #include "RimFaultInViewCollection.h"
+#include "RimFilterInViewCollection.h"
 #include "RimFlowDiagSolution.h"
 #include "RimProject.h"
 #include "RimSimWellInView.h"
@@ -155,6 +156,7 @@ void RicShowContributingWellsFeatureImpl::modifyViewToShowContributingWells( Rim
     propertyFilter->resultDefinition()->loadDataAndUpdate();
 
     propertyFilterCollection->updateConnectedEditors();
+    if ( auto* facade = viewToModify->filterInViewCollection() ) facade->updateConnectedEditors();
 
     Riu3DMainWindowTools::setExpanded( propertyFilterCollection );
 

--- a/ApplicationLibCode/Commands/OperationsUsingObjReferences/RicPasteCellFiltersFeature.cpp
+++ b/ApplicationLibCode/Commands/OperationsUsingObjReferences/RicPasteCellFiltersFeature.cpp
@@ -24,7 +24,10 @@
 #include "RimCase.h"
 #include "RimCellFilter.h"
 #include "RimCellFilterCollection.h"
+#include "RimEclipseView.h"
 #include "RimFilterInViewCollection.h"
+
+#include "Riu3DMainWindowTools.h"
 
 #include "cafPdmObjectGroup.h"
 #include "cafPdmPointer.h"
@@ -74,13 +77,24 @@ void RicPasteCellFiltersFeature::onActionTriggered( bool isChecked )
     caf::PdmObjectGroup objectGroup;
     RicPasteFeatureImpl::findObjectsFromClipboardRefs( &objectGroup );
 
+    RimCellFilter* lastPasted = nullptr;
     for ( auto obj : objectGroup.objects )
     {
         auto duplicatedObject = obj->copyObject<RimCellFilter>();
         if ( duplicatedObject )
         {
             cellFilterCollection->addFilterAndNotifyChanges( duplicatedObject, eclipseCase );
+            lastPasted = duplicatedObject;
         }
+    }
+
+    if ( lastPasted )
+    {
+        if ( auto* eclipseView = lastPasted->firstAncestorOrThisOfType<RimEclipseView>() )
+        {
+            if ( auto* facade = eclipseView->filterInViewCollection() ) facade->updateConnectedEditors();
+        }
+        Riu3DMainWindowTools::selectAsCurrentItem( lastPasted );
     }
 }
 

--- a/ApplicationLibCode/Commands/OperationsUsingObjReferences/RicPasteCellFiltersFeature.cpp
+++ b/ApplicationLibCode/Commands/OperationsUsingObjReferences/RicPasteCellFiltersFeature.cpp
@@ -18,16 +18,14 @@
 
 #include "RicPasteCellFiltersFeature.h"
 
+#include "CellFilterCommands/RicCellFilterFeatureTools.h"
 #include "RicPasteFeatureImpl.h"
 
 #include "Rim3dView.h"
 #include "RimCase.h"
 #include "RimCellFilter.h"
 #include "RimCellFilterCollection.h"
-#include "RimEclipseView.h"
 #include "RimFilterInViewCollection.h"
-
-#include "Riu3DMainWindowTools.h"
 
 #include "cafPdmObjectGroup.h"
 #include "cafPdmPointer.h"
@@ -88,14 +86,7 @@ void RicPasteCellFiltersFeature::onActionTriggered( bool isChecked )
         }
     }
 
-    if ( lastPasted )
-    {
-        if ( auto* eclipseView = lastPasted->firstAncestorOrThisOfType<RimEclipseView>() )
-        {
-            if ( auto* facade = eclipseView->filterInViewCollection() ) facade->updateConnectedEditors();
-        }
-        Riu3DMainWindowTools::selectAsCurrentItem( lastPasted );
-    }
+    RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastPasted );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -2364,6 +2364,14 @@ RimDataFilterInViewCollection* RimEclipseView::dataFiltersInView() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RimFilterInViewCollection* RimEclipseView::filterInViewCollection() const
+{
+    return m_filterInViewCollection();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RimEclipseView::hasActivePropertyOrDataFilters() const
 {
     if ( eclipsePropertyFilterCollection()->hasActiveFilters() ) return true;

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
@@ -130,6 +130,7 @@ public:
     void                                      setOverridePropertyFilterCollection( RimEclipsePropertyFilterCollection* pfc );
 
     RimDataFilterInViewCollection* dataFiltersInView() const;
+    RimFilterInViewCollection*     filterInViewCollection() const;
 
     bool hasActivePropertyOrDataFilters() const;
     bool hasActiveDynamicPropertyOrDataFilters() const;


### PR DESCRIPTION
## Summary
- Cherry-picked from grid-ensemble-gui-cleanup: select newly created cell filter in the tree and refresh the per-view `RimFilterInViewCollection` facade.
- Add public `RimEclipseView::filterInViewCollection()` accessor (was only the private field on dev).
- Refresh the facade when an Eclipse property filter is added (`addPropertyFilter`), inserted into a combined filter, inserted at index, removed via undo, linked to the cell result, or created by the well-allocation "Show Contributing Wells" flow.
- `RicPasteCellFiltersFeature` now uses the shared `RicCellFilterFeatureTools::selectAndRefreshFilterTree` helper instead of duplicating the select-and-refresh logic.