### PR TITLE
#14379 Guard against missing intersection view in Show 2D Intersection View

### DIFF
--- a/ApplicationLibCode/Commands/IntersectionViewCommands/RicNewIntersectionViewFeature.cpp
+++ b/ApplicationLibCode/Commands/IntersectionViewCommands/RicNewIntersectionViewFeature.cpp
@@ -73,6 +73,12 @@ void RicNewIntersectionViewFeature::onActionTriggered( bool isChecked )
             }
 
             Rim2dIntersectionView* intersectionView = intersection->correspondingIntersectionView();
+            if ( !intersectionView )
+            {
+                RiaLogging::error( QString( "No intersection view found for intersection '%1'." ).arg( intersection->name() ).toStdString() );
+                continue;
+            }
+
             intersectionView->setVisible( true );
             intersectionView->loadDataAndUpdate();
 


### PR DESCRIPTION
Fixes #14379

## Problem
`RicNewIntersectionViewFeature::onActionTriggered` dereferences the result of `RimExtrudedCurveIntersection::correspondingIntersectionView()` without a null check. That method returns `nullptr` when no `Rim2dIntersectionView` refers to the intersection, causing a segfault when assigning `setVisible( true )` through the null pointer.

## Fix
Skip the intersection with an error log message when no corresponding intersection view exists, matching the null-guard pattern used at every other call site of `correspondingIntersectionView()`.