### PR TITLE
Fix null dereference in 2D intersection view synchronization

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Rim2dIntersectionViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim2dIntersectionViewCollection.cpp
@@ -108,9 +108,12 @@ void Rim2dIntersectionViewCollection::syncFromExistingIntersections( bool doUpda
         }
         else
         {
-            view->cellVisibilityChanged.disconnect( it->second );
+            if ( view )
+            {
+                view->cellVisibilityChanged.disconnect( it->second );
+                view->cellVisibilityChanged.connect( it->second, &Rim2dIntersectionView::onCellVisibilityChanged );
+            }
             m_intersectionViews.push_back( it->second );
-            view->cellVisibilityChanged.connect( it->second, &Rim2dIntersectionView::onCellVisibilityChanged );
         }
     }
 


### PR DESCRIPTION
## Summary

`Rim2dIntersectionViewCollection::syncFromExistingIntersections` reused an existing 2D intersection view in a branch that dereferenced the `RimGridView` ancestor (`view->cellVisibilityChanged...`) without a null check. The sibling branch that creates a new view already guards this with `if ( view )`.

Intersections that have no `RimGridView` ancestor — for example intersections created through the gRPC/Python API on a detached intersection collection — have a null ancestor, so the disconnect/connect calls crash.

This change guards those calls with the same null check used in the new-view branch and always pushes the existing view back into the collection regardless.

## Background

Found while investigating a SIGSEGV reported during `CreateChildPdmObject` → `onChildAdded` → `synchronize2dIntersectionViews`. This null-deref is a distinct latent crash in the same function (the reported trace was in the new-view branch, which already handled null). A separate heap-corruption issue in the gRPC create path is still under investigation and is not addressed here.
