### PR TITLE
CI: Key vcpkg cache on cl.exe hash instead of MSVC toolset version

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -197,22 +197,32 @@ jobs:
         shell: bash
         run: echo "sha=$(git rev-parse HEAD:ThirdParty/vcpkg)" >> $GITHUB_OUTPUT
 
-      - name: Get MSVC toolset version (Windows)
-        # vcpkg keys its binary ABI hash on the MSVC toolset version, which is
-        # not reflected by the vcpkg submodule SHA. Without it in the cache key,
-        # a runner-image MSVC bump makes the restored binaries ABI-incompatible
-        # and vcpkg rebuilds everything. VCToolsVersion is exported to the
-        # environment by the "Use MSVC (Windows)" step above.
-        id: msvc-version
+      - name: Get MSVC compiler hash (Windows)
+        # vcpkg keys each binary's ABI on a SHA-1 of the actual cl.exe binary
+        # content (see ThirdParty/vcpkg/scripts/detect_compiler/CMakeLists.txt),
+        # not on the VCToolsVersion folder name. GitHub ships rebuilt cl.exe
+        # binaries under the same VCToolsVersion across runner image releases, so
+        # vcpkg's ABI hash changes while VCToolsVersion stays fixed; the restored
+        # binaries are then rejected and vcpkg rebuilds everything. Because the
+        # cache key did not change, the action skips saving the freshly built
+        # binaries, so the stale entry never refreshes and the rebuild loop
+        # persists across runs. Hash cl.exe directly so the cache key tracks
+        # exactly what vcpkg tracks: a cl.exe change yields a new key, one cold
+        # rebuild, then a successful save under the new key. cl.exe is on PATH
+        # via the "Use MSVC (Windows)" step above.
+        id: compiler-hash
         if: contains(matrix.config.os, 'windows')
         shell: bash
-        run: echo "version=${VCToolsVersion}" >> $GITHUB_OUTPUT
+        run: |
+          cl_path=$(cygpath -u "$(where.exe cl.exe | head -n 1 | tr -d '\r')")
+          echo "Using compiler: $cl_path"
+          echo "hash=$(sha1sum "$cl_path" | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
       - name: Restore vcpkg cache
         id: vcpkg-cache
         uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.msvc-version.outputs.version }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.compiler-hash.outputs.hash }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           prefix: vcpkg-${{ matrix.config.cxx}}/
           
       - name: Print CMake version


### PR DESCRIPTION
## Problem

The Windows vcpkg binary cache is restored on every run, but vcpkg periodically rejects all restored binaries and rebuilds everything from source (a ~3 h Windows build vs ~10 min when the cache is used).

The previous fix (#... `CI: Include MSVC toolset version in vcpkg cache key`) added `VCToolsVersion` to the cache key, but it is still too coarse.

## Root cause

vcpkg keys each binary's ABI on a **SHA-1 of the actual `cl.exe` binary content** (`ThirdParty/vcpkg/scripts/detect_compiler/CMakeLists.txt`), not on the `VCToolsVersion` folder name. GitHub ships **rebuilt `cl.exe` binaries under the same `VCToolsVersion`** across runner image releases. When that happens vcpkg's compiler hash changes — propagating into every package's ABI — so the restored binaries no longer match and vcpkg rebuilds everything. Because the cache key (containing only `VCToolsVersion`) is unchanged, the cache action then skips saving the freshly built binaries, so the stale entry never refreshes and the rebuild loop persists across runs.

This was confirmed on two `dev` runs with **identical** `VCToolsVersion` (14.44.35207), Windows SDK and vcpkg submodule SHA, but **different runner images**:

| | restores from cache | rebuilds all |
|---|---|---|
| runner image | `win22/20260616.203` | `win22/20260622.215` |
| vcpkg restore | Restored **102** packages | Restored **0** packages |

Both downloaded the byte-identical binary cache; only the `cl.exe` content (and thus vcpkg's ABI hashes) differed.

## Fix

Replace the `VCToolsVersion` component of the Windows cache key with a SHA-1 of the `cl.exe` binary itself — exactly the input vcpkg hashes. The key now changes if and only if vcpkg would reject the cache: a real `cl.exe` change yields a new key, one cold rebuild, then a successful save under the new key, while image bumps that don't touch `cl.exe` keep restoring from cache.

Scope is limited to the Windows branch (`if: contains(matrix.config.os, 'windows')`); Linux is unaffected.