### PR TITLE
#14167 Sector Model: Open BCPROP dropdowns on first click

### DIFF
--- a/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportSectorModelUi.cpp
@@ -399,6 +399,7 @@ void RicExportSectorModelUi::defineEditorAttribute( const caf::PdmFieldHandle* f
         {
             tvAttr->resizePolicy              = caf::PdmUiTableViewEditorAttribute::RESIZE_TO_FILL_CONTAINER;
             tvAttr->alwaysEnforceResizePolicy = true;
+            tvAttr->editOnSingleClick         = true;
         }
     }
     else if ( ( field == &m_exportFolder ) || ( field == &m_simulationJobFolder ) )

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewDelegate.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewDelegate.cpp
@@ -39,6 +39,8 @@
 #include "cafPdmUiFieldEditorHandle.h"
 #include "cafPdmUiTableViewQModel.h"
 
+#include <QComboBox>
+
 namespace caf
 {
 //--------------------------------------------------------------------------------------------------
@@ -48,7 +50,8 @@ PdmUiTableViewDelegate::PdmUiTableViewDelegate( QObject* parent, PdmUiTableViewQ
     : QStyledItemDelegate( parent )
     , m_model( model )
 {
-    m_activeEditorCount = 0;
+    m_activeEditorCount       = 0;
+    m_openComboBoxPopupOnEdit = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -84,6 +87,15 @@ void PdmUiTableViewDelegate::setEditorData( QWidget* editor, const QModelIndex& 
     {
         fieldHandle->updateUi();
     }
+
+    if ( m_openComboBoxPopupOnEdit )
+    {
+        if ( auto* comboBox = qobject_cast<QComboBox*>( editor ) )
+        {
+            // Defer until the editor is shown and its geometry is set, otherwise the popup may be misplaced.
+            QMetaObject::invokeMethod( comboBox, "showPopup", Qt::QueuedConnection );
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -110,6 +122,14 @@ void PdmUiTableViewDelegate::slotEditorDestroyed( QObject* obj )
 bool PdmUiTableViewDelegate::isEditorOpen() const
 {
     return m_activeEditorCount > 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiTableViewDelegate::setOpenComboBoxPopupOnEdit( bool enable )
+{
+    m_openComboBoxPopupOnEdit = enable;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewDelegate.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewDelegate.h
@@ -59,6 +59,8 @@ public:
 
     bool isEditorOpen() const;
 
+    void setOpenComboBoxPopupOnEdit( bool enable );
+
 protected slots:
     void slotEditorDestroyed( QObject* obj );
 
@@ -70,6 +72,9 @@ private:
 
     // Counter for active table cell editors
     mutable int m_activeEditorCount;
+
+    // Open combo box popups as soon as the cell editor is created
+    bool m_openComboBoxPopupOnEdit;
 };
 
 } // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewEditor.cpp
@@ -233,6 +233,11 @@ void PdmUiTableViewEditor::configureAndUpdateUi( const QString& uiConfigName )
                 editorAttrib.enableDropTarget = val.value();
             }
 
+            if ( auto val = uiItem->attribute<bool>( Keys::EDIT_ON_SINGLE_CLICK, uiConfigName ) )
+            {
+                editorAttrib.editOnSingleClick = val.value();
+            }
+
             if ( auto val = uiItem->attribute<QVariantList>( Keys::COLUMN_WIDTHS, uiConfigName ) )
             {
                 editorAttrib.columnWidths.clear();
@@ -282,6 +287,14 @@ void PdmUiTableViewEditor::configureAndUpdateUi( const QString& uiConfigName )
         m_tableView->setAcceptDrops( editorAttrib.enableDropTarget );
         m_tableView->setDropIndicatorShown( editorAttrib.enableDropTarget );
         m_tableModelPdm->enableDropTarget( editorAttrib.enableDropTarget );
+
+        // Start editing on a single click and open combo box popups immediately, so the user does not have to
+        // click several times in a cell before being able to change the value.
+        if ( editorAttrib.editOnSingleClick )
+        {
+            m_tableView->setEditTriggers( QAbstractItemView::AllEditTriggers );
+        }
+        m_delegate->setOpenComboBoxPopupOnEdit( editorAttrib.editOnSingleClick );
     }
 
     m_tableModelPdm->setArrayFieldAndBuildEditors( childArrayFH, uiConfigName );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewEditor.h
@@ -107,6 +107,7 @@ public:
         , alwaysEnforceResizePolicy( false )
         , resizePolicy( NO_AUTOMATIC_RESIZE )
         , enableDropTarget( false )
+        , editOnSingleClick( false )
     {
     }
 
@@ -120,6 +121,7 @@ public:
     bool             alwaysEnforceResizePolicy;
     ResizePolicy     resizePolicy;
     bool             enableDropTarget;
+    bool             editOnSingleClick; ///< Start editing on a single click and open combo box popups immediately
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -148,6 +150,7 @@ public:
         static inline const QString COLUMN_WIDTHS                = QStringLiteral( "columnWidths" );
         static inline const QString BASE_COLOR                   = QStringLiteral( "baseColor" );
         static inline const QString ENABLE_DROP_TARGET           = QStringLiteral( "enableDropTarget" );
+        static inline const QString EDIT_ON_SINGLE_CLICK         = QStringLiteral( "editOnSingleClick" );
     };
 
     // Set of all supported attributes for validation
@@ -160,7 +163,8 @@ public:
                                                                    Keys::RESIZE_POLICY,
                                                                    Keys::COLUMN_WIDTHS,
                                                                    Keys::BASE_COLOR,
-                                                                   Keys::ENABLE_DROP_TARGET };
+                                                                   Keys::ENABLE_DROP_TARGET,
+                                                                   Keys::EDIT_ON_SINGLE_CLICK };
 
     void enableHeaderText( bool enable );
     void setTableSelectionLevel( int selectionLevel );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewQModel.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewQModel.cpp
@@ -45,6 +45,9 @@
 #include "cafPdmUiOrdering.h"
 #include "cafPdmUiTableRowEditor.h"
 
+#include <QCoreApplication>
+#include <QEvent>
+
 namespace caf
 {
 //--------------------------------------------------------------------------------------------------
@@ -541,6 +544,15 @@ QWidget* PdmUiTableViewQModel::getEditorWidgetAndTransferOwnership( QWidget* par
         // using QPointer
         editor->createWidgets( parent );
         QWidget* editorWidget = editor->editorWidget();
+        if ( !editorWidget ) return nullptr;
+
+        // The editor handle is shared by every row in a column. When the edit on one cell ends, the view
+        // schedules its editor widget for deletion via deleteLater(). Moving to another cell in the same
+        // column reuses that very widget before the deferred deletion has run, so without this the widget
+        // is destroyed moments after the new editor opens - silently cancelling the edit and forcing the
+        // user to click a second time. Cancel the pending deletion so the reused widget stays alive.
+        QCoreApplication::removePostedEvents( editorWidget, QEvent::DeferredDelete );
+
         editorWidget->setParent( parent );
 
         return editorWidget;


### PR DESCRIPTION
The boundary conditions table required several clicks in each cell before a value could be changed, because the table view used Qt's default edit triggers. Add an opt-in editOnSingleClick attribute to the table view editor that starts editing on a single click and opens combo box popups immediately, and enable it for the BCPROP keywords table.