### PR TITLE
#14112 Contour map: guard null legend config in defineUiOrdering

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp
@@ -613,7 +613,10 @@ void RimContourMapProjection::defineUiOrdering( QString uiConfigName, caf::PdmUi
         }
     }
 
-    legendConfig()->uiOrdering( "NumLevelsOnly", *mainGroup );
+    if ( legendConfig() )
+    {
+        legendConfig()->uiOrdering( "NumLevelsOnly", *mainGroup );
+    }
     mainGroup->add( &m_resolution );
     mainGroup->add( &m_showContourLines );
     mainGroup->add( &m_showContourLabels );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp
@@ -112,6 +112,9 @@ RimRegularLegendConfig* RimEclipseContourMapProjection::legendConfig() const
 //--------------------------------------------------------------------------------------------------
 void RimEclipseContourMapProjection::updateLegend()
 {
+    RimRegularLegendConfig* legend = legendConfig();
+    if ( !legend ) return;
+
     RimEclipseCellColors* cellColors = view()->cellResult();
 
     auto [minValAllTimeSteps, maxValAllTimeSteps] = minmaxValuesAllTimeSteps();
@@ -119,11 +122,11 @@ void RimEclipseContourMapProjection::updateLegend()
     double minVal = m_contourMapProjection ? m_contourMapProjection->minValue() : std::numeric_limits<double>::infinity();
     double maxVal = m_contourMapProjection ? m_contourMapProjection->maxValue() : -std::numeric_limits<double>::infinity();
 
-    legendConfig()->setAutomaticRanges( minValAllTimeSteps, maxValAllTimeSteps, minVal, maxVal );
+    legend->setAutomaticRanges( minValAllTimeSteps, maxValAllTimeSteps, minVal, maxVal );
 
     if ( isColumnResult() )
     {
-        legendConfig()->setTitle( QString( "Map Projection\n%1" ).arg( m_resultAggregation().uiText() ) );
+        legend->setTitle( QString( "Map Projection\n%1" ).arg( m_resultAggregation().uiText() ) );
     }
     else
     {
@@ -134,7 +137,7 @@ void RimEclipseContourMapProjection::updateLegend()
         }
         projectionLegendText += QString( "\nResult: %1" ).arg( cellColors->resultVariableUiShortName() );
 
-        legendConfig()->setTitle( projectionLegendText );
+        legend->setTitle( projectionLegendText );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMapProjection.cpp
@@ -112,23 +112,26 @@ RimRegularLegendConfig* RimStatisticsContourMapProjection::legendConfig() const
 //--------------------------------------------------------------------------------------------------
 void RimStatisticsContourMapProjection::updateLegend()
 {
+    RimRegularLegendConfig* legend = legendConfig();
+    if ( !legend ) return;
+
     auto [minValAllTimeSteps, maxValAllTimeSteps] = minmaxValuesAllTimeSteps();
 
     double minVal = m_contourMapProjection ? m_contourMapProjection->minValue() : std::numeric_limits<double>::infinity();
     double maxVal = m_contourMapProjection ? m_contourMapProjection->maxValue() : -std::numeric_limits<double>::infinity();
 
-    legendConfig()->setAutomaticRanges( minValAllTimeSteps, maxValAllTimeSteps, minVal, maxVal );
+    legend->setAutomaticRanges( minValAllTimeSteps, maxValAllTimeSteps, minVal, maxVal );
 
     if ( statisticsContourMap()->isColumnResult() )
     {
-        legendConfig()->setTitle( QString( "Map Projection\n%1" ).arg( resultVariableName() ) );
+        legend->setTitle( QString( "Map Projection\n%1" ).arg( resultVariableName() ) );
     }
     else
     {
         QString projectionLegendText = QString( "Map Projection\n%1" ).arg( resultAggregationText() );
         projectionLegendText += QString( "\nResult: %1" ).arg( resultVariableName() );
 
-        legendConfig()->setTitle( projectionLegendText );
+        legend->setTitle( projectionLegendText );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMapView.cpp
@@ -155,7 +155,10 @@ void RimStatisticsContourMapView::defineUiTreeOrdering( caf::PdmUiTreeOrdering& 
 {
     uiTreeOrdering.add( m_overlayInfoConfig() );
     uiTreeOrdering.add( m_contourMapProjection );
-    uiTreeOrdering.add( cellResult()->legendConfig() );
+    if ( cellResult() && cellResult()->legendConfig() )
+    {
+        uiTreeOrdering.add( cellResult()->legendConfig() );
+    }
     uiTreeOrdering.add( wellCollection() );
     uiTreeOrdering.add( faultCollection() );
     uiTreeOrdering.add( annotationCollection() );

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp
@@ -223,7 +223,7 @@ void RimEclipseCellColors::defineUiOrdering( QString uiConfigName, caf::PdmUiOrd
 {
     RimEclipseResultDefinition::defineUiOrdering( uiConfigName, uiOrdering );
 
-    if ( uiConfigName == "AddLegendLevels" )
+    if ( uiConfigName == "AddLegendLevels" && legendConfig() )
     {
         legendConfig()->uiOrdering( "NumIntervalsOnly", uiOrdering );
     }


### PR DESCRIPTION
Fixes the crash reported in #14112.

## Root cause
Selecting a contour map projection in the tree updates its property panel, which calls `RimContourMapProjection::defineUiOrdering`. At `RimContourMapProjection.cpp:616` it dereferenced `legendConfig()` without a null check:

```cpp
legendConfig()->uiOrdering( "NumLevelsOnly", *mainGroup );
```

`legendConfig()` resolves to `view()->cellResult()->legendConfig()`, which returns the `m_legendConfigPtrField` pointer field and can be null.

Because `PdmUiObjectHandle::uiOrdering` is **non-virtual**, calling it through a null pointer does not crash immediately — execution enters with `this == nullptr` and survives until the **virtual** `this->defineUiOrdering()` dispatch at `cafPdmUiObjectHandle.cpp:40`, where reading the vtable from a null `this` segfaults. This matches the reported stack trace exactly.

## Fix
Guard the `legendConfig()` dereference, consistent with the existing null checks elsewhere in the same file (e.g. `RimContourMapProjection.cpp:187`). The remaining unguarded `legendConfig()` uses in the contour map projection classes and views are guarded as well.