### PR TITLE
Trigger a debug break in CAF_ASSERT before aborting

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafAssert.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafAssert.h
@@ -4,12 +4,23 @@
 #include <cstdio>
 #include <cstdlib>
 
+// Break into an attached debugger at the assert site. std::abort() alone does not trigger a debug
+// break with the release CRT, so asserts in RelWithDebInfo builds would terminate without stopping
+// in the debugger. Without a debugger attached, the breakpoint exception terminates the process
+// with the assert site at the top of the crash stack.
+#if defined( _MSC_VER )
+#define CAF_DEBUG_BREAK() __debugbreak()
+#else
+#define CAF_DEBUG_BREAK() __builtin_trap()
+#endif
+
 #define CAF_ASSERT( expr )                                                                   \
     do                                                                                       \
     {                                                                                        \
         if ( !( expr ) ) /* NOLINT */                                                        \
         {                                                                                    \
             std::printf( "%s : %i : CAF_ASSERT( %s ) failed\n", __FILE__, __LINE__, #expr ); \
+            CAF_DEBUG_BREAK();                                                               \
             std::abort();                                                                    \
         }                                                                                    \
     } while ( false )


### PR DESCRIPTION
A failing `CAF_ASSERT` calls `std::abort()`, which does not trigger a debug break with the release CRT. In RelWithDebInfo builds the process terminates without stopping in the debugger, making the assert site hard to inspect.

`CAF_ASSERT` now executes `__debugbreak()` on MSVC (`__builtin_trap()` on GCC/Clang) after printing the assert message and before aborting. With a debugger attached, execution halts at the assert site with full call stack in all build configurations. Without a debugger, the breakpoint exception terminates the process with the assert site at the top of the crash stack.
