### PR TITLE
Resolve references when creating contour map from 3D view

### DIFF
--- a/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp
@@ -269,6 +269,8 @@ RimEclipseContourMapView* RicNewContourMapViewFeature::createEclipseContourMapFr
 
     contourMap->synchronizeLocalAnnotationsFromGlobal();
 
+    // Resolve references after contour map has been inserted into Rim structures
+    contourMap->resolveReferencesRecursively();
     contourMap->initAfterReadRecursively();
 
     eclipseCase->contourMapCollection()->updateConnectedEditors();
@@ -328,6 +330,8 @@ RimEclipseContourMapView* RicNewContourMapViewFeature::createEclipseContourMap( 
     auto col = RiuGuiTheme::getColorByVariableName( "backgroundColor2" );
     contourMap->setBackgroundColor( RiaColorTools::fromQColorTo3f( col ) ); // Ignore original view background
 
+    // Resolve references after contour map has been inserted into Rim structures
+    contourMap->resolveReferencesRecursively();
     contourMap->initAfterReadRecursively();
 
     return contourMap;
@@ -387,8 +391,7 @@ RimGeoMechContourMapView* RicNewContourMapViewFeature::createGeoMechContourMapFr
     geoMechCase->contourMapCollection()->addView( contourMap );
 
     // Resolve references after contour map has been inserted into Rim structures
-    std::vector<caf::PdmFieldHandle*> fieldsWithFailingResolve;
-    contourMap->resolveReferencesRecursively( &fieldsWithFailingResolve );
+    contourMap->resolveReferencesRecursively();
     contourMap->initAfterReadRecursively();
 
     return contourMap;
@@ -412,6 +415,8 @@ RimGeoMechContourMapView* RicNewContourMapViewFeature::createGeoMechContourMap( 
     auto col = RiuGuiTheme::getColorByVariableName( "backgroundColor2" );
     contourMap->setBackgroundColor( RiaColorTools::fromQColorTo3f( col ) ); // Ignore original view background
 
+    // Resolve references after contour map has been inserted into Rim structures
+    contourMap->resolveReferencesRecursively();
     contourMap->initAfterReadRecursively();
 
     return contourMap;


### PR DESCRIPTION
Fixes #14372

**Problem**

`RicNewContourMapViewFeature::createEclipseContourMapFrom3dView` copies the source view via XML serialization but never calls `resolveReferencesRecursively()`, so `PdmPtrField` references in the copied view stay unresolved. When the source view shows Ternary Saturation, `RimEclipseCellColors::changeLegendConfig()` skips reassignment, leaving `legendConfig()` null, and intersection result coloring crashes dereferencing it.

**Fix**

Resolve references after the contour map is inserted into the project tree, matching what `createEclipseContourMapFromExistingContourMap` and the geoMech contour map paths already do.
