### PR TITLE
#14183 Fix crash in AABB cell search tree from unsynchronized lazy build

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -273,8 +273,14 @@ void RigMainGrid::computeCachedData( std::string* aabbTreeInfo )
     initAllSubGridsParentGridPointer();
     initAllSubCellsMainGridCellIndex();
 
-    m_cellSearchTree = nullptr;
-    doBuildCellSearchTree( aabbTreeInfo );
+    {
+        // Serialize (re)building of the cell search tree, as it may be accessed concurrently from
+        // multi-threaded queries (e.g. findIntersectingCells). Building without this guard can cause
+        // a use-after-free / data race on the lazily built tree.
+        std::scoped_lock<std::mutex> lock( m_cellSearchTreeMutex );
+        m_cellSearchTree = nullptr;
+        doBuildCellSearchTree( aabbTreeInfo );
+    }
 
     computeBoundingBox();
 }
@@ -839,15 +845,25 @@ std::tuple<QString, double, cvf::StructGridInterface::FaceType> RigMainGrid::min
 //--------------------------------------------------------------------------------------------------
 std::vector<size_t> RigMainGrid::findIntersectingCells( const cvf::BoundingBox& inputBB ) const
 {
-    if ( m_cellSearchTree.isNull() )
+    cvf::ref<cvf::BoundingBoxTree> searchTree;
     {
-        doBuildCellSearchTree();
+        // Lazily build the cell search tree under a lock to avoid a use-after-free / data race when
+        // findIntersectingCells is called concurrently from multiple threads (e.g. OpenMP regions).
+        std::scoped_lock<std::mutex> lock( m_cellSearchTreeMutex );
+        if ( m_cellSearchTree.isNull() )
+        {
+            doBuildCellSearchTree();
+        }
+
+        // Keep a local reference so the tree stays alive if another thread rebuilds m_cellSearchTree
+        // while this thread performs the read-only intersection query below.
+        searchTree = m_cellSearchTree;
     }
 
     std::vector<size_t> cellIndices;
-    if ( m_cellSearchTree.notNull() )
+    if ( searchTree.notNull() )
     {
-        m_cellSearchTree->findIntersections( inputBB, &cellIndices );
+        searchTree->findIntersections( inputBB, &cellIndices );
     }
     return cellIndices;
 }

--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.h
@@ -29,6 +29,7 @@
 
 #include <QString>
 
+#include <mutex>
 #include <vector>
 
 class RigActiveCellInfo;
@@ -169,4 +170,5 @@ private:
     mutable bool                           m_isFaceNormalsOutwards;
     mutable bool                           m_isFaceNormalsOutwardsComputed;
     mutable cvf::ref<cvf::BoundingBoxTree> m_cellSearchTree;
+    mutable std::mutex                     m_cellSearchTreeMutex;
 };


### PR DESCRIPTION
Fixes #14183

## Problem

The reported segfault happens deep inside `AABBTree::buildTree` → `leafBoundingBox` → `BoundingBox::addValid`. That code is correct for valid, single-threaded input — `addValid` only does member arithmetic, so it can only crash when the leaf bounding box it reads is in freed/corrupted memory.

The real cause is an **unsynchronized lazy build of `m_cellSearchTree`**:

- `RigMainGrid::findIntersectingCells()` is `const` and lazily builds the mutable `m_cellSearchTree` with no lock, yet it is called from many OpenMP-parallel query paths.
- When two threads race the `isNull()` check, both run `m_cellSearchTree = new cvf::BoundingBoxTree`. The second assignment drops the first tree's `cvf::ref` count to 0 and **deletes it while the first thread is still inside `buildTreeFromBoundingBoxes(...)`** → use-after-free / concurrent mutation of the tree's internal leaf arrays → wild leaf pointer → the observed crash.
- `computeCachedData()` widens the window by setting `m_cellSearchTree = nullptr` and rebuilding.

## Fix

- Add `mutable std::mutex m_cellSearchTreeMutex` to `RigMainGrid`.
- `computeCachedData()`: the null + rebuild now runs under the lock.
- `findIntersectingCells()`: the lazy build is now use a lock to guard the tree, and it takes a local `cvf::ref` to the tree so a concurrent rebuild cannot free it during the read-only `findIntersections` query (which runs outside the lock — concurrent reads of a finished tree are safe).