### PR TITLE
#14007 Contour Map: reset projection for all result types on case reload

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
@@ -148,15 +148,13 @@ void RimReloadCaseTools::updateAll3dViews( RimEclipseCase* eclipseCase )
     {
         CVF_ASSERT( contourMap );
 
-        if ( contourMap->cellResult()->resultType() == RiaDefines::ResultCatType::GENERATED )
-        {
-            // When a generated result is selected, the data might come from a calculation. Make sure that all
-            // computations are updated based on new data.
-            // See RimEclipseContourMapProjection::generateResults()
-            contourMap->contourMapProjection()->clearGeometry();
-            if ( auto projection = dynamic_cast<RimEclipseContourMapProjection*>( contourMap->contourMapProjection() ) )
-                projection->clearGridMappingAndRedraw();
-        }
+        // Reloading the grid file destroys and recreates RigEclipseCaseData, including the RigCaseCellResultsData
+        // that the contour map projection caches by raw pointer. The cached grid mapping and result data are only
+        // refreshed when the projection is rebuilt, so reset it here to avoid dereferencing the freed case data on
+        // the next redraw. See RimEclipseContourMapProjection::updateGridInformation() and generateResults().
+        contourMap->contourMapProjection()->clearGeometry();
+        if ( auto projection = dynamic_cast<RimEclipseContourMapProjection*>( contourMap->contourMapProjection() ) )
+            projection->clearGridMappingAndRedraw();
 
         contourMap->loadDataAndUpdate();
         contourMap->updateGridBoxData();


### PR DESCRIPTION
Fixes #14007

Reloading an Eclipse grid file destroys and recreates `RigEclipseCaseData` and its `RigCaseCellResultsData`. The contour map projection caches raw pointers to this case data in `RimEclipseContourMapProjection::updateGridInformation()` and only refreshes them when the projection is rebuilt. Previously `RimReloadCaseTools::updateAll3dViews()` reset the projection on reload only when a `GENERATED` result was selected, so for any other result type the next scheduled redraw dereferenced the freed `RigCaseCellResultsData` in `generateResults`, crashing in `hasResultEntry` (a `std::map<QString, QString>` lookup on freed memory).

This resets the grid mapping for all contour map views on reload so fresh case data pointers are captured before the redraw. A null guard does not help here because the cached pointer is non-null but dangling.
