### PR TITLE
#14155 Fix crash in well allocation plot from mismatched iterators

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp
@@ -770,16 +770,18 @@ void RimWellAllocationOverTimePlot::setValidTimeStepRangeForCase()
         return;
     }
 
+    const std::vector<QDateTime> caseTimeStepDates = m_case->timeStepDates();
+
     auto isTimeStepInCase = [&]( const QDateTime timeStep ) -> bool
-    { return std::find( m_case->timeStepDates().cbegin(), m_case->timeStepDates().cend(), timeStep ) != m_case->timeStepDates().cend(); };
+    { return std::find( caseTimeStepDates.cbegin(), caseTimeStepDates.cend(), timeStep ) != caseTimeStepDates.cend(); };
     if ( m_selectedFromTimeStep().isValid() && isTimeStepInCase( m_selectedFromTimeStep() ) && m_selectedToTimeStep().isValid() &&
          isTimeStepInCase( m_selectedToTimeStep() ) )
     {
         return;
     }
 
-    m_selectedFromTimeStep = m_case->timeStepDates().front();
-    m_selectedToTimeStep   = m_case->timeStepDates().back();
+    m_selectedFromTimeStep = caseTimeStepDates.front();
+    m_selectedToTimeStep   = caseTimeStepDates.back();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp
@@ -1006,7 +1006,8 @@ bool RimWellConnectivityTable::isTimeStepInCase( const QDateTime& timeStep ) con
 {
     if ( !m_case ) return false;
 
-    return std::find( m_case->timeStepDates().cbegin(), m_case->timeStepDates().cend(), timeStep ) != m_case->timeStepDates().cend();
+    const std::vector<QDateTime> caseTimeStepDates = m_case->timeStepDates();
+    return std::find( caseTimeStepDates.cbegin(), caseTimeStepDates.cend(), timeStep ) != caseTimeStepDates.cend();
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #14155

## Problem

`RimCase::timeStepDates()` returns `std::vector<QDateTime>` **by value**. The lambda in `setValidTimeStepRangeForCase()` called `cbegin()` and `cend()` in separate invocations:

```cpp
std::find( m_case->timeStepDates().cbegin(), m_case->timeStepDates().cend(), timeStep )
```

Each call builds and destroys a separate temporary vector, so `cbegin()` and `cend()` point into two different (already-destroyed) buffers. Passing mismatched iterators to `std::find` is undefined behavior: `first` never reaches `last`, so it walks off freed memory and segfaults inside the lambda, as seen in the stacktrace.

## Fix

Snapshot `timeStepDates()` into a single local vector and use its iterators. The identical pattern in `RimWellConnectivityTable::isTimeStepInCase()` was fixed the same way.