### PR TITLE
#14153 Guard against empty well path geometry in MSW cell segment generation

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp
@@ -708,7 +708,7 @@ std::vector<WellPathCellIntersectionInfo> RicWellPathExportMswTableData::generat
 
     const std::vector<cvf::Vec3d>& coords = wellPathGeometry->uniqueWellPathPoints();
     const std::vector<double>&     mds    = wellPathGeometry->uniqueMeasuredDepths();
-    CVF_ASSERT( !coords.empty() && !mds.empty() );
+    if ( coords.empty() || mds.empty() ) return {};
 
     const RigMainGrid* mainGrid = eclipseCase->mainGrid();
 


### PR DESCRIPTION
Fixes #14153

Exporting completions for visible well paths could abort the application via a `CVF_ASSERT` in `RicWellPathExportMswTableData::generateCellSegments`. The assert (`CVF_ASSERT( !coords.empty() && !mds.empty() )`) fires when a well path has a geometry object that exists but contains no unique well path points or measured depths, and the assert handler calls `abort()`, taking down the whole application.

This replaces the assert with a graceful early return of an empty intersection list, matching the two existing guards in the same function (missing geometry and empty intersections). Callers already handle an empty result: `computeIntitialMeasuredDepth` returns `0.0` for empty intersections and the downstream segment generation degrades gracefully.
