### PR TITLE
#14185 Well Log: Guard against degenerate well path geometry in intersection calculation

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/Well/RigEclipseWellLogExtractor.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigEclipseWellLogExtractor.cpp
@@ -56,9 +56,20 @@ void RigEclipseWellLogExtractor::calculateIntersection()
 {
     std::map<RigMDCellIdxEnterLeaveKey, HexIntersectionInfo> uniqueIntersections;
 
-    bool isCellFaceNormalsOut = m_caseData->mainGrid()->isFaceNormalsOutwards();
-
     if ( m_wellPathGeometry->wellPathPoints().empty() ) return;
+
+    // The intersection loop iterates over the well path points while indexing the measured depths in lockstep. A
+    // mismatch between the two arrays would read out of bounds, so guard against it instead of relying on the
+    // RigWellPath constructor assert, which is a no-op in release builds.
+    if ( m_wellPathGeometry->wellPathPoints().size() != m_wellPathGeometry->measuredDepths().size() )
+    {
+        RiaLogging::error( "Well path geometry has a mismatch between the number of points and measured depths. "
+                           "Skipping intersection calculation for " +
+                           m_wellCaseErrorMsgName );
+        return;
+    }
+
+    bool isCellFaceNormalsOut = m_caseData->mainGrid()->isFaceNormalsOutwards();
 
     double tolerance = computeLengthThreshold();
 

--- a/ApplicationLibCode/UnitTests/RigWellLogExtractor-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellLogExtractor-Test.cpp
@@ -26,6 +26,8 @@
 #include "Well/RigEclipseWellLogExtractor.h"
 #include "Well/RigWellPath.h"
 
+#include "cvfAssert.h"
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -75,6 +77,70 @@ TEST( RigEclipseWellLogExtractor, ShortWellPathInsideOneCell )
     auto intersections = e->cellIntersectionInfosAlongWellPath();
     EXPECT_FALSE( intersections.empty() );
 }
+
+//--------------------------------------------------------------------------------------------------
+/// A degenerate well path geometry (empty or a single point) must not crash the extractor. The
+/// intersection calculation indexes the well path points and the measured depths in lockstep, so
+/// these cases must be handled gracefully and yield no intersections.
+//--------------------------------------------------------------------------------------------------
+TEST( RigEclipseWellLogExtractor, DegenerateWellPathDoesNotCrash )
+{
+    cvf::ref<RigEclipseCaseData> reservoir         = new RigEclipseCaseData( nullptr );
+    cvf::ref<RifReaderMockModel> mockFileInterface = new RifReaderMockModel;
+
+    mockFileInterface->setWorldCoordinates( cvf::Vec3d( 10, 10, 10 ), cvf::Vec3d( 20, 20, 20 ) );
+    mockFileInterface->setCellCounts( cvf::Vec3st( 5, 6, 7 ) );
+    mockFileInterface->enableWellData( false );
+    mockFileInterface->open( "", reservoir.p() );
+    reservoir->mainGrid()->computeCachedData();
+
+    const cvf::Vec3d center = reservoir->mainGrid()->cell( 0 ).center();
+
+    // Empty well path geometry.
+    {
+        cvf::ref<RigWellPath>                wellPathGeometry = new RigWellPath;
+        cvf::ref<RigEclipseWellLogExtractor> e = new RigEclipseWellLogExtractor( reservoir.p(), wellPathGeometry.p(), "empty" );
+        EXPECT_TRUE( e->cellIntersectionInfosAlongWellPath().empty() );
+    }
+
+    // Single point well path geometry.
+    {
+        cvf::ref<RigWellPath> wellPathGeometry = new RigWellPath;
+        wellPathGeometry->addWellPathPoint( center, 0.0 );
+        cvf::ref<RigEclipseWellLogExtractor> e = new RigEclipseWellLogExtractor( reservoir.p(), wellPathGeometry.p(), "single" );
+        EXPECT_TRUE( e->cellIntersectionInfosAlongWellPath().empty() );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A well path geometry with a mismatch between the number of points and measured depths must not
+/// read out of bounds. This invalid state can only be constructed when asserts are disabled (the
+/// RigWellPath setter asserts on equal sizes), matching the release builds where the original crash
+/// in RigEclipseWellLogExtractor::calculateIntersection was observed.
+//--------------------------------------------------------------------------------------------------
+#if CVF_ENABLE_ASSERTS == 0
+TEST( RigEclipseWellLogExtractor, MismatchedPointAndMeasuredDepthCountDoesNotCrash )
+{
+    cvf::ref<RigEclipseCaseData> reservoir         = new RigEclipseCaseData( nullptr );
+    cvf::ref<RifReaderMockModel> mockFileInterface = new RifReaderMockModel;
+
+    mockFileInterface->setWorldCoordinates( cvf::Vec3d( 10, 10, 10 ), cvf::Vec3d( 20, 20, 20 ) );
+    mockFileInterface->setCellCounts( cvf::Vec3st( 5, 6, 7 ) );
+    mockFileInterface->enableWellData( false );
+    mockFileInterface->open( "", reservoir.p() );
+    reservoir->mainGrid()->computeCachedData();
+
+    const cvf::Vec3d center = reservoir->mainGrid()->cell( 0 ).center();
+
+    cvf::ref<RigWellPath>   wellPathGeometry = new RigWellPath;
+    std::vector<cvf::Vec3d> wellPathPoints   = { center, center + cvf::Vec3d( 0, 0, 1 ), center + cvf::Vec3d( 0, 0, 2 ) };
+    std::vector<double>     mdValues         = { 0.0, 1.0 }; // Deliberately one fewer than the number of points.
+    wellPathGeometry->setWellPathPoints( wellPathPoints, mdValues );
+
+    cvf::ref<RigEclipseWellLogExtractor> e = new RigEclipseWellLogExtractor( reservoir.p(), wellPathGeometry.p(), "mismatch" );
+    EXPECT_TRUE( e->cellIntersectionInfosAlongWellPath().empty() );
+}
+#endif
 
 //--------------------------------------------------------------------------------------------------
 /// Reproduces https://github.com/OPM/ResInsight/issues/13967


### PR DESCRIPTION
Fixes #14185

## Problem

A `SIGSEGV` was reported in `RigEclipseWellLogExtractor::calculateIntersection()` during MSW completion export of fishbones (triggered headless over gRPC). `calculateIntersection` iterates over the well path points while indexing the measured depths in lockstep:

```cpp
for ( size_t wpp = 0; wpp < wellPathPoints().size() - 1; ++wpp )
{
    ...
    md1 = measuredDepths()[wpp];
    md2 = measuredDepths()[wpp + 1];
}
```

If the well path geometry has more points than measured depths, this reads out of bounds. The only protection was a `CVF_ASSERT` in the `RigWellPath` constructor, which compiles to a no-op in release builds, exactly the configuration where the crash was observed.

## Fix

- Add an explicit guard in `calculateIntersection` that returns (logging an error) when the number of well path points and measured depths differ.
- Move the unguarded `mainGrid()->isFaceNormalsOutwards()` call to after the geometry validity checks, so degenerate geometry is rejected before the grid is touched.

## Tests

Added unit tests in `RigWellLogExtractor-Test.cpp` covering empty, single point, and mismatched point/measured-depth-count well path geometries. The mismatch test is gated behind `#if CVF_ENABLE_ASSERTS == 0`, since the invalid state cannot be constructed while asserts are enabled (the `RigWellPath` setter asserts on equal sizes), matching the release build pattern used elsewhere in the test suite.
