### PR TITLE
#14172 Fix crash in 3D well target editor from null parent well geometry

### DIFF
--- a/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicWellTarget3dEditor.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicWellTarget3dEditor.cpp
@@ -125,17 +125,19 @@ void RicWellTarget3dEditor::configureAndUpdateUi( const QString& uiConfigName )
         {
             if ( auto parentWellPath = wellPath->wellPathTieIn()->parentWell() )
             {
-                auto geo    = parentWellPath->wellPathGeometry();
-                auto points = geo->wellPathPoints();
-
-                for ( auto& p : points )
+                if ( auto geo = parentWellPath->wellPathGeometry() )
                 {
-                    p = dispXf->transformToDisplayCoord( p );
-                }
+                    auto points = geo->wellPathPoints();
 
-                // For the first target of a lateral, use the coordinates from the parent well as snap-to locations for
-                // the 3D manipulator sphere
-                m_manipulator->setPolyline( points );
+                    for ( auto& p : points )
+                    {
+                        p = dispXf->transformToDisplayCoord( p );
+                    }
+
+                    // For the first target of a lateral, use the coordinates from the parent well as snap-to locations
+                    // for the 3D manipulator sphere
+                    m_manipulator->setPolyline( points );
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #14172

## Summary

Guards against a null `wellPathGeometry()` in `RicWellTarget3dEditor::configureAndUpdateUi`. When configuring the 3D well target editor for the first target of a lateral, the parent well's geometry was dereferenced (`geo->wellPathPoints()`) without a null check. The parent-well pointer can be non-null while its geometry is not yet available, causing a null dereference when copying the points vector — matching the reported stacktrace bottoming out in `std::vector<cvf::Vec3d>::size()`.

This is the same class of issue as the recent `#14121` null `wellPathGeometry()` guarding; this spot was not previously covered.
