### PR TITLE
clang-tidy CI: skip generated files under build/ in path filter

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -65,8 +65,10 @@ jobs:
         continue-on-error: true
         run: |
           cd build
-          run-clang-tidy-19 -config-file ../ApplicationLibCode/.clang-tidy -fix files ApplicationLibCode
-          run-clang-tidy-19 -config-file ../GrpcInterface/.clang-tidy -fix files GrpcInterface
+          # The path regex excludes generated files (moc/qrc) under build/, which are listed in
+          # compile_commands.json but not produced when the project is only configured, not built.
+          run-clang-tidy-19 -config-file ../ApplicationLibCode/.clang-tidy -fix '^(?!.*/build/).*(files|ApplicationLibCode)'
+          run-clang-tidy-19 -config-file ../GrpcInterface/.clang-tidy -fix '^(?!.*/build/).*(files|GrpcInterface)'
       - name: Run clang-format after clang-tidy
         continue-on-error: true
         run: |


### PR DESCRIPTION
The nightly `clang-tidy` workflow only configures the project (`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`) without building it. As a result, `compile_commands.json` lists generated `moc`/`qrc` translation units under `build/` that are never produced, and `run-clang-tidy` emits spurious `clang-diagnostic-error` lines such as:

```
error: no such file or directory: '.../build/.../RigGeoMechDataModel_autogen/mocs_compilation.cpp'
error: no such file or directory: '.../build/ApplicationLibCode/qrc_ApplicationLibCode.cpp'
error: unable to handle compilation, expected exactly one compiler job in ''
```

This change scopes the `run-clang-tidy` path filter with an anchored negative lookahead `^(?!.*/build/)` so files under `build/` are skipped. Real source (never under `build/`) is still linted, and the existing include set is otherwise preserved.

The step is already `continue-on-error: true`, so this only removes log noise; it was not failing the job.
