### PR TITLE
#14140 Eclipse: guard against out-of-range keyword occurrence crash

### DIFF
--- a/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
@@ -302,9 +302,16 @@ bool RifEclipseOutputFileTools::keywordData( const ecl_file_type* ecl_file,
 
 #pragma omp critical( critical_section_keywordData_double )
     {
-        ecl_kw_type* kwData = ecl_file_iget_named_kw( ecl_file,
-                                                      RiaStringEncodingTools::toNativeEncoded( keyword ).data(),
-                                                      static_cast<int>( fileKeywordOccurrence ) );
+        auto nativeKeyword = RiaStringEncodingTools::toNativeEncoded( keyword );
+
+        // Guard against out-of-range occurrence. ecl_file_iget_named_kw() performs an unchecked vector access and
+        // crashes (SIGSEGV) if the requested occurrence does not exist in the active file view.
+        ecl_kw_type* kwData = nullptr;
+        if ( static_cast<int>( fileKeywordOccurrence ) < ecl_file_get_num_named_kw( ecl_file, nativeKeyword.data() ) )
+        {
+            kwData = ecl_file_iget_named_kw( ecl_file, nativeKeyword.data(), static_cast<int>( fileKeywordOccurrence ) );
+        }
+
         if ( kwData )
         {
             size_t numValues = ecl_kw_get_size( kwData );
@@ -334,9 +341,16 @@ bool RifEclipseOutputFileTools::keywordData( const ecl_file_type* ecl_file,
 
 #pragma omp critical( critical_section_keywordData_int )
     {
-        ecl_kw_type* kwData = ecl_file_iget_named_kw( ecl_file,
-                                                      RiaStringEncodingTools::toNativeEncoded( keyword ).data(),
-                                                      static_cast<int>( fileKeywordOccurrence ) );
+        auto nativeKeyword = RiaStringEncodingTools::toNativeEncoded( keyword );
+
+        // Guard against out-of-range occurrence. ecl_file_iget_named_kw() performs an unchecked vector access and
+        // crashes (SIGSEGV) if the requested occurrence does not exist in the active file view.
+        ecl_kw_type* kwData = nullptr;
+        if ( static_cast<int>( fileKeywordOccurrence ) < ecl_file_get_num_named_kw( ecl_file, nativeKeyword.data() ) )
+        {
+            kwData = ecl_file_iget_named_kw( ecl_file, nativeKeyword.data(), static_cast<int>( fileKeywordOccurrence ) );
+        }
+
         if ( kwData )
         {
             size_t numValues = ecl_kw_get_size( kwData );

--- a/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp
@@ -240,7 +240,12 @@ bool RifEclipseUnifiedRestartFileAccess::results( const QString& resultName, siz
 
     for ( size_t i = 0; i < gridCount; i++ )
     {
-        ecl_file_select_block( m_ecl_file, INTEHEAD_KW, static_cast<int>( timeStep * ( gridCount + m_noDataGridCount ) + i ) );
+        // Skip the block when it cannot be selected (e.g. truncated/corrupt file or an unexpected grid/time step
+        // combination). Querying a stale active view could otherwise yield inconsistent keyword indices.
+        if ( !ecl_file_select_block( m_ecl_file, INTEHEAD_KW, static_cast<int>( timeStep * ( gridCount + m_noDataGridCount ) + i ) ) )
+        {
+            continue;
+        }
 
         int namedKeywordCount = ecl_file_get_num_named_kw( m_ecl_file, resultName.toLatin1().data() );
         for ( int iOcc = 0; iOcc < namedKeywordCount; iOcc++ )


### PR DESCRIPTION
Fixes #14140.

The crash is an out-of-bounds vector read inside libecl, triggered when `RifEclipseOutputFileTools::keywordData` requests a keyword occurrence that does not exist in the currently selected file block. `ecl_file_iget_named_kw()` indexes its internal `kw_index`/`kw_list` vectors with unchecked `operator[]`, so an out-of-range occurrence reads out of bounds and segfaults instead of failing safely.

This happens via the user-driven path of changing a cell-color result in the tree-selection editor, where a truncated/corrupt restart file or an unexpected grid/time-step combination leaves the active file view inconsistent with the requested occurrence.

Changes:

`RifEclipseOutputFileTools.cpp` - both `keywordData` overloads (double and int) now bounds-check the requested occurrence against `ecl_file_get_num_named_kw()` before calling `ecl_file_iget_named_kw()`. If out of range, `kwData` stays null and the existing guard handles it. The native-encoded keyword is computed once and reused.

`RifEclipseUnifiedRestartFileAccess.cpp` - `results()` now checks the previously ignored return value of `ecl_file_select_block()` and skips the block when selection fails, so a stale active view is not queried.

No changes to the vendored libecl.
