### PR TITLE
Add clazy Qt static analysis report workflow

### DIFF
--- a/.github/workflows/clazy-report.yml
+++ b/.github/workflows/clazy-report.yml
@@ -1,0 +1,82 @@
+name: clazy-report
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Once every night
+    - cron: "0 1 * * *"
+
+env:
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+jobs:
+  ResInsight-clazy:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update --option="APT::Acquire::Retries=3"
+          sudo apt-get install --option="APT::Acquire::Retries=3" libxkbcommon-x11-0 libgl1-mesa-dev mesa-common-dev libglfw3-dev libglu1-mesa-dev libhdf5-dev
+          sudo apt-get install clang-tidy-19 clang-format-19 clang-19 llvm-19-dev libclang-19-dev ninja-build
+
+      - name: Build clazy from source (against clang/llvm-19)
+        # Ubuntu's packaged clazy is built against an older Clang that cannot
+        # parse libstdc++-14's C++23 headers. Build clazy 1.15 (requires
+        # Clang 19+) against the installed llvm-19 so it matches our compiler.
+        run: |
+          git clone --depth 1 --branch 1.15 https://github.com/KDE/clazy.git clazy-src
+          cmake -S clazy-src -B clazy-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$HOME/clazy-install" \
+            -DLLVM_ROOT=/usr/lib/llvm-19
+          cmake --build clazy-build
+          cmake --build clazy-build --target install
+          echo "$HOME/clazy-install/bin" >> "$GITHUB_PATH"
+
+      - name: Install Qt
+        uses: CeetronSolutions/install-qt-action@bump-node24
+        with:
+          version: 6.7.0
+          dir: "${{ github.workspace }}/Qt/"
+          cache: true
+          modules: "qtnetworkauth"
+
+      - name: vcpkg bootstrap
+        run: ThirdParty/vcpkg/bootstrap-vcpkg.sh
+
+      - name: Get vcpkg submodule SHA
+        id: vcpkg-sha
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD:ThirdParty/vcpkg)" >> $GITHUB_OUTPUT
+
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
+        with:
+          cache-key: ${{ runner.os }}-clang-tidy-19-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+
+      - name: Create compile commands
+        env:
+          VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 -DRESINSIGHT_USE_OPENMP=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+      - name: Run clazy (Qt checks, report only)
+        continue-on-error: true
+        run: |
+          cd build
+          # One process per file across all cores; clazy-standalone is otherwise
+          # single-threaded and slow over the whole tree.
+          # Skip UnitTests: gtest is only fetched for the test target, so its
+          # headers are absent on this configure-only tree.
+          find ../ApplicationLibCode -path '*/UnitTests/*' -prune -o -name '*.cpp' -print0 \
+            | xargs -0 -P "$(nproc)" -n 1 clazy-standalone -checks=level1,no-range-loop-detach,no-non-pod-global-static -p compile_commands.json
+          find ../GrpcInterface -name '*.cpp' -print0 \
+            | xargs -0 -P "$(nproc)" -n 1 clazy-standalone -checks=level1,no-range-loop-detach,no-non-pod-global-static -p compile_commands.json


### PR DESCRIPTION
Adds a dedicated `clazy-report` workflow that runs clazy (Qt-oriented static analyzer) as a non-blocking, report-only step. The `clang-tidy` workflow is left unchanged.

## What it does
- Configures the build with `CMAKE_EXPORT_COMPILE_COMMANDS=ON` to generate `compile_commands.json` (it does not build or run clang-tidy, clang-format, or create a pull request).
- Builds clazy 1.15 from source against the installed clang/llvm-19. Ubuntu's packaged clazy is built against an older Clang that cannot parse libstdc++-14's C++23 headers, so it must match the compiler used to generate `compile_commands.json`.
- Runs `clazy-standalone` over `ApplicationLibCode` and `GrpcInterface`, one process per file across all cores.
- Excludes the two highest-volume checks (`range-loop-detach`, `non-pod-global-static`) to surface higher-signal Qt findings.
- Skips `ApplicationLibCode/UnitTests` because gtest is only fetched for the test target and its headers are absent on this configure-only tree.

The clazy step is `continue-on-error: true` — it reports Qt findings in the log and never fails the run or modifies files.

Triggers: `workflow_dispatch` and a nightly `cron`.