### PR TITLE
#14296 Fix contour map crash on degenerate grid bounds

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapGrid.cpp
@@ -18,6 +18,7 @@
 
 #include "RigContourMapGrid.h"
 
+#include <algorithm>
 #include <cmath>
 
 using namespace cvf;
@@ -279,6 +280,12 @@ cvf::Vec2ui RigContourMapGrid::calculateMapSize( const cvf::Vec3d& gridExtent, d
 {
     uint projectionSizeX = static_cast<uint>( std::ceil( gridExtent.x() / sampleSpacing ) );
     uint projectionSizeY = static_cast<uint>( std::ceil( gridExtent.y() / sampleSpacing ) );
+
+    // A contour map must have at least one cell (two vertices) in each direction to be tesselated.
+    // A degenerate bounding box with zero extent in a direction would otherwise produce a zero-sized
+    // map and trigger an assert when generating the triangle patch.
+    projectionSizeX = std::max( projectionSizeX, 1u );
+    projectionSizeY = std::max( projectionSizeY, 1u );
 
     return cvf::Vec2ui( projectionSizeX, projectionSizeY );
 }

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapGrid.cpp
@@ -281,7 +281,7 @@ cvf::Vec2ui RigContourMapGrid::calculateMapSize( const cvf::Vec3d& gridExtent, d
     uint projectionSizeX = static_cast<uint>( std::ceil( gridExtent.x() / sampleSpacing ) );
     uint projectionSizeY = static_cast<uint>( std::ceil( gridExtent.y() / sampleSpacing ) );
 
-    // A contour map must have at least one cell (two vertices) in each direction to be tesselated.
+    // A contour map must have at least one cell (two vertices) in each direction to be tessellated.
     // A degenerate bounding box with zero extent in a direction would otherwise produce a zero-sized
     // map and trigger an assert when generating the triangle patch.
     projectionSizeX = std::max( projectionSizeX, 1u );


### PR DESCRIPTION
Fixes #14296

**Problem**
When a contour-map grid's bounding box has zero extent in X or Y, `RigContourMapGrid::calculateMapSize` returns 0 elements in that direction, giving a single vertex. Triangle generation then calls `tesselatePatchAsTriangles`, whose `CVF_ASSERT(pointCount >= 2)` fires and crashes (release builds keep this assert). Hit when creating a statistics contour map view from an ensemble case with degenerate active-cell bounds.

**Fix**
Clamp the computed map size to a minimum of one cell (two vertices) per direction in `calculateMapSize`. This is the shared chokepoint for all contour-map types, so it guards every caller.
