### PR TITLE
#14334 Fix formation dip sign when aligning fracture with formation dip

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.cpp
@@ -542,6 +542,14 @@ void RimFracture::setAzimuth( double azimuth )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+double RimFracture::azimuth() const
+{
+    return m_azimuth();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimFracture::setFractureTemplateNoUpdate( RimFractureTemplate* fractureTemplate )
 {
     if ( fractureTemplate && fractureTemplate->fractureTemplateUnit() != fractureUnit() )

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.h
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.h
@@ -101,7 +101,8 @@ public:
     void   setTilt( double tilt );
     double tilt() const;
 
-    void setAzimuth( double azimuth );
+    void   setAzimuth( double azimuth );
+    double azimuth() const;
 
     void                 setFractureTemplateNoUpdate( RimFractureTemplate* fractureTemplate );
     void                 setFractureTemplate( RimFractureTemplate* fractureTemplate );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp
@@ -107,7 +107,8 @@ std::expected<caf::PdmObjectHandle*, QString> RimcWellPath_addFracture::execute(
             cvf::Vec3d formationDirection = RimStimPlanModel::projectVectorIntoFracturePlane( position, fractureDirectionNormal, direction );
             if ( !formationDirection.isUndefined() )
             {
-                double formationDip = RigStimPlanModelTools::calculateFormationDipFromHorizontal( formationDirection );
+                double formationDip =
+                    RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( formationDirection, wellPathFracture->azimuth() );
                 RiaLogging::info( std::format( "Computed formation dip: {}", formationDip ) );
 
                 wellPathFracture->setDip( formationDip );

--- a/ApplicationLibCode/ReservoirDataModel/RigStimPlanModelTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigStimPlanModelTools.cpp
@@ -36,6 +36,8 @@
 
 #include <QString>
 
+#include <cmath>
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -105,8 +107,28 @@ double RigStimPlanModelTools::calculateAngleFromVertical( const cvf::Vec3d& dire
 //--------------------------------------------------------------------------------------------------
 double RigStimPlanModelTools::calculateFormationDipFromHorizontal( const cvf::Vec3d& direction )
 {
-    // Convert from angle-with-vertical to angle-from-horizontal
-    return calculateAngleFromVertical( direction ) - 90.0;
+    // Convert from angle-with-vertical to angle-from-horizontal, and take abs since
+    // direction sign depends on fracture normal orientation.
+    return std::abs( calculateAngleFromVertical( direction ) - 90.0 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( const cvf::Vec3d& formationDirection, double azimuthDegrees )
+{
+    // The orientation of the formation direction vector depends on the fracture normal, which can
+    // point either way along the well. Canonicalize it to point along the fracture azimuth direction
+    // before computing the dip: a positive result then means the formation descends toward the
+    // azimuth direction, matching the sign convention of the fracture dip rotation in
+    // RimFracture::transformMatrix().
+    double     azimuthRadians = cvf::Math::toRadians( azimuthDegrees );
+    cvf::Vec3d azimuthDirection( std::sin( azimuthRadians ), std::cos( azimuthRadians ), 0.0 );
+
+    cvf::Vec3d direction = formationDirection;
+    if ( direction * azimuthDirection < 0.0 ) direction = -direction;
+
+    return 90.0 - calculateAngleFromVertical( direction );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/RigStimPlanModelTools.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigStimPlanModelTools.h
@@ -52,6 +52,7 @@ public:
 
     static double calculateAngleFromVertical( const cvf::Vec3d& direction );
     static double calculateFormationDipFromHorizontal( const cvf::Vec3d& direction );
+    static double calculateFormationDipAlignedToAzimuth( const cvf::Vec3d& formationDirection, double azimuthDegrees );
 
     static QString vecToString( const cvf::Vec3d& vec );
 

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigGridExportAdapter-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigNonUniformRefinement-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigStatisticsMath-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigStimPlanModelTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellPathIntersectionTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogExtractionCurveImpl-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivPipeGeometryGenerator-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigStimPlanModelTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigStimPlanModelTools-Test.cpp
@@ -1,0 +1,80 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RigStimPlanModelTools.h"
+
+#include "cvfMath.h"
+
+#include <cmath>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigStimPlanModelTools, calculateFormationDipAlignedToAzimuth )
+{
+    const double epsilon = 1.0e-9;
+
+    // Formation direction vectors for a bed with 20 degree dip. The orientation of the vector
+    // (+/-) depends on the fracture normal, which follows the well drilling direction. The result
+    // must be independent of that orientation, and positive when the bed descends toward the
+    // fracture azimuth direction.
+    const double omega = 20.0;
+    const double c     = std::cos( cvf::Math::toRadians( omega ) );
+    const double s     = std::sin( cvf::Math::toRadians( omega ) );
+
+    // Azimuth 90 (east). Bed dipping down toward east: positive dip.
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( c, 0.0, -s ), 90.0 ), epsilon );
+    // Same bed, opposite vector orientation (well drilled the other way): same result.
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( -c, 0.0, s ), 90.0 ), epsilon );
+    // Bed dipping down toward west: negative dip.
+    EXPECT_NEAR( -omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( c, 0.0, s ), 90.0 ), epsilon );
+    EXPECT_NEAR( -omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( -c, 0.0, -s ), 90.0 ), epsilon );
+
+    // Azimuth 270 (west). Same bed dipping toward east now descends away from the azimuth direction.
+    EXPECT_NEAR( -omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( c, 0.0, -s ), 270.0 ), epsilon );
+    EXPECT_NEAR( -omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( -c, 0.0, s ), 270.0 ), epsilon );
+
+    // Azimuth 0 (north). Bed dipping down toward north: positive dip.
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( 0.0, c, -s ), 0.0 ), epsilon );
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( 0.0, -c, s ), 0.0 ), epsilon );
+
+    // Horizontal formation direction: zero dip for any azimuth.
+    EXPECT_NEAR( 0.0, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( 1.0, 0.0, 0.0 ), 90.0 ), epsilon );
+    EXPECT_NEAR( 0.0, RigStimPlanModelTools::calculateFormationDipAlignedToAzimuth( cvf::Vec3d( 0.0, 1.0, 0.0 ), 45.0 ), epsilon );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigStimPlanModelTools, calculateFormationDipFromHorizontal )
+{
+    const double epsilon = 1.0e-9;
+
+    const double omega = 20.0;
+    const double c     = std::cos( cvf::Math::toRadians( omega ) );
+    const double s     = std::sin( cvf::Math::toRadians( omega ) );
+
+    // Result is non-negative and independent of the vector orientation.
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipFromHorizontal( cvf::Vec3d( c, 0.0, -s ) ), epsilon );
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipFromHorizontal( cvf::Vec3d( -c, 0.0, s ) ), epsilon );
+    EXPECT_NEAR( omega, RigStimPlanModelTools::calculateFormationDipFromHorizontal( cvf::Vec3d( c, 0.0, s ) ), epsilon );
+
+    EXPECT_NEAR( 0.0, RigStimPlanModelTools::calculateFormationDipFromHorizontal( cvf::Vec3d( 1.0, 0.0, 0.0 ) ), epsilon );
+}


### PR DESCRIPTION
The sign of the projected formation direction vector flips with the fracture direction normal, which follows the well drilling direction, while the fracture azimuth defining the dip rotation in RimFracture::transformMatrix() is only defined mod 180 degrees. Canonicalize the formation direction against the fracture azimuth direction before computing the dip, so a positive dip means the formation descends toward the azimuth direction.

Restore std::abs() in calculateFormationDipFromHorizontal() so the StimPlan model formation dip (BedDipDeg in the Asymmetric FRK export) keeps the non-negative convention from #8877.

Fixes #14334.