### PR TITLE
Fix crash when activating combo box with stale option index

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl
@@ -27,13 +27,19 @@ void PdmFieldUiCap<FieldType>::setValueFromUiEditor( const QVariant& uiValue, bo
         if ( uiValue.metaType().id() == QMetaType::UInt )
         {
             uint optionIndex = uiValue.toUInt();
-            CAF_ASSERT( optionIndex < static_cast<unsigned int>( m_optionEntryCache.size() ) );
 
-            QVariant optionVariantValue = m_optionEntryCache[optionIndex].value();
+            // The editor may hold a stale index if the option cache was rebuilt (e.g. options removed) after the
+            // editor was populated but before the user activated an item. Ignore out-of-range selections instead of
+            // asserting, mirroring the multi-value branch below.
+            if ( optionIndex < static_cast<unsigned int>( m_optionEntryCache.size() ) )
+            {
+                QVariant optionVariantValue = m_optionEntryCache[optionIndex].value();
 
-            typename FieldType::FieldDataType fieldValue;
-            PdmUiFieldSpecialization<typename FieldType::FieldDataType>::setFromVariant( optionVariantValue, fieldValue );
-            m_field->setValue( fieldValue );
+                typename FieldType::FieldDataType fieldValue;
+                PdmUiFieldSpecialization<typename FieldType::FieldDataType>::setFromVariant( optionVariantValue,
+                                                                                             fieldValue );
+                m_field->setValue( fieldValue );
+            }
         }
         else if ( uiValue.metaType().id() == QMetaType::QVariantList )
         {


### PR DESCRIPTION
Fixes #14266

**Problem**

`PdmFieldUiCap::setValueFromUiEditor` aborted via `CAF_ASSERT` when the activated combo-box index exceeded the option cache. The shared `m_optionEntryCache` is rebuilt on every `valueOptions()` call, so a combo populated earlier can hold a stale index after the option list shrinks (for example when a summary ensemble is removed or reloaded). In release builds the assert aborts the application. Reported via crash telemetry for `PdmPtrField<RimSummaryEnsemble*>` combo boxes in 2026.02.2 and 2026.06.0.

**Fix**

Guard the single-value index against the cache size and ignore out-of-range selections, mirroring the existing bounds-check in the multi-value branch of the same function. The field is left unchanged and refreshed to a consistent state on the next UI update.
