### PR TITLE
#14383 Guard against missing keyword exception when reading simulation well data

### DIFF
--- a/ApplicationLibCode/FileInterface/RifReaderEclipseWell.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseWell.cpp
@@ -19,6 +19,7 @@
 #include "RifReaderEclipseWell.h"
 
 #include "RiaEclipseUnitTools.h"
+#include "RiaLogging.h"
 
 #include "RifEclipseRestartDataAccess.h"
 
@@ -461,7 +462,16 @@ void RifReaderEclipseWell::readWellCells( RifEclipseRestartDataAccess* restartDa
     well_info_type* ert_well_info = well_info_alloc( gridNames );
     if ( !ert_well_info ) return;
 
-    restartDataAccess->readWellData( ert_well_info, importCompleteMswData );
+    try
+    {
+        restartDataAccess->readWellData( ert_well_info, importCompleteMswData );
+    }
+    catch ( const std::exception& e )
+    {
+        RiaLogging::error( QString( "Failed to read simulation well data: %1" ).arg( e.what() ).toStdString() );
+        well_info_free( ert_well_info );
+        return;
+    }
 
     std::vector<double>    daysSinceSimulationStart;
     std::vector<QDateTime> timeSteps;


### PR DESCRIPTION
Fixes #14383

## Problem
When importing an Eclipse case with a truncated or malformed restart file, a keyword lookup in the ERT library (ecl_file_view_get_global_index using kw_index.at) throws std::out_of_range. The exception escapes uncaught through readWellData and the application terminates.

## Fix
Wrap the well data reading in RifReaderEclipseWell::readWellCells in try/catch. On failure, log an error and skip simulation well import so the grid import can continue.
