### PR TITLE
#14188 GrpcInterface: Propagate parameter validation errors in command service

### DIFF
--- a/GrpcInterface/RiaGrpcCommandService.cpp
+++ b/GrpcInterface/RiaGrpcCommandService.cpp
@@ -84,7 +84,15 @@ grpc::Status RiaGrpcCommandService::Execute( grpc::ServerContext* context, const
             }
             else
             {
-                assignPdmObjectValues( commandHandle, *request, grpcOneOfMessage );
+                auto result = assignPdmObjectValues( commandHandle, *request, grpcOneOfMessage );
+                if ( !result )
+                {
+                    telemetryAttributes["command.status"] = "error";
+                    telemetryAttributes["command.error"]  = result.error().toStdString();
+                    RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.command_execute", telemetryAttributes );
+
+                    return grpc::Status( grpc::INVALID_ARGUMENT, result.error().toStdString() );
+                }
                 telemetryAttributes["command.type"] = "standard";
             }
 
@@ -260,9 +268,10 @@ void RiaGrpcCommandService::assignPdmFieldValue( caf::PdmValueField*    pdmValue
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RiaGrpcCommandService::assignPdmObjectValues( caf::PdmObjectHandle*                    pdmObjectHandle,
-                                                   const google::protobuf::Message&         params,
-                                                   const google::protobuf::FieldDescriptor* paramDescriptor )
+std::expected<void, QString>
+    RiaGrpcCommandService::assignPdmObjectValues( caf::PdmObjectHandle*                    pdmObjectHandle,
+                                                  const google::protobuf::Message&         params,
+                                                  const google::protobuf::FieldDescriptor* paramDescriptor )
 {
     FieldDescriptor::Type fieldDataType = paramDescriptor->type();
     const Reflection*     reflection    = params.GetReflection();
@@ -274,8 +283,7 @@ void RiaGrpcCommandService::assignPdmObjectValues( caf::PdmObjectHandle*        
     const rips::PdmObject* ripsPdmObject = dynamic_cast<const rips::PdmObject*>( &subMessage );
     if ( ripsPdmObject )
     {
-        copyPdmObjectFromRipsToCaf( ripsPdmObject, pdmObjectHandle );
-        return;
+        return copyPdmObjectFromRipsToCaf( ripsPdmObject, pdmObjectHandle );
     }
 
     auto messageDescriptor = paramDescriptor->message_type();
@@ -306,7 +314,8 @@ void RiaGrpcCommandService::assignPdmObjectValues( caf::PdmObjectHandle*        
                 CAF_ASSERT( childObject );
                 if ( childObject )
                 {
-                    assignPdmObjectValues( childObject, subMessage, parameter );
+                    auto result = assignPdmObjectValues( childObject, subMessage, parameter );
+                    if ( !result ) return result;
                 }
             }
             else if ( pdmValueFieldHandle )
@@ -315,6 +324,8 @@ void RiaGrpcCommandService::assignPdmObjectValues( caf::PdmObjectHandle*        
             }
         }
     }
+
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/GrpcInterface/RiaGrpcCommandService.h
+++ b/GrpcInterface/RiaGrpcCommandService.h
@@ -60,7 +60,7 @@ private:
     void                           assignPdmFieldValue( caf::PdmValueField*                      pdmValueField,
                                                         const google::protobuf::Message&         params,
                                                         const google::protobuf::FieldDescriptor* paramDescriptor );
-    void                           assignPdmObjectValues( caf::PdmObjectHandle*                    pdmObject,
+    std::expected<void, QString>   assignPdmObjectValues( caf::PdmObjectHandle*                    pdmObject,
                                                           const google::protobuf::Message&         params,
                                                           const google::protobuf::FieldDescriptor* paramDescriptor );
 

--- a/GrpcInterface/RiaGrpcPdmObjectService.cpp
+++ b/GrpcInterface/RiaGrpcPdmObjectService.cpp
@@ -568,7 +568,16 @@ grpc::Status RiaGrpcPdmObjectService::CallPdmObjectMethod( grpc::ServerContext* 
             caf::PdmObjectMethodFactory::instance()->createMethod( matchingObject, methodKeyword );
         if ( method )
         {
-            copyPdmObjectFromRipsToCaf( &( request->params() ), method.get() );
+            if ( auto result = copyPdmObjectFromRipsToCaf( &( request->params() ), method.get() ); !result )
+            {
+                telemetryAttributes["pdm.status"] = "failed";
+                telemetryAttributes["pdm.error"]  = result.error().toStdString();
+                RiaOpenTelemetryManager::instance().reportEventAsync( "grpc.pdm_method_call", telemetryAttributes );
+
+                RiaLogging::error(
+                    QString( "Method '%1' failed. Error: %2" ).arg( methodKeyword ).arg( result.error() ).toStdString() );
+                return grpc::Status( grpc::INVALID_ARGUMENT, result.error().toStdString() );
+            }
 
             // clang-tidy-19 has a bug that did the following:
             //   std::expected<caf::PdmObjectHandle, QString> result = method->execute();


### PR DESCRIPTION
Fixes #14188.

`copyPdmObjectFromRipsToCaf` returns `std::expected<void, QString>` (implicitly `[[nodiscard]]`), but its result was discarded in `RiaGrpcCommandService::assignPdmObjectValues`, producing build warning C4834.

Instead of silencing the warning, this propagates the error:

- `assignPdmObjectValues` now returns `std::expected<void, QString>`.
- The `copyPdmObjectFromRipsToCaf` result is returned directly, and the recursive call forwards failures.
- `Execute` checks the result and returns a gRPC `INVALID_ARGUMENT` status (with telemetry) on failure, mirroring the existing pattern in `RiaGrpcPdmObjectService`.

As a result, parameter-validation errors are now surfaced to the Python client instead of being silently ignored, and the C4834 warning is resolved.
