### PR TITLE
Guard progress dialog event processing against re-entrant recursion

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
@@ -466,9 +466,10 @@ ProgressInfoBlocker::~ProgressInfoBlocker()
 
 std::atomic<bool> ProgressInfoStatic::s_running = false;
 
-bool ProgressInfoStatic::s_disabled            = false;
-bool ProgressInfoStatic::s_isButtonConnected   = false;
-bool ProgressInfoStatic::s_shouldProcessEvents = true;
+bool ProgressInfoStatic::s_disabled                  = false;
+bool ProgressInfoStatic::s_isButtonConnected         = false;
+int  ProgressInfoStatic::s_eventProcessingBlockDepth = 0;
+bool ProgressInfoStatic::s_isProcessingEvents        = false;
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -545,7 +546,7 @@ void ProgressInfoStatic::start( ProgressInfo&  progressInfo,
         dialog->setLabelText( currentComposedLabel() );
     }
 
-    if ( s_shouldProcessEvents ) QCoreApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
+    processEventsIfPossible();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -572,7 +573,7 @@ void ProgressInfoStatic::setProgressDescription( const QString& description )
         dialog->setLabelText( currentComposedLabel() );
     }
 
-    if ( s_shouldProcessEvents ) QCoreApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
+    processEventsIfPossible();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -627,7 +628,7 @@ void ProgressInfoStatic::setProgress( size_t progressValue )
         dialog->setValue( (int)( 100.0 * value ) );
     }
 
-    if ( s_shouldProcessEvents ) QCoreApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
+    processEventsIfPossible();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -767,11 +768,36 @@ bool ProgressInfoStatic::isUpdatePossible()
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Pump the event loop so the progress dialog can repaint during long running operations.
+///
+/// processEvents() dispatches queued events, which may trigger further progress updates that call
+/// this method again. A re-entrancy guard makes sure only the outermost call pumps events: nested
+/// calls return immediately, preventing the unbounded recursion (and stack overflow) that would
+/// otherwise occur. Explicit ProgressInfoEventProcessingBlocker scopes suppress pumping entirely.
+//--------------------------------------------------------------------------------------------------
+void ProgressInfoStatic::processEventsIfPossible()
+{
+    if ( s_eventProcessingBlockDepth != 0 ) return;
+
+    if ( s_isProcessingEvents ) return;
+    s_isProcessingEvents = true;
+
+    // Reset the guard even if a dispatched event handler throws, otherwise event processing would
+    // be permanently disabled for the rest of the session.
+    struct GuardReset
+    {
+        ~GuardReset() { s_isProcessingEvents = false; }
+    } guardReset;
+
+    QCoreApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 ProgressInfoEventProcessingBlocker::ProgressInfoEventProcessingBlocker()
 {
-    ProgressInfoStatic::s_shouldProcessEvents = false;
+    ProgressInfoStatic::s_eventProcessingBlockDepth++;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -779,7 +805,8 @@ ProgressInfoEventProcessingBlocker::ProgressInfoEventProcessingBlocker()
 //--------------------------------------------------------------------------------------------------
 ProgressInfoEventProcessingBlocker::~ProgressInfoEventProcessingBlocker()
 {
-    ProgressInfoStatic::s_shouldProcessEvents = true;
+    CAF_ASSERT( ProgressInfoStatic::s_eventProcessingBlockDepth > 0 );
+    ProgressInfoStatic::s_eventProcessingBlockDepth--;
 }
 
 } // namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafProgressInfo.h
+++ b/Fwk/AppFwk/cafUserInterface/cafProgressInfo.h
@@ -110,6 +110,7 @@ public:
 
 private:
     static bool isUpdatePossible();
+    static void processEventsIfPossible();
 
 private:
     friend class ProgressInfoBlocker;
@@ -117,9 +118,12 @@ private:
 
     static std::atomic<bool> s_running;
 
+    // The following flags are only ever accessed on the GUI thread (callers marshal via
+    // isOnGuiThread()), so plain types are sufficient.
     static bool s_disabled;
     static bool s_isButtonConnected;
-    static bool s_shouldProcessEvents;
+    static int  s_eventProcessingBlockDepth;
+    static bool s_isProcessingEvents;
 };
 
 } // namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PROJECT_FILES
     cafPdmUiCheckBoxAndTextEditorTest.cpp
     cafPdmUiPropertyViewDialogTest.cpp
     cafIconProviderTest.cpp
+    cafProgressInfoTest.cpp
     gtest/gtest-all.cpp
 )
 

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafProgressInfoTest.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafProgressInfoTest.cpp
@@ -1,0 +1,88 @@
+
+#include "gtest/gtest.h"
+
+#include "cafProgressInfo.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QObject>
+
+#include <algorithm>
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Reproduces the re-entrant event processing that drove the progress dialog into unbounded
+/// recursion. Each queued event, when dispatched, updates the progress which in turn pumps the
+/// event loop. Without a re-entrancy guard the freshly queued event is dispatched immediately,
+/// re-entering this handler and growing the call stack until it overflows.
+//--------------------------------------------------------------------------------------------------
+class RecursiveProgressTrigger : public QObject
+{
+public:
+    RecursiveProgressTrigger( caf::ProgressInfo& progressInfo, int eventCount )
+        : m_progressInfo( progressInfo )
+        , m_remainingEvents( eventCount )
+    {
+    }
+
+    int maxDepth() const { return m_maxDepth; }
+
+    void postNext() { QCoreApplication::postEvent( this, new QEvent( QEvent::User ) ); }
+
+protected:
+    void customEvent( QEvent* event ) override
+    {
+        if ( event->type() != QEvent::User ) return;
+
+        ++m_currentDepth;
+        m_maxDepth = std::max( m_maxDepth, m_currentDepth );
+
+        if ( m_remainingEvents > 0 )
+        {
+            --m_remainingEvents;
+
+            // Keep an event queued so the loop always has something to dispatch, then trigger a
+            // progress update. The update pumps the event loop; the re-entrancy guard must keep
+            // that nested pump from dispatching the queued event and recursing back into here.
+            postNext();
+            m_progressInfo.setProgress( static_cast<size_t>( ++m_progressValue ) );
+        }
+
+        --m_currentDepth;
+    }
+
+private:
+    caf::ProgressInfo& m_progressInfo;
+    int                m_remainingEvents = 0;
+    int                m_currentDepth    = 0;
+    int                m_maxDepth        = 0;
+    size_t             m_progressValue   = 1;
+};
+
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+/// Regression test for the recursive stack overflow in the progress dialog. A large number of
+/// queued events each trigger a progress update that pumps the event loop. With the re-entrancy
+/// guard in place the nested updates return without pumping, so every event is dispatched at
+/// depth 1. Without the guard each dispatched event recurses through setProgress() -> processEvents()
+/// and the call stack grows until it overflows.
+//--------------------------------------------------------------------------------------------------
+TEST( ProgressInfoTest, EventProcessingDoesNotRecurseUnbounded )
+{
+    const int eventCount = 5000;
+
+    // delayShowingProgress = true keeps the dialog hidden (no real window) while still creating it,
+    // so progress updates pump the event loop exactly as they do in production.
+    caf::ProgressInfo progressInfo( static_cast<size_t>( eventCount + 2 ), "Recursion test", true, false );
+
+    RecursiveProgressTrigger trigger( progressInfo, eventCount );
+    trigger.postNext();
+
+    // Kick off processing through a progress update, mirroring production where a progress update
+    // is what pumps the event loop.
+    progressInfo.setProgress( 1 );
+
+    EXPECT_EQ( trigger.maxDepth(), 1 );
+}


### PR DESCRIPTION
Fixes #14306

The progress dialog pumps the Qt event loop during long running operations so it can repaint. A dispatched event could trigger a further progress update, which pumped the event loop again, recursing without bound until the call stack overflowed.

A re-entrancy guard now ensures only the outermost call pumps events; nested calls return immediately. The previous boolean suppression flag for `ProgressInfoEventProcessingBlocker` is replaced with a nestable depth counter so nested blocker scopes restore correctly. The guard is reset via RAII so a thrown event handler cannot leave event processing permanently disabled. All these flags are only accessed on the GUI thread (callers marshal via `isOnGuiThread()`), so plain types are used.

A regression test reproduces the unbounded recursion by queuing events that each trigger a progress update, and asserts every event is dispatched at depth 1.
