### PR TITLE
#14116 GeoMech: fix out-of-bounds crash mapping step index to time step

### DIFF
--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp
@@ -994,8 +994,7 @@ std::vector<std::string> RigFemPartResultsCollection::stepNames() const
 //--------------------------------------------------------------------------------------------------
 const std::pair<int, int> RigFemPartResultsCollection::stepListIndexToTimeStepAndDataFrameIndex( int stepIndex ) const
 {
-    if ( stepIndex < 0 ) return std::make_pair( stepIndex, -1 );
-    CVF_ASSERT( stepIndex < static_cast<int>( m_stepList.size() ) );
+    if ( stepIndex < 0 || stepIndex >= static_cast<int>( m_stepList.size() ) ) return std::make_pair( stepIndex, -1 );
     return m_stepList[stepIndex];
 }
 


### PR DESCRIPTION
Fixes #14116

`RigFemPartResultsCollection::stepListIndexToTimeStepAndDataFrameIndex` only guarded against negative indices and relied on a `CVF_ASSERT` for the upper bound. That assert is compiled out in release builds, so when a GeoMech case has no steps loaded (empty `m_stepList`), `RimGeoMechView::onClampCurrentTimestep` clamps the current time step to `0` and the subsequent lookup reads `m_stepList[0]` out of bounds, causing the reported segfault.

The early-return guard now also covers indices at or beyond the end of `m_stepList`, returning the existing `(stepIndex, -1)` sentinel for all build configurations. This protects every caller of the accessor.