### PR TITLE
#14168 Fix crash creating grid statistics plot for result without statistics cache entry

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimHistogramCalculator.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimHistogramCalculator.cpp
@@ -252,7 +252,7 @@ RigHistogramData RimHistogramCalculator::histogramData( RimEclipseView*         
     {
         RigEclipseResultAddress eclResAddr  = eclResultDefinition->eclipseResultAddress();
         RigCaseCellResultsData* cellResults = eclResultDefinition->currentGridCellResults();
-        if ( cellResults && eclResAddr.isValid() )
+        if ( cellResults && eclResAddr.isValid() && cellResults->hasResultEntry( eclResAddr ) )
         {
             if ( timeRange == StatisticsTimeRangeType::ALL_TIMESTEPS )
             {


### PR DESCRIPTION
Fixes #14168

Creating a grid statistics plot from a 3D view context menu could abort the application. When the view's currently displayed result has an address that is valid by name but is not present in the case result cache, `findScalarResultIndexFromAddress` returned `UNDEFINED_SIZE_T`, and `RigCaseCellResultsData::statistics()` was then indexed out of range, tripping the `CAF_ASSERT` (which calls `std::abort()` and is reported through the crash handler).

The all-cells branch in `RimHistogramCalculator::histogramData` only checked `eclResAddr.isValid()`, which verifies the address has a name and category but does not verify the result is actually loaded as a statistics-cache entry. The branch now also requires `cellResults->hasResultEntry( eclResAddr )`, so an empty histogram is produced (and filtered out downstream by `isHistogramVectorValid()`) instead of aborting.
