### PR TITLE
#14395 Guard against date resampling period NONE in summary table

### DIFF
--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
@@ -252,6 +252,9 @@ std::pair<std::vector<time_t>, std::vector<double>>
                                                const std::vector<double>&                 values,
                                                RiaDefines::DateTimePeriod                 period )
 {
+    // The resampler requires a valid period and non-empty data, return input data unchanged
+    if ( period == RiaDefines::DateTimePeriod::NONE || timeSteps.empty() || values.empty() ) return { timeSteps, values };
+
     RiaTimeHistoryCurveResampler resampler;
     resampler.setCurveData( values, timeSteps );
 


### PR DESCRIPTION
Fixes #14395

## Problem
Selecting "None" in the Date Resampling combo box of a Summary Table passes `DateTimePeriod::NONE` into `RiaTimeHistoryCurveResampler`, which asserts and crashes the application.

## Fix
`RiaSummaryTools::resampledValuesForPeriod()` now returns the input time steps and values unchanged when the period is NONE or the input is empty, so "None" behaves as "no resampling" for all callers.
