### PR TITLE
#14302 Fix crash deleting all linked views with active cell filters

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewController.cpp
@@ -1119,7 +1119,13 @@ bool RimViewController::askUserToRestoreOriginalCellFilterCollection( const QStr
 {
     RimGridView* activeView = RiaApplication::instance()->activeGridView();
 
-    QMessageBox msgBox( activeView->viewer()->layoutWidget() );
+    QWidget* parentWidget = nullptr;
+    if ( activeView && activeView->viewer() )
+    {
+        parentWidget = activeView->viewer()->layoutWidget();
+    }
+
+    QMessageBox msgBox( parentWidget );
     msgBox.setIcon( QMessageBox::Question );
 
     QString questionText;


### PR DESCRIPTION
Fixes #14302

## Problem
Deleting all linked views while the master view has active cell filters opens a confirmation dialog parented to `activeGridView()->viewer()->layoutWidget()`. Both `activeGridView()` (a dynamic_cast) and `viewer()` can return nullptr, causing a segfault.

## Fix
Guard both pointers and fall back to a null parent widget, which QMessageBox accepts. The dialog still appears and behavior is preserved.
