### PR TITLE
#14045 CI: Limit macOS workflow to workflow_dispatch and schedule triggers

### DIFF
--- a/.github/workflows/ResInsightMac.yml
+++ b/.github/workflows/ResInsightMac.yml
@@ -1,8 +1,6 @@
 name: ResInsight Mac Build
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
   schedule:
     # 02:00 UTC daily, offset from ResInsightWithCache.yml's 01:00 slot


### PR DESCRIPTION
@
Restrict the macOS build workflow (`ResInsightMac.yml`) to run only on `workflow_dispatch` and the daily `schedule`, removing the `push` and `pull_request` triggers.

This avoids the macOS workflow running on every push and PR while it is still being stabilised, reducing contention for the shared macOS Actions runners.
@