### PR TITLE
#14300 Guard flow diagnostics frame access against out-of-range time step

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigFlowDiagResults.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigFlowDiagResults.cpp
@@ -143,7 +143,7 @@ std::vector<double>* RigFlowDiagResults::findScalarResultFrame( const RigFlowDia
 {
     RigFlowDiagResultFrames* resFrames = findScalarResult( resVarAddr );
 
-    if ( resFrames )
+    if ( resFrames && timeStepIndex < resFrames->frameCount() )
     {
         std::vector<double>& frame = resFrames->frameData( timeStepIndex );
         if ( !frame.empty() ) return ( &frame );


### PR DESCRIPTION
Fixes #14300

## Problem
`RigFlowDiagResults::findScalarResultFrame` accessed `RigFlowDiagResultFrames::frameData(timeStepIndex)` with an unchecked `operator[]`. When the time step index exceeds the frame count (frames are sized to the time step count captured when the results were first cached), this returns a reference to out-of-bounds memory. The following `empty()` check then reads garbage and can spuriously report the vector as non-empty, so a pointer to a corrupt vector is returned and `MinMaxAccumulator::addData` crashes iterating it.

## Fix
Add a bounds check (`timeStepIndex < resFrames->frameCount()`) before accessing the frame, matching the existing guard in `calculateNativeResultsIfNotPreviouslyAttempted`.
