### PR TITLE
#14398 Guard against out of range time step in well allocation plot

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -440,10 +440,10 @@ void RimWellAllocationPlot::updateFromWell()
 
     QString flowTypeText = m_flowDiagSolution() ? "Well Allocation" : "Well Flow";
 
-    // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
-    const QStringList timeStepNames = m_case->timeStepStrings();
-    QString           timeStepText;
-    if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) timeStepText = timeStepNames[m_timeStep];
+    // timeStepName() is bounds checked: the stored time step can be out of range if the case has been replaced by a
+    // case with fewer time steps
+    QString timeStepText;
+    if ( m_timeStep() >= 0 ) timeStepText = m_case->timeStepName( m_timeStep );
 
     setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + timeStepText + " (" + m_case->caseUserDescription() + ")" );
 

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -440,10 +440,10 @@ void RimWellAllocationPlot::updateFromWell()
 
     QString flowTypeText = m_flowDiagSolution() ? "Well Allocation" : "Well Flow";
 
-    // timeStepName() is bounds checked: the stored time step can be out of range if the case has been replaced by a
-    // case with fewer time steps
-    QString timeStepText;
-    if ( m_timeStep() >= 0 ) timeStepText = m_case->timeStepName( m_timeStep );
+    // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+    const QStringList timeStepNames = m_case->timeStepStrings();
+    QString           timeStepText;
+    if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) timeStepText = timeStepNames[m_timeStep];
 
     setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + timeStepText + " (" + m_case->caseUserDescription() + ")" );
 

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -439,8 +439,13 @@ void RimWellAllocationPlot::updateFromWell()
     QString wellStatusText = QString( "(%1)" ).arg( RimWellAllocationPlot::wellStatusTextForTimeStep( m_wellName, m_case, m_timeStep ) );
 
     QString flowTypeText = m_flowDiagSolution() ? "Well Allocation" : "Well Flow";
-    setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + m_case->timeStepStrings()[m_timeStep] + " (" +
-                    m_case->caseUserDescription() + ")" );
+
+    // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+    const QStringList timeStepNames = m_case->timeStepStrings();
+    QString           timeStepText;
+    if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) timeStepText = timeStepNames[m_timeStep];
+
+    setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + timeStepText + " (" + m_case->caseUserDescription() + ")" );
 
     /// Pie chart
 

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
@@ -300,10 +300,9 @@ QString RimGridCrossPlotDataSet::createAutoName() const
         nameTags += axisVariableString();
     }
 
-    if ( m_nameConfig->addTimestep() )
+    if ( m_nameConfig->addTimestep() && !timeStepString().isEmpty() )
     {
-        const QString timeStepStr = timeStepString();
-        if ( !timeStepStr.isEmpty() ) nameTags += timeStepStr;
+        nameTags += timeStepString();
     }
 
     QString fullTitle = nameTags.join( ", " );
@@ -467,9 +466,9 @@ QString RimGridCrossPlotDataSet::timeStepString() const
                 return "All Time Steps";
             }
 
-            // timeStepName() is bounds checked: the stored time step can be out of range if the data set has been
-            // switched to a case with fewer time steps
-            if ( m_timeStep() >= 0 ) return m_case->timeStepName( m_timeStep );
+            // The stored time step can be out of range if the data set has been switched to a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
             return "";
         }
     }

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
@@ -465,7 +465,11 @@ QString RimGridCrossPlotDataSet::timeStepString() const
             {
                 return "All Time Steps";
             }
-            return m_case->timeStepStrings()[m_timeStep];
+
+            // The stored time step can be out of range if the data set has been switched to a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
+            return "";
         }
     }
     return "";

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
@@ -300,9 +300,10 @@ QString RimGridCrossPlotDataSet::createAutoName() const
         nameTags += axisVariableString();
     }
 
-    if ( m_nameConfig->addTimestep() && !timeStepString().isEmpty() )
+    if ( m_nameConfig->addTimestep() )
     {
-        nameTags += timeStepString();
+        const QString timeStepStr = timeStepString();
+        if ( !timeStepStr.isEmpty() ) nameTags += timeStepStr;
     }
 
     QString fullTitle = nameTags.join( ", " );
@@ -466,9 +467,9 @@ QString RimGridCrossPlotDataSet::timeStepString() const
                 return "All Time Steps";
             }
 
-            // The stored time step can be out of range if the data set has been switched to a case with fewer time steps
-            const QStringList timeStepNames = m_case->timeStepStrings();
-            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
+            // timeStepName() is bounds checked: the stored time step can be out of range if the data set has been
+            // switched to a case with fewer time steps
+            if ( m_timeStep() >= 0 ) return m_case->timeStepName( m_timeStep );
             return "";
         }
     }

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
@@ -253,7 +253,10 @@ std::string RimGridStatisticsHistogramDataSource::name() const
         if ( m_case() && m_property->hasDynamicResult() )
         {
             if ( m_timeStep == -1 ) return "All Time Steps";
-            return m_case->timeStepStrings()[m_timeStep];
+
+            // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
         }
 
         return "";

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
@@ -254,9 +254,9 @@ std::string RimGridStatisticsHistogramDataSource::name() const
         {
             if ( m_timeStep == -1 ) return "All Time Steps";
 
-            // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
-            const QStringList timeStepNames = m_case->timeStepStrings();
-            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
+            // timeStepName() is bounds checked: the stored time step can be out of range if the case has been replaced
+            // by a case with fewer time steps
+            if ( m_timeStep() >= 0 ) return m_case->timeStepName( m_timeStep );
         }
 
         return "";

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
@@ -254,9 +254,9 @@ std::string RimGridStatisticsHistogramDataSource::name() const
         {
             if ( m_timeStep == -1 ) return "All Time Steps";
 
-            // timeStepName() is bounds checked: the stored time step can be out of range if the case has been replaced
-            // by a case with fewer time steps
-            if ( m_timeStep() >= 0 ) return m_case->timeStepName( m_timeStep );
+            // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
         }
 
         return "";


### PR DESCRIPTION
Fixes #14398

## Problem
When a case is replaced ("Replace Case") by a case with fewer time steps, an open Well Allocation Plot is reloaded with its stored time step index intact. `setCase()` clamps the time step, but the replace path reloads data on the same case object without calling it. All time-step-indexed calls in `updateFromWell()` are guarded except `m_case->timeStepStrings()[m_timeStep]`, where `QStringList::operator[]` performs no bounds check in release builds, causing a segfault.

The same unguarded indexing pattern exists in two more locations:
- `RimGridCrossPlotDataSet::timeStepString()` — crashes when the data set is switched to a case with fewer time steps via the combo box (`fieldChangedByUi` does not clamp `m_timeStep`), seen in crash telemetry as a segfault in `RimGridCrossPlotDataSet::createAutoName()`
- `RimGridStatisticsHistogramDataSource::name()` — identical latent bug

## Fix
Bounds-check the index and fall back to an empty time step label in all three locations. The `-1` ("All Time Steps") handling is preserved, and the surrounding code already handles a missing/invalid time step gracefully.