### PR TITLE
#14205 Fix crash when reloading Roff or GRDECL grid

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
@@ -189,6 +189,8 @@ RimEclipseCase* RimReloadCaseTools::gridModelFromSummaryCase( const RimSummaryCa
 //--------------------------------------------------------------------------------------------------
 RimSummaryCase* RimReloadCaseTools::findSummaryCaseFromEclipseResultCase( const RimEclipseResultCase* eclipseResultCase )
 {
+    if ( !eclipseResultCase ) return nullptr;
+
     RimSummaryCaseMainCollection* sumCaseColl = RiaSummaryTools::summaryCaseMainCollection();
     if ( !sumCaseColl ) return nullptr;
 


### PR DESCRIPTION
Fixes #14205

## Problem

Reloading a Roff or GRDECL (Eclipse Input) grid crashes with SIGSEGV. Eclipse result cases reload fine.

## Cause

`RimReloadCaseTools::reloadEclipseData` always runs the summary-reload path, passing `dynamic_cast<RimEclipseResultCase*>( eclipseCase )` into `findSummaryCaseFromEclipseResultCase`. For Roff/GRDECL input cases the case is not a `RimEclipseResultCase`, so the cast returns `nullptr`. The function then dereferences it via `eclipseResultCase->gridFileName()`, matching the reported stack trace (`findSummaryCaseFromEclipseResultCase` → `RimCase::gridFileName()`).

## Fix

Add a null guard at the top of `findSummaryCaseFromEclipseResultCase`. Non-result cases skip the summary-case lookup (which never applied to them) instead of crashing.
