### PR TITLE
#14148 Combined Filter: add delete context menu item

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimCombinedFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimCombinedFilter.cpp
@@ -46,6 +46,7 @@ RimCombinedFilter::RimCombinedFilter()
     CAF_PDM_InitScriptableObject( "Combined Filter", ":/CellFilter.png" );
 
     setName( "Combined Filter" );
+    setDeletable( true );
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_filters, "Filters", "Filters" );
     caf::PdmFieldReorderCapability::addToField( &m_filters );

--- a/ApplicationLibCode/UnitTests/RimDataFilterCollection-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimDataFilterCollection-Test.cpp
@@ -172,6 +172,9 @@ TEST( RimDataFilterCollection, addNewCombinedFilterReturnsEmpty )
     ASSERT_NE( nullptr, combined );
     EXPECT_EQ( size_t{ 1 }, coll.count() );
     EXPECT_TRUE( combined->filters().empty() );
+
+    // A combined filter must be deletable so the generic delete context-menu item is offered (#14148).
+    EXPECT_TRUE( combined->isDeletable() );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The combined filter node had no Delete entry in its right-click menu. The generic RicDeleteItemFeature only enables when isDeletable() is true, which defaults to false; every other cell filter opts in via setDeletable(true) in its constructor, but RimCombinedFilter omitted it. Add the call so the Delete item is offered, and assert it in the unit test.

Fixes #14148.