### PR TITLE
#14007 Contour Map: rebuild projection when cached case data is stale

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp
@@ -135,7 +135,7 @@ void RimContourMapProjection::generateResultsIfNecessary( int timeStep )
 {
     caf::ProgressInfo progress( 100, "Generate Results", true );
 
-    if ( !m_contourMapGrid || !m_contourMapProjection ) updateGridInformation();
+    if ( !m_contourMapGrid || !m_contourMapProjection || gridInformationIsStale() ) updateGridInformation();
 
     progress.setProgress( 10 );
 
@@ -408,6 +408,14 @@ bool RimContourMapProjection::gridMappingNeedsUpdating() const
         if ( ( *currentVisibility )[i] != ( *cellGridIdxVisibility )[i] ) return true;
     }
 
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimContourMapProjection::gridInformationIsStale() const
+{
     return false;
 }
 

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.h
@@ -135,6 +135,11 @@ protected:
 
     virtual bool gridMappingNeedsUpdating() const;
 
+    // Returns true when the cached grid information (e.g. raw pointers into the owning case) is no longer valid and
+    // the projection must be rebuilt via updateGridInformation(). Default is false; overridden where the projection
+    // caches data that can be invalidated by a case reload.
+    virtual bool gridInformationIsStale() const;
+
 private:
     bool                                     resultsNeedsUpdating( int timeStep ) const;
     bool                                     geometryNeedsUpdating() const;

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp
@@ -258,6 +258,23 @@ void RimEclipseContourMapProjection::updateGridInformation()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RimEclipseContourMapProjection::gridInformationIsStale() const
+{
+    auto* projection = dynamic_cast<const RigEclipseContourMapProjection*>( m_contourMapProjection.get() );
+    if ( !projection ) return false;
+
+    RimEclipseCase* eclipseCase = this->eclipseCase();
+    if ( !eclipseCase ) return false;
+
+    // Reloading the grid file frees and recreates RigEclipseCaseData. The projection caches raw pointers into the
+    // case data captured in updateGridInformation(), so a mismatch means those pointers are dangling and the
+    // projection must be rebuilt before they are dereferenced in generateResults().
+    return projection->eclipseCaseData() != eclipseCase->eclipseCaseData();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<double> RimEclipseContourMapProjection::retrieveParameterWeights()
 {
     std::vector<double> weights;

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.h
@@ -57,6 +57,7 @@ public:
 
 protected:
     void                updateGridInformation() override;
+    bool                gridInformationIsStale() const override;
     std::vector<double> retrieveParameterWeights() override;
     std::vector<double> generateResults( int timeStep ) const override;
     void                generateAndSaveResults( int timeStep ) override;

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp
@@ -71,6 +71,14 @@ void RigEclipseContourMapProjection::updateRealizationData( RigActiveCellInfo* a
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+const RigEclipseCaseData* RigEclipseContourMapProjection::eclipseCaseData() const
+{
+    return m_eclipseCaseData;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RigEclipseContourMapProjection::generateAndSaveResults( const RigEclipseResultAddress&                 resultAddress,
                                                              RigContourMapCalculator::ResultAggregationType resultAggregation,
                                                              int                                            timeStep,

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.h
@@ -68,6 +68,11 @@ public:
 
     void updateRealizationData( RigActiveCellInfo* activeCellInfo, RigCaseCellResultsData* resultData );
 
+    // The case data this projection cached its raw pointers from. Used to detect when the owning case has been
+    // reloaded (RigEclipseCaseData freed and recreated) so the projection can be rebuilt before the stale pointers
+    // are dereferenced.
+    const RigEclipseCaseData* eclipseCaseData() const;
+
     std::vector<bool> getMapCellVisibility( int viewStepIndex, RigContourMapCalculator::ResultAggregationType resultAggregation ) override;
     bool              isCellActive( size_t globalCellIdx ) const override;
 


### PR DESCRIPTION
## Problem

Reloading an Eclipse grid file destroys and recreates `RigEclipseCaseData` (and its `RigCaseCellResultsData`). The contour map projection caches raw pointers into the case data in `RigEclipseContourMapProjection`, captured once in `RimEclipseContourMapProjection::updateGridInformation()`.

`#14007` reset these projections on reload, but only inside `RimReloadCaseTools::updateAll3dViews()`. Callers of `RimEclipseCase::reloadEclipseGridFile()` that bypass `updateAll3dViews()` — notably `RimOpmFlowJob::onCompleted()` — leave the projection holding dangling pointers. The next animation frame change then dereferences the freed `RigCaseCellResultsData` in `generateResults` → `hasResultEntry`, crashing.

## Fix

Make the projection self-healing instead of relying on every reload path to remember to invalidate it. `RigEclipseContourMapProjection` now exposes the `RigEclipseCaseData*` it was built from, and `RimContourMapProjection::generateResultsIfNecessary()` rebuilds via `updateGridInformation()` when a new virtual `gridInformationIsStale()` reports that the cached case data no longer matches the current case:

```cpp
if ( !m_contourMapGrid || !m_contourMapProjection || gridInformationIsStale() )
    updateGridInformation();
```

The eclipse override returns `true` when `projection->eclipseCaseData() != eclipseCase()->eclipseCaseData()`, so the stale pointers are refreshed before they are ever dereferenced. This covers all reload paths, including ones not routed through `updateAll3dViews()`.

The default base implementation returns `false`, so statistics and GeoMech projections are unaffected. The existing `#14007` reset in `updateAll3dViews()` is left in place to keep driving the prompt redraw after a normal reload.
