### PR TITLE
#14384 Guard residual oil and gas data against missing static results

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigHydrocarbonFlowTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigHydrocarbonFlowTools.cpp
@@ -40,13 +40,19 @@ std::vector<double> RigHydrocarbonFlowTools::residualOilData( RigCaseCellResults
     {
         if ( floodingSettings.oilFlooding() == RigFloodingSettings::FloodingType::GAS_FLOODING )
         {
-            residualOil =
-                resultData.cellScalarResults( RigEclipseResultAddress( RiaDefines::ResultCatType::STATIC_NATIVE, RiaResultNames::sogcr() ), 0 );
+            RigEclipseResultAddress address( RiaDefines::ResultCatType::STATIC_NATIVE, RiaResultNames::sogcr() );
+            if ( resultData.ensureKnownResultLoaded( address ) )
+            {
+                residualOil = resultData.cellScalarResults( address, 0 );
+            }
         }
         else if ( floodingSettings.oilFlooding() == RigFloodingSettings::FloodingType::WATER_FLOODING )
         {
-            residualOil =
-                resultData.cellScalarResults( RigEclipseResultAddress( RiaDefines::ResultCatType::STATIC_NATIVE, RiaResultNames::sowcr() ), 0 );
+            RigEclipseResultAddress address( RiaDefines::ResultCatType::STATIC_NATIVE, RiaResultNames::sowcr() );
+            if ( resultData.ensureKnownResultLoaded( address ) )
+            {
+                residualOil = resultData.cellScalarResults( address, 0 );
+            }
         }
         else
         {
@@ -73,8 +79,11 @@ std::vector<double> RigHydrocarbonFlowTools::residualGasData( RigCaseCellResults
     {
         if ( floodingSettings.gasFlooding() == RigFloodingSettings::FloodingType::GAS_FLOODING )
         {
-            residualGas =
-                resultData.cellScalarResults( RigEclipseResultAddress( RiaDefines::ResultCatType::STATIC_NATIVE, RiaResultNames::sgcr() ), 0 );
+            RigEclipseResultAddress address( RiaDefines::ResultCatType::STATIC_NATIVE, RiaResultNames::sgcr() );
+            if ( resultData.ensureKnownResultLoaded( address ) )
+            {
+                residualGas = resultData.cellScalarResults( address, 0 );
+            }
         }
         else if ( floodingSettings.gasFlooding() == RigFloodingSettings::FloodingType::USER_DEFINED )
         {


### PR DESCRIPTION
Fixes #14384

## Problem
RigHydrocarbonFlowTools::residualOilData and residualGasData call cellScalarResults for SOWCR/SOGCR/SGCR without checking that the result exists. When the case does not contain the static result, findScalarResultIndexFromAddress returns UNDEFINED_SIZE_T and the result vector is indexed out of bounds in release builds, crashing during well target generation.

## Fix
Guard the loads with ensureKnownResultLoaded, matching the pattern used by RigWellTargetMappingTools::loadVectorByName. Missing results fall back to the existing default fill values.
