### PR TITLE
CI: Pin ruff to 0.15.* in Python linting workflow

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -12,7 +12,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install "ruff==0.15.*"
 
       # Always run strict lint check (catches all errors including unfixable ones)
       - name: (Python) Check with ruff


### PR DESCRIPTION
Pin ruff to the `0.15.*` series in the Python linting workflow so a new ruff minor release cannot change lint or format results without an explicit bump. Patch releases within 0.15 are still picked up automatically.
