### PR TITLE
#14104 Fix property/preferences dialog size handling

### DIFF
--- a/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
+++ b/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
@@ -33,6 +33,10 @@ const std::vector<RiaExperimentalFeatures::Feature>& RiaExperimentalFeatures::av
         { "osdu-well-logs", "OSDU Well Logs", "Enable import of well logs from OSDU." },
         { "undo-redo-view", "Undo/Redo View", "Show the command undo/redo history view." },
         { "oil-volume-result", "Oil Volume Result", "Compute the derived oil volume cell result." },
+        { "remember-dialog-size",
+          "Remember Dialog Size",
+          "Remember the size of property and preferences dialogs between sessions and restore it the next time they "
+          "open." },
     };
 
     return features;

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -118,6 +118,7 @@
 #include "cafEffectGenerator.h"
 #include "cafFixedAtlasFont.h"
 #include "cafPdmUiModelChangeDetector.h"
+#include "cafPdmUiPropertyViewDialog.h"
 #include "cafPdmUiTreeView.h"
 #include "cafProgressInfo.h"
 #include "cafQTreeViewStateSerializer.h"
@@ -1468,6 +1469,8 @@ void RiaGuiApplication::applyGuiPreferences( const RiaPreferences*              
     {
         caf::EffectGenerator::setRenderingMode( caf::EffectGenerator::FIXED_FUNCTION );
     }
+
+    caf::PdmUiPropertyViewDialog::enableGeometryPersistence( RiaPreferencesSystem::current()->isFeatureEnabled( "remember-dialog-size" ) );
 
     if ( m_mainWindow )
     {

--- a/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.cpp
@@ -18,12 +18,16 @@
 
 #include "RiuPropertyViewTabWidget.h"
 
+#include "RiaPreferencesSystem.h"
+
 #include "cafPdmObject.h"
 #include "cafPdmUiPropertyView.h"
 
 #include <QBoxLayout>
 #include <QDebug>
 #include <QDialogButtonBox>
+#include <QSettings>
+#include <QShowEvent>
 #include <QStringList>
 #include <QTabWidget>
 #include <QWidget>
@@ -36,6 +40,8 @@ RiuPropertyViewTabWidget::RiuPropertyViewTabWidget( QWidget*           parent,
                                                     const QString&     windowTitle,
                                                     const QStringList& uiConfigNameForTabs )
     : QDialog( parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint )
+    , m_windowTitle( windowTitle )
+    , m_objectClassKeyword( object ? object->classKeyword() : QString() )
 {
     setWindowTitle( windowTitle );
 
@@ -128,4 +134,69 @@ QSize RiuPropertyViewTabWidget::sizeHint() const
 QDialogButtonBox* RiuPropertyViewTabWidget::dialogButtonBox()
 {
     return m_dialogButtonBox;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuPropertyViewTabWidget::showEvent( QShowEvent* event )
+{
+    // Restore the stored size on first show. Doing this here rather than in the constructor ensures
+    // the geometry is applied reliably for a modal dialog and is not overridden by the initial sizing.
+    // When no size is stored, the size is left to sizeHint()/minimumSizeHint().
+    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "remember-dialog-size" ) && !m_geometryRestored )
+    {
+        m_geometryRestored = true;
+        restoreDialogGeometry();
+    }
+
+    QDialog::showEvent( event );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuPropertyViewTabWidget::done( int result )
+{
+    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "remember-dialog-size" ) )
+    {
+        saveDialogGeometry();
+    }
+
+    QDialog::done( result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RiuPropertyViewTabWidget::settingsKey() const
+{
+    QString title = m_windowTitle;
+    title.replace( '/', '_' );
+
+    return QString( "RiuPropertyViewTabWidget/%1/%2/geometry" ).arg( m_objectClassKeyword, title );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiuPropertyViewTabWidget::restoreDialogGeometry()
+{
+    QSettings settings;
+    QVariant  geometry = settings.value( settingsKey() );
+    if ( geometry.isValid() )
+    {
+        return restoreGeometry( geometry.toByteArray() );
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuPropertyViewTabWidget::saveDialogGeometry()
+{
+    QSettings settings;
+    settings.setValue( settingsKey(), saveGeometry() );
 }

--- a/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.h
+++ b/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.h
@@ -41,7 +41,19 @@ public:
     QSize             sizeHint() const override;
     QDialogButtonBox* dialogButtonBox();
 
+protected:
+    void showEvent( QShowEvent* event ) override;
+    void done( int result ) override;
+
 private:
+    QString settingsKey() const;
+    bool    restoreDialogGeometry();
+    void    saveDialogGeometry();
+
+private:
+    QString                              m_windowTitle;
+    QString                              m_objectClassKeyword;
     std::vector<caf::PdmUiPropertyView*> m_pageWidgets;
     QDialogButtonBox*                    m_dialogButtonBox;
+    bool                                 m_geometryRestored = false;
 };

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
@@ -39,10 +39,30 @@
 #include "cafPdmObject.h"
 #include "cafPdmUiPropertyView.h"
 
+#include <QSettings>
+#include <QShowEvent>
 #include <QVBoxLayout>
 
 namespace caf
 {
+bool PdmUiPropertyViewDialog::sm_geometryPersistenceEnabled = false;
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiPropertyViewDialog::enableGeometryPersistence( bool enable )
+{
+    sm_geometryPersistenceEnabled = enable;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool PdmUiPropertyViewDialog::isGeometryPersistenceEnabled()
+{
+    return sm_geometryPersistenceEnabled;
+}
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -91,28 +111,6 @@ QDialogButtonBox* PdmUiPropertyViewDialog::dialogButtonBox()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QSize PdmUiPropertyViewDialog::sizeHint() const
-{
-    // Ensure the preferred size is never degenerate, regardless of how the contained scroll area
-    // reports its hints.
-    return QDialog::sizeHint().expandedTo( QSize( 300, 200 ) );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-QSize PdmUiPropertyViewDialog::minimumSizeHint() const
-{
-    // The inner scroll area reports an artificially small minimum width, which lets some window
-    // managers open the dialog collapsed (issue #14104). Provide a sensible floor, capped by the
-    // content's preferred size so intentionally small dialogs are not enlarged.
-    QSize floor = QSize( 300, 150 ).boundedTo( QDialog::sizeHint() );
-    return QDialog::minimumSizeHint().expandedTo( floor );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void PdmUiPropertyViewDialog::initialize( PdmObject* object, const QString& windowTitle, const QString& uiConfigName )
 {
     m_pdmObject    = object;
@@ -147,6 +145,96 @@ void PdmUiPropertyViewDialog::setupUi()
     connect( m_buttonBox, SIGNAL( rejected() ), this, SLOT( reject() ) );
 
     dialogLayout->addWidget( m_buttonBox );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiPropertyViewDialog::showEvent( QShowEvent* event )
+{
+    // Restore a previously stored size on first show. Restoring here rather than in the constructor
+    // ensures the geometry is applied reliably for a modal dialog and is not overridden by the initial
+    // sizing (see issue #14104). When no size is stored, the size is left to sizeHint()/minimumSizeHint()
+    // and any explicit resize() done by the caller, so the default appearance is preserved.
+    if ( sm_geometryPersistenceEnabled && !m_geometryRestored )
+    {
+        m_geometryRestored = true;
+        restoreDialogGeometry();
+    }
+
+    QDialog::showEvent( event );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QSize PdmUiPropertyViewDialog::sizeHint() const
+{
+    // Ensure the preferred size is never degenerate, regardless of how the contained scroll area
+    // reports its hints.
+    return QDialog::sizeHint().expandedTo( QSize( 300, 200 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QSize PdmUiPropertyViewDialog::minimumSizeHint() const
+{
+    // The inner scroll area reports an artificially small minimum width, which lets some window
+    // managers open the dialog collapsed (issue #14104). Provide a sensible floor, capped by the
+    // content's preferred size so intentionally small dialogs are not enlarged.
+    QSize floor = QSize( 300, 150 ).boundedTo( QDialog::sizeHint() );
+    return QDialog::minimumSizeHint().expandedTo( floor );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiPropertyViewDialog::done( int result )
+{
+    if ( sm_geometryPersistenceEnabled )
+    {
+        saveDialogGeometry();
+    }
+
+    QDialog::done( result );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString PdmUiPropertyViewDialog::settingsKey() const
+{
+    QString id = m_uiConfigName.isEmpty() ? m_windowTitle : m_uiConfigName;
+    id.replace( '/', '_' );
+
+    QString classKeyword = m_pdmObject ? m_pdmObject->classKeyword() : QString();
+
+    return QString( "PdmUiPropertyViewDialog/%1/%2/geometry" ).arg( classKeyword, id );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool PdmUiPropertyViewDialog::restoreDialogGeometry()
+{
+    QSettings settings;
+    QVariant  geometry = settings.value( settingsKey() );
+    if ( geometry.isValid() )
+    {
+        return restoreGeometry( geometry.toByteArray() );
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiPropertyViewDialog::saveDialogGeometry()
+{
+    QSettings settings;
+    settings.setValue( settingsKey(), saveGeometry() );
 }
 
 } // End of namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
@@ -91,6 +91,28 @@ QDialogButtonBox* PdmUiPropertyViewDialog::dialogButtonBox()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+QSize PdmUiPropertyViewDialog::sizeHint() const
+{
+    // Ensure the preferred size is never degenerate, regardless of how the contained scroll area
+    // reports its hints.
+    return QDialog::sizeHint().expandedTo( QSize( 300, 200 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QSize PdmUiPropertyViewDialog::minimumSizeHint() const
+{
+    // The inner scroll area reports an artificially small minimum width, which lets some window
+    // managers open the dialog collapsed (issue #14104). Provide a sensible floor, capped by the
+    // content's preferred size so intentionally small dialogs are not enlarged.
+    QSize floor = QSize( 300, 150 ).boundedTo( QDialog::sizeHint() );
+    return QDialog::minimumSizeHint().expandedTo( floor );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void PdmUiPropertyViewDialog::initialize( PdmObject* object, const QString& windowTitle, const QString& uiConfigName )
 {
     m_pdmObject    = object;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.h
@@ -60,9 +60,23 @@ public:
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
+    // Persisting the dialog geometry to QSettings is gated behind an experimental feature. The
+    // application pushes the current setting via enableGeometryPersistence(). The size floor in
+    // sizeHint()/minimumSizeHint() is always applied, regardless of this setting.
+    static void enableGeometryPersistence( bool enable );
+    static bool isGeometryPersistenceEnabled();
+
+protected:
+    void showEvent( QShowEvent* event ) override;
+    void done( int result ) override;
+
 private:
     void initialize( PdmObject* object, const QString& windowTitle, const QString& uiConfigName );
     void setupUi();
+
+    QString settingsKey() const;
+    bool    restoreDialogGeometry();
+    void    saveDialogGeometry();
 
 private:
     QString            m_windowTitle;
@@ -70,6 +84,9 @@ private:
     PdmObject*         m_pdmObject;
     PdmUiPropertyView* m_pdmUiPropertyView;
     QDialogButtonBox*  m_buttonBox;
+    bool               m_geometryRestored = false;
+
+    static bool sm_geometryPersistenceEnabled;
 };
 
 } // End of namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.h
@@ -57,6 +57,9 @@ public:
 
     QDialogButtonBox* dialogButtonBox();
 
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
 private:
     void initialize( PdmObject* object, const QString& windowTitle, const QString& uiConfigName );
     void setupUi();

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PROJECT_FILES
     cafPdmUiTreeSelectionQModelTest.cpp
     cafPdmUiNumberFormatTest.cpp
     cafPdmUiCheckBoxAndTextEditorTest.cpp
+    cafPdmUiPropertyViewDialogTest.cpp
     cafIconProviderTest.cpp
     gtest/gtest-all.cpp
 )

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiPropertyViewDialogTest.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiPropertyViewDialogTest.cpp
@@ -1,0 +1,81 @@
+
+#include "gtest/gtest.h"
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+#include "cafPdmUiPropertyViewDialog.h"
+
+#include <QApplication>
+#include <QSettings>
+
+using namespace caf;
+
+class GeometryTestObj : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    GeometryTestObj()
+    {
+        CAF_PDM_InitObject( "GeometryTestObj" );
+        CAF_PDM_InitField( &m_value, "Value", 0, "Value" );
+    }
+
+    caf::PdmField<int> m_value;
+};
+CAF_PDM_SOURCE_INIT( GeometryTestObj, "GeometryTestObj" );
+
+//--------------------------------------------------------------------------------------------------
+/// Verify that the dialog stores its geometry on close and restores it on the next show.
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiPropertyViewDialogTest, GeometryRoundTrip )
+{
+    // Ensure QSettings has a defined, isolated location for the test.
+    QCoreApplication::setOrganizationName( "ResInsightTest" );
+    QCoreApplication::setApplicationName( "DialogGeometryTest" );
+    QSettings().clear();
+
+    // Geometry persistence is gated behind an experimental feature and disabled by default. Enable it
+    // explicitly for this test.
+    PdmUiPropertyViewDialog::enableGeometryPersistence( true );
+
+    const QSize userSize( 742, 531 );
+
+    {
+        GeometryTestObj obj;
+
+        PdmUiPropertyViewDialog dialog( nullptr, &obj, "Geometry Round Trip", "" );
+        dialog.show();
+        QApplication::processEvents();
+
+        dialog.resize( userSize );
+        QApplication::processEvents();
+
+        // done() is what saves the geometry; reject() routes through done().
+        dialog.reject();
+    }
+
+    // The settings store should now contain a value for this dialog.
+    {
+        QSettings settings;
+        bool      anyKey = false;
+        for ( const QString& key : settings.allKeys() )
+        {
+            if ( key.contains( "Geometry Round Trip" ) ) anyKey = true;
+        }
+        EXPECT_TRUE( anyKey ) << "No geometry was written to settings";
+    }
+
+    {
+        GeometryTestObj obj;
+
+        PdmUiPropertyViewDialog dialog( nullptr, &obj, "Geometry Round Trip", "" );
+        dialog.show();
+        QApplication::processEvents();
+
+        EXPECT_EQ( dialog.size().width(), userSize.width() );
+        EXPECT_EQ( dialog.size().height(), userSize.height() );
+
+        dialog.reject();
+    }
+}


### PR DESCRIPTION
Fixes #14104

The property export dialog could open at a very small size on some window manager configurations (observed on certain RHEL8 setups). The change is split into two commits.

**Add minimum size floor to property view dialog**

`PdmUiPropertyViewDialog` never asserted a size, and the inner scroll area reports an artificially small minimum size hint that some window managers honor literally, collapsing the dialog. The dialog now overrides `sizeHint()` and `minimumSizeHint()` to provide a sensible floor that the window manager cannot collapse. The floor is capped by the content's preferred size so intentionally small dialogs are not enlarged. This fix is always active.

**Remember user-defined size of property and preferences dialogs**

The dialog size is persisted for both `PdmUiPropertyViewDialog` and the Preferences dialog `RiuPropertyViewTabWidget`. The geometry is saved to the application settings on close and restored on the next show, so a user-adjusted size is remembered across sessions. Restoring is done in `showEvent` rather than the constructor so it is applied reliably for a modal dialog. The settings key includes the bound object class keyword so distinct dialogs that share a window title do not collide.

This persistence is gated behind a new "Remember Dialog Size" experimental feature, disabled by default. `PdmUiPropertyViewDialog` cannot access `RiaPreferencesSystem`, so the application pushes the current setting via the static `enableGeometryPersistence()`, following the existing pattern used for class-name display. `RiuPropertyViewTabWidget` queries the feature directly.
