### PR TITLE
#14274 Fix invalid index range in dataChanged() from table row editor

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableRowEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableRowEditor.cpp
@@ -79,7 +79,7 @@ void PdmUiTableRowEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( m_model )
     {
         QModelIndex miStart = m_model->index( m_row, 0 );
-        QModelIndex miEnd   = m_model->index( m_row, m_model->columnCount() );
+        QModelIndex miEnd   = m_model->index( m_row, m_model->columnCount() - 1 );
 
         m_model->notifyDataChanged( miStart, miEnd );
     }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewQModel.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewQModel.cpp
@@ -739,7 +739,7 @@ QItemSelection PdmUiTableViewQModel::modelIndexFromPdmObject( PdmObjectHandle* p
         if ( obj == pdmObject )
         {
             // Select whole row
-            itemSelection.select( this->createIndex( i, 0 ), this->createIndex( i, this->columnCount() ) );
+            itemSelection.select( this->createIndex( i, 0 ), this->createIndex( i, this->columnCount() - 1 ) );
         }
     }
 


### PR DESCRIPTION
Valid Qt column indices are 0..columnCount()-1, but the bottom-right model index was constructed with column columnCount(). Since QAbstractItemModel::index() validates its arguments, this produced an invalid QModelIndex(-1,-1) passed to dataChanged(), causing a console warning on every table row update, e.g. when adding or moving 3D well path pick targets. Fix the same off-by-one in modelIndexFromPdmObject().

Fixes #14274.