### PR TITLE
CI: Include MSVC toolset version in vcpkg cache key

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -197,11 +197,22 @@ jobs:
         shell: bash
         run: echo "sha=$(git rev-parse HEAD:ThirdParty/vcpkg)" >> $GITHUB_OUTPUT
 
+      - name: Get MSVC toolset version (Windows)
+        # vcpkg keys its binary ABI hash on the MSVC toolset version, which is
+        # not reflected by the vcpkg submodule SHA. Without it in the cache key,
+        # a runner-image MSVC bump makes the restored binaries ABI-incompatible
+        # and vcpkg rebuilds everything. VCToolsVersion is exported to the
+        # environment by the "Use MSVC (Windows)" step above.
+        id: msvc-version
+        if: contains(matrix.config.os, 'windows')
+        shell: bash
+        run: echo "version=${VCToolsVersion}" >> $GITHUB_OUTPUT
+
       - name: Restore vcpkg cache
         id: vcpkg-cache
         uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.msvc-version.outputs.version }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           prefix: vcpkg-${{ matrix.config.cxx}}/
           
       - name: Print CMake version


### PR DESCRIPTION
## Problem

On the Windows job of `ResInsightWithCache.yml`, the vcpkg binary cache is **restored** on every run (GitHub reports a cache hit), but vcpkg then **rebuilds all 102 packages from source**.

Evidence — two runs on the same day with the **identical** cache key and **identical** MSVC toolset (`14.44.35207`):

| Run | GH cache | vcpkg result |
|---|---|---|
| Nightly `dev` (01:44) | hit, 355 MB restored | `Restored 0 package(s)` → builds all 102 |
| PR branch (12:37) | hit | `Restored 102 package(s)` → builds 0 |

## Root cause

vcpkg keys each binary by an ABI hash that includes the **MSVC toolset version**. The cache key only contained `runner.os`, the compiler *name* (`cl`), the vcpkg submodule SHA, and the `vcpkg-configuration.json` hash — none of which capture the toolset version.

When the runner image bumps MSVC, the restored binaries become ABI-incompatible and vcpkg rebuilds everything. Because the cache key is unchanged, the action then logs `Cache already present … Skipping save` (GitHub cache entries are immutable), so the freshly built binaries are discarded and the stale entry can never refresh — the rebuild loop persists on every subsequent run. The default branch (`dev`) is the worst victim, since every PR reads its cache.

## Fix

Add the MSVC toolset version (`VCToolsVersion`, exported by the existing `Use MSVC (Windows)` step) to the cache key on Windows. A toolset bump now produces a new key → one cold rebuild → a successful save under the new key → subsequent runs restore from cache. The step is Windows-only, so the Ubuntu key is unaffected.
