### PR TITLE
#14289 Guard against deleted result definition in geometry selection items

### DIFF
--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RimGeoMechGeometrySelectionItem.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RimGeoMechGeometrySelectionItem.cpp
@@ -57,7 +57,11 @@ RimGeoMechGeometrySelectionItem::~RimGeoMechGeometrySelectionItem()
 //--------------------------------------------------------------------------------------------------
 void RimGeoMechGeometrySelectionItem::setFromSelectionItem( const RiuGeoMechSelectionItem* selectionItem )
 {
-    m_geoMechCase = selectionItem->m_resultDefinition->geoMechCase();
+    // The result definition is a guarded pointer that is null if the result definition has been deleted.
+    if ( selectionItem->m_resultDefinition )
+    {
+        m_geoMechCase = selectionItem->m_resultDefinition->geoMechCase();
+    }
 
     m_gridIndex               = selectionItem->m_gridIndex;
     m_cellIndex               = selectionItem->m_cellIndex;

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseGeometrySelectionItem.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseGeometrySelectionItem.cpp
@@ -64,7 +64,11 @@ void RimEclipseGeometrySelectionItem::setFromSelectionItem( const RiuEclipseSele
     m_gridIndex = selectionItem->m_gridIndex;
     m_cellIndex = selectionItem->m_gridLocalCellIndex;
 
-    m_eclipseCase = selectionItem->m_resultDefinition->eclipseCase();
+    // The result definition is a guarded pointer that is null if the result definition has been deleted.
+    if ( selectionItem->m_resultDefinition )
+    {
+        m_eclipseCase = selectionItem->m_resultDefinition->eclipseCase();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/docs/agents/crash-triage.md
+++ b/docs/agents/crash-triage.md
@@ -34,6 +34,7 @@ signatures with **no linked issue** reach this stage.
 - Branches and PRs go to your **personal fork** remote, never `origin` (OPM upstream).
 - Commit/PR messages start with `#<issue>`; no AI attribution; no `## Test plan` section.
 - One signature per run unless explicitly told to batch.
+- Keep all comments and descriptions (issues, PRs, notes, code) short and concise.
 
 ## Procedure
 


### PR DESCRIPTION
Fixes #14289

## Problem
RimEclipseGeometrySelectionItem::setFromSelectionItem dereferences RiuEclipseSelectionItem::m_resultDefinition without a null check. That member is a guarded pointer that becomes null when the result definition is deleted (e.g. a case/view is closed while a 3D selection persists). On a later time-step change the stale selection is re-pushed and eclipseCase() is invoked on a null pointer, crashing the application. RimGeoMechGeometrySelectionItem::setFromSelectionItem has the identical unguarded dereference.

## Fix
Guard the dereference with a null check in both the Eclipse and GeoMech geometry selection items, matching the pattern already used by the caller and other selection-item consumers. When the result definition is gone the case is left unset, a state downstream code already handles.
