### PR TITLE
#11802 Suppress harmless Qt6 invalid-primaries QColorSpace warning

### DIFF
--- a/ApplicationExeCode/RiaMain.cpp
+++ b/ApplicationExeCode/RiaMain.cpp
@@ -38,6 +38,7 @@
 #include "cvfqtUtils.h"
 
 #include <QFile>
+#include <QtGlobal>
 
 #ifndef WIN32
 #include <sys/types.h>
@@ -50,6 +51,31 @@ void manageSegFailure( int signalCode );
 #ifndef WIN32
 void manageSegFailureSA( int signalCode, siginfo_t* info, void* ucontext );
 #endif
+
+namespace
+{
+QtMessageHandler g_previousMessageHandler = nullptr;
+
+//--------------------------------------------------------------------------------------------------
+/// Filter out a harmless Qt6 warning seen on some Linux platforms (e.g. RHEL8) where Qt validates an
+/// empty (all-zero) QColorSpacePrimaries and prints:
+///   "QColorSpace attempted constructed from invalid primaries: QPointF(0,0) ..."
+/// The message has no functional impact, so suppress it while forwarding everything else unchanged.
+/// See https://github.com/OPM/ResInsight/issues/11802
+//--------------------------------------------------------------------------------------------------
+void riaFilteredMessageHandler( QtMsgType type, const QMessageLogContext& context, const QString& msg )
+{
+    if ( msg.startsWith( QLatin1String( "QColorSpace attempted constructed from invalid primaries" ) ) )
+    {
+        return;
+    }
+
+    if ( g_previousMessageHandler )
+    {
+        g_previousMessageHandler( type, context, msg );
+    }
+}
+} // namespace
 
 RiaApplication* createApplication( int& argc, char* argv[] )
 {
@@ -83,6 +109,9 @@ int main( int argc, char* argv[] )
         return 1;
     }
 #endif
+
+    // Install a message handler to filter out a harmless Qt6 color-space warning (see #11802)
+    g_previousMessageHandler = qInstallMessageHandler( riaFilteredMessageHandler );
 
     RiaMainTools::deleteStaleSettingsLockFiles();
 


### PR DESCRIPTION
## Summary

Fixes #11802.

On some Linux platforms (e.g. Equinor's RHEL8), running ResInsight with Qt6 prints a noisy warning to the terminal:

```
QColorSpace attempted constructed from invalid primaries: QPointF(0,0) QPointF(0,0) QPointF(0,0) QPointF(0,0)
```

### Root cause

The message is emitted by Qt6 when it validates an empty, all-zero `QColorSpacePrimaries` (note all four points are `QPointF(0,0)` — a default-constructed struct, not a real-but-off color profile). The warning is purely cosmetic and has no functional impact.

### Change

Install a `QtMessageHandler` early in `main()` that suppresses this one specific message and forwards everything else to the previous handler unchanged. Low-risk: a single string-prefix match, with all other diagnostics preserved.