### PR TITLE
#14161 Fix crash in sim well centerline from null eclipse case

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp
@@ -129,6 +129,8 @@ void RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline( c
 
     auto eclipseView = rimWell->firstAncestorOrThisOfTypeAsserted<RimEclipseView>();
 
+    if ( !eclipseView->eclipseCase() || !eclipseView->eclipseCase()->eclipseCaseData() ) return;
+
     RigEclipseCaseData* eclipseCaseData      = eclipseView->eclipseCase()->eclipseCaseData();
     bool                isAutoDetectBranches = eclipseView->wellCollection()->isAutoDetectingBranches();
 


### PR DESCRIPTION
Fixes #14161

## Root cause

`RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline` dereferenced `eclipseView->eclipseCase()` without a null check:

```cpp
RigEclipseCaseData* eclipseCaseData = eclipseView->eclipseCase()->eclipseCaseData();
```

When the view's eclipse case is null, calling the member function `eclipseCaseData()` on the null `RimEclipseCase*` segfaults. This is reached during a timestep frame change that redraws simulation well pipes (`RiuViewer::setCurrentFrame` -> `RimEclipseView::onUpdateDisplayModelForCurrentTimeStep` -> `RivSimWellPipesPartMgr::buildWellPipeParts`).

## Fix

Added the same null guard already used by the sibling method `RimSimWellInView::wellHeadTopBottomPosition`:

```cpp
if ( !eclipseView->eclipseCase() || !eclipseView->eclipseCase()->eclipseCaseData() ) return;
```

Returning early leaves the branch output vectors empty, which all callers already handle gracefully (no pipe geometry is drawn) — the correct behavior when there is no case data.