### PR TITLE
#14144 Guard against buffer overflow when reading corrupt well data records

### DIFF
--- a/ThirdParty/Ert/lib/ecl/fortio.c
+++ b/ThirdParty/Ert/lib/ecl/fortio.c
@@ -523,8 +523,10 @@ bool fortio_complete_read(fortio_type *fortio , int record_size) {
    bytes read; the function will return -1 on failure.
 */
 
-static int fortio_fread_record(fortio_type *fortio , char *buffer) {
+static int fortio_fread_record(fortio_type *fortio , char *buffer , int max_record_size) {
   int record_size = fortio_init_read(fortio);
+  if (record_size > max_record_size)
+    return -1;  /* Corrupt/inconsistent record header: would overflow buffer */
   if (record_size >= 0) {
     size_t items_read = fread(buffer , 1 , record_size , fortio->stream);
     if (items_read == record_size) {
@@ -552,7 +554,7 @@ bool fortio_fread_buffer(fortio_type * fortio, char * buffer , int buffer_size) 
 
   while (true) {
     char * buffer_ptr = &buffer[total_bytes_read];
-    int bytes_read = fortio_fread_record(fortio , buffer_ptr);
+    int bytes_read = fortio_fread_record(fortio , buffer_ptr , buffer_size - total_bytes_read);
 
     if (bytes_read < 0)
       break;


### PR DESCRIPTION
Fixes #14144

A truncated or corrupt restart (UNRST) file can contain a Fortran record-length header that is larger than the destination buffer allocated for the keyword being read. `fortio_fread_record` then performed `fread(buffer, 1, record_size, stream)` with no bound against the remaining buffer capacity, writing past the heap allocation and crashing (segfault in `fread` at `fortio.c:529`, reached while loading well connection data via `well_state_add_connections__`).

This bounds each record read to the remaining buffer capacity. `fortio_fread_record` now takes a `max_record_size` argument and returns `-1` (the existing failure path) if the on-disk record header claims more bytes than will fit. For valid files the record sizes always sum to exactly the buffer size, so each record fits in the remaining space and the new check never fires. EOF handling is unchanged. On a corrupt file the oversized read is now rejected before `fread`, propagating up through `ecl_kw_fread_data` as a normal failed read instead of corrupting the heap.
