### PR TITLE
#14099 Move export dock layout action back to developer features

### DIFF
--- a/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
+++ b/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
@@ -32,7 +32,6 @@ const std::vector<RiaExperimentalFeatures::Feature>& RiaExperimentalFeatures::av
     static const std::vector<Feature> features = {
         { "osdu-well-logs", "OSDU Well Logs", "Enable import of well logs from OSDU." },
         { "undo-redo-view", "Undo/Redo View", "Show the command undo/redo history view." },
-        { "export-dock-layout", "Export Dock Layout", "Add a window menu action to export the dock layout to the clipboard." },
         { "oil-volume-result", "Oil Volume Result", "Compute the derived oil volume cell result." },
     };
 

--- a/ApplicationLibCode/UserInterface/RiuMainWindowBase.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindowBase.cpp
@@ -18,6 +18,7 @@
 
 #include "RiuMainWindowBase.h"
 
+#include "RiaApplication.h"
 #include "RiaDefines.h"
 #include "RiaPreferences.h"
 #include "RiaPreferencesSystem.h"
@@ -767,7 +768,7 @@ void RiuMainWindowBase::addDefaultEntriesToWindowsMenu()
         }
     }
 
-    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "export-dock-layout" ) )
+    if ( RiaApplication::enableDevelopmentFeatures() )
     {
         QAction* exportLayoutAction = m_windowMenu->addAction( "Export Layout to Clipboard" );
         connect( exportLayoutAction, SIGNAL( triggered() ), this, SLOT( exportDockLayout() ) );


### PR DESCRIPTION
Revert 380b471. The 'Export Layout to Clipboard' window menu action is a developer-only utility, not an experimental feature. Gate it behind RiaApplication::enableDevelopmentFeatures() again and drop the 'export-dock-layout' experimental feature registration.