### PR TITLE
Add manually-triggered workflow to remove PendingRelease label from all issues

### DIFF
--- a/.github/workflows/remove-pending-release.yml
+++ b/.github/workflows/remove-pending-release.yml
@@ -1,0 +1,31 @@
+name: Remove label 'PendingRelease' from all issues
+on:
+  workflow_dispatch:
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const label = "PendingRelease";
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              labels: label,
+              per_page: 100
+            });
+            core.info(`Found ${issues.length} issue(s) with label '${label}'`);
+            for (const issue of issues) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: label
+              });
+              core.info(`Removed '${label}' from #${issue.number}`);
+            }
+            core.info(`Done. Removed '${label}' from ${issues.length} issue(s).`);


### PR DESCRIPTION
Adds a new GitHub Actions workflow that removes the `PendingRelease` label from all issues in the repository.

## Details
- **Trigger:** `workflow_dispatch` only — runs exclusively when started manually from the Actions tab. No automatic triggers.
- **Behavior:** Paginates over every issue carrying the `PendingRelease` label (all states) and removes the label, logging each affected issue and a final count.
- **Permissions:** Scoped to `issues: write`, matching the existing `close-label.yml` workflow and using the same `actions/github-script@v9` action.

This complements `close-label.yml` (which adds `PendingRelease` to closed issues) by providing a one-click way to clear the label after a release.