### PR TITLE
#13801 Fix invalid progress max when reading well logs

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp
@@ -226,7 +226,7 @@ bool RimWellPathCollection::loadDataAndUpdate()
         return false;
     };
 
-    auto countWellLogs = []( const std::vector<RimWellPath*>& wellPaths ) -> bool
+    auto countWellLogs = []( const std::vector<RimWellPath*>& wellPaths ) -> size_t
     {
         size_t count = 0;
         for ( RimWellPath* wellPath : wellPaths )


### PR DESCRIPTION
The countWellLogs lambda in RimWellPathCollection::loadDataAndUpdate() declared its return type as bool, truncating the well log count to 0 or 1. The progress max was then too low, and loading projects with two or more well logs ran the progress value past max, triggering reportError() in caf::ProgressInfo during regression tests.

Fixes #13801.