### PR TITLE
#14298 Fix crash on out-of-range delta base time step in result info

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp
@@ -1035,9 +1035,13 @@ QString RimEclipseResultDefinition::additionalResultText() const
         const RigCaseCellResultsData* gridCellResults = currentGridCellResults();
         if ( gridCellResults )
         {
-            stepDates = gridCellResults->timeStepDates();
-            resultText += QString( "<b>Base Time Step</b>: %1" )
-                              .arg( stepDates[m_timeLapseBaseTimestep()].toString( RiaQDateTimeTools::dateFormatString() ) );
+            stepDates        = gridCellResults->timeStepDates();
+            int baseTimeStep = m_timeLapseBaseTimestep();
+            if ( baseTimeStep >= 0 && baseTimeStep < static_cast<int>( stepDates.size() ) )
+            {
+                resultText +=
+                    QString( "<b>Base Time Step</b>: %1" ).arg( stepDates[baseTimeStep].toString( RiaQDateTimeTools::dateFormatString() ) );
+            }
         }
     }
     if ( isDeltaCaseActive() )


### PR DESCRIPTION
Fixes #14298

**Problem**
`RimEclipseResultDefinition::additionalResultText()` indexes the time-step-dates vector with `m_timeLapseBaseTimestep()` without bounds-checking. `isDeltaTimeStepActive()` only ensures the index is `>= 0`, so a stale base time step larger than the current case's time-step count causes an out-of-range `std::vector::operator[]` and crashes when the 3D overlay info text is built.

**Fix**
Bounds-check the base time step against the number of available time steps before indexing.
