### PR TITLE
Fix crash when capturing snapshot with a given size

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
@@ -604,15 +604,20 @@ std::vector<Rim3dView*> Rim3dView::validComparisonViews() const
     auto isIntersectionView = []( const Rim3dView* view ) { return dynamic_cast<const Rim2dIntersectionView*>( view ) != nullptr; };
 
     std::vector<Rim3dView*> validComparisonViews;
-    for ( auto view : RimProject::current()->allViews() )
+
+    // Project can be null while it is being torn down.
+    if ( auto project = RimProject::current() )
     {
-        if ( dynamic_cast<RimSeismicView*>( view ) ) continue;
-
-        bool isSameViewType = isIntersectionView( this ) == isIntersectionView( view );
-
-        if ( view != this && isSameViewType )
+        for ( auto view : project->allViews() )
         {
-            validComparisonViews.push_back( view );
+            if ( dynamic_cast<RimSeismicView*>( view ) ) continue;
+
+            bool isSameViewType = isIntersectionView( this ) == isIntersectionView( view );
+
+            if ( view != this && isSameViewType )
+            {
+                validComparisonViews.push_back( view );
+            }
         }
     }
 

--- a/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
@@ -650,7 +650,7 @@ QImage RimMultiPlot::captureSnapshot( int width, int height )
 
     QSize orgViewSize = m_viewer->size();
 
-    image = RimViewWindow::internalCaptureSnapshot( m_viewer->bookWidget(), width, height );
+    image = RimViewWindow::internalCaptureSnapshot( m_dockWidget, m_viewer->bookWidget(), width, height );
 
     m_viewer->resize( orgViewSize );
     doUpdateLayout();

--- a/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp
@@ -20,24 +20,21 @@
 
 #include "RiaColorTables.h"
 #include "RiaColorTools.h"
-#include "RiaFieldHandleTools.h"
 #include "RiaGuiApplication.h"
 #include "RiaPreferencesSystem.h"
 
 #include "RicfCommandObject.h"
 
 #include "RimDockWindowController.h"
-#include "RimProject.h"
 
 #include "RiuDockWidgetTools.h"
 
 #include "cafPdmUiTreeAttributes.h"
-#include "cafPdmUiTreeViewEditor.h"
 
 #include "DockManager.h"
 #include "DockWidget.h"
 
-#include <QDebug>
+#include <QApplication>
 #include <QImage>
 #include <QPainter>
 #include <QPixmap>
@@ -234,15 +231,22 @@ QImage RimViewWindow::snapshotWindowContent()
 //--------------------------------------------------------------------------------------------------
 QImage RimViewWindow::captureSnapshot( int width, int height )
 {
-    return internalCaptureSnapshot( viewWidget(), width, height );
+    return internalCaptureSnapshot( m_dockWidget, viewWidget(), width, height );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QImage RimViewWindow::internalCaptureSnapshot( QWidget* widget, int width, int height )
+QImage RimViewWindow::internalCaptureSnapshot( ads::CDockWidget* dockWidget, QWidget* widget, int width, int height )
 {
     if ( !widget ) return QImage();
+
+    if ( dockWidget && !dockWidget->isCurrentTab() )
+    {
+        // Move the dock widget that is stacked behind others in the same dock area to the top to make sure the snapshot is rendered
+        dockWidget->setAsCurrentTab();
+        QApplication::processEvents();
+    }
 
     bool shouldResize = width > 0 && height > 0 && ( widget->width() != width || widget->height() != height );
 
@@ -250,6 +254,10 @@ QImage RimViewWindow::internalCaptureSnapshot( QWidget* widget, int width, int h
     if ( shouldResize )
     {
         widget->setFixedSize( width, height );
+
+        // setFixedSize() only posts a deferred resize. If the pending resize is delivered from inside QWidget::render() below, a child
+        // QScrollArea may move its viewport mid-render and crash in Qt's backing-store blit (QWidgetRepaintManager::bltRect).
+        QApplication::processEvents();
     }
     else
     {

--- a/ApplicationLibCode/ProjectDataModel/RimViewWindow.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewWindow.h
@@ -25,8 +25,7 @@
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 
-#include <QImage>
-
+class QImage;
 class RimDockWindowController;
 
 namespace ads
@@ -103,7 +102,7 @@ protected:
 
     void defineObjectEditorAttribute( QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
-    static QImage internalCaptureSnapshot( QWidget* widget, int width, int height );
+    static QImage internalCaptureSnapshot( ads::CDockWidget* dockWidget, QWidget* widget, int width, int height );
 
 private:
     friend class RimProject;

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -1208,9 +1208,13 @@ std::vector<RimViewWindow*> RiuMainWindow::viewWindows()
 {
     std::vector<RimViewWindow*> views;
 
-    for ( auto v : RimProject::current()->descendantsOfType<Rim3dView>() )
+    // Project can be null while it is being torn down.
+    if ( auto project = RimProject::current() )
     {
-        if ( v->dockWidget() ) views.push_back( v );
+        for ( auto v : project->descendantsOfType<Rim3dView>() )
+        {
+            if ( v->dockWidget() ) views.push_back( v );
+        }
     }
 
     return views;

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -797,9 +797,13 @@ std::vector<RimViewWindow*> RiuPlotMainWindow::viewWindows()
 {
     std::vector<RimViewWindow*> views;
 
-    for ( auto v : RimProject::current()->descendantsOfType<RimPlotWindow>() )
+    // Project can be null while it is being torn down.
+    if ( auto project = RimProject::current() )
     {
-        if ( v->dockWidget() ) views.push_back( v );
+        for ( auto v : project->descendantsOfType<RimPlotWindow>() )
+        {
+            if ( v->dockWidget() ) views.push_back( v );
+        }
     }
 
     return views;


### PR DESCRIPTION
## Problem

A regression test crashed with an access violation (null read at `0x0`) inside Qt's backing-store blit (`QWidgetRepaintManager::bltRect`) while capturing a plot snapshot.

## Root cause

`RimViewWindow::internalCaptureSnapshot` calls `setFixedSize(width, height)` and then immediately `widget->render(&painter)`. `setFixedSize()` only *posts* a deferred resize. `QWidget::render()` then delivers that pending resize **synchronously from inside the render call** (`prepareToRender` → `activateChildLayoutsRecursively` → `sendPendingMoveAndResizeEvents`). A child `QScrollArea` reacts by updating its scrollbars and moving its viewport mid-render (`updateScrollBars` → `valueChanged` → `QWidget::move`), which tries to blit a backing store that does not exist while rendering off-screen → crash.

## Fix

Flush the pending resize/move events with `QApplication::processEvents()` right after `setFixedSize()`, so the layout settles in the widget's normal state before `render()` is called. This mirrors the existing `QApplication::processEvents()` usage already present in the snapshot flow (`RicSnapshotAllPlotsToFileFeature.cpp`).