### PR TITLE
#14175 Summary: Fix crash when deleting summary ensemble

### DIFF
--- a/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp
+++ b/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp
@@ -122,12 +122,19 @@ void RicDeleteSummaryCaseCollectionFeature::onActionTriggered( bool isChecked )
     {
         summaryCaseMainCollection->removeEnsemble( ensemble );
         ensemble->cleanupBeforeDelete();
+    }
+
+    // Rebuild the tree and connected editors while the detached ensembles are still alive, so no tree item
+    // editor ends up referencing freed objects during the update (see caf::CmdDeleteItemExec for the same
+    // ordering). Deleting the ensembles before the tree update caused a use-after-free crash.
+    summaryCaseMainCollection->updateConnectedEditors();
+
+    for ( RimSummaryEnsemble* ensemble : ensembles )
+    {
         delete ensemble;
     }
 
     RimWellPlotTools::loadDataAndUpdateDepthTrackPlots( depthTrackPlots );
-
-    summaryCaseMainCollection->updateConnectedEditors();
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #14175.

## Problem

Deleting a summary case group/ensemble could crash with heap corruption (`_int_free` → `abort`) during tree teardown:

```
[10] caf::PdmUiEditorHandle::~PdmUiEditorHandle()
[11] caf::PdmUiTreeItemEditor::~PdmUiTreeItemEditor()
[12] caf::PdmUiTreeOrdering::~PdmUiTreeOrdering()
[17] caf::PdmUiTreeOrdering::removeChildren(int, int)
[18] caf::PdmUiTreeViewQModel::updateSubTreeRecursive(...)
[22] caf::PdmUiItem::updateConnectedEditors() const
[23] RicDeleteSummaryCaseCollectionFeature::onActionTriggered(bool)
```

`RicDeleteSummaryCaseCollectionFeature::onActionTriggered` deleted the ensemble objects before rebuilding the project tree. When `updateConnectedEditors()` then tore down the stale tree subtree, a `PdmUiTreeItemEditor` was destroyed whose `m_pdmItem` still pointed at a freed `PdmUiItem`, so `~PdmUiEditorHandle` called `removeFieldEditor(this)` on freed memory.

## Fix

Reorder to match the proven-safe pattern in `caf::CmdDeleteItemExec::redo()`: detach the ensembles, rebuild the connected editors while the objects are still alive, then delete. The tree item editors now unregister from live objects during the update, so nothing dangling remains when the ensembles are finally freed.
