### PR TITLE
#14138 Fix crash when picking a cell with a combined MULT result

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp
@@ -66,6 +66,10 @@ double RigCombMultResultAccessor::cellScalar( size_t gridLocalCellIndex ) const
 //--------------------------------------------------------------------------------------------------
 double RigCombMultResultAccessor::cellFaceScalar( size_t gridLocalCellIndex, cvf::StructGridInterface::FaceType faceId ) const
 {
+    // A non-directional face (e.g. NO_FACE from a plain cell pick) has no neighbor multiplier to combine.
+    // Return 1.0, consistent with the "no change in MULT factor" convention used in nativeMultScalar.
+    if ( faceId == cvf::StructGridInterface::NO_FACE ) return 1.0;
+
     size_t i, j, k, neighborGridCellIdx;
     m_grid->ijkFromCellIndex( gridLocalCellIndex, &i, &j, &k );
 


### PR DESCRIPTION
Fixes #14138

### Problem

Picking a cell (not a specific cell face) in a view that displays a combined MULT result crashed ResInsight with an assertion failure in `cvf::StructGridInterface::oppositeFace()`.

`RiuResultTextBuilder::m_face` defaults to `NO_FACE` for a plain cell pick. This is passed into `RigCombMultResultAccessor::cellFaceScalar()`, which calls `oppositeFace(faceId)` on the neighbor. `oppositeFace()` has no case for `NO_FACE` and hits `CVF_ASSERT(false)`.

### Fix

Guard `RigCombMultResultAccessor::cellFaceScalar()` against a non-directional face: when `faceId == NO_FACE` there is no neighbor multiplier to combine, so return `1.0`, consistent with the existing "no change in MULT factor" convention in `nativeMultScalar()`.
