### PR TITLE
#14174 Fix crash when creating Correlation Report Plot

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
@@ -371,13 +371,19 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToReport( Rim
         plot->correlationPlot()->setCurveDefinitions( curveDefsTornadoAndCrossPlot );
         plot->crossPlot()->setCurveDefinitions( curveDefsTornadoAndCrossPlot );
 
-        time_t timeStep = *( plot->matrixPlot()->allAvailableTimeSteps().rbegin() );
-        auto   correlationSortedEnsembleParameters =
-            ensembles.front()->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
-        if ( !correlationSortedEnsembleParameters.empty() )
+        auto availableTimeSteps = plot->matrixPlot()->allAvailableTimeSteps();
+        if ( availableTimeSteps.empty() ) return;
+
+        time_t timeStep = *( availableTimeSteps.rbegin() );
+        if ( !curveDefsTornadoAndCrossPlot.empty() )
         {
-            QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
-            plot->crossPlot()->setEnsembleParameter( crossPlotEnsembleParameterName );
+            auto correlationSortedEnsembleParameters =
+                ensembles.front()->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
+            if ( !correlationSortedEnsembleParameters.empty() )
+            {
+                QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
+                plot->crossPlot()->setEnsembleParameter( crossPlotEnsembleParameterName );
+            }
         }
         plot->matrixPlot()->setTimeStep( timeStep );
     }
@@ -418,10 +424,16 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToReport( RimCor
         plot->crossPlot()->setCurveDefinitions( curveDefsTornadoAndCrossPlot );
         plot->crossPlot()->setTimeStep( timeStep );
 
-        auto correlationSortedEnsembleParameters =
-            ensemble->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
-        QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
-        plot->crossPlot()->setEnsembleParameter( crossPlotEnsembleParameterName );
+        if ( !curveDefsTornadoAndCrossPlot.empty() )
+        {
+            auto correlationSortedEnsembleParameters =
+                ensemble->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
+            if ( !correlationSortedEnsembleParameters.empty() )
+            {
+                QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
+                plot->crossPlot()->setEnsembleParameter( crossPlotEnsembleParameterName );
+            }
+        }
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
@@ -375,16 +375,7 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToReport( Rim
         if ( availableTimeSteps.empty() ) return;
 
         time_t timeStep = *( availableTimeSteps.rbegin() );
-        if ( !curveDefsTornadoAndCrossPlot.empty() )
-        {
-            auto correlationSortedEnsembleParameters =
-                ensembles.front()->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
-            if ( !correlationSortedEnsembleParameters.empty() )
-            {
-                QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
-                plot->crossPlot()->setEnsembleParameter( crossPlotEnsembleParameterName );
-            }
-        }
+        applyBestCorrelatedParameterToCrossPlot( plot->crossPlot(), ensembles.front(), curveDefsTornadoAndCrossPlot, timeStep );
         plot->matrixPlot()->setTimeStep( timeStep );
     }
 }
@@ -424,17 +415,26 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToReport( RimCor
         plot->crossPlot()->setCurveDefinitions( curveDefsTornadoAndCrossPlot );
         plot->crossPlot()->setTimeStep( timeStep );
 
-        if ( !curveDefsTornadoAndCrossPlot.empty() )
-        {
-            auto correlationSortedEnsembleParameters =
-                ensemble->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
-            if ( !correlationSortedEnsembleParameters.empty() )
-            {
-                QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
-                plot->crossPlot()->setEnsembleParameter( crossPlotEnsembleParameterName );
-            }
-        }
+        applyBestCorrelatedParameterToCrossPlot( plot->crossPlot(), ensemble, curveDefsTornadoAndCrossPlot, timeStep );
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationPlotCollection::applyBestCorrelatedParameterToCrossPlot( RimParameterResultCrossPlot* crossPlot,
+                                                                            RimSummaryEnsemble*          ensemble,
+                                                                            const std::vector<RiaSummaryCurveDefinition>& curveDefsTornadoAndCrossPlot,
+                                                                            std::time_t timeStep )
+{
+    if ( curveDefsTornadoAndCrossPlot.empty() ) return;
+
+    auto correlationSortedEnsembleParameters =
+        ensemble->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
+    if ( correlationSortedEnsembleParameters.empty() ) return;
+
+    QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
+    crossPlot->setEnsembleParameter( crossPlotEnsembleParameterName );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
@@ -33,6 +33,27 @@
 
 CAF_PDM_SOURCE_INIT( RimCorrelationPlotCollection, "CorrelationPlotCollection" );
 
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void applyBestCorrelatedParameterToCrossPlot( RimParameterResultCrossPlot*                  crossPlot,
+                                              RimSummaryEnsemble*                           ensemble,
+                                              const std::vector<RiaSummaryCurveDefinition>& curveDefsTornadoAndCrossPlot,
+                                              std::time_t                                   timeStep )
+{
+    if ( curveDefsTornadoAndCrossPlot.empty() ) return;
+
+    auto correlationSortedEnsembleParameters =
+        ensemble->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
+    if ( correlationSortedEnsembleParameters.empty() ) return;
+
+    QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
+    crossPlot->setEnsembleParameter( crossPlotEnsembleParameterName );
+}
+} // namespace
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -417,24 +438,6 @@ void RimCorrelationPlotCollection::applyEnsembleFieldAndTimeStepToReport( RimCor
 
         applyBestCorrelatedParameterToCrossPlot( plot->crossPlot(), ensemble, curveDefsTornadoAndCrossPlot, timeStep );
     }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimCorrelationPlotCollection::applyBestCorrelatedParameterToCrossPlot( RimParameterResultCrossPlot* crossPlot,
-                                                                            RimSummaryEnsemble*          ensemble,
-                                                                            const std::vector<RiaSummaryCurveDefinition>& curveDefsTornadoAndCrossPlot,
-                                                                            std::time_t timeStep )
-{
-    if ( curveDefsTornadoAndCrossPlot.empty() ) return;
-
-    auto correlationSortedEnsembleParameters =
-        ensemble->correlationSortedEnsembleParameters( curveDefsTornadoAndCrossPlot.front().summaryAddressY(), timeStep );
-    if ( correlationSortedEnsembleParameters.empty() ) return;
-
-    QString crossPlotEnsembleParameterName = correlationSortedEnsembleParameters.front().first.name;
-    crossPlot->setEnsembleParameter( crossPlotEnsembleParameterName );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.h
@@ -27,6 +27,7 @@
 #include <ctime>
 #include <vector>
 
+class RiaSummaryCurveDefinition;
 class RimCorrelationPlot;
 class RimCorrelationMatrixPlot;
 class RimCorrelationReportPlot;
@@ -94,6 +95,11 @@ private:
                                                 const std::vector<QString>& matrixQuantityNames,
                                                 const QString&              tornadoAndCrossPlotQuantityName,
                                                 std::time_t                 timeStep );
+
+    static void applyBestCorrelatedParameterToCrossPlot( RimParameterResultCrossPlot*                  crossPlot,
+                                                         RimSummaryEnsemble*                           ensemble,
+                                                         const std::vector<RiaSummaryCurveDefinition>& curveDefsTornadoAndCrossPlot,
+                                                         std::time_t                                   timeStep );
 
 private:
     caf::PdmChildArrayField<RimAbstractCorrelationPlot*>  m_correlationPlots;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.h
@@ -27,7 +27,6 @@
 #include <ctime>
 #include <vector>
 
-class RiaSummaryCurveDefinition;
 class RimCorrelationPlot;
 class RimCorrelationMatrixPlot;
 class RimCorrelationReportPlot;
@@ -95,11 +94,6 @@ private:
                                                 const std::vector<QString>& matrixQuantityNames,
                                                 const QString&              tornadoAndCrossPlotQuantityName,
                                                 std::time_t                 timeStep );
-
-    static void applyBestCorrelatedParameterToCrossPlot( RimParameterResultCrossPlot*                  crossPlot,
-                                                         RimSummaryEnsemble*                           ensemble,
-                                                         const std::vector<RiaSummaryCurveDefinition>& curveDefsTornadoAndCrossPlot,
-                                                         std::time_t                                   timeStep );
 
 private:
     caf::PdmChildArrayField<RimAbstractCorrelationPlot*>  m_correlationPlots;


### PR DESCRIPTION
Fixes #14174

## Problem
Creating a new Correlation Report Plot could crash with a segfault in `RiaSummaryCurveDefinition::summaryAddressY()`.

`createCorrelationReportPlot(true)` calls `applyFirstEnsembleFieldAddressesToReport(report, {"FOPT","FWPT","FGPT"}, "FOPT")`. The tornado/cross-plot curve definitions are only populated from addresses matching `"FOPT"`. If the first ensemble in the project has no `FOPT` summary vector, that vector stays empty, and the subsequent unconditional `curveDefsTornadoAndCrossPlot.front().summaryAddressY()` dereferences invalid memory.

## Fix
In `RimCorrelationPlotCollection`:
- Only compute the best-correlated cross-plot parameter when `curveDefsTornadoAndCrossPlot` is non-empty.
- Guard against an empty `allAvailableTimeSteps()` set before dereferencing `rbegin()`.
- Apply the same guards to the symmetric `applyEnsembleFieldAndTimeStepToReport` path, which additionally called `.front()` on `correlationSortedEnsembleParameters` without an empty check.

The matrix plot still receives its curve definitions and time step; only the optional cross-plot parameter pre-selection is skipped when there is no matching vector — degrading gracefully instead of crashing.