### PR TITLE
#14370 Guard against NULL base when selecting summary file lists

### DIFF
--- a/ApplicationLibCode/UnitTests/RifReaderEclipseSummary-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifReaderEclipseSummary-Test.cpp
@@ -27,6 +27,8 @@
 
 #include <QDateTime>
 #include <QDir>
+#include <QFileInfo>
+#include <QTemporaryDir>
 
 #include <memory>
 
@@ -50,6 +52,30 @@ TEST( RifEclEclipseSummary, TestConversionFromNativeCompletionSyntax )
         std::string result = RifEclEclipseSummary::normalizeCompletionAddress( native );
         EXPECT_EQ( result, expected ) << "Expected: " << expected << " but got: " << result;
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RifEclipseSummaryToolsTest, FindSummaryFilesWithDirectoryNamedAsCase )
+{
+    // Reproduces https://github.com/OPM/ResInsight/issues/14370: finding the CASE.Snnnn summary data
+    // files crashed when a non-empty directory with the same name as the case exists next to the files.
+    QTemporaryDir tempDir;
+    ASSERT_TRUE( tempDir.isValid() );
+
+    QDir dir( tempDir.path() );
+    ASSERT_TRUE( dir.mkpath( "CASE" ) );
+
+    for ( const QString& fileName :
+          { QString( "CASE.SMSPEC" ), QString( "CASE.S0001" ), QString( "CASE.S0002" ), QString( "CASE/ANYFILE.txt" ) } )
+    {
+        QFile file( dir.filePath( fileName ) );
+        ASSERT_TRUE( file.open( QIODevice::WriteOnly ) );
+        file.write( "dummy" );
+    }
+
+    EXPECT_TRUE( RifEclipseSummaryTools::hasSummaryDataFiles( dir.filePath( "CASE.SMSPEC" ) ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ThirdParty/Ert/lib/ecl/ecl_util.cpp
+++ b/ThirdParty/Ert/lib/ecl/ecl_util.cpp
@@ -544,6 +544,9 @@ int ecl_util_fname_report_cmp(const void *f1, const void *f2) {
 */
 
 static bool numeric_extension_predicate(const char * filename, const char * base, const char leading_char) {
+  if (!filename || !base)
+    return false;
+
   if (strncmp(filename, base, strlen(base)) != 0)
     return false;
 
@@ -604,6 +607,21 @@ static int ecl_util_select_predicate_filelist(const char * path, const char * ba
   {
     char * tmp = util_alloc_filename(path, base, NULL);
     util_alloc_file_components(tmp, &full_path, &pure_base, NULL);
+    if (!pure_base) {
+      /* If an existing directory has the same name as the full case path,
+         util_alloc_file_components() treats the whole string as a path and
+         returns NULL for the basename. Split on the last path separator
+         instead to recover the intended base. */
+      const char * last_sep = strrchr(tmp, UTIL_PATH_SEP_CHAR);
+      free(full_path);
+      if (last_sep) {
+        full_path = util_alloc_substring_copy(tmp, 0, last_sep - tmp);
+        pure_base = util_alloc_string_copy(last_sep + 1);
+      } else {
+        full_path = NULL;
+        pure_base = util_alloc_string_copy(tmp);
+      }
+    }
     free(tmp);
   }
 


### PR DESCRIPTION
Fixes #14370

## Problem
`ecl_util_select_predicate_filelist` recovers the case base name by re-splitting `"<path>/<base>"` with `util_alloc_file_components`. When a directory with the same name as the case exists next to the summary files (e.g. importing `/work/run/CASE.SMSPEC` while the directory `/work/run/CASE/` exists), that function treats the whole string as an existing directory path and returns a NULL basename. The NULL is then passed as the base to `numeric_extension_predicate`, which crashes in `strlen`/`strncmp` on the first directory entry scanned.

## Fix
When the re-split yields no basename, split on the last path separator instead so the intended base is recovered and `BASE.Snnnn` matching works in the correct directory. Additionally guard `numeric_extension_predicate` against NULL arguments. Behavior is unchanged for all inputs that did not previously crash.
