### PR TITLE
Add input guards to fortio_fread_buffer for parity with resdata PR #1189

### DIFF
--- a/ThirdParty/Ert/lib/ecl/fortio.c
+++ b/ThirdParty/Ert/lib/ecl/fortio.c
@@ -550,6 +550,11 @@ static int fortio_fread_record(fortio_type *fortio , char *buffer , int max_reco
 */
 
 bool fortio_fread_buffer(fortio_type * fortio, char * buffer , int buffer_size) {
+  if (buffer == NULL && buffer_size != 0)
+    return false;
+  if (buffer_size < 0)
+    return false;
+
   int total_bytes_read = 0;
 
   while (true) {


### PR DESCRIPTION
Adds two input-validation guards to `fortio_fread_buffer` in ResInsight's vendored copy of resdata (`ThirdParty/Ert/lib/ecl/fortio.c`), for parity with upstream resdata PR equinor/resdata#1189 ("Fix validation of record_size in fortio_fread_buffer").

The function now rejects a null `buffer` (with non-zero size) and a negative `buffer_size` up front, returning `false` instead of risking a null dereference or falling through to `util_abort`.

ResInsight carries an older fork of resdata, so the upstream rewrite cannot be applied verbatim. The core buffer-overflow protection from the upstream fix is already present in this fork via #14144 ("Guard against buffer overflow when reading corrupt well data records"); these two input-validation guards are the only remaining delta.
