### PR TITLE
#14262 Fix missing grid statistics context menu entries

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
@@ -620,6 +620,15 @@ void RiuViewerCommands::displayContextMenu( QMouseEvent* event )
         else
         {
             menuBuilder.addSeparator();
+            menuBuilder << "RicCreateGridStatisticsPlotFeature";
+            menuBuilder << "RicShowGridStatisticsFeature";
+            // Grid statistics commands operate on the result shown in the overlay info box, so only
+            // offer them when the context menu is invoked inside that box, not on the view geometry.
+            if ( m_viewer->isMousePosWithinInfoBox( event->x(), event->y() ) )
+            {
+                menuBuilder << "RicCopyGridStatisticsToClipboardFeature";
+            }
+            menuBuilder.addSeparator();
             menuBuilder << "RicNewGridTimeHistoryCurveFeature";
             menuBuilder << "RicShowFlowCharacteristicsPlotFeature";
             if ( dynamic_cast<RimEclipseView*>( gridView ) )
@@ -635,14 +644,6 @@ void RiuViewerCommands::displayContextMenu( QMouseEvent* event )
             menuBuilder.subMenuEnd();
             menuBuilder.addSeparator();
 
-            // Grid statistics commands operate on the result shown in the overlay info box, so only
-            // offer them when the context menu is invoked inside that box, not on the view geometry.
-            if ( m_viewer->isMousePosWithinInfoBox( event->x(), event->y() ) )
-            {
-                menuBuilder << "RicCreateGridStatisticsPlotFeature";
-                menuBuilder << "RicShowGridStatisticsFeature";
-                menuBuilder << "RicCopyGridStatisticsToClipboardFeature";
-            }
             menuBuilder << "RicSelectColorResult";
             menuBuilder.addSeparator();
             menuBuilder << "RicHideGridGeometryFeature";


### PR DESCRIPTION
Fixes #14262

The grid statistics plot and show commands were only added to the 3D view context menu when the cursor was inside the overlay info box, so right-clicking on the grid geometry no longer offered them. This was a regression from earlier versions.

Always add the create and show grid statistics commands, and keep only the copy-to-clipboard command gated by the info box position, since that command operates on the result currently shown in the info box.
