### PR TITLE
CI: modernize runners and bump setup-uv to Node.js 24

### DIFF
--- a/.github/workflows/AppFwkUnitTest.yml
+++ b/.github/workflows/AppFwkUnitTest.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2025]
+        os: [ubuntu-latest, windows-2025-vs2026]
         qtver: [6.5.3]
         include:
           - qtver: 6.5.3

--- a/.github/workflows/AppFwkUnitTest.yml
+++ b/.github/workflows/AppFwkUnitTest.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2025-vs2026]
-        qtver: [6.5.3]
+        qtver: [6.6.3]
         include:
-          - qtver: 6.5.3
+          - qtver: 6.6.3
             build_flags: -DCEE_USE_QT6=ON -DCEE_USE_QT5=OFF
     steps:
       - name: Checkout
@@ -59,7 +59,7 @@ jobs:
           cmake --install . --prefix ${{github.workspace}}/cmakebuild/install
 
       - name: Run Unit Tests Qt6
-        if: matrix.qtver == '6.5.3'
+        if: matrix.qtver == '6.6.3'
         shell: bash
         run: |
           cmakebuild/install/bin/cafPdmCore_UnitTests
@@ -68,6 +68,6 @@ jobs:
           cmakebuild/install/bin/cafPdmScripting_UnitTests
 
       - name: Run Unit Tests Windows Qt6 (does not work on Linux)
-        if: (contains( matrix.os, 'windows') && (matrix.qtver == '6.5.3'))
+        if: (contains( matrix.os, 'windows') )
         shell: bash
         run: cmakebuild/install/bin/cafUserInterface_UnitTests

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -21,27 +21,13 @@ jobs:
         build_type: [Release]
         config:
           - {
-              name: "Windows Latest MSVC",
-              os: windows-2022,
-              cc: "cl",
-              cxx: "cl",
-              build-python-module: true,
-              execute-unit-tests: true,
-              execute-pytests: true,
-              unity-build: true,
-              publish-to-pypi: false,
-              vcpkg-bootstrap: bootstrap-vcpkg.bat,
-              qt-version: 6.6.3,
-              ri-unit-test-path: "ResInsight-tests",
-            }
-          - {
               name: "Windows_2022_qt_610",
-              os: windows-2022,
+              os: windows-2025-vs2026,
               cc: "cl",
               cxx: "cl",
               build-python-module: false,
               execute-unit-tests: true,
-              execute-pytests: false,
+              execute-pytests: true,
               unity-build: true,
               publish-to-pypi: false,
               vcpkg-bootstrap: bootstrap-vcpkg.bat,

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -100,7 +100,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: Get Python executable path
         shell: bash

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -25,7 +25,7 @@ jobs:
               os: windows-2022,
               cc: "cl",
               cxx: "cl",
-              build-python-module: false,
+              build-python-module: true,
               execute-unit-tests: true,
               execute-pytests: true,
               unity-build: true,

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -86,7 +86,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Get Python executable path
         shell: bash

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -22,7 +22,7 @@ jobs:
         config:
           - {
               name: "Windows_2022_qt_610",
-              os: windows-2025-vs2026,
+              os: windows-2022,
               cc: "cl",
               cxx: "cl",
               build-python-module: false,

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -162,7 +162,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.11.0
+  GIT_TAG v1.15.2
 )
 
 set(BUILD_GMOCK


### PR DESCRIPTION
Resolves the Node.js 20 deprecation warning in CI and updates Windows runners.

- Bump `astral-sh/setup-uv` from v6 to v8 so the action runs on Node.js 24 (v6 runs on the now-deprecated Node.js 20). v7.0.0 made the Node 20 to 24 switch; the only other v7 breaking change was removal of the unused `server-url` input.
- Drop the `Windows Latest MSVC` matrix entry and move the qt-610 build to the `windows-2025-vs2026` runner, enabling pytests there.
- Use the `windows-2025-vs2026` runner for the AppFwk unit tests.
