### PR TITLE
#14279 Guard line editor editing-finished against deleted field

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
@@ -350,6 +350,11 @@ QMargins PdmUiLineEditor::calculateLabelContentMargins() const
 //--------------------------------------------------------------------------------------------------
 void PdmUiLineEditor::slotEditingFinished()
 {
+    // The field may have been destroyed (e.g. its owning object was deleted) while the editor still
+    // had focus. Hiding the editor during teardown emits editingFinished, so guard against the now
+    // null field before committing. PdmUiItem::~PdmUiItem() clears the editor's item pointer.
+    if ( !uiField() ) return;
+
     QVariant v;
 
     uiField()->enableAutoValue( false );


### PR DESCRIPTION
Fixes #14279

## Problem

Deleting a tree item (e.g. an ensemble curve set) while a line editor in the property panel still has focus with a pending edit crashes ResInsight. `RicDeleteItemExec::redo()` deletes the object, then the property panel teardown (`cleanupBeforeSettingPdmObject`) hides the field editors. Hiding a focused, modified `QLineEdit` makes Qt emit `editingFinished`, so `PdmUiLineEditor::slotEditingFinished()` runs and calls `uiField()->enableAutoValue( false )`. Because the field's owning object was just deleted, `PdmUiItem::~PdmUiItem()` has cleared the editor's item pointer and `uiField()` returns null, so this is a null dereference.

## Fix

Guard `PdmUiLineEditor::slotEditingFinished()` with an early return when `uiField()` is null, before committing. This matches the existing pattern in the combo box and double value editors, which already null-check `uiField()` at the start of their slots. There is nothing to commit when the field is gone, and the editor is about to be deleted by the teardown. Behavior is unchanged for live fields.
