### PR TITLE
#14178 Fix crash in slider editor from re-entrant field write

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp
@@ -151,7 +151,14 @@ QWidget* PdmUiSliderEditor::createEditorWidget( QWidget* parent )
 //--------------------------------------------------------------------------------------------------
 void PdmUiSliderEditor::slotSliderValueChanged( int position )
 {
-    m_spinBox->setValue( position );
+    if ( m_spinBox )
+    {
+        // Block signals to avoid re-entering slotSpinBoxValueChanged(), which would write to the
+        // field a second time and may tear down this editor's widgets while we are still executing.
+        bool wasBlocked = m_spinBox->blockSignals( true );
+        m_spinBox->setValue( position );
+        m_spinBox->blockSignals( wasBlocked );
+    }
 
     writeValueToField();
 }
@@ -171,6 +178,8 @@ void PdmUiSliderEditor::slotSpinBoxValueChanged( int spinBoxValue )
 //--------------------------------------------------------------------------------------------------
 void PdmUiSliderEditor::updateSliderPosition()
 {
+    if ( m_spinBox.isNull() || m_slider.isNull() ) return;
+
     QString textValue = m_spinBox->text();
 
     bool convertOk      = false;
@@ -178,7 +187,12 @@ void PdmUiSliderEditor::updateSliderPosition()
     if ( convertOk )
     {
         newSliderValue = qBound( m_attributes.m_minimum, newSliderValue, m_attributes.m_maximum );
+
+        // Block signals to avoid re-entering slotSliderValueChanged(), which would write to the
+        // field a second time and may tear down this editor's widgets while we are still executing.
+        bool wasBlocked = m_slider->blockSignals( true );
         m_slider->setValue( newSliderValue );
+        m_slider->blockSignals( wasBlocked );
     }
 }
 
@@ -187,6 +201,8 @@ void PdmUiSliderEditor::updateSliderPosition()
 //--------------------------------------------------------------------------------------------------
 void PdmUiSliderEditor::writeValueToField()
 {
+    if ( m_spinBox.isNull() ) return;
+
     QString  textValue = m_spinBox->text();
     QVariant v;
     v = textValue;


### PR DESCRIPTION
@
Fixes #14178.

## Root cause

The integer `PdmUiSliderEditor` cross-updates the spin box and slider, but did not block signals while doing so. A single user interaction (e.g. clicking the spin box step arrow) therefore wrote to the PDM field **twice**:

```
slotSpinBoxValueChanged()
  updateSliderPosition() -> m_slider->setValue()   // emits valueChanged
    slotSliderValueChanged() -> writeValueToField() // WRITE #1 (nested)
                                                     //   may rebuild the property panel and
                                                     //   destroy the spin box internal QLineEdit
  writeValueToField()                                // WRITE #2 -> m_spinBox->text()
                                                     //   dereferences the dangling line edit -> crash
```

The crash in the stack trace is `QAbstractSpinBox::text()` -> `lineEdit()->displayText()` on a line edit that was destroyed during the nested write.

## Fix

- Block the other widget signals while programmatically syncing in `slotSliderValueChanged` and `updateSliderPosition`, so the field is written exactly once per interaction. The previous blocked state is saved and restored so it nests safely with `configureAndUpdateUi`, which already blocks slider signals.
- Add null guards in `updateSliderPosition` and `writeValueToField`.
@