### PR TITLE
#14209 Guard contour map aggregation against out-of-range result index

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp
@@ -124,7 +124,12 @@ double RigContourMapCalculator::calculateMeanValue( const RigContourMapProjectio
     RiaWeightedMeanCalculator<double> calculator;
     for ( auto [cellIdx, weight] : matchingCells )
     {
-        double cellValue = gridCellValues[contourMapProjection.gridResultIndex( cellIdx )];
+        const auto valueIndex = contourMapProjection.gridResultIndex( cellIdx );
+
+        // Safety check, should not happen
+        if ( valueIndex >= gridCellValues.size() ) continue;
+
+        double cellValue = gridCellValues[valueIndex];
         if ( std::abs( cellValue ) != std::numeric_limits<double>::infinity() )
         {
             calculator.addValueAndWeight( cellValue, weight );
@@ -147,7 +152,12 @@ double RigContourMapCalculator::calculateGeometricMeanValue( const RigContourMap
     RiaWeightedGeometricMeanCalculator calculator;
     for ( auto [cellIdx, weight] : matchingCells )
     {
-        double cellValue = gridCellValues[contourMapProjection.gridResultIndex( cellIdx )];
+        const auto valueIndex = contourMapProjection.gridResultIndex( cellIdx );
+
+        // Safety check, should not happen
+        if ( valueIndex >= gridCellValues.size() ) continue;
+
+        double cellValue = gridCellValues[valueIndex];
         if ( std::abs( cellValue ) != std::numeric_limits<double>::infinity() )
         {
             if ( cellValue < 1.0e-8 )
@@ -174,7 +184,12 @@ double RigContourMapCalculator::calculateHarmonicMeanValue( const RigContourMapP
     RiaWeightedHarmonicMeanCalculator calculator;
     for ( auto [cellIdx, weight] : matchingCells )
     {
-        double cellValue = gridCellValues[contourMapProjection.gridResultIndex( cellIdx )];
+        const auto valueIndex = contourMapProjection.gridResultIndex( cellIdx );
+
+        // Safety check, should not happen
+        if ( valueIndex >= gridCellValues.size() ) continue;
+
+        double cellValue = gridCellValues[valueIndex];
         if ( std::fabs( cellValue ) < 1.0e-8 )
         {
             return 0.0;
@@ -201,7 +216,12 @@ double RigContourMapCalculator::calculateMaxValue( const RigContourMapProjection
     double maxValue = -std::numeric_limits<double>::infinity();
     for ( auto [cellIdx, weight] : matchingCells )
     {
-        double cellValue = gridCellValues[contourMapProjection.gridResultIndex( cellIdx )];
+        const auto valueIndex = contourMapProjection.gridResultIndex( cellIdx );
+
+        // Safety check, should not happen
+        if ( valueIndex >= gridCellValues.size() ) continue;
+
+        double cellValue = gridCellValues[valueIndex];
         if ( std::abs( cellValue ) != std::numeric_limits<double>::infinity() )
         {
             maxValue = std::max( maxValue, cellValue );
@@ -224,7 +244,12 @@ double RigContourMapCalculator::calculateMinValue( const RigContourMapProjection
     double minValue = std::numeric_limits<double>::infinity();
     for ( auto [cellIdx, weight] : matchingCells )
     {
-        double cellValue = gridCellValues[contourMapProjection.gridResultIndex( cellIdx )];
+        const auto valueIndex = contourMapProjection.gridResultIndex( cellIdx );
+
+        // Safety check, should not happen
+        if ( valueIndex >= gridCellValues.size() ) continue;
+
+        double cellValue = gridCellValues[valueIndex];
         minValue         = std::min( minValue, cellValue );
     }
     return minValue;


### PR DESCRIPTION
Fixes #14209

## Problem
RigContourMapCalculator::calculateMeanValue indexes gridCellValues with gridResultIndex(cellIdx) without a bounds check. That index comes from the active-cell result mapping, which can exceed the per-timestep gridCellValues size, causing an out-of-range read and a crash. calculateTopValue and calculateSum already guard against this; the mean/geometric/harmonic/max/min aggregators did not.

## Fix
Apply the existing "valueIndex >= gridCellValues.size()" guard to the five unguarded aggregation helpers, skipping out-of-range cells.
