### PR TITLE
#14104 Store dialog size as plain width/height instead of binary geometry

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.cpp
@@ -105,7 +105,9 @@ QSize RiuPropertyViewTabWidget::minimumSizeHint() const
         maxSizeHint = maxSizeHint.expandedTo( pageSize );
     }
 
-    return maxSizeHint;
+    // The inner scroll area reports an artificially small minimum width, which lets some window
+    // managers open the dialog collapsed (issue #14104). Provide a sensible floor.
+    return maxSizeHint.expandedTo( QSize( 300, 150 ) );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -141,16 +143,27 @@ QDialogButtonBox* RiuPropertyViewTabWidget::dialogButtonBox()
 //--------------------------------------------------------------------------------------------------
 void RiuPropertyViewTabWidget::showEvent( QShowEvent* event )
 {
-    // Restore the stored size on first show. Doing this here rather than in the constructor ensures
-    // the geometry is applied reliably for a modal dialog and is not overridden by the initial sizing.
-    // When no size is stored, the size is left to sizeHint()/minimumSizeHint().
-    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "remember-dialog-size" ) && !m_geometryRestored )
+    // Let the base class perform its initial sizing first, so the dialog is associated with the
+    // screen it actually opens on before we adjust its size.
+    QDialog::showEvent( event );
+
+    if ( !m_geometryRestored )
     {
         m_geometryRestored = true;
-        restoreDialogGeometry();
-    }
 
-    QDialog::showEvent( event );
+        // Restore the stored size on first show. Doing this here rather than in the constructor
+        // ensures the size is applied reliably for a modal dialog and is not overridden by the
+        // initial sizing.
+        const bool restored = RiaPreferencesSystem::current()->isFeatureEnabled( "remember-dialog-size" ) && restoreDialogGeometry();
+        if ( !restored )
+        {
+            // No stored size: the dialog was laid out while associated with the screen it was built
+            // on, which on a multi-monitor setup can have a different DPI than the screen it ends up
+            // on. Recompute the layout for the current screen so the dialog is not shown collapsed
+            // (issue #14104). sizeHint()/minimumSizeHint() provide the floor.
+            adjustSize();
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPropertyViewTabWidget.cpp
@@ -174,19 +174,23 @@ QString RiuPropertyViewTabWidget::settingsKey() const
     QString title = m_windowTitle;
     title.replace( '/', '_' );
 
-    return QString( "RiuPropertyViewTabWidget/%1/%2/geometry" ).arg( m_objectClassKeyword, title );
+    return QString( "RiuPropertyViewTabWidget/%1/%2" ).arg( m_objectClassKeyword, title );
 }
 
 //--------------------------------------------------------------------------------------------------
-///
+/// Restore the dialog size from the stored width and height. Only the size is persisted; the window
+/// position is left to the window manager to avoid the off-screen/wrong-monitor problems that come
+/// with restoring an absolute position.
 //--------------------------------------------------------------------------------------------------
 bool RiuPropertyViewTabWidget::restoreDialogGeometry()
 {
     QSettings settings;
-    QVariant  geometry = settings.value( settingsKey() );
-    if ( geometry.isValid() )
+    QVariant  width  = settings.value( settingsKey() + "/width" );
+    QVariant  height = settings.value( settingsKey() + "/height" );
+    if ( width.isValid() && height.isValid() )
     {
-        return restoreGeometry( geometry.toByteArray() );
+        resize( width.toInt(), height.toInt() );
+        return true;
     }
 
     return false;
@@ -198,5 +202,6 @@ bool RiuPropertyViewTabWidget::restoreDialogGeometry()
 void RiuPropertyViewTabWidget::saveDialogGeometry()
 {
     QSettings settings;
-    settings.setValue( settingsKey(), saveGeometry() );
+    settings.setValue( settingsKey() + "/width", size().width() );
+    settings.setValue( settingsKey() + "/height", size().height() );
 }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
@@ -210,19 +210,23 @@ QString PdmUiPropertyViewDialog::settingsKey() const
 
     QString classKeyword = m_pdmObject ? m_pdmObject->classKeyword() : QString();
 
-    return QString( "PdmUiPropertyViewDialog/%1/%2/geometry" ).arg( classKeyword, id );
+    return QString( "PdmUiPropertyViewDialog/%1/%2" ).arg( classKeyword, id );
 }
 
 //--------------------------------------------------------------------------------------------------
-///
+/// Restore the dialog size from the stored width and height. Only the size is persisted; the window
+/// position is left to the window manager to avoid the off-screen/wrong-monitor problems that come
+/// with restoring an absolute position.
 //--------------------------------------------------------------------------------------------------
 bool PdmUiPropertyViewDialog::restoreDialogGeometry()
 {
     QSettings settings;
-    QVariant  geometry = settings.value( settingsKey() );
-    if ( geometry.isValid() )
+    QVariant  width  = settings.value( settingsKey() + "/width" );
+    QVariant  height = settings.value( settingsKey() + "/height" );
+    if ( width.isValid() && height.isValid() )
     {
-        return restoreGeometry( geometry.toByteArray() );
+        resize( width.toInt(), height.toInt() );
+        return true;
     }
 
     return false;
@@ -234,7 +238,8 @@ bool PdmUiPropertyViewDialog::restoreDialogGeometry()
 void PdmUiPropertyViewDialog::saveDialogGeometry()
 {
     QSettings settings;
-    settings.setValue( settingsKey(), saveGeometry() );
+    settings.setValue( settingsKey() + "/width", size().width() );
+    settings.setValue( settingsKey() + "/height", size().height() );
 }
 
 } // End of namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyViewDialog.cpp
@@ -152,17 +152,27 @@ void PdmUiPropertyViewDialog::setupUi()
 //--------------------------------------------------------------------------------------------------
 void PdmUiPropertyViewDialog::showEvent( QShowEvent* event )
 {
-    // Restore a previously stored size on first show. Restoring here rather than in the constructor
-    // ensures the geometry is applied reliably for a modal dialog and is not overridden by the initial
-    // sizing (see issue #14104). When no size is stored, the size is left to sizeHint()/minimumSizeHint()
-    // and any explicit resize() done by the caller, so the default appearance is preserved.
-    if ( sm_geometryPersistenceEnabled && !m_geometryRestored )
+    // Let the base class perform its initial sizing first, so the dialog is associated with the
+    // screen it actually opens on before we adjust its size.
+    QDialog::showEvent( event );
+
+    if ( !m_geometryRestored )
     {
         m_geometryRestored = true;
-        restoreDialogGeometry();
-    }
 
-    QDialog::showEvent( event );
+        // Restore a previously stored size on first show. Doing this here rather than in the
+        // constructor ensures the size is applied reliably for a modal dialog and is not overridden
+        // by the initial sizing (see issue #14104).
+        const bool restored = sm_geometryPersistenceEnabled && restoreDialogGeometry();
+        if ( !restored )
+        {
+            // No stored size: the dialog was laid out while associated with the screen it was built
+            // on, which on a multi-monitor setup can have a different DPI than the screen it ends up
+            // on. Recompute the layout for the current screen so the dialog is not shown collapsed
+            // (issue #14104). sizeHint()/minimumSizeHint() provide the floor.
+            adjustSize();
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses issue #14104, where the property export dialog opens too small, fails to remember a user-defined size, and can appear collapsed on multi-monitor setups.

## Changes

**1. Store dialog size as plain width/height instead of a binary blob**

Persisting the size of `PdmUiPropertyViewDialog` and `RiuPropertyViewTabWidget` previously used Qt's binary `saveGeometry()`/`restoreGeometry()` encoding, an opaque base64 blob tied to Qt's internal geometry-stream version that also captures window position and screen/DPI state. The size is now stored as plain integer `width` and `height` values in `QSettings`, restored with `resize()`:

- Values are human-readable in the INI/registry and not tied to the Qt geometry-stream version.
- Only the size is persisted; window position is left to the window manager, avoiding dialogs restored off-screen or on a disconnected monitor.

**2. Fix dialogs opening collapsed on multi-monitor setups**

Export dialogs that rely solely on `sizeHint()` (no explicit `resize()` by the caller) could open collapsed when shown on a screen whose DPI differs from the screen they were built on. `showEvent` now lets the base class do its initial sizing first, then calls `adjustSize()` when no stored size is restored, recomputing the layout for the screen the dialog actually opens on. `RiuPropertyViewTabWidget` also gets a minimum-size floor so the inner scroll area's artificially small minimum width cannot collapse the dialog.

The shared `QVerticalScrollArea` minimum width is intentionally left unchanged, since it is also used by the docked property editor panel where a small minimum is desirable.

## Notes

Size persistence remains gated behind the experimental "Remember Dialog Size" feature (disabled by default) introduced earlier. The multi-monitor DPI scenario should be verified manually on an actual dual-DPI configuration.

Closes #14104
