### PR TITLE
#14075 Histogram: Use arithmetic mean instead of P50 in ensemble histograms

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimEnsembleParameterHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimEnsembleParameterHistogramDataSource.cpp
@@ -173,9 +173,12 @@ RimHistogramDataSource::HistogramResult RimEnsembleParameterHistogramDataSource:
 
     result.valuesY = computeHistogramFrequencies( histogram, graphType, frequencyType );
 
-    result.p10  = histCalc.calculatePercentil( 0.1, RigStatisticsMath::PercentileStyle::SWITCHED );
-    result.mean = histCalc.calculatePercentil( 0.5, RigStatisticsMath::PercentileStyle::SWITCHED );
-    result.p90  = histCalc.calculatePercentil( 0.9, RigStatisticsMath::PercentileStyle::SWITCHED );
+    double p10, p50, p90, mean;
+    RigStatisticsMath::calculateStatisticsCurves( values, &p10, &p50, &p90, &mean, RigStatisticsMath::PercentileStyle::SWITCHED );
+
+    result.p10  = p10;
+    result.mean = mean;
+    result.p90  = p90;
 
     return result;
 }

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimEnsembleSummaryVectorHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimEnsembleSummaryVectorHistogramDataSource.cpp
@@ -249,9 +249,12 @@ RimHistogramDataSource::HistogramResult RimEnsembleSummaryVectorHistogramDataSou
 
     result.valuesY = computeHistogramFrequencies( histogram, graphType, frequencyType );
 
-    result.p10  = histCalc.calculatePercentil( 0.1, RigStatisticsMath::PercentileStyle::SWITCHED );
-    result.mean = histCalc.calculatePercentil( 0.5, RigStatisticsMath::PercentileStyle::SWITCHED );
-    result.p90  = histCalc.calculatePercentil( 0.9, RigStatisticsMath::PercentileStyle::SWITCHED );
+    double p10, p50, p90, mean;
+    RigStatisticsMath::calculateStatisticsCurves( values, &p10, &p50, &p90, &mean, RigStatisticsMath::PercentileStyle::SWITCHED );
+
+    result.p10  = p10;
+    result.mean = mean;
+    result.p90  = p90;
 
     return result;
 }


### PR DESCRIPTION
Closes #14075.

## Summary
- `RimEnsembleSummaryVectorHistogramDataSource` and `RimEnsembleParameterHistogramDataSource` were storing the P50 percentile from the binned histogram in `result.mean`. For skewed ensemble distributions (e.g. `RGIP_SEG`) the median is well below the arithmetic mean, which is why the histogram showed ~1.3 while the summary plot showed ~1.9 for the same vector.
- Both sites now compute `result.p10`, `result.p90` and `result.mean` in a single call to `RigStatisticsMath::calculateStatisticsCurves(values, ...)`, matching the statistics path used by the summary plot. `result.mean` is now the arithmetic mean rather than the histogram P50.
- This replaces the previous separate `histCalc.calculatePercentil()` / `calculateMean()` calls, so p10/p90 are now the interpolated percentile estimates consistent with the summary-plot ensemble statistics.