### PR TITLE
#14213 HDF5Exporter: Guard null m_hdfFile in createGroup

### DIFF
--- a/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp
@@ -110,7 +110,7 @@ H5::Group RifHdf5Exporter::createGroup( H5::Group* parentGroup, const std::strin
         {
         }
     }
-    else
+    else if ( m_hdfFile )
     {
         try
         {


### PR DESCRIPTION
Fixes #14213

## Problem
When `new H5::H5File` throws in the `RifHdf5Exporter` constructor, the exception is swallowed and `m_hdfFile` is left null (#13883 made this reliable). `createGroup( nullptr, ... )` then dereferences the null `m_hdfFile`; the surrounding `try/catch(...)` cannot catch the resulting SIGSEGV. This crashes HDF5 summary export when the target file cannot be created (unwritable directory, locked file, disk full, invalid path).

## Fix
Guard the `else` branch with `m_hdfFile` before dereferencing, matching the existing `parentGroup` null check in the same function. On failure an empty `H5::Group` is returned, which callers already handle (`writeDataset` wraps `createDataSet` in `try/catch`).