### PR TITLE
Histogram Plots: Implement Show Plot Data

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramPlot.cpp
@@ -24,10 +24,13 @@
 
 #include "RicHistogramPlotTools.h"
 
+#include "RifCsvDataTableFormatter.h"
+
 #include "Histogram/RimEnsembleParameterHistogramDataSource.h"
 #include "Histogram/RimEnsembleSummaryVectorHistogramDataSource.h"
 #include "RimHistogramCurve.h"
 #include "RimHistogramCurveCollection.h"
+#include "RimHistogramDataSource.h"
 #include "RimMultiPlot.h"
 #include "RimPlotAxisLogRangeCalculator.h"
 #include "Summary/Ensemble/RimSummaryEnsembleParameter.h"
@@ -35,6 +38,7 @@
 #include "Summary/RimSummaryAddress.h"
 #include "Tools/RimPlotAxisTools.h"
 
+#include "RiuContextMenuLauncher.h"
 #include "RiuPlotAxis.h"
 #include "RiuPlotMainWindow.h"
 #include "RiuPlotMainWindowTools.h"
@@ -211,16 +215,44 @@ RiuPlotWidget* RimHistogramPlot::plotWidget()
 //--------------------------------------------------------------------------------------------------
 QString RimHistogramPlot::asciiDataForPlotExport() const
 {
-    return asciiDataForHistogramPlotExport( RiaDefines::DateTimePeriod::YEAR, false );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-QString RimHistogramPlot::asciiDataForHistogramPlotExport( RiaDefines::DateTimePeriod resamplingPeriod, bool showTimeAsLongString ) const
-{
-    // TODO: add implementation
     QString text;
+
+    for ( RimHistogramCurve* curve : histogramCurves() )
+    {
+        if ( !curve->isChecked() || !curve->dataSource() ) continue;
+
+        // Compute as line graph to get one value per bin, independent of how the curve is rendered
+        auto result = curve->dataSource()->compute( GraphType::LINE_GRAPH, frequencyType() );
+        if ( result.valuesX.empty() || result.valuesX.size() != result.valuesY.size() ) continue;
+
+        QString headerX = "Bin Center";
+        if ( !curve->unitNameX().empty() ) headerX += QString( " [%1]" ).arg( QString::fromStdString( curve->unitNameX() ) );
+
+        QString headerY = caf::AppEnum<FrequencyType>::uiText( frequencyType() );
+        if ( !curve->unitNameY().empty() ) headerY += QString( " [%1]" ).arg( QString::fromStdString( curve->unitNameY() ) );
+
+        QString     tableText;
+        QTextStream stringStream( &tableText );
+
+        // Use tab as field separator to make the text paste into separate columns in Excel
+        RifCsvDataTableFormatter formatter( stringStream, "\t" );
+        formatter.setUseQuotes( false );
+
+        formatter.header( { RifTextDataTableColumn( headerX ), RifTextDataTableColumn( headerY ) } );
+
+        for ( size_t i = 0; i < result.valuesX.size(); i++ )
+        {
+            formatter.add( result.valuesX[i] );
+            formatter.add( result.valuesY[i] );
+            formatter.rowCompleted();
+        }
+        formatter.tableCompleted();
+
+        if ( !text.isEmpty() ) text += "\n";
+        text += curve->curveName() + "\n";
+        text += tableText;
+    }
+
     return text;
 }
 
@@ -1025,6 +1057,8 @@ RiuPlotWidget* RimHistogramPlot::doCreatePlotViewWidget( QWidget* mainWindowPare
     if ( !plotWidget() )
     {
         m_histogramPlot = new RiuQwtPlotWidget( this, mainWindowParent );
+
+        new RiuContextMenuLauncher( m_histogramPlot, { "RicShowPlotDataFeature" } );
 
         QObject::connect( plotWidget(), SIGNAL( curveOrderNeedsUpdate() ), this, SLOT( onUpdateCurveOrder() ) );
 

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramPlot.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "RiaDateTimeDefines.h"
 #include "RiaPlotDefines.h"
 
 #include "RimPlot.h"
@@ -104,7 +103,6 @@ public:
     QWidget* viewWidget() override;
 
     QString asciiDataForPlotExport() const override;
-    QString asciiDataForHistogramPlotExport( RiaDefines::DateTimePeriod resamplingPeriod, bool showTimeAsLongString ) const;
 
     FrequencyType frequencyType() const;
     GraphType     graphType() const;


### PR DESCRIPTION
Fixes #14360

"Show Plot Data" for histogram plots opened an empty text window, as `RimHistogramPlot::asciiDataForPlotExport()` was an unimplemented stub. In addition, the command was not available when right-clicking inside the plot widget.

Changes:

- Implement `asciiDataForPlotExport()` for histogram plots. For each visible curve, the export contains the curve name, a header row and one tab-separated row per bin (bin center and frequency). The values are computed from the curve's data source with the plot's current frequency type, so the exported numbers match what is plotted.
- Export one row per bin independent of graph type. Computing with the bar graph type would emit the step outline where every bin edge appears twice.
- Remove the unused `asciiDataForHistogramPlotExport( DateTimePeriod, bool )` helper. The parameters were copied from the summary plot equivalent and have no meaning for histograms.
- Add a `RiuContextMenuLauncher` with `RicShowPlotDataFeature` to the histogram plot widget, following the same pattern as correlation, analysis and VFP plots.
- Format the table with `RifCsvDataTableFormatter` using tab as field separator, so the text can be pasted into Excel with bin centers and frequencies in separate columns.

Example output:

```
Histogram Plot

SOIL, NORNE_ATW2013_RFTPLT_V2, All Time Steps
Bin Center	Relative Frequency [%]
0.02797	55.97580
0.08950	0.23812
...
```
