### PR TITLE
#14150 Fix crash in replaceTemplateTextWithValues with data-derived values

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp
@@ -163,19 +163,43 @@ QStringList RiaTextStringTools::splitString( const QString& text, const QRegular
 //--------------------------------------------------------------------------------------------------
 QString RiaTextStringTools::replaceTemplateTextWithValues( const QString& templateText, const std::map<QString, QString>& valueMap )
 {
+    // Returns true if the character is part of a word (letter, digit or underscore), matching the default
+    // ASCII word-boundary semantics of QRegularExpression's \b.
+    auto isWordCharacter = []( QChar c ) -> bool
+    { return ( c >= 'a' && c <= 'z' ) || ( c >= 'A' && c <= 'Z' ) || ( c >= '0' && c <= '9' ) || c == '_'; };
+
     QString resolvedText = templateText;
 
-    // Use a regular expression to find all occurrences of ${key} in the text and replace with the value
+    // Replace all occurrences of each key with its value. A replacement is only performed when the key is
+    // followed by a word boundary, so that e.g. "$WELL" is not replaced inside "$WELL_BRANCH".
+    //
+    // The value is inserted as literal text. Using QString::replace() with a QRegularExpression is avoided
+    // on purpose, as the value can contain data-derived characters (backslash, '$', etc.) that would be
+    // interpreted as backreferences by the replacement engine.
 
     for ( const auto& [key, value] : valueMap )
     {
-        QString regexString = key;
-        regexString.replace( "$", "\\$" );
-        regexString += "\\b";
+        if ( key.isEmpty() ) continue;
 
-        QRegularExpression rx( regexString );
+        int searchFrom = 0;
+        while ( true )
+        {
+            const int pos = resolvedText.indexOf( key, searchFrom );
+            if ( pos < 0 ) break;
 
-        resolvedText.replace( rx, value );
+            const int  nextCharPos    = pos + key.length();
+            const bool atWordBoundary = nextCharPos >= resolvedText.length() || !isWordCharacter( resolvedText.at( nextCharPos ) );
+
+            if ( atWordBoundary )
+            {
+                resolvedText.replace( pos, key.length(), value );
+                searchFrom = pos + value.length();
+            }
+            else
+            {
+                searchFrom = nextCharPos;
+            }
+        }
     }
 
     return resolvedText;

--- a/ApplicationLibCode/UnitTests/RifTextDataTableFormatter-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifTextDataTableFormatter-Test.cpp
@@ -367,4 +367,36 @@ TEST( RifTextDataTableFormatter, ReplaceTokensInString )
 
         EXPECT_STREQ( resolvedText.toStdString().data(), "VALUE1, $KEY1_WITH_MORE_2" );
     }
+
+    {
+        // Values are inserted as literal text. Characters that have special meaning in a regular expression
+        // replacement (backslash followed by a digit, '$', etc.) must not be interpreted.
+        std::map<QString, QString> keyValues = {
+            { "$CASE", "C:\\data\\1stModel" },
+            { "$WELL", "Well $1 (B)" },
+        };
+
+        auto templateText = QString( "$CASE - $WELL" );
+        auto resolvedText = RiaTextStringTools::replaceTemplateTextWithValues( templateText, keyValues );
+
+        EXPECT_STREQ( resolvedText.toStdString().data(), "C:\\data\\1stModel - Well $1 (B)" );
+    }
+
+    {
+        // A value containing an invalid UTF-16 sequence (here a lone surrogate), inserted by one key, must
+        // not break replacement of a subsequent key. The previous regex based implementation fed such data
+        // through the regex engine and could crash or silently skip the replacement.
+        QString badValue;
+        badValue.append( QChar( 0xD83D ) ); // lone high surrogate (invalid UTF-16)
+
+        std::map<QString, QString> keyValues = {
+            { "$AIR_GAP", badValue },
+            { "$CASE", "MyCase" },
+        };
+
+        auto templateText = QString( "$AIR_GAP and $CASE" );
+        auto resolvedText = RiaTextStringTools::replaceTemplateTextWithValues( templateText, keyValues );
+
+        EXPECT_TRUE( resolvedText.endsWith( "MyCase" ) );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #14150, a segmentation fault with the stack trace pointing at `RiaTextStringTools::replaceTemplateTextWithValues` (`RiaTextStringTools.cpp:178`) during well log plot auto-naming.

## Root cause

The function built a regular expression per key (`\$CASE\b`, etc.) and used `QString::replace(QRegularExpression, value)` to insert each value. When a value inserted by an earlier key contained an invalid UTF-16 sequence (e.g. a lone surrogate from a data-derived case or well name), a later key's `globalMatch` ran the PCRE2 engine over the now-malformed subject, causing an out-of-bounds read and the crash.

## Fix

Replaced the regex-based substitution with a literal `indexOf`/`replace` loop that preserves the existing word-boundary behavior (so `$WELL` is not replaced inside `$WELL_BRANCH`). Values are never fed through the regex engine, and empty keys are skipped.

The change was verified against the original code: the new invalid-UTF-16 test case fails before the fix (the replacement is silently skipped / crashes inside PCRE2) and passes after.
