### PR TITLE
#14083 Well Disks: Keep disk radius stable when toggling well visibility

### DIFF
--- a/ApplicationLibCode/ModelVisualization/RivWellDiskPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellDiskPartMgr.cpp
@@ -113,6 +113,12 @@ void RivWellDiskPartMgr::buildWellDiskParts( size_t frameIndex, const caf::Displ
     cvf::Vec3d diskPosition = whEndPos;
     diskPosition.z() += pipeRadius + arrowLength * 2.0;
 
+    // Stagger disks vertically per well so wells whose disks overlap do not render coplanar and z-fight.
+    // resultWellIndex() gives a stable, unique per-well index; arrowLength keeps the spacing consistent with the disk
+    // scale and view zoom.
+    const double diskStaggerFactor = 0.05; // fraction of arrowLength per well index
+    diskPosition.z() += m_rimWell->resultWellIndex() * arrowLength * diskStaggerFactor;
+
     cvf::Vec3d textPosition = diskPosition;
     textPosition.z() += 0.1;
 

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -1263,14 +1263,17 @@ void RimEclipseView::onLoadDataAndUpdate()
 
     faultCollection()->synchronizeFaults();
 
-    m_wellCollection->scaleWellDisks();
-
     if ( m_surfaceCollection ) m_surfaceCollection->loadData( m_currentTimeStep );
 
     scheduleReservoirGridGeometryRegen();
     m_simWellsPartManager->clearGeometryCache();
 
     synchronizeWellsWithResults();
+
+    // Scale well disks after the wells have been (re)populated by synchronizeWellsWithResults(). Calling this earlier
+    // would iterate an empty well list, leaving each well's disk marked invalid so the disks are not drawn on the first
+    // display-model build after a project reload (see #14083).
+    m_wellCollection->scaleWellDisks();
 
     synchronizeLocalAnnotationsFromGlobal();
 

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
@@ -872,6 +872,12 @@ bool RimSimWellInViewCollection::showWellDiskQuantityLables() const
 void RimSimWellInViewCollection::scaleWellDisks()
 {
     if ( !isActive ) return;
+
+    // m_showWellDisks is a transient aggregate (disableIO) derived from the per-well showWellDisks() states. After a
+    // project reload it is still at its default (False) until the property panel is built, so sync it from the restored
+    // per-well states here to avoid skipping disk scaling on the first display-model build (see #14083).
+    updateStateForVisibilityCheckboxes();
+
     if ( m_showWellDisks().isFalse() ) return;
 
     RimWellDiskConfig wellDiskConfig = getActiveWellDiskConfig();

--- a/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp
@@ -884,14 +884,13 @@ void RimSimWellInViewCollection::scaleWellDisks()
 void RimSimWellInViewCollection::scaleWellDisksFromConfig( const RimWellDiskConfig& wellDiskConfig )
 {
     if ( !m_reservoirView ) return;
-    size_t frameIndex = static_cast<size_t>( m_reservoirView->currentTimeStep() );
 
+    // Compute the normalization range over all wells, independent of their current visibility. Using only the
+    // visible wells would make the disk radius of one well depend on whether other wells are filtered out (see #14083).
     double minValue = std::numeric_limits<double>::max();
     double maxValue = -minValue;
     for ( RimSimWellInView* w : wells )
     {
-        if ( !w->isWellDiskVisible( frameIndex ) ) continue;
-
         bool   isOk  = true;
         double value = w->calculateInjectionProductionFractions( wellDiskConfig, &isOk );
         if ( isOk )


### PR DESCRIPTION
Normalize disk radius over all wells instead of only the currently visible ones. Computing the min/max range over visible wells only made one well's disk radius depend on whether unrelated wells were filtered out, so toggling a range filter on one well changed another well's disk.

Fixes #14083.