### PR TITLE
#14281 Guard findReservoir against null main window

### DIFF
--- a/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp
+++ b/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp
@@ -152,7 +152,10 @@ RimEclipseCase* RiaSocketServer::findReservoir( int caseId )
 
         // If the active mdi window is different from an Eclipse view, search through available mdi windows to find the
         // last activated Eclipse view. The sub windows are returned with the most recent activated window at the back.
-        QList<QMdiSubWindow*> subWindows = RiuMainWindow::instance()->subWindowList( QMdiArea::ActivationHistoryOrder );
+        RiuMainWindow* mainWindow = RiuMainWindow::instance();
+        if ( !mainWindow ) return nullptr;
+
+        QList<QMdiSubWindow*> subWindows = mainWindow->subWindowList( QMdiArea::ActivationHistoryOrder );
         for ( int i = subWindows.size() - 1; i > -1; i-- )
         {
             RiuViewer* viewer = subWindows[i]->widget()->findChild<RiuViewer*>();


### PR DESCRIPTION
Fixes #14281

## Problem

When an Octave/Python script requests the active cell property (`RiaGetActiveCellProperty`) with `caseId < 0` and no active Eclipse view exists, `RiaSocketServer::findReservoir()` falls back to searching the MDI sub windows via `RiuMainWindow::instance()->subWindowList( ... )`. `RiuMainWindow::instance()` returns null when no 3D main window is present, so the call dereferences a null `this` inside `subWindowList` and crashes.

## Fix

Null-check `RiuMainWindow::instance()` before using it, returning null from `findReservoir` when there is no main window. With no main window there are no MDI sub windows to search, so the function returns null exactly as it would have after the loop.

This is a targeted backport for the 2026.06 release branch. On `dev` the whole MDI fallback (and `subWindowList`) was already removed by "Remove last traces of MDI" (a1fe3739d1), so the crash path does not exist there.
