### PR TITLE
#14111 Preserve time-of-day in exported DATES keyword

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -172,8 +172,17 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
     if ( dateAsComment )
     {
         QLocale locale( QLocale::English );
-        QString month = locale.monthName( date.date().month(), QLocale::ShortFormat ).toUpper();
-        result += QString( "-- Date: %1 %2 %3\n" ).arg( date.date().day() ).arg( month ).arg( date.date().year() );
+        QString month   = locale.monthName( date.date().month(), QLocale::ShortFormat ).toUpper();
+        QString dateStr = QString( "-- Date: %1 %2 %3" ).arg( date.date().day() ).arg( month ).arg( date.date().year() );
+
+        // Mirror the TIME field emitted in DATES keywords (see RimKeywordFactory::datesKeyword): include the
+        // time-of-day in the comment only when the timestamp is not at midnight.
+        const QTime time = date.time();
+        if ( time.isValid() && ( time.hour() != 0 || time.minute() != 0 || time.second() != 0 || time.msec() != 0 ) )
+        {
+            dateStr += ( time.msec() != 0 ) ? time.toString( " HH:mm:ss.zzz" ) : time.toString( " HH:mm:ss" );
+        }
+        result += dateStr + "\n";
     }
     else
     {

--- a/ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp
@@ -754,6 +754,16 @@ Opm::DeckKeyword datesKeyword( const QDateTime& date )
     items.push_back( RifOpmDeckTools::item( D::MONTH::itemName, month.toStdString() ) );
     items.push_back( RifOpmDeckTools::item( D::YEAR::itemName, year ) );
 
+    // Emit the optional TIME field (HH:MM:SS[.SSS], default 00:00:00) only when the timestamp carries a
+    // non-midnight time, so date-only events keep their plain DAY/MONTH/YEAR output. QDateTime resolves
+    // to milliseconds, which is the finest precision we can preserve here.
+    const QTime time = date.time();
+    if ( time.isValid() && ( time.hour() != 0 || time.minute() != 0 || time.second() != 0 || time.msec() != 0 ) )
+    {
+        const QString timeStr = ( time.msec() != 0 ) ? time.toString( "HH:mm:ss.zzz" ) : time.toString( "HH:mm:ss" );
+        items.push_back( RifOpmDeckTools::item( D::TIME::itemName, timeStr.toStdString() ) );
+    }
+
     Opm::DeckKeyword kw{ D() };
     kw.addRecord( Opm::DeckRecord{ std::move( items ) } );
     return kw;

--- a/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
+++ b/GrpcInterface/Python/rips/PythonExamples/wells_and_fractures/well_event_schedule.py
@@ -80,6 +80,24 @@ def main():
     )
     print("   Added perforation event on 2024-04-01 (MD 2400-2600m, completion 2)")
 
+    # Add a perforation event with an explicit time-of-day. event_date accepts an ISO 8601
+    # timestamp, so a non-midnight time (here with millisecond precision) is preserved and
+    # emitted as the optional TIME field of the DATES keyword (e.g. "DATES\n 15 'MAY' 2024
+    # '14:45:30.500' /"). Date-only events keep their plain DAY/MONTH/YEAR output.
+    _perf_event3 = timeline.add_perf_event(
+        event_date="2024-05-15T14:45:30.500",
+        well_path=well_path,
+        start_md=2300.0,
+        end_md=2350.0,
+        diameter=0.1,
+        skin_factor=0.4,
+        state="OPEN",
+        completion_number=3,
+    )
+    print(
+        "   Added perforation event on 2024-05-15T14:45:30.500 (MD 2300-2350m, completion 3, time-of-day preserved)"
+    )
+
     # Add valve event (requires existing perforation)
     _valve_event = timeline.add_valve_event(
         event_date="2024-03-01",
@@ -271,6 +289,13 @@ def main():
             found_keywords = [kw for kw in expected_keywords if kw in schedule_text]
 
             print(f"   Keywords found: {', '.join(found_keywords)}")
+
+            # The 2024-05-15T14:45:30.500 perforation event should surface as a DATES
+            # keyword carrying the optional TIME field with millisecond precision.
+            if "14:45:30.500" in schedule_text:
+                print(
+                    "   ✓ DATES keyword preserves event time-of-day (TIME field: 14:45:30.500)"
+                )
 
             if "WELSEGS" in schedule_text:
                 print("   ✓ WELSEGS keyword generated (MSW well segments)")

--- a/GrpcInterface/Python/rips/tests/test_well_events.py
+++ b/GrpcInterface/Python/rips/tests/test_well_events.py
@@ -309,6 +309,38 @@ class TestScheduleGeneration:
         assert "2024" in schedule_text, "Schedule should contain the event date"
         assert "WELSEGS" in schedule_text, "Schedule should contain MSW WELSEGS keyword"
 
+    def test_generate_schedule_preserves_time_of_day(self, project_with_case_and_well):
+        """Event timestamps with a time-of-day must be preserved in the exported DATES keyword (issue #14111)."""
+        project, case, timeline = project_with_case_and_well
+
+        # Get well path
+        well_paths = project.well_paths()
+        well_path_a = [wp for wp in well_paths if "A" in wp.name][0]
+
+        # Event date carrying an explicit, non-midnight time-of-day (ISO 8601).
+        timeline.add_perf_event(
+            event_date="2024-01-01T12:34:56.789",
+            well_path=well_path_a,
+            start_md=2000.0,
+            end_md=2200.0,
+            diameter=0.1,
+            skin_factor=0.5,
+            state="OPEN",
+        )
+
+        timeline.set_timestamp(timestamp="2024-12-31")
+
+        schedule_text = timeline.generate_schedule_text(
+            eclipse_case=case,
+            export_msw_for_wells=project.well_paths(),
+            first_date_as_comment=False,
+        )
+
+        assert "DATES" in schedule_text, "Schedule should contain DATES keyword"
+        assert "12:34:56.789" in schedule_text, (
+            "DATES keyword should preserve the event time-of-day with millisecond precision (TIME field)"
+        )
+
     def test_generate_schedule_with_control_events(self, project_with_case_and_well):
         """Test schedule generation with well control events and MSW."""
         project, case, timeline = project_with_case_and_well


### PR DESCRIPTION
The Event Timeline stores event timestamps with full time-of-day precision, but the exported SCHEDULE deck only emitted DAY/MONTH/YEAR in the DATES keyword, dropping any sub-day precision the user had set.

Emit the optional TIME field (HH:MM:SS[.SSS]) in datesKeyword() whenever the timestamp is non-midnight, formatting with millisecond precision when present. Date-only events keep their previous DAY/MONTH/YEAR-only output. The first-date comment in the schedule generator mirrors the same time so it stays consistent with the keyword.

Fixes #14111.