### PR TITLE
#14193 Fix crash in context menu when Eclipse view has no main grid

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
@@ -1118,13 +1118,13 @@ void RiuViewerCommands::findCellAndGridIndex( Rim3dView*                       m
         eclipseCase = dynamic_cast<RimEclipseCase*>( mainOrComparisonView->ownerCase() );
     }
 
-    if ( eclipseCase )
+    if ( eclipseCase && eclipseCase->mainGrid() )
     {
         const RigCell& cell = eclipseCase->mainGrid()->cell( globalCellIndex );
         *cellIndex          = cell.gridLocalCellIndex();
         *gridIndex          = cell.hostGrid()->gridIndex();
     }
-    else if ( geomechCase )
+    else if ( geomechCase && geomechCase->geoMechData() )
     {
         RigFemPartCollection* parts = geomechCase->geoMechData()->femParts();
         auto [partId, elementIdx]   = parts->partIdAndElementIndex( globalCellIndex );
@@ -1223,12 +1223,12 @@ void RiuViewerCommands::ijkFromCellIndex( Rim3dView* mainOrComparisonView, size_
     RimEclipseView* eclipseView = dynamic_cast<RimEclipseView*>( mainOrComparisonView );
     RimGeoMechView* geomView    = dynamic_cast<RimGeoMechView*>( mainOrComparisonView );
 
-    if ( eclipseView && eclipseView->eclipseCase() )
+    if ( eclipseView && eclipseView->eclipseCase() && eclipseView->eclipseCase()->eclipseCaseData() )
     {
         eclipseView->eclipseCase()->eclipseCaseData()->grid( gridIdx )->ijkFromCellIndex( cellIndex, i, j, k );
     }
 
-    if ( geomView && geomView->geoMechCase() )
+    if ( geomView && geomView->geoMechCase() && geomView->femParts() )
     {
         geomView->femParts()->part( gridIdx )->getOrCreateStructGrid()->ijkFromCellIndex( cellIndex, i, j, k );
     }

--- a/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
@@ -426,7 +426,7 @@ void RiuViewerCommands::displayContextMenu( QMouseEvent* event )
             menuBuilder.addSeparator();
 
             RimEclipseView* eclipseView = dynamic_cast<RimEclipseView*>( mainOrComparisonView );
-            if ( eclipseView )
+            if ( eclipseView && eclipseView->mainGrid() )
             {
                 // fault commands
                 const RigFault* fault = eclipseView->mainGrid()->findFaultFromCellIndexAndCellFace( m_currentCellIndex, m_currentFaceIndex );


### PR DESCRIPTION
Fixes #14193

## Problem

Right-clicking in the 3D view could crash with a segfault reported inside `cvf::ref<RigFaultsPrCellAccumulator>::isNull()`.

The reported crash line (`RiuViewerCommands.cpp:425`) is the optimizer-placed line marker; the real crash site is the fault-command block:

```cpp
RimEclipseView* eclipseView = dynamic_cast<RimEclipseView*>( mainOrComparisonView );
if ( eclipseView )
{
    const RigFault* fault = eclipseView->mainGrid()->findFaultFromCellIndexAndCellFace( m_currentCellIndex, m_currentFaceIndex );
```

`RimEclipseView::mainGrid()` legitimately returns `nullptr` when the view's case or case data is not available (case still loading, comparison view, or mid-teardown). The result was dereferenced without a null check. `findFaultFromCellIndexAndCellFace()` immediately reads `m_faultsPrCellAcc.isNull()`, which on a null `this` reads an invalid address — exactly what the crash handler caught. The `RigFaultsPrCellAccumulator` type in the trace is just the template instantiation living at that bad offset.

## Fix

Guard the call with a null check on `mainGrid()`, matching the existing pattern already used elsewhere in this same file (e.g. `if ( eclipseView && eclipseView->mainGrid() )`).
