### PR TITLE
#14192 Python: Fix duplicate discrete property legend on repeated cat…

### DIFF
--- a/ApplicationLibCode/Commands/RicFaciesPropertiesImportTools.cpp
+++ b/ApplicationLibCode/Commands/RicFaciesPropertiesImportTools.cpp
@@ -87,17 +87,40 @@ void RicFaciesPropertiesImportTools::importFaciesPropertiesFromFile( const QStri
 //--------------------------------------------------------------------------------------------------
 RimColorLegend* RicFaciesPropertiesImportTools::createColorLegendMatchDefaultRockColors( const std::map<int, QString>& codeNames )
 {
-    const caf::ColorTable&    colorTable            = RiaColorTables::contrastCategoryPaletteColors();
     RimColorLegendCollection* colorLegendCollection = RimProject::current()->colorLegendCollection;
-    RimColorLegend*           rockTypeColorLegend   = colorLegendCollection->findByName( RiaDefines::rockTypeColorLegendName() );
+
+    const auto colors = matchDefaultRockColors( codeNames );
 
     auto colorLegend = new RimColorLegend;
     colorLegend->setColorLegendName( RiaDefines::faciesColorLegendName() );
 
+    size_t colorIndex = 0;
     for ( const auto& it : codeNames )
     {
         auto colorLegendItem = new RimColorLegendItem;
+        colorLegendItem->setValues( it.second, it.first, colors[colorIndex++] );
+        colorLegend->appendColorLegendItem( colorLegendItem );
+    }
 
+    colorLegendCollection->appendCustomColorLegend( colorLegend );
+    colorLegendCollection->updateConnectedEditors();
+
+    return colorLegend;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Find a color for each category name by fuzzy matching against the rock type color legend.
+/// Returns one color per entry in codeNames, ordered by ascending value.
+//--------------------------------------------------------------------------------------------------
+std::vector<cvf::Color3f> RicFaciesPropertiesImportTools::matchDefaultRockColors( const std::map<int, QString>& codeNames )
+{
+    const caf::ColorTable&    colorTable            = RiaColorTables::contrastCategoryPaletteColors();
+    RimColorLegendCollection* colorLegendCollection = RimProject::current()->colorLegendCollection;
+    RimColorLegend*           rockTypeColorLegend   = colorLegendCollection->findByName( RiaDefines::rockTypeColorLegendName() );
+
+    std::vector<cvf::Color3f> colors;
+    for ( const auto& it : codeNames )
+    {
         // Try to find a color from the rock type color legend by fuzzy matching names
         cvf::Color3f color;
         if ( rockTypeColorLegend && !predefinedColorMatch( it.second, rockTypeColorLegend, color ) &&
@@ -107,14 +130,10 @@ RimColorLegend* RicFaciesPropertiesImportTools::createColorLegendMatchDefaultRoc
             color = colorTable.cycledColor3f( it.first );
         }
 
-        colorLegendItem->setValues( it.second, it.first, color );
-        colorLegend->appendColorLegendItem( colorLegendItem );
+        colors.push_back( color );
     }
 
-    colorLegendCollection->appendCustomColorLegend( colorLegend );
-    colorLegendCollection->updateConnectedEditors();
-
-    return colorLegend;
+    return colors;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/RicFaciesPropertiesImportTools.h
+++ b/ApplicationLibCode/Commands/RicFaciesPropertiesImportTools.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <map>
+#include <vector>
 
 class RimColorLegend;
 class RimStimPlanModelTemplate;
@@ -41,6 +42,8 @@ public:
                                                 bool                      createColorLegend = false );
 
     static RimColorLegend* createColorLegendMatchDefaultRockColors( const std::map<int, QString>& codeNames );
+
+    static std::vector<cvf::Color3f> matchDefaultRockColors( const std::map<int, QString>& codeNames );
 
 private:
     static int  computeEditDistance( const QString& a, const QString& b );

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
@@ -19,6 +19,7 @@
 #include "RifRoffFileTools.h"
 
 #include "RiaApplication.h"
+#include "RiaFractureDefines.h"
 #include "RiaLogging.h"
 #include "RiaQStringFormatter.h"
 #include "RiaResultNames.h"
@@ -579,20 +580,17 @@ std::pair<bool, std::map<QString, QString>> RifRoffFileTools::createInputPropert
 
                     auto rimCase = eclipseCaseData->ownerCase();
 
-                    // Delete existing color legend, as new legend will be populated by values from file
-                    colorLegendCollection->deleteColorLegend( rimCase, newResultName );
-
-                    RimColorLegend* colorLegend = nullptr;
+                    // Update existing color legend in place, or create one, with values from file
                     if ( keywordUpperCase == RiaResultNames::facies() )
                     {
-                        colorLegend = RicFaciesPropertiesImportTools::createColorLegendMatchDefaultRockColors( codeNames );
+                        const auto colors = RicFaciesPropertiesImportTools::matchDefaultRockColors( codeNames );
+                        colorLegendCollection->updateColorLegend( rimCase, newResultName, RiaDefines::faciesColorLegendName(), codeNames, colors );
                     }
                     else
                     {
-                        colorLegend = colorLegendCollection->createColorLegend( newResultName, codeNames );
+                        colorLegendCollection->updateColorLegend( rimCase, newResultName, newResultName, codeNames );
                     }
 
-                    colorLegendCollection->setDefaultColorLegendForResult( rimCase, newResultName, colorLegend );
                     colorLegendCollection->updateAllRequiredEditors();
                 }
 
@@ -831,9 +829,7 @@ bool RifRoffFileTools::appendZoneIndexPropertyFromSubgrids( RigEclipseCaseData* 
 
             auto rimCase = caseData->ownerCase();
 
-            colorLegendCollection->deleteColorLegend( rimCase, resultName );
-            RimColorLegend* colorLegend = colorLegendCollection->createColorLegend( resultName, codeNames );
-            colorLegendCollection->setDefaultColorLegendForResult( rimCase, resultName, colorLegend );
+            colorLegendCollection->updateColorLegend( rimCase, resultName, resultName, codeNames );
             colorLegendCollection->updateAllRequiredEditors();
         }
     }

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegend.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegend.cpp
@@ -102,6 +102,21 @@ void RimColorLegend::appendColorLegendItem( RimColorLegendItem* colorLegendItem 
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Replace all color legend items. Takes ownership of the new items.
+//--------------------------------------------------------------------------------------------------
+void RimColorLegend::setColorLegendItems( const std::vector<RimColorLegendItem*>& colorLegendItems )
+{
+    m_colorLegendItems.deleteChildren();
+
+    for ( auto colorLegendItem : colorLegendItems )
+    {
+        m_colorLegendItems.push_back( colorLegendItem );
+    }
+
+    onColorLegendItemHasChanged();
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 std::vector<RimColorLegendItem*> RimColorLegend::colorLegendItems() const

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegend.h
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegend.h
@@ -54,6 +54,7 @@ public:
     void addReorderCapability();
 
     void                             appendColorLegendItem( RimColorLegendItem* colorLegendItem );
+    void                             setColorLegendItems( const std::vector<RimColorLegendItem*>& colorLegendItems );
     std::vector<RimColorLegendItem*> colorLegendItems() const;
 
     cvf::Color3ubArray colorArray() const;

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -119,10 +119,11 @@ RimColorLegend* RimColorLegendCollection::createColorLegend( const QString& colo
 //--------------------------------------------------------------------------------------------------
 void RimColorLegendCollection::deleteColorLegend( const RimCase* rimCase, const QString& resultName )
 {
+    auto legend = findDefaultLegendForResult( rimCase, resultName );
+
     m_defaultColorLegendNameForResult.erase( createLookupKey( rimCase, resultName ) );
 
-    auto legend = findDefaultLegendForResult( rimCase, resultName );
-    if ( !legend ) return;
+    if ( !legend || isStandardColorLegend( legend ) ) return;
 
     m_customColorLegends.removeChild( legend );
     delete legend;

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -115,6 +115,50 @@ RimColorLegend* RimColorLegendCollection::createColorLegend( const QString& colo
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Update the custom color legend registered as default for the given result in place, so that
+/// objects referring to the legend keep their binding. Creates and registers a new custom legend
+/// if none exists or the registered legend is a standard legend. If colors is empty, palette
+/// colors are assigned automatically.
+//--------------------------------------------------------------------------------------------------
+RimColorLegend* RimColorLegendCollection::updateColorLegend( const RimCase*                   rimCase,
+                                                             const QString&                   resultName,
+                                                             const QString&                   colorLegendName,
+                                                             const std::vector<int>&          categoryValues,
+                                                             const std::vector<QString>&      categoryNames,
+                                                             const std::vector<cvf::Color3f>& colors )
+{
+    CAF_ASSERT( categoryValues.size() == categoryNames.size() );
+    CAF_ASSERT( colors.empty() || colors.size() == categoryValues.size() );
+
+    auto legend = findDefaultLegendForResult( rimCase, resultName );
+    if ( !legend || isStandardColorLegend( legend ) )
+    {
+        legend = new RimColorLegend();
+        appendCustomColorLegend( legend );
+    }
+
+    legend->setColorLegendName( colorLegendName );
+
+    auto paletteColors = RiaColorTables::categoryPaletteColors().color3ubArray();
+
+    std::vector<RimColorLegendItem*> items;
+    for ( size_t i = 0; i < categoryValues.size(); i++ )
+    {
+        cvf::Color3f color = colors.empty() ? cvf::Color3f( paletteColors[i % paletteColors.size()] ) : colors[i];
+
+        auto item = new RimColorLegendItem();
+        item->setValues( categoryNames[i], categoryValues[i], color );
+        items.push_back( item );
+    }
+
+    legend->setColorLegendItems( items );
+
+    setDefaultColorLegendForResult( rimCase, resultName, legend );
+
+    return legend;
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RimColorLegendCollection::deleteColorLegend( const RimCase* rimCase, const QString& resultName )

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -89,32 +89,6 @@ void RimColorLegendCollection::deleteCustomColorLegends()
 }
 
 //--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RimColorLegend* RimColorLegendCollection::createColorLegend( const QString& colorLegendName, const std::map<int, QString>& valuesAndNames )
-{
-    auto colors = RiaColorTables::categoryPaletteColors().color3ubArray();
-
-    auto colorLegend = new RimColorLegend();
-    colorLegend->setColorLegendName( colorLegendName );
-    int colorIndex = 0;
-    for ( const auto& [value, name] : valuesAndNames )
-    {
-        auto         item  = new RimColorLegendItem();
-        auto         color = colors[colorIndex++ % colors.size()];
-        cvf::Color3f color3f( color );
-
-        item->setValues( name, value, color3f );
-
-        colorLegend->appendColorLegendItem( item );
-    }
-
-    appendCustomColorLegend( colorLegend );
-
-    return colorLegend;
-}
-
-//--------------------------------------------------------------------------------------------------
 /// Update the custom color legend registered as default for the given result in place, so that
 /// objects referring to the legend keep their binding. Creates and registers a new custom legend
 /// if none exists or the registered legend is a standard legend. If colors is empty, palette
@@ -156,6 +130,26 @@ RimColorLegend* RimColorLegendCollection::updateColorLegend( const RimCase*     
     setDefaultColorLegendForResult( rimCase, resultName, legend );
 
     return legend;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Overload taking values and names as a map, with optional colors ordered by ascending value.
+//--------------------------------------------------------------------------------------------------
+RimColorLegend* RimColorLegendCollection::updateColorLegend( const RimCase*                   rimCase,
+                                                             const QString&                   resultName,
+                                                             const QString&                   colorLegendName,
+                                                             const std::map<int, QString>&    valuesAndNames,
+                                                             const std::vector<cvf::Color3f>& colors )
+{
+    std::vector<int>     categoryValues;
+    std::vector<QString> categoryNames;
+    for ( const auto& [value, name] : valuesAndNames )
+    {
+        categoryValues.push_back( value );
+        categoryNames.push_back( name );
+    }
+
+    return updateColorLegend( rimCase, resultName, colorLegendName, categoryValues, categoryNames, colors );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h
@@ -51,13 +51,17 @@ public:
     bool isStandardColorLegend( RimColorLegend* colorLegend );
     void deleteCustomColorLegends();
 
-    RimColorLegend* createColorLegend( const QString& colorLegendName, const std::map<int, QString>& valuesAndNames );
     RimColorLegend* updateColorLegend( const RimCase*                   rimCase,
                                        const QString&                   resultName,
                                        const QString&                   colorLegendName,
                                        const std::vector<int>&          categoryValues,
                                        const std::vector<QString>&      categoryNames,
                                        const std::vector<cvf::Color3f>& colors );
+    RimColorLegend* updateColorLegend( const RimCase*                   rimCase,
+                                       const QString&                   resultName,
+                                       const QString&                   colorLegendName,
+                                       const std::map<int, QString>&    valuesAndNames,
+                                       const std::vector<cvf::Color3f>& colors = {} );
     void            createColorLegendFromFormationNames( RimFormationNames* rimFormationNames );
     void            deleteColorLegend( const RimCase* rimCase, const QString& resultName );
     void            setDefaultColorLegendForResult( const RimCase* rimCase, const QString& resultName, RimColorLegend* colorLegend );

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h
@@ -22,6 +22,8 @@
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 
+#include "cvfColor3.h"
+
 class RimCase;
 class RimColorLegend;
 class RimColorLegendItem;
@@ -50,6 +52,12 @@ public:
     void deleteCustomColorLegends();
 
     RimColorLegend* createColorLegend( const QString& colorLegendName, const std::map<int, QString>& valuesAndNames );
+    RimColorLegend* updateColorLegend( const RimCase*                   rimCase,
+                                       const QString&                   resultName,
+                                       const QString&                   colorLegendName,
+                                       const std::vector<int>&          categoryValues,
+                                       const std::vector<QString>&      categoryNames,
+                                       const std::vector<cvf::Color3f>& colors );
     void            createColorLegendFromFormationNames( RimFormationNames* rimFormationNames );
     void            deleteColorLegend( const RimCase* rimCase, const QString& resultName );
     void            setDefaultColorLegendForResult( const RimCase* rimCase, const QString& resultName, RimColorLegend* colorLegend );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcColorLegend.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcColorLegend.cpp
@@ -105,6 +105,54 @@ QString RimcColorLegend_addColorLegendItem::classKeywordReturnedType() const
     return RimColorLegendItem::classKeywordStatic();
 }
 
+CAF_PDM_OBJECT_METHOD_SOURCE_INIT( RimColorLegendCollection, RimcColorLegendCollection_updateColorLegend, "UpdateColorLegend" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimcColorLegendCollection_updateColorLegend::RimcColorLegendCollection_updateColorLegend( caf::PdmObjectHandle* self )
+    : caf::PdmObjectCreationMethod( self )
+{
+    CAF_PDM_InitObject( "Update Color Legend", "", "", "Update the color legend bound to a (case, resultName) pair in place, creating it if needed" );
+
+    CAF_PDM_InitScriptableFieldNoDefault( &m_case, "Case", "Case" );
+    CAF_PDM_InitScriptableField( &m_resultName, "ResultName", QString(), "Result Name" );
+    CAF_PDM_InitScriptableField( &m_legendName, "LegendName", QString(), "Legend Name" );
+    CAF_PDM_InitScriptableFieldNoDefault( &m_categoryValues, "CategoryValues", "Category Values" );
+    CAF_PDM_InitScriptableFieldNoDefault( &m_categoryNames, "CategoryNames", "Category Names" );
+    CAF_PDM_InitScriptableFieldNoDefault( &m_colors, "Colors", "Colors" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::expected<caf::PdmObjectHandle*, QString> RimcColorLegendCollection_updateColorLegend::execute()
+{
+    auto collection = self<RimColorLegendCollection>();
+    if ( !collection ) return std::unexpected( "No color legend collection found" );
+
+    if ( !m_case() ) return std::unexpected( "No case provided" );
+
+    if ( m_categoryValues().size() != m_categoryNames().size() )
+        return std::unexpected( "CategoryValues and CategoryNames must have matching sizes" );
+
+    if ( !m_colors().empty() && m_colors().size() != m_categoryValues().size() )
+        return std::unexpected( "Colors must be empty or match the size of CategoryValues" );
+
+    auto legend = collection->updateColorLegend( m_case(), m_resultName(), m_legendName(), m_categoryValues(), m_categoryNames(), m_colors() );
+    collection->updateConnectedEditors();
+
+    return legend;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RimcColorLegendCollection_updateColorLegend::classKeywordReturnedType() const
+{
+    return RimColorLegend::classKeywordStatic();
+}
+
 CAF_PDM_OBJECT_METHOD_SOURCE_INIT( RimColorLegendCollection,
                                    RimcColorLegendCollection_setDefaultColorLegendForResult,
                                    "SetDefaultColorLegendForResult" );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcColorLegend.h
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcColorLegend.h
@@ -70,6 +70,28 @@ private:
 //==================================================================================================
 ///
 //==================================================================================================
+class RimcColorLegendCollection_updateColorLegend : public caf::PdmObjectCreationMethod
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RimcColorLegendCollection_updateColorLegend( caf::PdmObjectHandle* self );
+
+    std::expected<caf::PdmObjectHandle*, QString> execute() override;
+    QString                                       classKeywordReturnedType() const override;
+
+private:
+    caf::PdmPtrField<RimCase*>               m_case;
+    caf::PdmField<QString>                   m_resultName;
+    caf::PdmField<QString>                   m_legendName;
+    caf::PdmField<std::vector<int>>          m_categoryValues;
+    caf::PdmField<std::vector<QString>>      m_categoryNames;
+    caf::PdmField<std::vector<cvf::Color3f>> m_colors;
+};
+
+//==================================================================================================
+///
+//==================================================================================================
 class RimcColorLegendCollection_setDefaultColorLegendForResult : public caf::PdmVoidObjectMethod
 {
     CAF_PDM_HEADER_INIT;

--- a/GrpcInterface/Python/rips/category_mapping.py
+++ b/GrpcInterface/Python/rips/category_mapping.py
@@ -3,8 +3,9 @@ Category name/color binding for discrete (INTEGER) grid cell results.
 
 Provides a convenience API on Case for labeling integer result values with
 human-readable names and optional colors. Internally, this reuses the existing
-ColorLegend infrastructure: a new custom ColorLegend is created and registered
-as the default legend for the (case, resultName) pair. When the property is
+ColorLegend infrastructure: a custom ColorLegend is registered as the default
+legend for the (case, resultName) pair, and repeated calls update that legend
+in place so views referencing it keep their binding. When the property is
 shown in a 3D view, the legend's item names are used as the category labels.
 """
 
@@ -55,10 +56,14 @@ def set_discrete_property_category_names(
     data_type="INTEGER") or set_active_cell_property(..., data_type="INTEGER")
     to display text labels instead of raw integers in the 3D view legend.
 
+    Repeated calls for the same property update the existing color legend in
+    place, so views referencing the legend keep their binding.
+
     Arguments:
         property_name (str): Name of the discrete property result.
         value_names (Dict[int, str]): Mapping from integer value to label.
-            An empty dict removes any existing mapping for this property.
+            Labels must not contain commas. An empty dict removes any
+            existing mapping for this property.
         value_colors (Optional[Dict[int, str]]): Optional per-value colors as
             strings accepted by QColor (e.g. "red", "#ff8800"). Values without
             a color entry get an auto-assigned palette color.
@@ -66,7 +71,7 @@ def set_discrete_property_category_names(
             Defaults to the property name.
 
     Returns:
-        The created ColorLegend, or None if value_names was empty.
+        The created or updated ColorLegend, or None if value_names was empty.
     """
     project = self.ancestor(Project)
     if project is None:
@@ -76,34 +81,34 @@ def set_discrete_property_category_names(
     if collection is None:
         raise RuntimeError("Could not find ColorLegendCollection in project")
 
-    collection.delete_color_legend(case=self, result_name=property_name)
-
     if not value_names:
+        collection.delete_color_legend(case=self, result_name=property_name)
         return None
 
     name = legend_name if legend_name else property_name
-    legend = collection.create_color_legend(name=name)
 
+    category_values = []
+    category_names = []
+    category_colors = []
     colors = value_colors or {}
     palette_index = 0
-    for value, label in value_names.items():
+    for value, label in sorted(value_names.items()):
         color = colors.get(value)
         if color is None:
             color = _DEFAULT_PALETTE[palette_index % len(_DEFAULT_PALETTE)]
             palette_index += 1
-        legend.add_color_legend_item(
-            category_value=value,
-            category_name=label,
-            color=color,
-        )
+        category_values.append(value)
+        category_names.append(label)
+        category_colors.append(color)
 
-    collection.set_default_color_legend_for_result(
+    return collection.update_color_legend(
         case=self,
         result_name=property_name,
-        color_legend=legend,
+        legend_name=name,
+        category_values=category_values,
+        category_names=category_names,
+        colors=category_colors,
     )
-
-    return legend
 
 
 def _find_default_legend(case: Case, property_name: str) -> Optional[ColorLegend]:

--- a/GrpcInterface/Python/rips/tests/test_color_legend.py
+++ b/GrpcInterface/Python/rips/tests/test_color_legend.py
@@ -130,3 +130,43 @@ def test_discrete_property_category_no_duplicate_legend(rips_instance, initializ
         1: "Shale",
         2: "Coal",
     }
+
+
+def test_discrete_property_category_update_preserves_legend_identity(
+    rips_instance, initialize_test
+):
+    case_path = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+    case = rips_instance.project.load_case(path=case_path)
+    assert case is not None
+
+    collection = rips_instance.project.color_legend_collection()
+
+    def legend_count():
+        return len(collection.descendants(rips.ColorLegend))
+
+    legend1 = case.set_discrete_property_category_names(
+        property_name="FACIES", value_names={0: "Sand", 1: "Shale"}
+    )
+    assert legend1 is not None
+    after_first = legend_count()
+
+    # A repeated call must update the existing legend object in place so that
+    # views referencing it keep their binding.
+    new_names = {0: "Sandstone", 1: "Shale", 2: "Coal"}
+    new_colors = {0: "#e6c878", 1: "#646464", 2: "#202020"}
+    legend2 = case.set_discrete_property_category_names(
+        property_name="FACIES", value_names=new_names, value_colors=new_colors
+    )
+    assert legend2.address() == legend1.address()
+    assert legend_count() == after_first
+
+    # The items are fully replaced, with no leftovers from the first call.
+    assert case.discrete_property_category_names("FACIES") == new_names
+    assert case.discrete_property_category_colors("FACIES") == new_colors
+
+    # The legend can be renamed in place as well.
+    legend3 = case.set_discrete_property_category_names(
+        property_name="FACIES", value_names=new_names, legend_name="My Facies"
+    )
+    assert legend3.address() == legend1.address()
+    assert legend3.color_legend_name == "My Facies"

--- a/GrpcInterface/Python/rips/tests/test_color_legend.py
+++ b/GrpcInterface/Python/rips/tests/test_color_legend.py
@@ -101,3 +101,32 @@ def test_discrete_property_category_round_trip(rips_instance, initialize_test):
     case.set_discrete_property_category_names(property_name="FACIES", value_names={})
     assert case.discrete_property_category_names("FACIES") == {}
     assert case.discrete_property_category_colors("FACIES") == {}
+
+
+def test_discrete_property_category_no_duplicate_legend(rips_instance, initialize_test):
+    case_path = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+    case = rips_instance.project.load_case(path=case_path)
+    assert case is not None
+
+    collection = rips_instance.project.color_legend_collection()
+
+    def legend_count():
+        return len(collection.descendants(rips.ColorLegend))
+
+    case.set_discrete_property_category_names(
+        property_name="FACIES", value_names={0: "Sand", 1: "Shale"}
+    )
+    after_first = legend_count()
+
+    # Calling again for the same property must replace, not accumulate.
+    case.set_discrete_property_category_names(
+        property_name="FACIES", value_names={0: "Sand", 1: "Shale", 2: "Coal"}
+    )
+    assert legend_count() == after_first
+
+    # The mapping still reflects the latest call.
+    assert case.discrete_property_category_names("FACIES") == {
+        0: "Sand",
+        1: "Shale",
+        2: "Coal",
+    }


### PR DESCRIPTION
…egory-name calls

RimColorLegendCollection::deleteColorLegend erased the default-legend map entry before looking the legend up, so findDefaultLegendForResult always returned null and the old legend was never removed from m_customColorLegends. Each set_discrete_property_category_names call for the same property left an orphaned legend behind and appended a new one.

Look up the legend before erasing the map key, and guard against deleting a standard legend that may have been registered as a default.

Fixes #14192.