### PR TITLE
#14294 Fix crash duplicating GeoMech property filters into linked view

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimGeoMechPropertyFilterCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimGeoMechPropertyFilterCollection.cpp
@@ -57,6 +57,7 @@ void RimGeoMechPropertyFilterCollection::loadAndInitializePropertyFilters()
     for ( size_t i = 0; i < propertyFilters.size(); i++ )
     {
         RimGeoMechPropertyFilter* propertyFilter = propertyFilters[i];
+        propertyFilter->setParentContainer( this );
         propertyFilter->resultDefinition()->setGeoMechCase( reservoirView()->geoMechCase() );
         propertyFilter->resultDefinition()->loadResult();
         propertyFilter->computeResultValueRange();


### PR DESCRIPTION
Fixes #14294

**Problem**

Duplicating GeoMech property filters into a managed (linked) view deserializes them with `readObjectFromXmlString`, which does not call `initAfterRead`. The filters' `m_parentContainer` stays null, and `loadAndInitializePropertyFilters()` then crashes on `CVF_ASSERT( m_parentContainer )` in `computeResultValueRange()`.

**Fix**

Re-establish the parent container link in `RimGeoMechPropertyFilterCollection::loadAndInitializePropertyFilters()` before computing the value range, matching what `initAfterRead()` does and the existing Eclipse property filter behaviour.
