### PR TITLE
#14306 Fix orphaned progress dialog when importing summary ensembles

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -21,6 +21,7 @@
 #include "RiaEclipseFileNameTools.h"
 #include "RiaEnsembleNameTools.h"
 #include "RiaLogging.h"
+#include "RiaOpenMPTools.h"
 #include "RiaPreferencesSummary.h"
 #include "RiaPreferencesSystem.h"
 #include "RiaQStringFormatter.h"
@@ -59,6 +60,7 @@
 
 #include <QCoreApplication>
 #include <QDir>
+#include <atomic>
 #include <memory>
 
 CAF_PDM_SOURCE_INIT( RimSummaryCaseMainCollection, "SummaryCaseCollection" );
@@ -583,6 +585,8 @@ void RimSummaryCaseMainCollection::loadFileSummaryCaseData( const std::vector<Ri
         [[maybe_unused]] bool canUseMultipleThreads =
             ( prefs->summaryDataReader() != RiaPreferencesSummary::SummaryReaderMode::HDF5_OPM_COMMON );
 
+        std::atomic<int> completedCount = 0;
+
 #pragma omp parallel for schedule( dynamic ) if ( canUseMultipleThreads )
         for ( int cIdx = 0; cIdx < static_cast<int>( fileSummaryCases.size() ); ++cIdx )
         {
@@ -611,7 +615,14 @@ void RimSummaryCaseMainCollection::loadFileSummaryCaseData( const std::vector<Ri
                 }
             }
 
-            progInfo.setProgress( cIdx );
+            int completed = ++completedCount;
+
+            // Only update progress from the GUI thread; worker-thread updates are marshaled via a
+            // queued connection and may be delivered after this ProgressInfo scope has ended.
+            if ( RiaOpenMPTools::currentThreadIndex() == 0 )
+            {
+                progInfo.setProgress( completed );
+            }
         }
         for ( const auto& txt : threadSafeLogger.messages() )
         {

--- a/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafProgressInfo.cpp
@@ -565,6 +565,9 @@ void ProgressInfoStatic::setProgressDescription( const QString& description )
 
     if ( !isUpdatePossible() ) return;
 
+    // Ignore stale updates delivered after the owning ProgressInfo scope has ended.
+    if ( descriptionStack().empty() ) return;
+
     descriptionStack().back() = description;
 
     QProgressDialog* dialog = progressDialog();
@@ -591,6 +594,9 @@ void ProgressInfoStatic::setProgress( size_t progressValue )
     }
 
     if ( !isUpdatePossible() ) return;
+
+    // Ignore stale updates delivered after the owning ProgressInfo scope has ended.
+    if ( progressStack().empty() ) return;
 
     std::vector<size_t>& progressStack_v     = progressStack();
     std::vector<size_t>& progressSpanStack_v = progressSpanStack();
@@ -644,10 +650,12 @@ void ProgressInfoStatic::incrementProgress()
 
     if ( !isUpdatePossible() ) return;
 
+    // Ignore stale updates delivered after the owning ProgressInfo scope has ended.
+    if ( progressStack().empty() ) return;
+
     std::vector<size_t>& progressStack_v     = progressStack();
     std::vector<size_t>& progressSpanStack_v = progressSpanStack();
 
-    CAF_ASSERT( progressStack_v.size() );
     ProgressInfoStatic::setProgress( progressStack_v.back() + progressSpanStack_v.back() );
 }
 
@@ -667,7 +675,9 @@ void ProgressInfoStatic::setNextProgressIncrement( size_t nextStepSize )
 
     if ( !isUpdatePossible() ) return;
 
-    CAF_ASSERT( progressSpanStack().size() );
+    // Ignore stale updates delivered after the owning ProgressInfo scope has ended.
+    if ( progressSpanStack().empty() ) return;
+
     std::vector<size_t>& maxProgressStack_v = maxProgressStack();
     std::vector<size_t>& progressStack_v    = progressStack();
 


### PR DESCRIPTION
## Problem

After importing a summary ensemble, a progress dialog could be left orphaned — stuck at 0% with no way to close it (and an intermittent crash in `RimSummaryCaseMainCollection::loadFileSummaryCaseData`).

## Root cause

`loadFileSummaryCaseData()` drives `caf::ProgressInfo` from **worker threads** inside an OpenMP loop. When `setProgress()` is called off the GUI thread it is marshaled to the GUI thread via `Qt::QueuedConnection`. These updates can be delivered **after** the `ProgressInfo` scope has ended and the progress stacks have been popped:

- `progressStack().back()` is then called on an empty vector (undefined behavior), and
- `dialog->setValue()` resurrects the just-closed dialog at 0% with nothing left to close it.

The recent #14306 re-entrancy guard removed the recursive `processEvents()` over-draining that previously happened to flush these queued events before teardown, which exposed this latent bug.

## Fix

1. **`RimSummaryCaseMainCollection.cpp`** — Update progress only from the master thread (`RiaOpenMPTools::currentThreadIndex() == 0`), using an `std::atomic<int>` counter so the displayed value is monotonic instead of the out-of-order `cIdx` from dynamic scheduling. No more worker-thread queued progress updates.

2. **`cafProgressInfo.cpp`** — Guard the asynchronously-marshaled mutators (`setProgress`, `incrementProgress`, `setProgressDescription`, `setNextProgressIncrement`) with an empty-stack check, so any stale queued update delivered after teardown is a harmless no-op instead of UB plus a resurrected dialog.

The #14306 re-entrancy guard itself is unchanged.