### PR TITLE
Run Mac build workflow when a tag is created

### DIFF
--- a/.github/workflows/ResInsightMac.yml
+++ b/.github/workflows/ResInsightMac.yml
@@ -2,6 +2,9 @@ name: ResInsight Mac Build
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '*'
   schedule:
     # 02:00 UTC daily, offset from ResInsightWithCache.yml's 01:00 slot
     # so the two workflows do not contend for the same Actions runners.


### PR DESCRIPTION
Add a `push` trigger filtered to tags so the Mac build workflow runs whenever a tag is created, in addition to the existing manual dispatch and daily schedule.

Tag pushes use the `refs/tags/<tag>` ref, which is distinct from branch refs, so the existing concurrency group will not cause tag builds to cancel or be cancelled by branch builds.
