### PR TITLE
#14376 Guard ODB API calls in RifOdbReader destructor

### DIFF
--- a/ApplicationLibCode/GeoMech/OdbReader/RifOdbReader.cpp
+++ b/ApplicationLibCode/GeoMech/OdbReader/RifOdbReader.cpp
@@ -119,11 +119,25 @@ RifOdbReader::RifOdbReader()
 //--------------------------------------------------------------------------------------------------
 RifOdbReader::~RifOdbReader()
 {
-    close();
+    // The ODB API can throw from close() and odb_finalizeAPI(). An exception escaping the
+    // destructor calls std::terminate, taking down the application during project close.
+    try
+    {
+        close();
+    }
+    catch ( ... )
+    {
+    }
 
     if ( --sm_instanceCount == 0 )
     {
-        odb_finalizeAPI();
+        try
+        {
+            odb_finalizeAPI();
+        }
+        catch ( ... )
+        {
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #14376

## Problem
When closing a project containing a GeoMech (ODB) case, the Abaqus ODB API can throw from `close()`/`odb_finalizeAPI()` inside `RifOdbReader::~RifOdbReader()`. Destructors are implicitly noexcept, so the exception invokes `std::terminate` and crashes the application.

## Fix
Wrap the two ODB API calls in `try/catch` so exceptions from the third-party API cannot escape the destructor. Each call is guarded separately so the API instance counting stays consistent if `close()` throws.