### PR TITLE
CI: remove redundant Get CMake and Ninja step from AppFwkUnitTest

### DIFF
--- a/.github/workflows/AppFwkUnitTest.yml
+++ b/.github/workflows/AppFwkUnitTest.yml
@@ -39,9 +39,6 @@ jobs:
           cache: true
           cache-key-prefix: ${{ matrix.qtver }}-${{ matrix.os }}
 
-      - name: Get CMake and Ninja
-        uses: lukka/get-cmake@latest
-
       - name: Use MSVC (Windows)
         if: contains(matrix.os, 'windows')
         uses: TheMrMilchmann/setup-msvc-dev@v4


### PR DESCRIPTION
Removes the `Get CMake and Ninja` step (lukka/get-cmake@latest) from the AppFwkUnitTest workflow.