### PR TITLE
#14179 Fix crash building cell search tree for LGR-heavy grids

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -858,8 +858,12 @@ std::vector<size_t> RigMainGrid::findIntersectingCells( const cvf::BoundingBox& 
 void RigMainGrid::doBuildCellSearchTree( std::string* aabbTreeInfo ) const
 {
     const double maxNumberOfLeafNodes = 4000000;
-    const double factor               = std::ceil( cellCount() / maxNumberOfLeafNodes );
-    const size_t cellsPerBoundingBox  = std::max( size_t( 1 ), static_cast<size_t>( factor ) );
+    // Use the total cell count (including LGR cells) when deciding the number of cells per bounding box.
+    // The non-optimized buildCellSearchTree() creates one leaf per cell across totalCellCount(), so basing
+    // the threshold on the main grid cell count only can route LGR-heavy grids into that path and exhaust
+    // memory while building the search tree.
+    const double factor              = std::ceil( totalCellCount() / maxNumberOfLeafNodes );
+    const size_t cellsPerBoundingBox = std::max( size_t( 1 ), static_cast<size_t>( factor ) );
 
     if ( cellsPerBoundingBox > 1 )
     {


### PR DESCRIPTION
Fixes #14179

## Problem

ResInsight crashes (SIGSEGV from out-of-memory) while building the cell search (AABB) tree when importing certain Eclipse cases. The reported stack ends in `RigMainGrid::buildCellSearchTree()` during the construction/growth of the bounding-box vectors.

## Root cause

`RigMainGrid::doBuildCellSearchTree()` caps the number of AABB leaf nodes at 4M and uses that to choose between two construction paths:

- `buildCellSearchTreeOptimized()` — aggregates `cellsPerBoundingBox` cells per bounding box and folds LGR sub-cells into their parent main cell.
- `buildCellSearchTree()` (fallback for `cellsPerBoundingBox == 1`) — creates **one leaf per cell**, iterating `totalCellCount()` (main grid **plus all LGR cells**).

The threshold was computed from `cellCount()`, which is `RigGridBase::cellCount()` = main grid I×J×K only and **excludes LGR cells**. For a grid whose main-grid cell count is under the cap but whose *total* cell count (with heavy local grid refinement) is far larger, the code computes `cellsPerBoundingBox == 1` and takes the non-optimized fallback. That path then allocates one leaf / bounding box per cell across `totalCellCount()`, exhausting memory and crashing.

This was a latent issue once the `cellsPerBoundingBox == 1` fallback to `buildCellSearchTree()` was introduced: the fallback scales with `totalCellCount()` while the gating threshold still used `cellCount()`.

## Fix

Compute the threshold from `totalCellCount()` instead of `cellCount()`. LGR-inflated grids are now routed to the optimized aggregating path, and the cheap one-leaf-per-cell fallback only runs when the total cell count is within the cap, keeping the leaf count bounded.