### PR TITLE
#14385 Catch exceptions when saving deck file during sector model export

### DIFF
--- a/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmFlowDeckFile.cpp
@@ -18,6 +18,8 @@
 
 #include "RifOpmFlowDeckFile.h"
 
+#include "RiaLogging.h"
+
 #include "RifOpmDeckTools.h"
 
 #include "opm/common/utility/TimeService.hpp"
@@ -332,8 +334,15 @@ bool RifOpmFlowDeckFile::saveDeck( std::string folder, std::string filename )
 {
     if ( m_fileDeck.get() != nullptr )
     {
-        m_fileDeck->dump( folder, filename, Opm::FileDeck::OutputMode::COPY );
-        return true;
+        try
+        {
+            m_fileDeck->dump( folder, filename, Opm::FileDeck::OutputMode::COPY );
+            return true;
+        }
+        catch ( const std::exception& e )
+        {
+            RiaLogging::error( QString( "Failed to save deck: %1" ).arg( e.what() ).toStdString() );
+        }
     }
     return false;
 }
@@ -345,8 +354,15 @@ bool RifOpmFlowDeckFile::saveDeckInline( std::string folder, std::string filenam
 {
     if ( m_fileDeck.get() != nullptr )
     {
-        m_fileDeck->dump( folder, filename, Opm::FileDeck::OutputMode::INLINE );
-        return true;
+        try
+        {
+            m_fileDeck->dump( folder, filename, Opm::FileDeck::OutputMode::INLINE );
+            return true;
+        }
+        catch ( const std::exception& e )
+        {
+            RiaLogging::error( QString( "Failed to save deck: %1" ).arg( e.what() ).toStdString() );
+        }
     }
     return false;
 }

--- a/ApplicationLibCode/UnitTests/RifOpmFlowDeckFile-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifOpmFlowDeckFile-Test.cpp
@@ -463,6 +463,35 @@ TEST( RifOpmFlowDeckFileTest, BcpropKeyword )
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Saving to a folder that cannot be created must fail gracefully instead of crashing.
+/// Opm::FileDeck::dump() throws std::filesystem::filesystem_error when the output folder cannot
+/// be created. Here a regular file is used as a parent path component to trigger the exception.
+//--------------------------------------------------------------------------------------------------
+TEST( RifOpmFlowDeckFileTest, SaveDeckToInvalidFolder )
+{
+    static const QString testDataFolder = QString( "%1/RifOpmFlowDeckFile/" ).arg( TEST_DATA_DIR );
+    QString              fileName       = testDataFolder + "SIMPLE_NO_REGDIMS.DATA";
+
+    RifOpmFlowDeckFile deckFile;
+    bool               loadSuccess = deckFile.loadDeck( fileName.toStdString() ).has_value();
+    ASSERT_TRUE( loadSuccess ) << "Failed to load test deck file";
+
+    QTemporaryDir tempDir;
+    ASSERT_TRUE( tempDir.isValid() );
+
+    QString blockerFilePath = tempDir.filePath( "blocker" );
+    QFile   blockerFile( blockerFilePath );
+    ASSERT_TRUE( blockerFile.open( QIODevice::WriteOnly ) );
+    blockerFile.close();
+
+    std::string invalidFolder = ( blockerFilePath + "/subfolder" ).toStdString();
+
+    EXPECT_FALSE( deckFile.saveDeck( invalidFolder, "test.DATA" ) ) << "saveDeck should return false for an invalid output folder";
+    EXPECT_FALSE( deckFile.saveDeckInline( invalidFolder, "test.DATA" ) )
+        << "saveDeckInline should return false for an invalid output folder";
+}
+
+//--------------------------------------------------------------------------------------------------
 /// Verify that a keyword is inserted as the first entry inside the requested section.
 //--------------------------------------------------------------------------------------------------
 TEST( RifOpmFlowDeckFileTest, InsertKeywordAtSectionStart )


### PR DESCRIPTION
Fixes #14385

## Problem
Opm::FileDeck::dump performs filesystem operations (create_directories, canonical, touch_file) that throw fs::filesystem_error when the export location is unwritable or invalid. The exception escapes uncaught during sector model export and the application terminates.

## Fix
Catch exceptions in RifOpmFlowDeckFile::saveDeck and saveDeckInline, log the error and return false. The caller already reports a save failure to the user.
