### PR TITLE
#14277 Hide property filter insert when not a collection child

### DIFF
--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertFeature.cpp
@@ -23,6 +23,7 @@
 #include "RicEclipsePropertyFilterInsertExec.h"
 
 #include "RimEclipsePropertyFilter.h"
+#include "RimEclipsePropertyFilterCollection.h"
 
 #include "cafCmdExecCommandManager.h"
 
@@ -38,12 +39,21 @@ CAF_CMD_SOURCE_INIT( RicEclipsePropertyFilterInsertFeature, "RicEclipsePropertyF
 bool RicEclipsePropertyFilterInsertFeature::isCommandEnabled() const
 {
     std::vector<RimEclipsePropertyFilter*> propertyFilters = RicEclipsePropertyFilterFeatureImpl::selectedPropertyFilters();
-    if ( propertyFilters.size() == 1 )
+    if ( propertyFilters.size() != 1 ) return false;
+
+    RimEclipsePropertyFilter* propertyFilter = propertyFilters[0];
+
+    // Insert places a sibling next to the selected filter in its property-filter collection. This is
+    // only possible when the filter is a direct child of the collection - not when it is nested in a
+    // combined filter, or hosted at case level with no property-filter collection ancestor.
+    auto* propertyFilterCollection = propertyFilter->firstAncestorOrThisOfType<RimEclipsePropertyFilterCollection>();
+    if ( !propertyFilterCollection ) return false;
+    if ( propertyFilterCollection->propertyFiltersField().indexOf( propertyFilter ) >= propertyFilterCollection->propertyFiltersField().size() )
     {
-        return RicEclipsePropertyFilterFeatureImpl::isPropertyFilterCommandAvailable( propertyFilters[0] );
+        return false;
     }
 
-    return false;
+    return RicEclipsePropertyFilterFeatureImpl::isPropertyFilterCommandAvailable( propertyFilter );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #14277

## Problem

Right-clicking an Eclipse property filter and choosing "Insert Property Filter" crashes when the filter is not a direct child of a `RimEclipsePropertyFilterCollection`. After the combined-filter / `RimFilterInViewCollection` restructure, a property filter can live inside a `RimCombinedFilter` (per-view or case-level host), so `RicEclipsePropertyFilterInsertExec::redo()` reaches `firstAncestorOrThisOfTypeAsserted<RimEclipsePropertyFilterCollection>()` with no collection ancestor and aborts.

## Fix

`RicEclipsePropertyFilterInsertFeature::isCommandEnabled()` now returns false unless the selected filter is a direct child of a property-filter collection. Because the context menu builder only adds an action when it can be executed, the "Insert Property Filter" entry is no longer offered for filters nested in a combined filter or hosted at case level, so the asserting path is unreachable. Behavior for ordinary collection-level property filters is unchanged.
