### PR TITLE
Synchronise all plots under a Summary Ensemble Correlation report

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.cpp
@@ -138,7 +138,7 @@ void RimAbstractCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* ch
     if ( changedField == &m_timeStep )
     {
         loadDataAndUpdate();
-        updateConnectedEditors();
+        updateAllRequiredEditors();
     }
     else if ( changedField == &m_showPlotTitle || changedField == &m_useAutoPlotTitle || changedField == &m_description )
     {
@@ -169,7 +169,7 @@ void RimAbstractCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* ch
             }
         }
 
-        updateConnectedEditors();
+        updateAllRequiredEditors();
     }
     else if ( changedField == &m_curveSetForFiltering )
     {
@@ -730,6 +730,22 @@ void RimAbstractCorrelationPlot::appendDataSourceFields( QString uiConfigName, c
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RimAbstractCorrelationPlot::isContainedInReportPlot() const
+{
+    return m_isReportSubPlot;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimAbstractCorrelationPlot::setReportSubPlot( bool enable )
+{
+    m_isReportSubPlot = enable;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimAbstractCorrelationPlot::onCaseRemoved( const SignalEmitter* emitter, RimSummaryCase* summaryCase )
 {
     loadDataAndUpdate();
@@ -799,7 +815,15 @@ void RimAbstractCorrelationPlot::onSelectVariablesButtonClicked()
             }
             connectAllCaseSignals();
             loadDataAndUpdate();
-            updateConnectedEditors();
+            updateAllRequiredEditors();
+            onDataSourceChanged();
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimAbstractCorrelationPlot::onDataSourceChanged()
+{
 }

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimAbstractCorrelationPlot.h
@@ -64,6 +64,8 @@ public:
     void                         setExcludedSummaryCases( const std::vector<RimSummaryCase*>& summaryCases );
     std::vector<RimSummaryCase*> excludedSummaryCases() const;
 
+    void setReportSubPlot( bool enable );
+
     RiuQwtPlotWidget* viewer();
     RiuPlotWidget*    plotWidget() override;
     void              detachAllCurves() override;
@@ -125,6 +127,16 @@ protected:
 
     void appendDataSourceFields( QString uiConfigName, caf::PdmUiOrdering& uiOrdering );
 
+    // True when this plot is a sub-plot of a correlation report. The report controls the data source and
+    // correlation settings, so individually only the plot settings are exposed in the property editor. The
+    // flag is set by the owning report (see setReportSubPlot) rather than derived by walking ancestors.
+    bool isContainedInReportPlot() const;
+
+    // Called after the selected summary vectors (data source) have been changed through the selection dialog.
+    // Subclasses may override to propagate the change to dependent plots. The matrix plot uses this to select its
+    // first cell, which in turn updates the sibling plots in a correlation report.
+    virtual void onDataSourceChanged();
+
 private:
     void onCaseRemoved( const SignalEmitter* emitter, RimSummaryCase* summaryCase );
     void connectAllCaseSignals();
@@ -158,4 +170,7 @@ private:
     caf::PdmField<bool>                                m_editCaseFilter;
 
     std::vector<RimSummaryCase*> m_excludedCases;
+
+    // Set by the owning correlation report; not serialized, re-established by the report on construction and read.
+    bool m_isReportSubPlot = false;
 };

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp
@@ -301,18 +301,35 @@ void RimCorrelationMatrixPlot::fieldChangedByUi( const caf::PdmFieldHandle* chan
         }
         updateLegend();
         loadDataAndUpdate();
-        updateConnectedEditors();
+        updateAllRequiredEditors();
 
-        auto curves     = curveDefinitions();
-        auto parameters = m_selectedParametersList();
-        if ( !curves.empty() && !parameters.empty() )
-        {
-            auto firstCurve     = curves.front();
-            auto firstParameter = parameters.front();
-
-            matrixCellSelected.send( { firstParameter, firstCurve } );
-        }
+        selectFirstItem();
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Select the first matrix cell (first parameter / first summary vector) and notify listeners. In a
+/// correlation report this propagates the current data source to the tornado, cross and summary plots.
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationMatrixPlot::selectFirstItem()
+{
+    auto curves     = curveDefinitions();
+    auto parameters = m_selectedParametersList();
+    if ( !curves.empty() && !parameters.empty() )
+    {
+        matrixCellSelected.send( { parameters.front(), curves.front() } );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// When the selected summary vectors change, re-select the first cell so the dependent plots in a
+/// correlation report are updated with the new data source.
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationMatrixPlot::onDataSourceChanged()
+{
+    if ( m_selectedParametersList().empty() ) selectAllParameters();
+
+    selectFirstItem();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -320,27 +337,35 @@ void RimCorrelationMatrixPlot::fieldChangedByUi( const caf::PdmFieldHandle* chan
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationMatrixPlot::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-    caf::PdmUiGroup* correlationGroup = uiOrdering.addNewGroup( "Correlation Settings" );
-    correlationGroup->add( &m_excludeParametersWithoutVariation );
-    correlationGroup->add( &m_selectedParametersList );
-    correlationGroup->add( &m_showAbsoluteValues );
-    correlationGroup->add( &m_sortByValues );
-    if ( !m_showAbsoluteValues() && m_sortByValues() != Sorting::NO_SORTING )
+    bool embeddedInReportPanel = ( uiConfigName == "report" );
+
+    // When selected individually inside a correlation report, the data source and correlation settings are
+    // controlled from the report plot, so only the plot settings are exposed here. Outside a report, or when
+    // the fields are embedded in the report's own panel, the full set is shown.
+    if ( embeddedInReportPanel || !isContainedInReportPlot() )
     {
-        correlationGroup->add( &m_sortByAbsoluteValues );
-    }
-    if ( m_sortByValues() != Sorting::NO_SORTING )
-    {
-        correlationGroup->add( &m_showOnlyTopNCorrelations );
-        if ( m_showOnlyTopNCorrelations() )
+        caf::PdmUiGroup* correlationGroup = uiOrdering.addNewGroup( "Correlation Settings" );
+        correlationGroup->add( &m_excludeParametersWithoutVariation );
+        correlationGroup->add( &m_selectedParametersList );
+        correlationGroup->add( &m_showAbsoluteValues );
+        correlationGroup->add( &m_sortByValues );
+        if ( !m_showAbsoluteValues() && m_sortByValues() != Sorting::NO_SORTING )
         {
-            correlationGroup->add( &m_topNFilterCount );
+            correlationGroup->add( &m_sortByAbsoluteValues );
         }
+        if ( m_sortByValues() != Sorting::NO_SORTING )
+        {
+            correlationGroup->add( &m_showOnlyTopNCorrelations );
+            if ( m_showOnlyTopNCorrelations() )
+            {
+                correlationGroup->add( &m_topNFilterCount );
+            }
+        }
+
+        appendDataSourceFields( uiConfigName, uiOrdering );
     }
 
-    appendDataSourceFields( uiConfigName, uiOrdering );
-
-    if ( uiConfigName != "report" )
+    if ( !embeddedInReportPanel )
     {
         caf::PdmUiGroup* plotGroup = uiOrdering.addNewGroup( "Plot Settings" );
         plotGroup->add( &m_showPlotTitle );

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.h
@@ -124,6 +124,7 @@ private:
     void onLoadDataAndUpdate() override;
 
     void childFieldChangedByUi( const caf::PdmFieldHandle* changedChildField ) override;
+    void onDataSourceChanged() override;
 
     void updateAxes() override;
 
@@ -133,6 +134,7 @@ private:
     void updateLegend() override;
     void onPlotItemSelected( std::shared_ptr<RiuPlotItem> plotItem, bool toggle, int sampleIndex ) override;
     void applySelectedParameterHighlight();
+    void selectFirstItem();
 
 private:
     caf::PdmField<bool>                 m_showAbsoluteValues;

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlot.cpp
@@ -108,7 +108,7 @@ void RimCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedFie
             selectAllParameters();
         }
         loadDataAndUpdate();
-        updateConnectedEditors();
+        updateAllRequiredEditors();
     }
 }
 
@@ -117,23 +117,28 @@ void RimCorrelationPlot::fieldChangedByUi( const caf::PdmFieldHandle* changedFie
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationPlot::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-    caf::PdmUiGroup* correlationGroup = uiOrdering.addNewGroup( "Correlation Settings" );
-    correlationGroup->add( &m_excludeParametersWithoutVariation );
-    correlationGroup->add( &m_selectedParametersList );
-
-    correlationGroup->add( &m_showAbsoluteValues );
-    if ( !m_showAbsoluteValues() )
+    // When used as a sub-plot of a correlation report, the data source and correlation settings are controlled
+    // from the report plot, so only the plot settings are exposed here.
+    if ( !isContainedInReportPlot() )
     {
-        correlationGroup->add( &m_sortByAbsoluteValues );
-    }
+        caf::PdmUiGroup* correlationGroup = uiOrdering.addNewGroup( "Correlation Settings" );
+        correlationGroup->add( &m_excludeParametersWithoutVariation );
+        correlationGroup->add( &m_selectedParametersList );
 
-    correlationGroup->add( &m_showOnlyTopNCorrelations );
-    if ( m_showOnlyTopNCorrelations() )
-    {
-        correlationGroup->add( &m_topNFilterCount );
-    }
+        correlationGroup->add( &m_showAbsoluteValues );
+        if ( !m_showAbsoluteValues() )
+        {
+            correlationGroup->add( &m_sortByAbsoluteValues );
+        }
 
-    appendDataSourceFields( uiConfigName, uiOrdering );
+        correlationGroup->add( &m_showOnlyTopNCorrelations );
+        if ( m_showOnlyTopNCorrelations() )
+        {
+            correlationGroup->add( &m_topNFilterCount );
+        }
+
+        appendDataSourceFields( uiConfigName, uiOrdering );
+    }
 
     caf::PdmUiGroup* plotGroup = uiOrdering.addNewGroup( "Plot Settings" );
     plotGroup->add( &m_showPlotTitle );
@@ -206,6 +211,23 @@ void RimCorrelationPlot::onLoadDataAndUpdate()
         updatePlotTitle();
         m_plotWidget->scheduleReplot();
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// When the selected summary vector changes, notify listeners so the sibling plots in a correlation
+/// report are updated with the new data source.
+//--------------------------------------------------------------------------------------------------
+void RimCorrelationPlot::onDataSourceChanged()
+{
+    auto curves = curveDefinitions();
+    if ( curves.empty() ) return;
+
+    if ( m_selectedParametersList().empty() ) selectAllParameters();
+
+    auto parameters = m_selectedParametersList();
+    if ( parameters.empty() ) return;
+
+    tornadoItemSelected.send( { parameters.front(), curves.front() } );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlot.h
@@ -67,6 +67,7 @@ private:
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
 
     void    onLoadDataAndUpdate() override;
+    void    onDataSourceChanged() override;
     void    updateAxes() override;
     QString asciiDataForPlotExport() const override;
 

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationReportPlot.cpp
@@ -230,12 +230,15 @@ RimCorrelationReportPlot::RimCorrelationReportPlot()
 
     m_correlationMatrixPlot = new RimCorrelationMatrixPlot;
     m_correlationMatrixPlot->setLegendsVisible( false );
+    m_correlationMatrixPlot->setReportSubPlot( true );
 
     m_correlationPlot = new RimCorrelationPlot;
     m_correlationPlot->setLegendsVisible( false );
+    m_correlationPlot->setReportSubPlot( true );
 
     m_parameterResultCrossPlot = new RimParameterResultCrossPlot;
     m_parameterResultCrossPlot->setLegendsVisible( true );
+    m_parameterResultCrossPlot->setReportSubPlot( true );
 
     m_summaryPlot = new RimSummaryPlot();
     m_summaryPlot->setLegendsVisible( false );
@@ -622,6 +625,11 @@ void RimCorrelationReportPlot::onLoadDataAndUpdate()
 //--------------------------------------------------------------------------------------------------
 void RimCorrelationReportPlot::initAfterRead()
 {
+    // The report sub-plot flag is not serialized, so re-establish it on the deserialized child plots.
+    m_correlationMatrixPlot->setReportSubPlot( true );
+    m_correlationPlot->setReportSubPlot( true );
+    m_parameterResultCrossPlot->setReportSubPlot( true );
+
     updateSummaryPlotTimeAnnotation();
 }
 
@@ -725,6 +733,10 @@ void RimCorrelationReportPlot::childFieldChangedByUi( const caf::PdmFieldHandle*
     else if ( m_summaryDockWidget && changedChildField == &m_summaryPlot )
         m_summaryDockWidget->toggleView( m_summaryPlot->showWindow() );
 
+    // Re-showing a dock widget creates a new dock area whose title bar defaults to visible, so re-apply
+    // the configured title bar visibility.
+    updateDockTitleBarsVisibility();
+
     // onLoadDataAndUpdate treats the matrix plot as the source of truth and copies its shared
     // properties to the others. When the change originated on the correlation or cross plot,
     // first mirror it back to the matrix plot so the subsequent propagation reflects the change.
@@ -797,7 +809,9 @@ void RimCorrelationReportPlot::onDataSelection( const caf::SignalEmitter*       
 
     updateSummaryPlotTimeAnnotation();
 
-    updateConnectedEditors();
+    // updateAllRequiredEditors (not just updateConnectedEditors) so the project tree refreshes the
+    // displayed text of the contained plot items when their data source changes.
+    updateAllRequiredEditors();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -815,6 +829,10 @@ void RimCorrelationReportPlot::onSummaryPlotMousePressed( double xPlotCoordinate
 
     m_correlationMatrixPlot->setTimeStep( *it );
     loadDataAndUpdate();
+
+    // The time step is part of the auto-generated titles, so refresh all editors to update the project
+    // tree text and the time step field in the property panel.
+    updateAllRequiredEditors();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimParameterResultCrossPlot.cpp
@@ -170,7 +170,7 @@ void RimParameterResultCrossPlot::fieldChangedByUi( const caf::PdmFieldHandle* c
     if ( changedField == &m_ensembleParameter )
     {
         loadDataAndUpdate();
-        updateConnectedEditors();
+        updateAllRequiredEditors();
     }
 }
 
@@ -179,13 +179,18 @@ void RimParameterResultCrossPlot::fieldChangedByUi( const caf::PdmFieldHandle* c
 //--------------------------------------------------------------------------------------------------
 void RimParameterResultCrossPlot::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-    appendDataSourceFields( uiConfigName, uiOrdering );
+    // When used as a sub-plot of a correlation report, the data source, cross plot parameter and filter are
+    // controlled from the report plot, so only the plot settings are exposed here.
+    if ( !isContainedInReportPlot() )
+    {
+        appendDataSourceFields( uiConfigName, uiOrdering );
 
-    caf::PdmUiGroup* crossPlotGroup = uiOrdering.addNewGroup( "Cross Plot Parameters" );
-    crossPlotGroup->add( &m_ensembleParameter );
+        caf::PdmUiGroup* crossPlotGroup = uiOrdering.addNewGroup( "Cross Plot Parameters" );
+        crossPlotGroup->add( &m_ensembleParameter );
 
-    auto filterGroup = uiOrdering.addNewGroup( "Filter" );
-    appendFilterFields( *filterGroup );
+        auto filterGroup = uiOrdering.addNewGroup( "Filter" );
+        appendFilterFields( *filterGroup );
+    }
 
     caf::PdmUiGroup* plotGroup = uiOrdering.addNewGroup( "Plot Settings" );
     plotGroup->setCollapsedByDefault();


### PR DESCRIPTION
Fixes #14235

Synchronises all plots under a Summary Ensemble Correlation report and moves data source ownership to the report.

## Changes

- Selecting a summary vector in the report now propagates to the contained tornado, cross and summary plots. A virtual `onDataSourceChanged()` hook on the abstract correlation plot is called after the vector selection; the matrix and tornado plots override it to re-select their first item so dependent plots update.
- As a report sub-plot, a plot's data source and correlation settings are owned by the report, so its property editor shows only plot settings; used individually it shows all options. A flag set by the report tracks this.
- `updateAllRequiredEditors()` is used for sub-plot interactions and summary-plot time step changes, so tree text and the property panel reflect updated auto-generated titles.
- Dock title bar visibility is re-applied after toggling a sub-plot dock, so a hidden title bar stays hidden when the sub-plot is shown again.
