### PR TITLE
#14079 Well Event: Export MSW keywords per well via explicit well list

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -41,12 +41,11 @@
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RicScheduleDataGenerator::generateSchedule( const RimWellEventTimeline&      timeline,
-                                                    RimEclipseCase&                  eclipseCase,
-                                                    const std::vector<RimWellPath*>& wellPaths,
-                                                    const std::vector<QDateTime>&    dates,
-                                                    bool                             includeWelsegs,
-                                                    bool                             includeCompsegs )
+QString RicScheduleDataGenerator::generateSchedule( const RimWellEventTimeline&         timeline,
+                                                    RimEclipseCase&                     eclipseCase,
+                                                    const std::vector<RimWellPath*>&    wellPaths,
+                                                    const std::vector<QDateTime>&       dates,
+                                                    const std::set<const RimWellPath*>& mswWells )
 {
     QString result;
 
@@ -58,7 +57,7 @@ QString RicScheduleDataGenerator::generateSchedule( const RimWellEventTimeline& 
     // Generate section for each date
     for ( const auto& date : dates )
     {
-        QString dateSection = generateDateSection( timeline, eclipseCase, wellPaths, date, includeWelsegs, includeCompsegs );
+        QString dateSection = generateDateSection( timeline, eclipseCase, wellPaths, date, mswWells );
         if ( !dateSection.isEmpty() )
         {
             result += dateSection;
@@ -114,12 +113,11 @@ void RicScheduleDataGenerator::mergeKeyword( std::map<QString, Opm::DeckKeyword>
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimeline&      timeline,
-                                                       RimEclipseCase&                  eclipseCase,
-                                                       const std::vector<RimWellPath*>& wellPaths,
-                                                       const QDateTime&                 date,
-                                                       bool                             includeWelsegs,
-                                                       bool                             includeCompsegs )
+QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimeline&         timeline,
+                                                       RimEclipseCase&                     eclipseCase,
+                                                       const std::vector<RimWellPath*>&    wellPaths,
+                                                       const QDateTime&                    date,
+                                                       const std::set<const RimWellPath*>& mswWells )
 {
     // Keyword priority order for output
     static const std::vector<QString> keywordOrder = { "WELSPECS",
@@ -162,7 +160,7 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
             mergeKeyword( keywordBlocks, "COMPDAT", std::move( *compdat ) );
         }
 
-        generateMswForWell( timeline, eclipseCase, *well, date, keywordBlocks, includeWelsegs, includeCompsegs );
+        generateMswForWell( timeline, eclipseCase, *well, date, keywordBlocks, mswWells );
         generateWellControlForWell( timeline, *well, date, keywordBlocks );
     }
 
@@ -276,9 +274,14 @@ void RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline&  
                                                    RimWellPath&                         wellPath,
                                                    const QDateTime&                     date,
                                                    std::map<QString, Opm::DeckKeyword>& keywordBlocks,
-                                                   bool                                 includeWelsegs,
-                                                   bool                                 includeCompsegs )
+                                                   const std::set<const RimWellPath*>&  mswWells )
 {
+    // MSW keywords are exported only for the wells the caller explicitly requested.
+    if ( !mswWells.contains( &wellPath ) )
+    {
+        return;
+    }
+
     auto* mswParams = wellPath.mswCompletionParameters();
     if ( !mswParams )
     {
@@ -319,19 +322,13 @@ void RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline&  
 
     const auto& mswData = mswDataResult.value();
 
-    if ( includeWelsegs )
-    {
-        int  maxSegments = 0;
-        int  maxBranches = 0;
-        auto welsegsKw   = RimKeywordFactory::welsegsKeyword( mswData, maxSegments, maxBranches );
-        mergeKeyword( keywordBlocks, "WELSEGS", std::move( welsegsKw ) );
-    }
+    int  maxSegments = 0;
+    int  maxBranches = 0;
+    auto welsegsKw   = RimKeywordFactory::welsegsKeyword( mswData, maxSegments, maxBranches );
+    mergeKeyword( keywordBlocks, "WELSEGS", std::move( welsegsKw ) );
 
-    if ( includeCompsegs )
-    {
-        auto compsegsKw = RimKeywordFactory::compsegsKeyword( mswData );
-        mergeKeyword( keywordBlocks, "COMPSEGS", std::move( compsegsKw ) );
-    }
+    auto compsegsKw = RimKeywordFactory::compsegsKeyword( mswData );
+    mergeKeyword( keywordBlocks, "COMPSEGS", std::move( compsegsKw ) );
 
     auto wsegvalvKw = RimKeywordFactory::wsegvalvKeyword( mswData );
     mergeKeyword( keywordBlocks, "WSEGVALV", std::move( wsegvalvKw ) );

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -35,6 +35,7 @@
 #include "opm/input/eclipse/Deck/DeckKeyword.hpp"
 #include "opm/input/eclipse/Deck/DeckRecord.hpp"
 
+#include <algorithm>
 #include <map>
 #include <set>
 
@@ -54,10 +55,23 @@ QString RicScheduleDataGenerator::generateSchedule( const RimWellEventTimeline& 
     result += "-- Schedule data based on well events\n";
     result += "--\n";
 
+    // The incoming well list is ordered by pointer (it originates from a std::set), which makes the
+    // per-well keyword records appear in a non-deterministic order. Sort once by the deck export
+    // name so every per-well keyword (WELSPECS, COMPDAT, COMPLUMP, WELSEGS/COMPSEGS, WSEGVALV/
+    // WSEGAICD, well control) is emitted in a stable, well-name-sorted order.
+    auto exportName = []( const RimWellPath* well ) -> QString
+    { return well && well->completionSettings() ? well->completionSettings()->wellNameForExport() : QString(); };
+
+    std::vector<RimWellPath*> sortedWellPaths = wellPaths;
+    std::stable_sort( sortedWellPaths.begin(),
+                      sortedWellPaths.end(),
+                      [&exportName]( const RimWellPath* a, const RimWellPath* b )
+                      { return QString::compare( exportName( a ), exportName( b ) ) < 0; } );
+
     // Generate section for each date
     for ( const auto& date : dates )
     {
-        QString dateSection = generateDateSection( timeline, eclipseCase, wellPaths, date, mswWells );
+        QString dateSection = generateDateSection( timeline, eclipseCase, sortedWellPaths, date, mswWells );
         if ( !dateSection.isEmpty() )
         {
             result += dateSection;

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -146,6 +146,11 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
     // Records for each keyword name are accumulated across wells, then serialised once below.
     std::map<QString, Opm::DeckKeyword> keywordBlocks;
 
+    // WELSEGS and COMPSEGS cannot be merged across wells: each block carries a per-well header
+    // record followed by that well's segment records, so they are kept as separate per-well blocks
+    // (keyed by keyword name, preserving well order) and serialised individually.
+    std::map<QString, std::vector<Opm::DeckKeyword>> unmergedBlocks;
+
     for ( auto* well : wellPaths )
     {
         if ( !well ) continue;
@@ -160,7 +165,7 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
             mergeKeyword( keywordBlocks, "COMPDAT", std::move( *compdat ) );
         }
 
-        generateMswForWell( timeline, eclipseCase, *well, date, keywordBlocks, mswWells );
+        generateMswForWell( timeline, eclipseCase, *well, date, keywordBlocks, unmergedBlocks, mswWells );
         generateWellControlForWell( timeline, *well, date, keywordBlocks );
     }
 
@@ -184,16 +189,26 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
         result += "\n";
     };
 
+    auto appendUnmergedBlocks = [&]( const QString& name )
+    {
+        auto it = unmergedBlocks.find( name );
+        if ( it == unmergedBlocks.end() ) return;
+        for ( const auto& kw : it->second )
+        {
+            appendKeywordText( kw );
+        }
+    };
+
     // Output keywords in priority order
     std::set<QString> emitted;
     for ( const auto& kw : keywordOrder )
     {
-        auto it = keywordBlocks.find( kw );
-        if ( it != keywordBlocks.end() )
+        if ( auto it = keywordBlocks.find( kw ); it != keywordBlocks.end() )
         {
             appendKeywordText( it->second );
-            emitted.insert( kw );
         }
+        appendUnmergedBlocks( kw );
+        emitted.insert( kw );
     }
 
     // Output remaining keywords not in the priority list
@@ -201,6 +216,14 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
     {
         if ( emitted.contains( kw ) ) continue;
         appendKeywordText( deckKw );
+    }
+    for ( const auto& [kw, blocks] : unmergedBlocks )
+    {
+        if ( emitted.contains( kw ) ) continue;
+        for ( const auto& deckKw : blocks )
+        {
+            appendKeywordText( deckKw );
+        }
     }
 
     return result;
@@ -269,12 +292,13 @@ std::optional<Opm::DeckKeyword> RicScheduleDataGenerator::generateCompdatForWell
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline&          timeline,
-                                                   RimEclipseCase&                      eclipseCase,
-                                                   RimWellPath&                         wellPath,
-                                                   const QDateTime&                     date,
-                                                   std::map<QString, Opm::DeckKeyword>& keywordBlocks,
-                                                   const std::set<const RimWellPath*>&  mswWells )
+void RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline&                       timeline,
+                                                   RimEclipseCase&                                   eclipseCase,
+                                                   RimWellPath&                                      wellPath,
+                                                   const QDateTime&                                  date,
+                                                   std::map<QString, Opm::DeckKeyword>&              keywordBlocks,
+                                                   std::map<QString, std::vector<Opm::DeckKeyword>>& unmergedBlocks,
+                                                   const std::set<const RimWellPath*>&               mswWells )
 {
     // MSW keywords are exported only for the wells the caller explicitly requested.
     if ( !mswWells.contains( &wellPath ) )
@@ -322,13 +346,21 @@ void RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline&  
 
     const auto& mswData = mswDataResult.value();
 
+    // WELSEGS and COMPSEGS are not merged across wells (see generateDateSection): each well keeps
+    // its own block, appended in well order.
+    auto appendUnmerged = [&unmergedBlocks]( const QString& name, Opm::DeckKeyword kw )
+    {
+        if ( kw.size() == 0 && !kw.isDataKeyword() ) return;
+        unmergedBlocks[name].push_back( std::move( kw ) );
+    };
+
     int  maxSegments = 0;
     int  maxBranches = 0;
     auto welsegsKw   = RimKeywordFactory::welsegsKeyword( mswData, maxSegments, maxBranches );
-    mergeKeyword( keywordBlocks, "WELSEGS", std::move( welsegsKw ) );
+    appendUnmerged( "WELSEGS", std::move( welsegsKw ) );
 
     auto compsegsKw = RimKeywordFactory::compsegsKeyword( mswData );
-    mergeKeyword( keywordBlocks, "COMPSEGS", std::move( compsegsKw ) );
+    appendUnmerged( "COMPSEGS", std::move( compsegsKw ) );
 
     auto wsegvalvKw = RimKeywordFactory::wsegvalvKeyword( mswData );
     mergeKeyword( keywordBlocks, "WSEGVALV", std::move( wsegvalvKw ) );

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -160,10 +160,7 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
             mergeKeyword( keywordBlocks, "WELSPECS", std::move( *welspecs ) );
         }
 
-        if ( auto compdat = generateCompdatForWell( timeline, eclipseCase, *well, date ) )
-        {
-            mergeKeyword( keywordBlocks, "COMPDAT", std::move( *compdat ) );
-        }
+        generateCompletionsForWell( timeline, eclipseCase, *well, date, keywordBlocks );
 
         generateMswForWell( timeline, eclipseCase, *well, date, keywordBlocks, unmergedBlocks, mswWells );
         generateWellControlForWell( timeline, *well, date, keywordBlocks );
@@ -262,10 +259,11 @@ std::optional<Opm::DeckKeyword> RicScheduleDataGenerator::generateWelspecsForWel
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::optional<Opm::DeckKeyword> RicScheduleDataGenerator::generateCompdatForWell( const RimWellEventTimeline& timeline,
-                                                                                  RimEclipseCase&             eclipseCase,
-                                                                                  RimWellPath&                well,
-                                                                                  const QDateTime&            date )
+void RicScheduleDataGenerator::generateCompletionsForWell( const RimWellEventTimeline&          timeline,
+                                                           RimEclipseCase&                      eclipseCase,
+                                                           RimWellPath&                         well,
+                                                           const QDateTime&                     date,
+                                                           std::map<QString, Opm::DeckKeyword>& keywordBlocks )
 {
     auto events = timeline.getEventsAtDate( date );
 
@@ -279,14 +277,15 @@ std::optional<Opm::DeckKeyword> RicScheduleDataGenerator::generateCompdatForWell
         }
     }
 
-    if ( !hasPerfEvents ) return std::nullopt;
+    if ( !hasPerfEvents ) return;
 
+    // Completion data is computed once and feeds both COMPDAT and COMPLUMP (the latter only emits
+    // records whose perforation has a completion number assigned). Both keywords merge across wells.
     auto compdata = RicWellPathExportCompletionDataFeatureImpl::completionDataForWellPath( &well, &eclipseCase, date );
     auto wellName = well.completionSettings()->wellNameForExport().toStdString();
 
-    auto compdatKw = RimKeywordFactory::compdatKeyword( compdata, wellName );
-    if ( compdatKw.name().empty() ) return std::nullopt;
-    return compdatKw;
+    mergeKeyword( keywordBlocks, "COMPDAT", RimKeywordFactory::compdatKeyword( compdata, wellName ) );
+    mergeKeyword( keywordBlocks, "COMPLUMP", RimKeywordFactory::complumpKeyword( compdata, wellName ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
@@ -72,14 +72,17 @@ private:
     static std::optional<Opm::DeckKeyword>
         generateCompdatForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
 
-    // Generate WELSEGS / COMPSEGS / WSEGVALV / WSEGAICD for a well at a specific date, merging into the accumulator.
+    // Generate WELSEGS / COMPSEGS / WSEGVALV / WSEGAICD for a well at a specific date.
+    // WSEGVALV / WSEGAICD are merged into keywordBlocks; WELSEGS / COMPSEGS cannot be merged across
+    // wells and are appended as separate per-well blocks in unmergedBlocks.
     // All four keywords are emitted only when the well is present in mswWells; otherwise none are.
-    static void generateMswForWell( const RimWellEventTimeline&          timeline,
-                                    RimEclipseCase&                      eclipseCase,
-                                    RimWellPath&                         well,
-                                    const QDateTime&                     date,
-                                    std::map<QString, Opm::DeckKeyword>& keywordBlocks,
-                                    const std::set<const RimWellPath*>&  mswWells );
+    static void generateMswForWell( const RimWellEventTimeline&                       timeline,
+                                    RimEclipseCase&                                   eclipseCase,
+                                    RimWellPath&                                      well,
+                                    const QDateTime&                                  date,
+                                    std::map<QString, Opm::DeckKeyword>&              keywordBlocks,
+                                    std::map<QString, std::vector<Opm::DeckKeyword>>& unmergedBlocks,
+                                    const std::set<const RimWellPath*>&               mswWells );
 
     // Generate well control / well keyword event keywords for a well at a specific date, merging into the accumulator
     static void generateWellControlForWell( const RimWellEventTimeline&          timeline,

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <optional>
+#include <set>
 #include <vector>
 
 class RimEclipseCase;
@@ -44,26 +45,25 @@ class RicScheduleDataGenerator
 {
 public:
     // Generate schedule for multiple wells at specified dates.
-    // includeWelsegs / includeCompsegs gate the corresponding multi-segment-well keywords;
-    // WSEGVALV and WSEGAICD remain unaffected.
-    static QString generateSchedule( const RimWellEventTimeline&      timeline,
-                                     RimEclipseCase&                  eclipseCase,
-                                     const std::vector<RimWellPath*>& wellPaths,
-                                     const std::vector<QDateTime>&    dates,
-                                     bool                             includeWelsegs  = true,
-                                     bool                             includeCompsegs = true );
+    // mswWells lists the wells for which the multi-segment-well keywords (WELSEGS, COMPSEGS,
+    // WSEGVALV, WSEGAICD) are exported. Wells not in the set get no MSW keywords; an empty set
+    // suppresses MSW export for all wells.
+    static QString generateSchedule( const RimWellEventTimeline&         timeline,
+                                     RimEclipseCase&                     eclipseCase,
+                                     const std::vector<RimWellPath*>&    wellPaths,
+                                     const std::vector<QDateTime>&       dates,
+                                     const std::set<const RimWellPath*>& mswWells );
 
     // Collect all unique dates from all wells' timelines
     static std::vector<QDateTime> collectAllDates( const RimWellEventTimeline& timeline, const std::vector<RimWellPath*>& wellPaths );
 
 private:
     // Generate schedule section for a single date
-    static QString generateDateSection( const RimWellEventTimeline&      timeline,
-                                        RimEclipseCase&                  eclipseCase,
-                                        const std::vector<RimWellPath*>& wellPaths,
-                                        const QDateTime&                 date,
-                                        bool                             includeWelsegs,
-                                        bool                             includeCompsegs );
+    static QString generateDateSection( const RimWellEventTimeline&         timeline,
+                                        RimEclipseCase&                     eclipseCase,
+                                        const std::vector<RimWellPath*>&    wellPaths,
+                                        const QDateTime&                    date,
+                                        const std::set<const RimWellPath*>& mswWells );
 
     static std::optional<Opm::DeckKeyword>
         generateWelspecsForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
@@ -73,14 +73,13 @@ private:
         generateCompdatForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
 
     // Generate WELSEGS / COMPSEGS / WSEGVALV / WSEGAICD for a well at a specific date, merging into the accumulator.
-    // includeWelsegs/includeCompsegs suppress only those two keywords; WSEGVALV/WSEGAICD always emit.
+    // All four keywords are emitted only when the well is present in mswWells; otherwise none are.
     static void generateMswForWell( const RimWellEventTimeline&          timeline,
                                     RimEclipseCase&                      eclipseCase,
                                     RimWellPath&                         well,
                                     const QDateTime&                     date,
                                     std::map<QString, Opm::DeckKeyword>& keywordBlocks,
-                                    bool                                 includeWelsegs,
-                                    bool                                 includeCompsegs );
+                                    const std::set<const RimWellPath*>&  mswWells );
 
     // Generate well control / well keyword event keywords for a well at a specific date, merging into the accumulator
     static void generateWellControlForWell( const RimWellEventTimeline&          timeline,

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
@@ -68,9 +68,13 @@ private:
     static std::optional<Opm::DeckKeyword>
         generateWelspecsForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
 
-    // Generate COMPDAT for a well at a specific date based on events
-    static std::optional<Opm::DeckKeyword>
-        generateCompdatForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
+    // Generate COMPDAT (and COMPLUMP, when perforations carry a completion number) for a well at a
+    // specific date based on events, merging both into the accumulator.
+    static void generateCompletionsForWell( const RimWellEventTimeline&          timeline,
+                                            RimEclipseCase&                      eclipseCase,
+                                            RimWellPath&                         well,
+                                            const QDateTime&                     date,
+                                            std::map<QString, Opm::DeckKeyword>& keywordBlocks );
 
     // Generate WELSEGS / COMPSEGS / WSEGVALV / WSEGAICD for a well at a specific date.
     // WSEGVALV / WSEGAICD are merged into keywordBlocks; WELSEGS / COMPSEGS cannot be merged across

--- a/ApplicationLibCode/FileInterface/RifEventKeywordFormatter.cpp
+++ b/ApplicationLibCode/FileInterface/RifEventKeywordFormatter.cpp
@@ -38,6 +38,7 @@
 #include "opm/input/eclipse/Parser/ParserKeywords/W.hpp"
 #include "opm/input/eclipse/Parser/ParserRecord.hpp"
 
+#include <iterator>
 #include <optional>
 #include <sstream>
 #include <unordered_map>
@@ -70,6 +71,7 @@ std::optional<Opm::DeckKeyword> RifEventKeywordFormatter::buildKeyword( const QS
         const Opm::ParserKeyword& parserKw = parser.getKeyword( kwName );
         Opm::DeckKeyword          kw( parserKw );
 
+        const size_t             numRecords   = static_cast<size_t>( std::distance( parserKw.begin(), parserKw.end() ) );
         const Opm::ParserRecord& parserRecord = parserKw.getRecord( 0 );
 
         auto stringValue = []( const RimWellEventKeywordItem* item ) -> std::string
@@ -91,7 +93,8 @@ std::optional<Opm::DeckKeyword> RifEventKeywordFormatter::buildKeyword( const QS
         // RPTRST / RPTSCHED-style keywords have a single ALL-sized item that holds a free-form
         // list of mnemonics ("BASIC=2 DEN ROCKC ..."). Emit each user-supplied key either as
         // "KEY=VALUE" (typed value) or bare "KEY" (FLAG), all packed into one DeckItem.
-        const bool isMnemonicList = parserRecord.size() == 1 && parserRecord.get( 0 ).sizeType() == Opm::ParserItem::item_size::ALL;
+        const bool isMnemonicList = numRecords == 1 && parserRecord.size() == 1 &&
+                                    parserRecord.get( 0 ).sizeType() == Opm::ParserItem::item_size::ALL;
 
         if ( isMnemonicList )
         {
@@ -119,28 +122,13 @@ std::optional<Opm::DeckKeyword> RifEventKeywordFormatter::buildKeyword( const QS
         }
         else
         {
-            // Positional keyword (WCONHIST, WELTARG, ...): emit items in the schema-defined order
-            // regardless of caller-supplied order (e.g. Python dict insertion order).
+            // Positional keyword (WCONHIST, WELTARG, TUNING, ...): emit items in the schema-defined
+            // order regardless of caller-supplied order (e.g. Python dict insertion order).
             std::unordered_map<std::string, const RimWellEventKeywordItem*> userItemsByName;
             userItemsByName.reserve( items.size() );
             for ( const auto* item : items )
             {
                 userItemsByName.emplace( item->itemName().toStdString(), item );
-            }
-
-            // Highest canonical index actually provided by the user. Trailing unspecified items are
-            // dropped, intermediate gaps become default markers ("1*").
-            std::optional<size_t>           lastProvidedIdx;
-            std::unordered_set<std::string> canonicalNames;
-            canonicalNames.reserve( parserRecord.size() );
-            for ( size_t i = 0; i < parserRecord.size(); ++i )
-            {
-                const std::string& name = parserRecord.get( i ).name();
-                canonicalNames.insert( name );
-                if ( userItemsByName.contains( name ) )
-                {
-                    lastProvidedIdx = i;
-                }
             }
 
             auto appendDeckItem = [&]( std::vector<Opm::DeckItem>& out, const std::string& name, const RimWellEventKeywordItem* item )
@@ -164,37 +152,81 @@ std::optional<Opm::DeckKeyword> RifEventKeywordFormatter::buildKeyword( const QS
                 }
             };
 
-            std::vector<Opm::DeckItem> deckItems;
-            if ( lastProvidedIdx.has_value() )
+            // Build one record's items: emit schema items up to the last one the user provided,
+            // turning intermediate gaps into default markers ("1*") and dropping trailing
+            // unspecified items.
+            auto buildRecordItems = [&]( const Opm::ParserRecord& record )
             {
-                deckItems.reserve( *lastProvidedIdx + 1 );
-                for ( size_t i = 0; i <= *lastProvidedIdx; ++i )
+                std::optional<size_t> lastProvidedIdx;
+                for ( size_t i = 0; i < record.size(); ++i )
                 {
-                    const std::string& name = parserRecord.get( i ).name();
-                    auto               it   = userItemsByName.find( name );
-                    if ( it == userItemsByName.end() )
+                    if ( userItemsByName.contains( record.get( i ).name() ) ) lastProvidedIdx = i;
+                }
+
+                std::vector<Opm::DeckItem> deckItems;
+                if ( lastProvidedIdx.has_value() )
+                {
+                    deckItems.reserve( *lastProvidedIdx + 1 );
+                    for ( size_t i = 0; i <= *lastProvidedIdx; ++i )
                     {
-                        deckItems.push_back( RifOpmDeckTools::defaultItem( name ) );
+                        const std::string& name = record.get( i ).name();
+                        auto               it   = userItemsByName.find( name );
+                        if ( it == userItemsByName.end() )
+                            deckItems.push_back( RifOpmDeckTools::defaultItem( name ) );
+                        else
+                            appendDeckItem( deckItems, name, it->second );
                     }
-                    else
-                    {
-                        appendDeckItem( deckItems, name, it->second );
-                    }
+                }
+                return deckItems;
+            };
+
+            // Item names known to the schema across all of the keyword's records.
+            std::unordered_set<std::string> canonicalNames;
+            for ( const auto& record : parserKw )
+            {
+                for ( size_t i = 0; i < record.size(); ++i )
+                {
+                    canonicalNames.insert( record.get( i ).name() );
                 }
             }
 
-            // Items not in the keyword's schema are still emitted in caller-supplied order
-            // after the canonical block.
-            for ( const auto* item : items )
+            if ( numRecords > 1 )
             {
-                const std::string name = item->itemName().toStdString();
-                if ( canonicalNames.contains( name ) ) continue;
-                appendDeckItem( deckItems, name, item );
-            }
+                // Multi-record keyword (e.g. TUNING): emit every record, each terminated by its own
+                // '/'. Records the user did not populate are still written (as a bare '/') so the
+                // record structure required by the schema is preserved.
+                for ( const auto& record : parserKw )
+                {
+                    kw.addRecord( Opm::DeckRecord{ buildRecordItems( record ) } );
+                }
 
-            if ( !deckItems.empty() )
+                for ( const auto* item : items )
+                {
+                    const std::string name = item->itemName().toStdString();
+                    if ( !canonicalNames.contains( name ) )
+                    {
+                        RiaLogging::warning(
+                            std::format( "Keyword '{}': item '{}' is not part of the keyword schema and was ignored.", kwName, name ) );
+                    }
+                }
+            }
+            else
             {
-                kw.addRecord( Opm::DeckRecord{ std::move( deckItems ) } );
+                // Single-record keyword: emit the canonical block, then any non-schema items in
+                // caller-supplied order.
+                std::vector<Opm::DeckItem> deckItems = buildRecordItems( parserRecord );
+
+                for ( const auto* item : items )
+                {
+                    const std::string name = item->itemName().toStdString();
+                    if ( canonicalNames.contains( name ) ) continue;
+                    appendDeckItem( deckItems, name, item );
+                }
+
+                if ( !deckItems.empty() )
+                {
+                    kw.addRecord( Opm::DeckRecord{ std::move( deckItems ) } );
+                }
             }
         }
 

--- a/ApplicationLibCode/ProjectDataModel/WellEvents/RimWellEventPerf.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellEvents/RimWellEventPerf.cpp
@@ -47,6 +47,7 @@ RimWellEventPerf::RimWellEventPerf()
     CAF_PDM_InitScriptableField( &m_diameter, "Diameter", 0.216, "Diameter" );
     CAF_PDM_InitScriptableField( &m_skinFactor, "SkinFactor", 0.0, "Skin Factor" );
     CAF_PDM_InitScriptableField( &m_state, "State", caf::AppEnum<State>( State::OPEN ), "State" );
+    CAF_PDM_InitScriptableField( &m_completionNumber, "CompletionNumber", 0, "Completion Number" );
 
     setDeletable( true );
 }
@@ -101,6 +102,14 @@ RimWellEventPerf::State RimWellEventPerf::state() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+int RimWellEventPerf::completionNumber() const
+{
+    return m_completionNumber();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimWellEventPerf::setStartMD( double md )
 {
     m_startMD = md;
@@ -136,6 +145,14 @@ void RimWellEventPerf::setSkinFactor( double skinFactor )
 void RimWellEventPerf::setState( State state )
 {
     m_state = state;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimWellEventPerf::setCompletionNumber( int completionNumber )
+{
+    m_completionNumber = completionNumber;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -181,6 +198,7 @@ void RimWellEventPerf::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderin
     uiOrdering.add( &m_diameter );
     uiOrdering.add( &m_skinFactor );
     uiOrdering.add( &m_state );
+    uiOrdering.add( &m_completionNumber );
 
     uiOrdering.skipRemainingFields();
 }

--- a/ApplicationLibCode/ProjectDataModel/WellEvents/RimWellEventPerf.h
+++ b/ApplicationLibCode/ProjectDataModel/WellEvents/RimWellEventPerf.h
@@ -48,6 +48,7 @@ public:
     double diameter() const;
     double skinFactor() const;
     State  state() const;
+    int    completionNumber() const;
 
     // Setters
     void setStartMD( double md );
@@ -55,6 +56,7 @@ public:
     void setDiameter( double diameter );
     void setSkinFactor( double skinFactor );
     void setState( State state );
+    void setCompletionNumber( int completionNumber );
 
     // Override from RimWellEvent
     EventType eventType() const override;
@@ -70,6 +72,7 @@ private:
     caf::PdmField<double>              m_diameter;
     caf::PdmField<double>              m_skinFactor;
     caf::PdmField<caf::AppEnum<State>> m_state;
+    caf::PdmField<int>                 m_completionNumber;
 };
 
 namespace caf

--- a/ApplicationLibCode/ProjectDataModel/WellEvents/RimWellEventTimeline.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellEvents/RimWellEventTimeline.cpp
@@ -489,6 +489,12 @@ bool RimWellEventTimeline::applyPerfEvent( const RimWellEventPerf& event, RimWel
     perfInterval->setSkinFactor( event.skinFactor() );
     perfInterval->setUnitSystemSpecificDefaults();
 
+    // A non-zero completion number drives COMPLUMP generation downstream.
+    if ( event.completionNumber() > 0 )
+    {
+        perfInterval->setCompletionNumber( event.completionNumber() );
+    }
+
     // Set the custom start date based on the event date
     perfInterval->enableCustomStartDate( true );
     perfInterval->setCustomStartDate( event.eventDate().date() );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.cpp
@@ -38,6 +38,7 @@
 #include <QDateTime>
 
 #include <algorithm>
+#include <set>
 
 CAF_PDM_OBJECT_METHOD_SOURCE_INIT( RimWellEventTimeline, RimcWellEventTimeline_addPerfEvent, "AddPerfEvent" );
 
@@ -568,8 +569,13 @@ RimcWellEventTimeline_generateSchedule::RimcWellEventTimeline_generateSchedule( 
     CAF_PDM_InitObject( "Generate Schedule", "", "", "Generate Eclipse schedule text for all wells in the collection" );
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_eclipseCase, "EclipseCase", "", "", "", "Eclipse Case" );
-    CAF_PDM_InitScriptableField( &m_includeWelsegs, "IncludeWelsegs", true, "", "", "", "Include WELSEGS keyword in the exported schedule" );
-    CAF_PDM_InitScriptableField( &m_includeCompsegs, "IncludeCompsegs", true, "", "", "", "Include COMPSEGS keyword in the exported schedule" );
+    CAF_PDM_InitScriptableFieldNoDefault( &m_exportMswForWells,
+                                          "ExportMswForWells",
+                                          "",
+                                          "",
+                                          "",
+                                          "Wells for which multi-segment-well keywords (WELSEGS, COMPSEGS, WSEGVALV, WSEGAICD) are "
+                                          "exported" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -619,8 +625,10 @@ std::expected<caf::PdmObjectHandle*, QString> RimcWellEventTimeline_generateSche
         return std::unexpected( QString( "No well paths with events found" ) );
     }
 
-    QString scheduleText =
-        RicScheduleDataGenerator::generateSchedule( *timeline, *eclipseCase, wellPathsWithEvents, dates, m_includeWelsegs(), m_includeCompsegs() );
+    std::vector<RimWellPath*>    mswWellPaths = m_exportMswForWells.ptrReferencedObjectsByType();
+    std::set<const RimWellPath*> mswWells( mswWellPaths.begin(), mswWellPaths.end() );
+
+    QString scheduleText = RicScheduleDataGenerator::generateSchedule( *timeline, *eclipseCase, wellPathsWithEvents, dates, mswWells );
 
     // Return the schedule text in a data container
     auto* dataObject           = new RimcDataContainerString();

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.cpp
@@ -58,6 +58,7 @@ RimcWellEventTimeline_addPerfEvent::RimcWellEventTimeline_addPerfEvent( caf::Pdm
     CAF_PDM_InitScriptableField( &m_skinFactor, "SkinFactor", 0.0, "", "", "", "Skin Factor" );
     auto defaultState = RimWellEventPerf::State::OPEN;
     CAF_PDM_InitScriptableField( &m_state, "State", defaultState, "", "", "", "State" );
+    CAF_PDM_InitScriptableField( &m_completionNumber, "CompletionNumber", 0, "", "", "", "Completion Number (for COMPLUMP, 0 = none)" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -84,6 +85,7 @@ std::expected<caf::PdmObjectHandle*, QString> RimcWellEventTimeline_addPerfEvent
     event->setDiameter( m_diameter() );
     event->setSkinFactor( m_skinFactor() );
     event->setState( m_state() );
+    event->setCompletionNumber( m_completionNumber() );
 
     return event;
 }

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.h
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.h
@@ -28,6 +28,7 @@
 #include "cafAppEnum.h"
 #include "cafPdmField.h"
 #include "cafPdmObjectMethod.h"
+#include "cafPdmPtrArrayField.h"
 #include "cafPdmPtrField.h"
 
 #include <QString>
@@ -225,7 +226,6 @@ public:
     QString                                       classKeywordReturnedType() const override;
 
 private:
-    caf::PdmPtrField<RimEclipseCase*> m_eclipseCase;
-    caf::PdmField<bool>               m_includeWelsegs;
-    caf::PdmField<bool>               m_includeCompsegs;
+    caf::PdmPtrField<RimEclipseCase*>   m_eclipseCase;
+    caf::PdmPtrArrayField<RimWellPath*> m_exportMswForWells;
 };

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.h
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcWellEventTimeline.h
@@ -57,6 +57,7 @@ private:
     caf::PdmField<double>                                m_diameter;
     caf::PdmField<double>                                m_skinFactor;
     caf::PdmField<caf::AppEnum<RimWellEventPerf::State>> m_state;
+    caf::PdmField<int>                                   m_completionNumber;
 };
 
 //==================================================================================================

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
@@ -172,6 +172,27 @@ def main():
     )
     print("   Added GRUPTREE event on 2024-01-01 (group tree definition)")
 
+    # Example 6: TUNING - Time stepping / convergence control.
+    # TUNING is a multi-record keyword: items are distributed into the record that
+    # defines them (record 1: TSINIT/TSMAXZ/TMAXWC, record 3: NEWTMX..MXWPIT), so the
+    # generated keyword has three records, each terminated by its own '/'.
+    _tuning_event = timeline.add_keyword_event(
+        event_date="2024-01-01",
+        keyword_name="TUNING",
+        keyword_data={
+            "TSINIT": 1,
+            "TSMAXZ": 30,
+            "TMAXWC": 1,
+            "NEWTMX": 12,
+            "NEWTMN": 1,
+            "LITMAX": 50,
+            "LITMIN": 1,
+            "MXWSIT": 50,
+            "MXWPIT": 50,
+        },
+    )
+    print("   Added TUNING event on 2024-01-01 (time stepping / convergence control)")
+
     # Apply events up to March 15, 2024
     # This should create:
     # - Tubing interval (Jan 1)
@@ -238,6 +259,7 @@ def main():
                 "WRFTPLT",
                 "RPTRST",
                 "GRUPTREE",
+                "TUNING",
             ]
             found_keywords = [kw for kw in expected_keywords if kw in schedule_text]
 
@@ -284,6 +306,7 @@ def main():
             print(f"   - WRFTPLT entries: {schedule_text.count('WRFTPLT')}")
             print(f"   - RPTRST entries: {schedule_text.count('RPTRST')}")
             print(f"   - GRUPTREE entries: {schedule_text.count('GRUPTREE')}")
+            print(f"   - TUNING entries: {schedule_text.count('TUNING')}")
 
             # Save to file
             output_file = "generated_schedule.sch"

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
@@ -52,7 +52,9 @@ def main():
     )
     print("   Added tubing event on 2024-01-01 (MD 0-2500m)")
 
-    # Add first perforation event
+    # Add first perforation event.
+    # completion_number assigns the perforation to a completion group, which makes
+    # the schedule emit a COMPLUMP keyword lumping these connections into group 1.
     _perf_event1 = timeline.add_perf_event(
         event_date="2024-02-01",
         well_path=well_path,
@@ -61,10 +63,11 @@ def main():
         diameter=0.1,
         skin_factor=0.5,
         state="OPEN",
+        completion_number=1,
     )
-    print("   Added perforation event on 2024-02-01 (MD 2000-2200m)")
+    print("   Added perforation event on 2024-02-01 (MD 2000-2200m, completion 1)")
 
-    # Add second perforation event (later)
+    # Add second perforation event (later), assigned to a different completion group.
     _perf_event2 = timeline.add_perf_event(
         event_date="2024-04-01",
         well_path=well_path,
@@ -73,8 +76,9 @@ def main():
         diameter=0.1,
         skin_factor=0.3,
         state="OPEN",
+        completion_number=2,
     )
-    print("   Added perforation event on 2024-04-01 (MD 2400-2600m)")
+    print("   Added perforation event on 2024-04-01 (MD 2400-2600m, completion 2)")
 
     # Add valve event (requires existing perforation)
     _valve_event = timeline.add_valve_event(
@@ -227,6 +231,8 @@ def main():
                 "DATES",
                 "WELSEGS",
                 "COMPSEGS",
+                "COMPDAT",
+                "COMPLUMP",
                 "WCONHIST",
                 "WELTARG",
                 "WRFTPLT",
@@ -250,6 +256,9 @@ def main():
             if "COMPSEGS" in schedule_text:
                 print("   ✓ COMPSEGS keyword generated (completion segments)")
 
+            if "COMPLUMP" in schedule_text:
+                print("   ✓ COMPLUMP keyword generated (perforation completion groups)")
+
             if "WSEGVALV" in schedule_text:
                 print("   ✓ WSEGVALV keyword generated (segment valves)")
                 # Extract valve parameters
@@ -268,6 +277,7 @@ def main():
             print(f"   - DATES entries: {schedule_text.count('DATES')}")
             print(f"   - WELSEGS entries: {schedule_text.count('WELSEGS')}")
             print(f"   - COMPSEGS entries: {schedule_text.count('COMPSEGS')}")
+            print(f"   - COMPLUMP entries: {schedule_text.count('COMPLUMP')}")
             print(f"   - WSEGVALV entries: {schedule_text.count('WSEGVALV')}")
             print(f"   - WCONHIST entries: {schedule_text.count('WCONHIST')}")
             print(f"   - WELTARG entries: {schedule_text.count('WELTARG')}")

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
@@ -206,8 +206,11 @@ def main():
         case = cases[0]
         print(f"   Using Eclipse case: {case.name}")
 
-        # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        # Generate schedule text. Pass the wells that should get multi-segment-well
+        # keywords (WELSEGS, COMPSEGS, WSEGVALV, WSEGAICD); an empty list omits them.
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[well_path]
+        )
 
         if schedule_text:
             print(f"\n   Generated schedule text ({len(schedule_text)} characters)")
@@ -320,8 +323,12 @@ def main():
     print("      keyword_data={'BASIC': 2, 'FREQ': 1}")
     print("  )")
     print("- timeline.set_timestamp(timestamp='2024-06-01')  # Apply events up to date")
-    print("- schedule_text = timeline.generate_schedule_text(eclipse_case=case)")
-    print("  # Generate Eclipse schedule text")
+    print(
+        "- schedule_text = timeline.generate_schedule_text(eclipse_case=case, export_msw_for_wells=[well_path])"
+    )
+    print(
+        "  # Generate Eclipse schedule text (export_msw_for_wells enables MSW keywords)"
+    )
 
 
 if __name__ == "__main__":

--- a/GrpcInterface/Python/rips/tests/test_well_events.py
+++ b/GrpcInterface/Python/rips/tests/test_well_events.py
@@ -1455,6 +1455,54 @@ class TestScheduleGeneration:
                 f"Well {wp.name!r} missing from grouped WELSPECS block: {welspecs_block!r}"
             )
 
+    def test_welsegs_compsegs_not_merged_across_wells(self, project_with_case_and_well):
+        """WELSEGS and COMPSEGS carry a per-well header record and therefore cannot
+        be merged across wells: each MSW well must get its own keyword block on the
+        same date, while the other keywords stay grouped.
+        """
+        project, case, timeline = project_with_case_and_well
+        well_paths = project.well_paths()
+        assert len(well_paths) >= 2, (
+            "Test requires at least two well paths in the fixture"
+        )
+
+        for wp in well_paths[:2]:
+            timeline.add_tubing_event(
+                event_date="2024-01-01",
+                well_path=wp,
+                start_md=0.0,
+                end_md=2500.0,
+                inner_diameter=0.15,
+                roughness=1.0e-5,
+            )
+            timeline.add_perf_event(
+                event_date="2024-01-01",
+                well_path=wp,
+                start_md=2000.0,
+                end_md=2200.0,
+                diameter=0.1,
+                state="OPEN",
+            )
+
+        timeline.set_timestamp(timestamp="2024-12-31")
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=well_paths[:2]
+        )
+        print(f"\nSchedule text for unmerged MSW keywords:\n{schedule_text}")
+
+        # One WELSEGS and one COMPSEGS header per MSW well (not merged into one block).
+        assert schedule_text.count("WELSEGS\n") == 2, (
+            f"WELSEGS should appear once per well; got {schedule_text.count('WELSEGS')}:\n{schedule_text}"
+        )
+        assert schedule_text.count("COMPSEGS\n") == 2, (
+            f"COMPSEGS should appear once per well; got {schedule_text.count('COMPSEGS')}:\n{schedule_text}"
+        )
+
+        # COMPDAT, by contrast, stays grouped under a single header.
+        assert schedule_text.count("COMPDAT\n") == 1, (
+            f"COMPDAT should stay grouped under one header; got {schedule_text.count('COMPDAT')}:\n{schedule_text}"
+        )
+
 
 class TestKeywordEvents:
     """Tests for well keyword event functionality."""

--- a/GrpcInterface/Python/rips/tests/test_well_events.py
+++ b/GrpcInterface/Python/rips/tests/test_well_events.py
@@ -2092,6 +2092,62 @@ class TestScheduleKeywordEvents:
 
         assert event is not None, "RPTSCHED event should be created"
 
+    def test_tuning_keyword_multi_record_output(self, project_with_case_and_well):
+        """TUNING is a multi-record keyword (3 records, each terminated by '/'). Items
+        spanning different records must be distributed into their own records, producing
+        three slashes rather than one.
+        """
+        project, case, timeline = project_with_case_and_well
+        well_path = project.well_paths()[0]
+
+        # A well event so the date section is emitted.
+        timeline.add_control_event(
+            event_date="2018-01-01",
+            well_path=well_path,
+            control_mode="ORAT",
+            control_value=1000.0,
+            oil_rate=1000.0,
+            is_producer=True,
+        )
+
+        # Items from record 1 (TSINIT, TSMAXZ, TMAXWC) and record 3 (NEWTMX..MXWPIT).
+        timeline.add_keyword_event(
+            event_date="2018-01-01",
+            keyword_name="TUNING",
+            keyword_data={
+                "TSINIT": 1,
+                "TSMAXZ": 30,
+                "TMAXWC": 1,
+                "NEWTMX": 12,
+                "NEWTMN": 1,
+                "LITMAX": 50,
+                "LITMIN": 1,
+                "MXWSIT": 50,
+                "MXWPIT": 50,
+            },
+        )
+
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
+
+        print(f"\nSchedule text with TUNING keyword:\n{schedule_text}")
+
+        assert "TUNING" in schedule_text, "Schedule should contain TUNING keyword"
+
+        # Isolate the TUNING block (header line up to the following blank line).
+        tuning_block = schedule_text.split("TUNING\n", 1)[1].split("\n\n", 1)[0]
+        record_terminators = [
+            line for line in tuning_block.splitlines() if line.strip().endswith("/")
+        ]
+        assert len(record_terminators) == 3, (
+            f"TUNING must emit three records (three '/'), got {len(record_terminators)}:\n{tuning_block}"
+        )
+
+        # Record 1 keeps TSMAXZ; record 3 keeps NEWTMX. Both values must survive.
+        assert "30" in tuning_block, "TSMAXZ value missing from TUNING record 1"
+        assert "12" in tuning_block, "NEWTMX value missing from TUNING record 3"
+
     def test_keyword_event_schedule_output(self, project_with_case_and_well):
         """Test that schedule keyword events appear in schedule text generation."""
         project, case, timeline = project_with_case_and_well

--- a/GrpcInterface/Python/rips/tests/test_well_events.py
+++ b/GrpcInterface/Python/rips/tests/test_well_events.py
@@ -1516,6 +1516,57 @@ class TestScheduleGeneration:
                 f"Well {wp.name!r} missing from grouped WELSPECS block: {welspecs_block!r}"
             )
 
+    def test_per_well_keywords_sorted_by_well_name(self, project_with_case_and_well):
+        """Per-well keyword records are emitted in deck-name-sorted well order, so WELSPECS
+        and COMPDAT share the same ascending well order rather than an arbitrary one.
+
+        Note: the fixture imports wells A then B, so insertion order already matches name
+        order; this test locks in the deterministic ascending ordering and cross-keyword
+        consistency that the sort guarantees.
+        """
+        project, case, timeline = project_with_case_and_well
+        well_paths = project.well_paths()
+        assert len(well_paths) >= 2, (
+            "Test requires at least two well paths in the fixture"
+        )
+
+        for wp in well_paths[:2]:
+            timeline.add_perf_event(
+                event_date="2024-01-01",
+                well_path=wp,
+                start_md=2000.0,
+                end_md=2200.0,
+                diameter=0.1,
+                state="OPEN",
+            )
+
+        timeline.set_timestamp(timestamp="2024-12-31")
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
+        print(f"\nSchedule text for sorted well order:\n{schedule_text}")
+
+        export_names = sorted(wp.name.replace(" ", "") for wp in well_paths[:2])
+
+        def first_positions(block):
+            squashed = block.replace(" ", "")
+            return [squashed.find(name) for name in export_names]
+
+        welspecs_block = schedule_text.split("WELSPECS\n", 1)[1].split("\n/\n", 1)[0]
+        compdat_block = schedule_text.split("COMPDAT\n", 1)[1].split("\n/\n", 1)[0]
+
+        for block_name, block in (
+            ("WELSPECS", welspecs_block),
+            ("COMPDAT", compdat_block),
+        ):
+            positions = first_positions(block)
+            assert all(p >= 0 for p in positions), (
+                f"Both wells must appear in the {block_name} block: {block!r}"
+            )
+            assert positions == sorted(positions), (
+                f"{block_name} wells not in ascending name order {export_names}: {block!r}"
+            )
+
     def test_welsegs_compsegs_not_merged_across_wells(self, project_with_case_and_well):
         """WELSEGS and COMPSEGS carry a per-well header record and therefore cannot
         be merged across wells: each MSW well must get its own keyword block on the

--- a/GrpcInterface/Python/rips/tests/test_well_events.py
+++ b/GrpcInterface/Python/rips/tests/test_well_events.py
@@ -1202,6 +1202,67 @@ class TestScheduleGeneration:
 
         assert "COMPDAT" in schedule_text
 
+    def test_perf_completion_number_triggers_complump(self, project_with_case_and_well):
+        """#13273 follow-up: a completion_number on add_perf_event must surface as a
+        COMPLUMP keyword (with that number) in the generated schedule.
+        """
+        project, case, timeline = project_with_case_and_well
+        well_path = project.well_paths()[0]
+
+        timeline.add_perf_event(
+            event_date="2024-01-01",
+            well_path=well_path,
+            start_md=2000.0,
+            end_md=2200.0,
+            diameter=0.1,
+            state="OPEN",
+            completion_number=3,
+        )
+
+        timeline.set_timestamp(timestamp="2024-01-01")
+
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
+
+        print(f"\nSchedule text for COMPLUMP test:\n{schedule_text}")
+
+        assert "COMPLUMP" in schedule_text, (
+            "Schedule should contain COMPLUMP when a perforation has a completion number"
+        )
+        # The completion number must appear inside the COMPLUMP block (header to trailing '/').
+        complump_block = schedule_text.split("COMPLUMP\n", 1)[1].split("\n/\n", 1)[0]
+        assert " 3 " in complump_block or complump_block.rstrip().endswith("3 /"), (
+            f"Completion number 3 missing from COMPLUMP block: {complump_block!r}"
+        )
+
+    def test_perf_without_completion_number_has_no_complump(
+        self, project_with_case_and_well
+    ):
+        """Without a completion_number, no COMPLUMP keyword should be emitted."""
+        project, case, timeline = project_with_case_and_well
+        well_path = project.well_paths()[0]
+
+        timeline.add_perf_event(
+            event_date="2024-01-01",
+            well_path=well_path,
+            start_md=2000.0,
+            end_md=2200.0,
+            diameter=0.1,
+            state="OPEN",
+        )
+
+        timeline.set_timestamp(timestamp="2024-01-01")
+
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
+
+        assert "COMPDAT" in schedule_text
+        assert "COMPLUMP" not in schedule_text, (
+            "COMPLUMP should not appear when no completion number is set"
+        )
+
     def test_schedule_multiple_dates_in_order(self, project_with_case_and_well):
         """Verify schedule dates are in chronological order."""
         project, case, timeline = project_with_case_and_well

--- a/GrpcInterface/Python/rips/tests/test_well_events.py
+++ b/GrpcInterface/Python/rips/tests/test_well_events.py
@@ -297,7 +297,9 @@ class TestScheduleGeneration:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         # Verify schedule text contains expected keywords
         assert schedule_text, "Schedule text should not be empty"
@@ -347,7 +349,9 @@ class TestScheduleGeneration:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         # Verify we have schedule text with completions and controls
         assert schedule_text, "Schedule text should not be empty"
@@ -388,7 +392,9 @@ class TestScheduleGeneration:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         # Verify schedule was generated
         assert schedule_text, "Schedule text should not be empty"
@@ -470,7 +476,9 @@ class TestScheduleGeneration:
         timeline.set_timestamp(timestamp="2024-02-01")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
         print("SCHEDULE:", schedule_text)
 
         # Verify schedule is generated
@@ -644,7 +652,9 @@ class TestScheduleGeneration:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
         print(schedule_text)
 
         # Verify schedule is generated with all dates
@@ -975,7 +985,9 @@ class TestScheduleGeneration:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate Eclipse schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         # Debug output
         print(f"\nSchedule text ({len(schedule_text)} characters):")
@@ -1073,7 +1085,9 @@ class TestScheduleGeneration:
         )
 
         timeline.set_timestamp(timestamp="2024-12-31")
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for WELSEGS test:\n{schedule_text}")
 
@@ -1125,7 +1139,9 @@ class TestScheduleGeneration:
         )
 
         timeline.set_timestamp(timestamp="2024-12-31")
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for WSEGVALV test:\n{schedule_text}")
 
@@ -1151,7 +1167,9 @@ class TestScheduleGeneration:
             is_producer=True,
         )
 
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for WCONPROD test:\n{schedule_text}")
 
@@ -1176,7 +1194,9 @@ class TestScheduleGeneration:
 
         timeline.set_timestamp(timestamp="2024-01-01")
 
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for COMPDAT test:\n{schedule_text}")
 
@@ -1216,7 +1236,9 @@ class TestScheduleGeneration:
         )
 
         # Control events don't require set_timestamp
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for date ordering test:\n{schedule_text}")
 
@@ -1231,18 +1253,20 @@ class TestScheduleGeneration:
         assert jan_pos < feb_pos, "January should come before February"
         assert feb_pos < jun_pos, "February should come before June"
 
-    def test_welsegs_compsegs_optional(self, project_with_case_and_well):
-        """Regression for #14064: callers can suppress WELSEGS and/or COMPSEGS
-        without affecting other keywords (WSEGVALV/WSEGAICD/COMPDAT/WELSPECS).
+    def test_msw_export_gated_by_well_list(self, project_with_case_and_well):
+        """#14079: the multi-segment-well keywords (WELSEGS, COMPSEGS, WSEGVALV,
+        WSEGAICD) are emitted only for wells listed in export_msw_for_wells.
+
+        With the default (empty list) none of them appear, while unrelated
+        keywords (COMPDAT) are unaffected. Listing the well enables them.
         """
         project, case, timeline = project_with_case_and_well
         well_paths = project.well_paths()
-        assert len(well_paths) >= 1
+        well_path_a = [wp for wp in well_paths if "A" in wp.name][0]
 
-        wp = well_paths[0]
         timeline.add_tubing_event(
             event_date="2024-01-01",
-            well_path=wp,
+            well_path=well_path_a,
             start_md=0.0,
             end_md=2500.0,
             inner_diameter=0.15,
@@ -1250,7 +1274,7 @@ class TestScheduleGeneration:
         )
         timeline.add_perf_event(
             event_date="2024-01-01",
-            well_path=wp,
+            well_path=well_path_a,
             start_md=2000.0,
             end_md=2200.0,
             diameter=0.1,
@@ -1258,37 +1282,139 @@ class TestScheduleGeneration:
         )
         timeline.set_timestamp(timestamp="2024-12-31")
 
-        # Baseline (defaults) must still emit WELSEGS and COMPSEGS.
-        baseline = timeline.generate_schedule_text(eclipse_case=case)
-        assert "WELSEGS" in baseline
-        assert "COMPSEGS" in baseline
+        # Default (no list) suppresses all MSW keywords, COMPDAT is unaffected.
+        default_text = timeline.generate_schedule_text(eclipse_case=case)
+        print(f"\nSchedule with no MSW wells:\n{default_text}")
+        assert "WELSEGS" not in default_text, (
+            f"WELSEGS should be absent:\n{default_text}"
+        )
+        assert "COMPSEGS" not in default_text, (
+            f"COMPSEGS should be absent:\n{default_text}"
+        )
+        assert "WSEGVALV" not in default_text
+        assert "WSEGAICD" not in default_text
+        assert "COMPDAT" in default_text
 
-        # Suppress both.
-        suppressed = timeline.generate_schedule_text(
-            eclipse_case=case, include_welsegs=False, include_compsegs=False
+        # An explicit empty list behaves identically to the default.
+        empty_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[]
         )
-        print(f"\nSchedule with WELSEGS/COMPSEGS suppressed:\n{suppressed}")
-        assert "WELSEGS" not in suppressed, (
-            f"WELSEGS should be suppressed:\n{suppressed}"
-        )
-        assert "COMPSEGS" not in suppressed, (
-            f"COMPSEGS should be suppressed:\n{suppressed}"
-        )
-        # COMPDAT (perforation completions) is unrelated to the MSW flags.
-        assert "COMPDAT" in suppressed
+        assert "WELSEGS" not in empty_text
+        assert "COMPSEGS" not in empty_text
 
-        # Independent toggling.
-        only_compsegs_off = timeline.generate_schedule_text(
-            eclipse_case=case, include_compsegs=False
+        # Listing the well enables WELSEGS and COMPSEGS for it.
+        enabled_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[well_path_a]
         )
-        assert "WELSEGS" in only_compsegs_off
-        assert "COMPSEGS" not in only_compsegs_off
+        assert "WELSEGS" in enabled_text, f"WELSEGS should be present:\n{enabled_text}"
+        assert "COMPSEGS" in enabled_text, (
+            f"COMPSEGS should be present:\n{enabled_text}"
+        )
+        assert "COMPDAT" in enabled_text
 
-        only_welsegs_off = timeline.generate_schedule_text(
-            eclipse_case=case, include_welsegs=False
+    def test_msw_export_selected_per_well(self, project_with_case_and_well):
+        """#14079: the well list selects MSW output per well and gates WSEGVALV
+        and WSEGAICD the same way as WELSEGS / COMPSEGS.
+
+        Well A carries an AICD valve (emits WSEGAICD, not WSEGVALV); well B
+        carries an ICD valve (emits WSEGVALV, not WSEGAICD). The presence of
+        each keyword therefore pinpoints exactly which well's MSW data was
+        exported.
+        """
+        project, case, timeline = project_with_case_and_well
+        well_paths = project.well_paths()
+        well_path_a = [wp for wp in well_paths if "A" in wp.name][0]
+        well_path_b = [wp for wp in well_paths if "B" in wp.name][0]
+
+        # Well A: tubing + perforation + AICD valve -> WSEGAICD.
+        timeline.add_tubing_event(
+            event_date="2024-01-01",
+            well_path=well_path_a,
+            start_md=0.0,
+            end_md=2500.0,
+            inner_diameter=0.20,
+            roughness=3.0e-5,
         )
-        assert "WELSEGS" not in only_welsegs_off
-        assert "COMPSEGS" in only_welsegs_off
+        timeline.add_perf_event(
+            event_date="2024-01-01",
+            well_path=well_path_a,
+            start_md=2250.0,
+            end_md=2400.0,
+            diameter=0.12,
+            state="OPEN",
+        )
+        timeline.add_valve_event(
+            event_date="2024-01-01",
+            well_path=well_path_a,
+            measured_depth=2300.0,
+            valve_type="AICD",
+            state="OPEN",
+            flow_coefficient=0.6,
+            area=0.00015,
+            aicd_strength=0.00021,
+            aicd_density_calib_fluid=1000.0,
+            aicd_viscosity_calib_fluid=1.0,
+            aicd_vol_flow_exp=2.1,
+            aicd_visc_func_exp=0.5,
+        )
+
+        # Well B: tubing + perforation + ICD valve -> WSEGVALV.
+        timeline.add_tubing_event(
+            event_date="2024-01-01",
+            well_path=well_path_b,
+            start_md=0.0,
+            end_md=2000.0,
+            inner_diameter=0.15,
+            roughness=2.0e-5,
+        )
+        timeline.add_perf_event(
+            event_date="2024-01-01",
+            well_path=well_path_b,
+            start_md=1500.0,
+            end_md=1700.0,
+            diameter=0.2,
+            state="OPEN",
+        )
+        timeline.add_valve_event(
+            event_date="2024-01-01",
+            well_path=well_path_b,
+            measured_depth=1600.0,
+            valve_type="ICD",
+            state="OPEN",
+            flow_coefficient=0.6,
+            area=0.00012,
+        )
+
+        timeline.set_timestamp(timestamp="2024-12-31")
+
+        # Both wells listed: all four MSW keywords present.
+        both = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[well_path_a, well_path_b]
+        )
+        assert "WELSEGS" in both
+        assert "COMPSEGS" in both
+        assert "WSEGVALV" in both  # from well B's ICD valve
+        assert "WSEGAICD" in both  # from well A's AICD valve
+
+        # Only well A: WSEGAICD present, WSEGVALV absent (B's ICD excluded).
+        only_a = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[well_path_a]
+        )
+        assert "WELSEGS" in only_a
+        assert "WSEGAICD" in only_a, f"WSEGAICD should be present:\n{only_a}"
+        assert "WSEGVALV" not in only_a, (
+            f"WSEGVALV (well B's ICD) should be excluded:\n{only_a}"
+        )
+
+        # Only well B: WSEGVALV present, WSEGAICD absent (A's AICD excluded).
+        only_b = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[well_path_b]
+        )
+        assert "WELSEGS" in only_b
+        assert "WSEGVALV" in only_b, f"WSEGVALV should be present:\n{only_b}"
+        assert "WSEGAICD" not in only_b, (
+            f"WSEGAICD (well A's AICD) should be excluded:\n{only_b}"
+        )
 
     def test_keywords_grouped_across_wells(self, project_with_case_and_well):
         """Regression for #14063: WELSPECS / COMPDAT records for multiple wells on
@@ -1311,7 +1437,9 @@ class TestScheduleGeneration:
             )
 
         timeline.set_timestamp(timestamp="2024-12-31")
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
         print(f"\nSchedule text for multi-well grouping:\n{schedule_text}")
 
         # Exactly one "WELSPECS\n" header for all wells.
@@ -1451,7 +1579,9 @@ class TestKeywordEvents:
         )
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for keyword event:\n{schedule_text}")
 
@@ -1513,7 +1643,9 @@ class TestKeywordEvents:
         )
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text for multiple keywords:\n{schedule_text}")
 
@@ -1551,7 +1683,9 @@ class TestKeywordEvents:
             },
         )
 
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
         print(f"\nSchedule text for canonical-order check:\n{schedule_text}")
 
         assert "WCONHIST" in schedule_text
@@ -1632,7 +1766,9 @@ class TestKeywordEvents:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule with perf and keyword events:\n{schedule_text}")
 
@@ -1671,7 +1807,9 @@ class TestKeywordEvents:
         )
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule with control and keyword events:\n{schedule_text}")
 
@@ -1725,7 +1863,9 @@ class TestKeywordEvents:
         )
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule with keyword events at multiple dates:\n{schedule_text}")
 
@@ -1766,7 +1906,9 @@ class TestKeywordEvents:
         assert event is not None, "Event with boolean values should be created"
 
         # Generate schedule to verify bool conversion
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule with boolean keyword values:\n{schedule_text}")
         assert schedule_text, "Schedule text should not be empty"
@@ -1867,7 +2009,9 @@ class TestScheduleKeywordEvents:
         )
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule text with RPTRST keyword:\n{schedule_text}")
 
@@ -1913,7 +2057,9 @@ class TestScheduleKeywordEvents:
         timeline.set_timestamp(timestamp="2024-12-31")
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(
             f"\nSchedule with mixed well and schedule-level keywords:\n{schedule_text}"
@@ -1966,7 +2112,9 @@ class TestScheduleKeywordEvents:
         )
 
         # Generate schedule text
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
 
         print(f"\nSchedule with keyword events at multiple dates:\n{schedule_text}")
 
@@ -2026,7 +2174,9 @@ class TestScheduleKeywordEvents:
             },
         )
 
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
         print(f"\nRPTRST mnemonic output:\n{schedule_text}")
 
         assert "RPTRST" in schedule_text

--- a/GrpcInterface/Python/rips/well_events.py
+++ b/GrpcInterface/Python/rips/well_events.py
@@ -6,7 +6,7 @@ in a timeline-based event system. Events can be perforation events, valve events
 tubing changes, well state changes, and production/injection control changes.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 from datetime import date, datetime
 
 from .pdmobject import add_method
@@ -15,6 +15,7 @@ from .generated.generated_classes import (
     KeywordEvent,
     WellEventKeyword,
     WellEventTimeline,
+    WellPath,
 )
 
 
@@ -111,7 +112,9 @@ def add_well_keyword_event(
 
         # Generate schedule
         case = project.cases()[0]
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=[well_path]
+        )
         print(schedule_text)
         ```
     """
@@ -284,8 +287,7 @@ def add_keyword_event(
 def generate_schedule_text(
     self: WellEventTimeline,
     eclipse_case: EclipseCase,
-    include_welsegs: bool = True,
-    include_compsegs: bool = True,
+    export_msw_for_wells: List[WellPath] = [],
 ) -> str:
     """Generate Eclipse schedule text for all wells in the collection.
 
@@ -298,12 +300,10 @@ def generate_schedule_text(
 
     Arguments:
         eclipse_case (EclipseCase): Eclipse case to use for schedule generation.
-        include_welsegs (bool): When False, omit the WELSEGS keyword from the
-            output. Other multi-segment-well keywords (COMPSEGS, WSEGVALV,
-            WSEGAICD) are not affected. Defaults to True.
-        include_compsegs (bool): When False, omit the COMPSEGS keyword from
-            the output. WELSEGS, WSEGVALV, WSEGAICD are not affected.
-            Defaults to True.
+        export_msw_for_wells (List[WellPath]): Wells for which the
+            multi-segment-well keywords (WELSEGS, COMPSEGS, WSEGVALV, WSEGAICD)
+            are exported. Wells not in the list get no MSW keywords. An empty
+            list (the default) suppresses MSW export for all wells.
 
     Returns:
         str: Eclipse schedule text containing DATES, COMPDAT, WELSEGS, WCONPROD, etc.
@@ -335,16 +335,17 @@ def generate_schedule_text(
             state="OPEN"
         )
 
-        # Generate schedule text for all wells
+        # Generate schedule text, exporting MSW keywords for all wells
         case = project.cases()[0]
-        schedule_text = timeline.generate_schedule_text(eclipse_case=case)
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case, export_msw_for_wells=project.well_paths()
+        )
         print(schedule_text)
         ```
     """
     container = self.generate_schedule(
         eclipse_case=eclipse_case,
-        include_welsegs=include_welsegs,
-        include_compsegs=include_compsegs,
+        export_msw_for_wells=export_msw_for_wells,
     )
     if container and container.values:
         return "".join(container.values)


### PR DESCRIPTION
Replace the include_welsegs / include_compsegs boolean flags on the schedule-generation API with a list of wells (export_msw_for_wells) that gates the multi-segment-well keywords. WSEGVALV and WSEGAICD are now gated the same way as WELSEGS and COMPSEGS: all four are emitted only for wells present in the list. An empty list (the default) suppresses MSW export for all wells, while COMPDAT and well-control keywords are unaffected.

C++: RicScheduleDataGenerator takes a std::set<const RimWellPath*> mswWells and generateMswForWell early-returns for wells not in the set. RimcWellEventTimeline_generateSchedule replaces the two bool fields with a scriptable PdmPtrArrayField<RimWellPath*>, resolved via ptrReferencedObjectsByType().

Python: generate_schedule_text / generate_schedule expose export_msw_for_wells (List[WellPath]) instead of the boolean flags. Updates the well_event_schedule example and adds regression tests covering the empty-list default, per-well selection, and WSEGVALV/WSEGAICD gating.

Fixes #14079.