### PR TITLE
#14374 Fail gracefully when importing a malformed GRID file

### DIFF
--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -1162,7 +1162,17 @@ bool RifReaderEclipseOutput::isEclipseAndSoursimTimeStepsEqual( const QDateTime&
 //--------------------------------------------------------------------------------------------------
 ecl_grid_type* RifReaderEclipseOutput::loadAllGrids() const
 {
-    ecl_grid_type* mainEclGrid = ecl_grid_alloc( RiaStringEncodingTools::toNativeEncoded( m_fileName ).data() );
+    ecl_grid_type* mainEclGrid = nullptr;
+    try
+    {
+        mainEclGrid = ecl_grid_alloc( RiaStringEncodingTools::toNativeEncoded( m_fileName ).data() );
+    }
+    catch ( const std::exception& e )
+    {
+        // A malformed grid file, e.g. a GRID file without the DIMENS keyword, makes the resdata keyword lookup throw
+        RiaLogging::error( std::format( "Failed to load grid file {} : {}", m_fileName.toStdString(), e.what() ) );
+        return nullptr;
+    }
 
     if ( mainEclGrid && m_ecl_init_file )
     {

--- a/ApplicationLibCode/UnitTests/RifReaderEclipseOutput-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifReaderEclipseOutput-Test.cpp
@@ -24,6 +24,7 @@
 
 #include "ert/ecl/ecl_kw_magic.h"
 #include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_kw.h>
 
 #include "RiaStringEncodingTools.h"
 #include "RiaTestDataDirectory.h"
@@ -39,9 +40,11 @@
 
 #include <QDebug>
 #include <QDir>
+#include <QTemporaryDir>
 
 #include <limits>
 #include <memory>
+#include <vector>
 
 using namespace RiaDefines;
 
@@ -176,6 +179,32 @@ TEST( RigReservoirTest, DualPorosityDepthResults )
 
         EXPECT_GT( comparedCellCount, size_t( 0 ) );
     }
+}
+
+TEST( RigReservoirTest, OpenGridFileWithoutDimensKeyword )
+{
+    // Importing a GRID file without the DIMENS keyword threw an uncaught std::out_of_range from the
+    // resdata keyword lookup and terminated the application. The import must fail gracefully instead.
+    QTemporaryDir tempDir;
+    ASSERT_TRUE( tempDir.isValid() );
+
+    QString gridFileName = QDir( tempDir.path() ).filePath( "TEST.GRID" );
+    {
+        std::vector<int> data( 10, 0 );
+        ecl_kw_fwrite_param( RiaStringEncodingTools::toNativeEncoded( gridFileName ).data(),
+                             false,
+                             "INTEHEAD",
+                             ECL_INT,
+                             (int)data.size(),
+                             data.data() );
+    }
+    ASSERT_TRUE( QFile::exists( gridFileName ) );
+
+    std::unique_ptr<RimEclipseResultCase> resultCase( new RimEclipseResultCase );
+    cvf::ref<RigEclipseCaseData>          reservoir = new RigEclipseCaseData( resultCase.get() );
+
+    cvf::ref<RifReaderEclipseOutput> readerInterfaceEcl = new RifReaderEclipseOutput;
+    EXPECT_FALSE( readerInterfaceEcl->open( gridFileName, reservoir.p() ) );
 }
 
 TEST( RigReservoirTest, BasicTest10kRestart )


### PR DESCRIPTION
Fixes #14374

## Problem
Importing a GRID file without the DIMENS keyword made the resdata keyword lookup (`kw_index.at()` in `ecl_file_view_get_global_index`) throw `std::out_of_range` from `ecl_grid_dual_porosity_GRID_check`. The exception was never caught, so the application terminated via `std::terminate`.

## Fix
Guard the grid allocation in `RifReaderEclipseOutput::loadAllGrids()` with try/catch. On failure the error is logged with the file name and the import fails through the existing "Failed to create a main grid" path instead of terminating. This also covers other missing-keyword throws in resdata grid loading.

A unit test reproduces the crash with a synthetic GRID file lacking DIMENS and verifies the import now fails gracefully.
