### PR TITLE
Guard against data lines before well name header in pressure depth reader

### DIFF
--- a/ApplicationLibCode/FileInterface/RifPressureDepthTextFileReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifPressureDepthTextFileReader.cpp
@@ -75,7 +75,7 @@ std::pair<std::vector<RigPressureDepthData>, QString> RifPressureDepthTextFileRe
         }
         else if ( isDateLine( line ) )
         {
-            if ( std::optional<QDateTime> date = parseDateLine( line ) )
+            if ( std::optional<QDateTime> date = parseDateLine( line ); date && !items.empty() )
             {
                 items.back().setTimeStep( date.value() );
             }
@@ -84,7 +84,7 @@ std::pair<std::vector<RigPressureDepthData>, QString> RifPressureDepthTextFileRe
         {
             // Ignored.
         }
-        else if ( std::optional<std::pair<double, double>> p = parseDataLine( line ) )
+        else if ( std::optional<std::pair<double, double>> p = parseDataLine( line ); p && !items.empty() )
         {
             auto [pressure, depth] = p.value();
             items.back().addPressureAtDepth( pressure, depth );

--- a/ApplicationLibCode/UnitTests/RifPressureDepthTextFileReader-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifPressureDepthTextFileReader-Test.cpp
@@ -96,6 +96,28 @@ PSIA FEET
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+TEST( RifPressureDepthTextFileReaderTest, DataBeforeWellNameHeader )
+{
+    auto content = R"(12008.00  22640.66
+DATE 18-NOV-2018
+12020.40  22674.44
+WELLNAME 'A1'
+DATE 18-NOV-2018
+12008.00  22640.66
+\n)";
+
+    auto [items, errorMessage] = RifPressureDepthTextFileReader::parse( content );
+
+    EXPECT_TRUE( errorMessage.isEmpty() );
+    ASSERT_EQ( 1u, items.size() );
+
+    EXPECT_EQ( "A1", items[0].wellName().toStdString() );
+    EXPECT_EQ( 1u, items[0].getPressureDepthValues().size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 TEST( RifPressureDepthTextFileReaderTest, LoadFileWithTabs )
 {
     QString fileName = CASE_REAL_TEST_DATA_DIRECTORY_04 + "example_file_tabs.txt";


### PR DESCRIPTION
Fixes #14392

## Problem
`RifPressureDepthTextFileReader::parse` calls `items.back()` when handling DATE lines and numeric data lines, but `items` only gets an entry when a WELLNAME header line has been seen. A file where a data line or DATE line appears before the first WELLNAME header calls `.back()` on an empty vector, which is undefined behavior and segfaults. The file comes directly from the import file dialog, so selecting a wrong or malformed text file crashes ResInsight.

## Fix
Guard both `items.back()` call sites with `!items.empty()` so such lines are skipped, consistent with how comment and text lines are already ignored. Adds a regression test with data and DATE lines before the WELLNAME header.
