### PR TITLE
Use restore-keys fallback and always save build cache with current date

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -272,10 +272,10 @@ jobs:
         run: buildcache -s
 
       - name: Save Buildcache
-        # Always save the cache with the current date, even if a build step
-        # failed, unless a cache for the current date was already restored
-        # (cache keys are immutable and cannot be overwritten)
-        if: always() && steps.cache-buildcache.outputs.cache-hit != 'true'
+        # Save the cache with the current date, unless a cache for the current
+        # date was already restored (cache keys are immutable and cannot be
+        # overwritten)
+        if: steps.cache-buildcache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ${{ env.BUILDCACHE_DIR }}

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -66,8 +66,8 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
-      # 300 MB, in bytes
-      BUILDCACHE_MAX_CACHE_SIZE: 314572800
+      # 500 MB, in bytes
+      BUILDCACHE_MAX_CACHE_SIZE: 524288000
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       # Supply-chain hardening: never install Python packages published within
       # the last week, to avoid pulling freshly published (potentially

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -66,6 +66,8 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
+      # 300 MB, in bytes
+      BUILDCACHE_MAX_CACHE_SIZE: 314572800
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       # Supply-chain hardening: never install Python packages published within
       # the last week, to avoid pulling freshly published (potentially

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -120,12 +120,15 @@ jobs:
       - name: Print time stamp
         run: echo "timestamp ${{ steps.current-time.outputs.formattedTime }}"
 
-      - name: Cache Buildcache
+      - name: Restore Buildcache
         id: cache-buildcache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.BUILDCACHE_DIR }}
           key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-${{ steps.current-time.outputs.formattedTime }}
+          # Fall back to the most recent cache for this configuration if no
+          # cache exists for the current date
+          restore-keys: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-
       - name: Create Folder for buildcache
         run: New-Item ${{ env.BUILDCACHE_DIR }} -ItemType "directory" -Force
         shell: pwsh
@@ -265,6 +268,16 @@ jobs:
 
       - name: Stats for buildcache
         run: buildcache -s
+
+      - name: Save Buildcache
+        # Always save the cache with the current date, even if a build step
+        # failed, unless a cache for the current date was already restored
+        # (cache keys are immutable and cannot be overwritten)
+        if: always() && steps.cache-buildcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.BUILDCACHE_DIR }}
+          key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-${{ steps.current-time.outputs.formattedTime }}
 
       - name: Run Unit Tests
         if: matrix.config.execute-unit-tests


### PR DESCRIPTION
The build cache key includes the current date, so on any day where no cache had been created yet (e.g. the scheduled 1am run failed or was skipped), builds started completely cold. In addition, the combined `actions/cache` step only saved the cache in its post-job phase when the whole job succeeded.

Changes:

- Split the combined `actions/cache` step into explicit `actions/cache/restore` and `actions/cache/save` steps.
- The restore step adds `restore-keys` with the date-less key prefix, so a missing cache for the current date falls back to the most recent cache for the same OS/compiler/Qt configuration.
- The save step runs right after the build with `if: always()`, so the cache is exported under the current date even if the build or a later step (unit tests, pytest) fails. The save is skipped when a cache for the current date was already restored, since cache keys are immutable.
