### PR TITLE
#14146 Guard against degenerate viewport in scale legend tick generation

### DIFF
--- a/Fwk/AppFwk/cafVizExtensions/cafOverlayScaleLegend.cpp
+++ b/Fwk/AppFwk/cafVizExtensions/cafOverlayScaleLegend.cpp
@@ -755,6 +755,11 @@ void OverlayScaleLegend::updateFromCamera( const Camera* camera )
         tickMaxCount             = windowSize.y() / ( 2 * textSize.x() );
     }
 
+    // Guard against degenerate viewport/domain sizes. A zero tick count or a zero domain range along the
+    // relevant axis would produce a non-finite step size, triggering an assert in TickMarkGenerator.
+    if ( tickMaxCount <= 0 ) return;
+    if ( windowMaxInDomainValue == windowOrigoInDomainValue ) return;
+
     m_currentScale =
         ( windowMaxPointValue - windowOrigoPointValue ) / ( windowMaxInDomainValue - windowOrigoInDomainValue );
     minStepSizeInDomain = ( windowMaxInDomainValue - windowOrigoInDomainValue ) / tickMaxCount;


### PR DESCRIPTION
Fixes #14146

## Problem

ResInsight could crash with a `std::abort()` originating from `CAF_ASSERT( val >= 0.0 )` in `caf::TickMarkGenerator::roundUpToLog_1_2_5_10()` (`cafTickMarkGenerator.h:74`). The signal handler reported this as a segmentation fault during the paint cycle, via `OverlayScaleLegend::updateFromCamera()` → `RiuViewer::optimizeClippingPlanes()`.

## Root cause

In `OverlayScaleLegend::updateFromCamera()`:

- `tickMaxCount` is an `int` computed as `windowSize / (2 * textSize.x())`. For a tiny/degenerate viewport this rounds down to `0`.
- `minStepSizeInDomain = range / tickMaxCount` then becomes `inf` (range != 0) or `NaN` (range == 0 along the active axis).
- This non-finite value is passed to `TickMarkGenerator`, where `NaN >= 0.0` is false, so `CAF_ASSERT` fires and calls `std::abort()`.

The existing guard only checked full-vector equality of the window corners, so it missed both the `tickMaxCount == 0` case and the case where only the active axis (x or y) has zero range.

## Fix

Added two early-return guards in the caller, before the divisions, so degenerate viewport/domain geometry skips the legend update instead of producing a non-finite step size:

```cpp
if ( tickMaxCount <= 0 ) return;
if ( windowMaxInDomainValue == windowOrigoInDomainValue ) return;
```

This also prevents the divide-by-zero in the `m_currentScale` computation.
