### PR TITLE
#14149 Fix crash when reading corrupt or truncated Eclipse INIT keyword

### DIFF
--- a/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp
+++ b/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp
@@ -241,8 +241,16 @@ static void ecl_file_kw_load_kw( ecl_file_kw_type * file_kw , fortio_type * fort
   {
     fortio_fseek( fortio , file_kw->file_offset , SEEK_SET );
     file_kw->kw = ecl_kw_fread_alloc( fortio );
-    ecl_file_kw_assert_kw( file_kw );
-    inv_map_add_kw( inv_map , file_kw , file_kw->kw );
+    /*
+      ecl_kw_fread_alloc() returns NULL if the keyword could not be read,
+      e.g. if the backing file has been truncated or is corrupt. Guard
+      against this to avoid a NULL dereference in ecl_file_kw_assert_kw();
+      the NULL keyword is propagated to the calling scope which handles it.
+    */
+    if (file_kw->kw != NULL) {
+      ecl_file_kw_assert_kw( file_kw );
+      inv_map_add_kw( inv_map , file_kw , file_kw->kw );
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #14149

## Problem

A NULL-pointer dereference crashes ResInsight when loading a static result whose keyword cannot be read from the Eclipse INIT file (truncated or corrupt data).

In `ecl_file_kw_load_kw()`, `ecl_kw_fread_alloc()` returns `NULL` when the keyword cannot be read. The code then called `ecl_file_kw_assert_kw()` unconditionally, which dereferenced the NULL keyword via `ecl_kw_get_data_type()` → SIGSEGV.

The reproduced stack trace (from the issue) goes through `RimViewLinker::updateCellResult` → `RifReaderEclipseOutput::staticResult` → `RifEclipseOutputFileTools::keywordData` → ERT.

## Fix

Guard the `ecl_file_kw_assert_kw()` and `inv_map_add_kw()` calls so they only run when the read actually produced a keyword. When the read fails, `file_kw->kw` stays `NULL` and propagates cleanly up the call chain:

- `ecl_file_kw_get_kw()` already guards on `file_kw->kw` before bumping `ref_count`, so it returns NULL.
- `RifEclipseOutputFileTools::keywordData()` already null-checks the returned keyword.

The result: a corrupt/truncated INIT keyword now yields a missing result instead of crashing the application.