### PR TITLE
#14275 Guard null QwtScaleWidget in alignAxis

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp
@@ -1154,13 +1154,14 @@ void RiuMultiPlotPage::alignAxis( QwtAxisId axis, int targetRowOrColumn, std::fu
 
             if ( riuQwtPlotWidget )
             {
-                QwtPlot* p = riuQwtPlotWidget->qwtPlot();
-                if ( p )
+                if ( QwtPlot* p = riuQwtPlotWidget->qwtPlot() )
                 {
-                    QwtScaleWidget* scaleWidget = p->axisWidget( axis );
-                    QwtScaleDraw*   sd          = scaleWidget->scaleDraw();
-                    sd->setMinimumExtent( 0.0 );
-                    maxExtent = std::max( sd->extent( scaleWidget->font() ), maxExtent );
+                    if ( QwtScaleWidget* scaleWidget = p->axisWidget( axis ) )
+                    {
+                        QwtScaleDraw* sd = scaleWidget->scaleDraw();
+                        sd->setMinimumExtent( 0.0 );
+                        maxExtent = std::max( sd->extent( scaleWidget->font() ), maxExtent );
+                    }
                 }
             }
         }
@@ -1179,11 +1180,12 @@ void RiuMultiPlotPage::alignAxis( QwtAxisId axis, int targetRowOrColumn, std::fu
             RiuQwtPlotWidget* riuQwtPlotWidget = dynamic_cast<RiuQwtPlotWidget*>( plotWidget );
             if ( riuQwtPlotWidget )
             {
-                QwtPlot* p = riuQwtPlotWidget->qwtPlot();
-                if ( p )
+                if ( QwtPlot* p = riuQwtPlotWidget->qwtPlot() )
                 {
-                    QwtScaleWidget* scaleWidget = p->axisWidget( axis );
-                    scaleWidget->scaleDraw()->setMinimumExtent( maxExtent );
+                    if ( QwtScaleWidget* scaleWidget = p->axisWidget( axis ) )
+                    {
+                        scaleWidget->scaleDraw()->setMinimumExtent( maxExtent );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #14275

## Problem
`QwtPlot::axisWidget( axisId )` returns `NULL` when the axis id is not valid for a plot. `RiuMultiPlotPage::alignAxis` queries fixed axis positions (`XTop`/`XBottom`/`YLeft`/`YRight`, index 0) against every visible plot and dereferenced the returned `QwtScaleWidget*` without a null check. This was reported repeatedly from release crash telemetry.

