### PR TITLE
#14118 Fix crash in loadAllGrids when grid file fails to load

### DIFF
--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -1164,7 +1164,7 @@ ecl_grid_type* RifReaderEclipseOutput::loadAllGrids() const
 {
     ecl_grid_type* mainEclGrid = ecl_grid_alloc( RiaStringEncodingTools::toNativeEncoded( m_fileName ).data() );
 
-    if ( m_ecl_init_file )
+    if ( mainEclGrid && m_ecl_init_file )
     {
         // TODO : ecl_grid_alloc() will automatically read ACTNUM from EGRID file, and reading of active cell
         // information can be skipped if PORV is available


### PR DESCRIPTION
Fixes #14118.

## Problem

`ecl_grid_alloc` can return `nullptr` for a corrupt or truncated grid file (`.EGRID`/`.GRID`). When a valid `INIT` file was present (`m_ecl_init_file` set), `loadAllGrids()` dereferenced the null grid pointer via `ecl_grid_dual_grid` / `ecl_grid_get_global_size` before returning, causing the segfault in the reported stack trace.

The caller `open()` already null-checks the return value of `loadAllGrids()`, but the dereference happened earlier, inside `loadAllGrids()` itself.

## Fix

Guard the init-file active cell logic on a non-null grid, so `loadAllGrids()` returns `nullptr` cleanly and the existing null check in `open()` reports the error and aborts the import gracefully.