### PR TITLE
#14321 CI: Add RHEL8 installation package workflow

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -49,6 +49,7 @@ jobs:
 
           cache_id=$(wait_run ResInsightWithCache.yml)
           mac_id=$(wait_run ResInsightMac.yml)
+          rhel8_id=$(wait_run rhel8-package.yml)
 
           mkdir -p artifacts
           # Windows, Ubuntu-gcc and Ubuntu-clang-19 (excludes python-distribution).
@@ -59,6 +60,12 @@ jobs:
           # the 'for d in ResInsight-*/' packaging loop would then skip.
           gh run download "$mac_id" --pattern 'ResInsight-macOS' --dir artifacts
           ls -R artifacts
+
+          # The RHEL8 artifact is already a CPack *.tar.gz, so keep it out of
+          # the 'artifacts/' zip loop below and attach it to the release as-is.
+          mkdir -p rhel8-package
+          gh run download "$rhel8_id" --pattern 'ResInsight-RHEL8' --dir rhel8-package
+          ls -R rhel8-package
 
       - name: Package each platform into a zip
         run: |
@@ -71,18 +78,21 @@ jobs:
             safe="${name// /_}"
             zip -r "../release-assets/${safe}-${{ github.ref_name }}.zip" "$name"
           done
-          ls -l ../release-assets
+          cd ..
+          # The RHEL8 CPack package is already compressed; attach it directly.
+          find rhel8-package -name '*.tar.gz' -exec cp {} release-assets/ \;
+          ls -l release-assets
 
       - name: Create or update draft release
         run: |
           tag='${{ github.ref_name }}'
           if gh release view "$tag" >/dev/null 2>&1; then
             # Re-run: refresh the assets on the existing (draft) release.
-            gh release upload "$tag" release-assets/*.zip --clobber
+            gh release upload "$tag" release-assets/* --clobber
           else
             gh release create "$tag" \
               --draft \
               --title "ResInsight $tag" \
               --notes "Automated draft release. Binaries are attached below." \
-              release-assets/*.zip
+              release-assets/*
           fi

--- a/.github/workflows/rhel8-package.yml
+++ b/.github/workflows/rhel8-package.yml
@@ -1,0 +1,131 @@
+name: RHEL8 Package
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+concurrency:
+  group: rhel8-package-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolves the prebuilt CI image name so it works in forks and upstream alike
+  # (GHCR requires a lowercase repository path).
+  resolve-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Compute image name
+        id: meta
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}/ci-rhel8:latest" >> "$GITHUB_OUTPUT"
+
+  rhel8-package:
+    needs: resolve-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    container:
+      # Prebuilt image with toolchain, baked vcpkg binary cache, and a warm
+      # ResInsight buildcache at /opt/buildcache.
+      # See .github/workflows/build-rhel8-image.yml
+      image: ${{ needs.resolve-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Source must live at /src to match the path the image's warmup compiled
+    # at; buildcache hashes the absolute source path so any drift collapses
+    # the hit rate. The clone step overrides this default since /src does not
+    # exist yet at that point.
+    defaults:
+      run:
+        working-directory: /src
+
+    steps:
+      - name: Clone source into /src
+        working-directory: /
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # actions/checkout writes inside GITHUB_WORKSPACE (e.g.
+        # /__w/ResInsight/ResInsight) which would not match the image's baked
+        # cache path. Clone manually into /src instead. GITHUB_SHA is fetched
+        # directly (GitHub allows any-SHA fetches on the workflow's own repo).
+        #
+        # The insteadOf rewrite is unset after the clone so the token is not
+        # left in /etc/gitconfig where a later `git config --list` for
+        # diagnostics could echo it into the log.
+        run: |
+          git config --global --add safe.directory '*'
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git clone --no-checkout "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" /src
+          cd /src
+          git fetch --no-tags --depth 1 origin "${GITHUB_SHA}"
+          git checkout FETCH_HEAD
+          git submodule update --init --recursive --depth 1
+          git config --global --unset url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf
+
+      # /src was just freshly cloned, so the ThirdParty/vcpkg/vcpkg binary
+      # produced by bootstrap-vcpkg.sh is not present. The image's baked
+      # /opt/vcpkg-cache supplies prebuilt dependencies; the binary itself
+      # still has to exist locally for `vcpkg install` to run.
+      - name: Bootstrap vcpkg
+        run: |
+          source /opt/rh/gcc-toolset-14/enable
+          cd ThirdParty/vcpkg
+          ./bootstrap-vcpkg.sh
+
+      - name: Use RHEL8 vcpkg configuration
+        run: cp vcpkg-configuration-rhel8.json vcpkg-configuration.json
+
+      - name: Configure CMake
+        env:
+          CC: /opt/rh/gcc-toolset-14/root/usr/bin/gcc
+          CXX: /opt/rh/gcc-toolset-14/root/usr/bin/g++
+          VCPKG_FEATURE_FLAGS: "binarycaching"
+          # Read vcpkg dependencies from the binary cache baked into the image.
+          # buildcache is auto-discovered on PATH by CMakeLists.txt's
+          # find_program() and wired as CMAKE_CXX_COMPILER_LAUNCHER -- no
+          # explicit setup step is needed. BUILDCACHE_DIR etc. are baked in
+          # the image ENV. Unity build must be OFF to match the warmup build
+          # (mismatched flag would collapse the cache hit rate).
+          VCPKG_BINARY_SOURCES: "clear;files,/opt/vcpkg-cache,read"
+        run: |
+          source /opt/rh/gcc-toolset-14/enable
+          cmake -S /src -B /src/cmakebuild -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/src/cmakebuild/install \
+            -DRESINSIGHT_ENABLE_UNITY_BUILD=false \
+            -DRESINSIGHT_ENABLE_HDF5=false \
+            -DRESINSIGHT_ENABLE_GRPC=false \
+            -DRESINSIGHT_GCC_STDCPP_EXP_PATH=/opt/libstdcxx-exp/lib \
+            -DCMAKE_TOOLCHAIN_FILE=ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+      - name: Build install target
+        run: |
+          source /opt/rh/gcc-toolset-14/enable
+          cmake --build /src/cmakebuild --target install -- -j$(nproc)
+
+      - name: Buildcache stats
+        if: always()
+        run: buildcache -s
+
+      # CPack writes the *.tar.gz (TGZ generator on Linux) into
+      # cmakebuild/packages, named e.g. ResInsight-<version>_el8.tar.gz.
+      - name: Create package
+        run: |
+          source /opt/rh/gcc-toolset-14/enable
+          cmake --build /src/cmakebuild --target package
+
+      - name: List package output
+        run: ls -l /src/cmakebuild/packages
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ResInsight-RHEL8
+          path: /src/cmakebuild/packages/*.tar.gz
+          retention-days: 5


### PR DESCRIPTION
## Summary

Resolves #14321 — create a RHEL8 installation package as a GitHub build artifact from a tag, and include it in the release workflow.

### New workflow: `.github/workflows/rhel8-package.yml`
- Triggers on tag push (`tags: '*'`) and `workflow_dispatch` for manual testing.
- Reuses the proven `rhel8-unit-tests.yml` setup: prebuilt RHEL8 CI container, `/src` clone path, vcpkg bootstrap with the baked binary cache, and buildcache.
- Configures with `-DCMAKE_INSTALL_PREFIX=/src/cmakebuild/install`, builds the `install` target, then runs the CPack `package` target.
- CPack (TGZ generator on Linux) emits `cmakebuild/packages/ResInsight-<version>_el8.tar.gz`, uploaded as the `ResInsight-RHEL8` artifact.

### Release integration: `.github/workflows/release-draft.yml`
- Waits for the `rhel8-package.yml` run on the same tag SHA.
- Downloads the `ResInsight-RHEL8` artifact and attaches the `*.tar.gz` directly to the draft release (already compressed, so no re-zip), alongside the existing zipped platform artifacts.

### Notes
- GRPC/HDF5 are left OFF to match the known-good, cached `rhel8-unit-tests.yml` configuration. Shipping the Python (rips) module in the package would be a follow-up that needs GRPC enabled and verified in the container.
- The `install` target is built before `package` so the binary is compiled before CPack stages it.
- Full end-to-end exercise requires pushing a tag; the package job alone can be tested via `workflow_dispatch`.