### PR TITLE
Guard against whitespace in AppEnum serialization text and fix affected enums

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Annotations/RimEquilibriumAxisAnnotation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Annotations/RimEquilibriumAxisAnnotation.cpp
@@ -33,6 +33,8 @@ namespace caf
 template <>
 void RimEquilibriumAxisAnnotation::ExportKeywordEnum::setUp()
 {
+    // The legacy serialization text "User Defined" is read back from XML as the single token "User", so
+    // use this token as alias to map old project files to PL_USER_DEFINED
     addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_USER_DEFINED, "USER_DEFINED", "User Defined", { "User" } );
     addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_EQUIL_WATER_OIL_CONTACT,
              "PL_EQUIL_WATER_OIL_CONTACT",

--- a/ApplicationLibCode/ProjectDataModel/Annotations/RimEquilibriumAxisAnnotation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Annotations/RimEquilibriumAxisAnnotation.cpp
@@ -33,8 +33,8 @@ namespace caf
 template <>
 void RimEquilibriumAxisAnnotation::ExportKeywordEnum::setUp()
 {
-    // The legacy serialization text "User Defined" is read back from XML as the single token "User", so
-    // use this token as alias to map old project files to PL_USER_DEFINED
+    // The alias is the serialization text used by previous versions, as read back from XML, and maps
+    // old project files to the correct enum value
     addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_USER_DEFINED, "USER_DEFINED", "User Defined", { "User" } );
     addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_EQUIL_WATER_OIL_CONTACT,
              "PL_EQUIL_WATER_OIL_CONTACT",

--- a/ApplicationLibCode/ProjectDataModel/Annotations/RimEquilibriumAxisAnnotation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Annotations/RimEquilibriumAxisAnnotation.cpp
@@ -33,7 +33,7 @@ namespace caf
 template <>
 void RimEquilibriumAxisAnnotation::ExportKeywordEnum::setUp()
 {
-    addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_USER_DEFINED, "User Defined", "User Defined" );
+    addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_USER_DEFINED, "USER_DEFINED", "User Defined", { "User" } );
     addItem( RimEquilibriumAxisAnnotation::PlotAxisAnnotationType::PL_EQUIL_WATER_OIL_CONTACT,
              "PL_EQUIL_WATER_OIL_CONTACT",
              "PL_EQUIL_WATER_OIL_CONTACT" );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
@@ -28,6 +28,7 @@ void caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>::setUp()
     // The alias is the serialization text used by previous versions, as read back from XML, and maps
     // old project files to the correct enum value. EXTRA_FINE and EXTRA_COARSE have no alias, as their
     // legacy texts contained whitespace and were never read back correctly from XML
+    // https://github.com/OPM/ResInsight/issues/14404
     addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
     addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "FINE", "Fine", { "Fine" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "NORMAL", "Normal", { "Normal" } );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
@@ -28,6 +28,8 @@ void caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>::setUp()
     // The serialization text must not contain spaces, as the XML import reads one whitespace-delimited
     // token and a partial match falls back to the default enum value
     addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
+    // The alias is the serialization text used by previous versions, as read back from XML, and maps
+    // old project files to the correct enum value
     addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "FINE", "Fine", { "Fine" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "NORMAL", "Normal", { "Normal" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::COARSE, "COARSE", "Coarse", { "Coarse" } );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
@@ -25,11 +25,13 @@ namespace caf
 template <>
 void caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>::setUp()
 {
-    addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "Extra Fine", "Extra Fine" );
+    // The serialization text must not contain spaces, as the XML import reads one whitespace-delimited
+    // token and a partial match falls back to the default enum value
+    addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
     addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "Fine", "Fine" );
     addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "Normal", "Normal" );
     addItem( RimContourMapResolutionTools::SamplingResolution::COARSE, "Coarse", "Coarse" );
-    addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_COARSE, "Extra Coarse", "Extra Coarse" );
+    addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_COARSE, "EXTRA_COARSE", "Extra Coarse" );
     setDefault( RimContourMapResolutionTools::SamplingResolution::NORMAL );
 }
 }; // namespace caf

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
@@ -26,7 +26,8 @@ template <>
 void caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>::setUp()
 {
     // The alias is the serialization text used by previous versions, as read back from XML, and maps
-    // old project files to the correct enum value
+    // old project files to the correct enum value. EXTRA_FINE and EXTRA_COARSE have no alias, as their
+    // legacy texts contained whitespace and were never read back correctly from XML
     addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
     addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "FINE", "Fine", { "Fine" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "NORMAL", "Normal", { "Normal" } );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
@@ -25,11 +25,9 @@ namespace caf
 template <>
 void caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>::setUp()
 {
-    // The serialization text must not contain spaces, as the XML import reads one whitespace-delimited
-    // token and a partial match falls back to the default enum value
-    addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
     // The alias is the serialization text used by previous versions, as read back from XML, and maps
     // old project files to the correct enum value
+    addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
     addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "FINE", "Fine", { "Fine" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "NORMAL", "Normal", { "Normal" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::COARSE, "COARSE", "Coarse", { "Coarse" } );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapResolutionTools.cpp
@@ -28,9 +28,9 @@ void caf::AppEnum<RimContourMapResolutionTools::SamplingResolution>::setUp()
     // The serialization text must not contain spaces, as the XML import reads one whitespace-delimited
     // token and a partial match falls back to the default enum value
     addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_FINE, "EXTRA_FINE", "Extra Fine" );
-    addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "Fine", "Fine" );
-    addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "Normal", "Normal" );
-    addItem( RimContourMapResolutionTools::SamplingResolution::COARSE, "Coarse", "Coarse" );
+    addItem( RimContourMapResolutionTools::SamplingResolution::FINE, "FINE", "Fine", { "Fine" } );
+    addItem( RimContourMapResolutionTools::SamplingResolution::NORMAL, "NORMAL", "Normal", { "Normal" } );
+    addItem( RimContourMapResolutionTools::SamplingResolution::COARSE, "COARSE", "Coarse", { "Coarse" } );
     addItem( RimContourMapResolutionTools::SamplingResolution::EXTRA_COARSE, "EXTRA_COARSE", "Extra Coarse" );
     setDefault( RimContourMapResolutionTools::SamplingResolution::NORMAL );
 }

--- a/ApplicationLibCode/ProjectDataModel/RimGridTimeHistoryCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridTimeHistoryCurve.cpp
@@ -246,7 +246,7 @@ QString RimGridTimeHistoryCurve::quantityName() const
         {
             if ( geoMechTopItem->m_elementFace >= 0 )
             {
-                text.append( ", " + caf::AppEnum<cvf::StructGridInterface::FaceType>::textFromIndex( geoMechTopItem->m_elementFace ) );
+                text.append( ", " + caf::AppEnum<cvf::StructGridInterface::FaceType>::uiTextFromIndex( geoMechTopItem->m_elementFace ) );
             }
             else
             {

--- a/ApplicationLibCode/UserInterface/RiuFemResultTextBuilder.cpp
+++ b/ApplicationLibCode/UserInterface/RiuFemResultTextBuilder.cpp
@@ -436,7 +436,7 @@ QString RiuFemResultTextBuilder::closestNodeResultText( RimGeoMechResultDefiniti
             {
                 text.append( QString( "Closest result: N[%1], on face: %2, %3\n" )
                                  .arg( closestNodeId )
-                                 .arg( caf::AppEnum<cvf::StructGridInterface::FaceType>::textFromIndex( m_face ) )
+                                 .arg( caf::AppEnum<cvf::StructGridInterface::FaceType>::uiTextFromIndex( m_face ) )
                                  .arg( scalarValue ) );
             }
             else if ( m_isIntersectionTriangleSet && activeResultPosition == RIG_ELEMENT_NODAL_FACE )

--- a/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp
+++ b/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp
@@ -229,7 +229,7 @@ QString RiuResultTextBuilder::geometrySelectionText( const QString& itemSeparato
                     {
                         cvf::StructGridInterface::FaceEnum faceEnum( m_face );
 
-                        QString faceText = faceEnum.text();
+                        QString faceText = faceEnum.uiText();
 
                         text += QString( "Face: %1" ).arg( faceText ) + itemSeparator;
                     }
@@ -417,7 +417,7 @@ QString RiuResultTextBuilder::faultResultDetails()
             text += QString( "Name: %1\n" ).arg( fault->name() );
 
             cvf::StructGridInterface::FaceEnum faceHelper( m_face );
-            text += "Face: " + faceHelper.text() + "\n";
+            text += "Face: " + faceHelper.uiText() + "\n";
 
             if ( m_eclipseView && m_eclipseView->faultResultSettings()->hasValidCustomResult() )
             {
@@ -937,7 +937,7 @@ QString RiuResultTextBuilder::nncDetails()
 
                             QString gridName = QString::fromStdString( hostGrid->gridName() );
                             text.append(
-                                QString( "NNC 1: cell [%1, %2, %3] face %4 (%5)\n" ).arg( i ).arg( j ).arg( k ).arg( face.text() ).arg( gridName ) );
+                                QString( "NNC 1: cell [%1, %2, %3] face %4 (%5)\n" ).arg( i ).arg( j ).arg( k ).arg( face.uiText() ).arg( gridName ) );
                         }
                     }
 
@@ -959,7 +959,7 @@ QString RiuResultTextBuilder::nncDetails()
 
                             QString                            gridName = QString::fromStdString( hostGrid->gridName() );
                             cvf::StructGridInterface::FaceEnum oppositeFaceEnum( cvf::StructGridInterface::oppositeFace( face ) );
-                            QString                            faceText = oppositeFaceEnum.text();
+                            QString                            faceText = oppositeFaceEnum.uiText();
 
                             text.append(
                                 QString( "NNC 2: cell [%1, %2, %3] face %4 (%5)\n" ).arg( i ).arg( j ).arg( k ).arg( faceText ).arg( gridName ) );

--- a/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp
@@ -244,7 +244,7 @@ void RiuSelectionChangedHandler::addResultCurveFromSelectionItem( const RiuGeoMe
         {
             if ( geomSelectionItem->m_elementFace >= 0 )
             {
-                curveName.append( ", " + caf::AppEnum<cvf::StructGridInterface::FaceType>::textFromIndex( geomSelectionItem->m_elementFace ) );
+                curveName.append( ", " + caf::AppEnum<cvf::StructGridInterface::FaceType>::uiTextFromIndex( geomSelectionItem->m_elementFace ) );
             }
             else
             {

--- a/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp
+++ b/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp
@@ -52,7 +52,7 @@ void cvf::StructGridInterface::FaceEnum::setUp()
     addItem( cvf::StructGridInterface::NEG_J, "NEG_J", "NEG J" );
     addItem( cvf::StructGridInterface::POS_K, "POS_K", "POS K" );
     addItem( cvf::StructGridInterface::NEG_K, "NEG_K", "NEG K" );
-    addItem( cvf::StructGridInterface::NO_FACE, "UnDef", "UnDef" );
+    addItem( cvf::StructGridInterface::NO_FACE, "UNDEF", "UnDef" );
 }
 } // namespace caf
 

--- a/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp
+++ b/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp
@@ -46,13 +46,13 @@ namespace caf
 template <>
 void cvf::StructGridInterface::FaceEnum::setUp()
 {
-    addItem( cvf::StructGridInterface::POS_I, "POS I", "" );
-    addItem( cvf::StructGridInterface::NEG_I, "NEG I", "" );
-    addItem( cvf::StructGridInterface::POS_J, "POS J", "" );
-    addItem( cvf::StructGridInterface::NEG_J, "NEG J", "" );
-    addItem( cvf::StructGridInterface::POS_K, "POS K", "" );
-    addItem( cvf::StructGridInterface::NEG_K, "NEG K", "" );
-    addItem( cvf::StructGridInterface::NO_FACE, "UnDef", "" );
+    addItem( cvf::StructGridInterface::POS_I, "POS_I", "POS I" );
+    addItem( cvf::StructGridInterface::NEG_I, "NEG_I", "NEG I" );
+    addItem( cvf::StructGridInterface::POS_J, "POS_J", "POS J" );
+    addItem( cvf::StructGridInterface::NEG_J, "NEG_J", "NEG J" );
+    addItem( cvf::StructGridInterface::POS_K, "POS_K", "POS K" );
+    addItem( cvf::StructGridInterface::NEG_K, "NEG_K", "NEG K" );
+    addItem( cvf::StructGridInterface::NO_FACE, "UnDef", "UnDef" );
 }
 } // namespace caf
 

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafAppEnum.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafAppEnum.cpp
@@ -43,6 +43,8 @@
 
 #include "cafAssert.h"
 
+#include <algorithm>
+
 namespace caf
 {
 
@@ -57,11 +59,25 @@ bool AppEnumMapperBase::EnumData::isMatching( const QString& text ) const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+namespace
+{
+    bool containsWhitespace( const QString& text )
+    {
+        return std::any_of( text.begin(), text.end(), []( const QChar& c ) { return c.isSpace(); } );
+    }
+} // namespace
+
 void AppEnumMapperBase::addItem( int enumVal, const QString& text, QString uiText, const QStringList& aliases )
 {
+    // The serialization text is read back from XML one whitespace-delimited token at a time, so texts and
+    // aliases with embedded whitespace would silently be replaced by the default enum value on import
+    // https://github.com/OPM/ResInsight/issues/14404
+    CAF_ASSERT( !containsWhitespace( text.trimmed() ) );
+
     // Make sure the alias text is unique for enum
     for ( const auto& alias : aliases )
     {
+        CAF_ASSERT( !containsWhitespace( alias ) );
         for ( const auto& enumData : m_mapping )
         {
             CAF_ASSERT( !enumData.isMatching( alias ) );


### PR DESCRIPTION
Fixes #14404

The serialization text of a `caf::AppEnum` item is read back from project XML one whitespace-delimited token at a time, so a text with an embedded space (e.g. "Extra Fine") is truncated on import, fails the lookup and silently falls back to the default enum value. The user-visible symptom is that the contour map Sampling Resolution "Extra Fine"/"Extra Coarse" is reset to "Normal" when a project is saved and reopened.

Changes:

- `RimContourMapResolutionTools`: serialization texts changed to `EXTRA_FINE`/`EXTRA_COARSE`, UI texts unchanged.
- `RimEquilibriumAxisAnnotation`: `"User Defined"` changed to `USER_DEFINED` with alias `User`, which also restores the value from legacy project files (the truncated token is unambiguous for this enum).
- `cvf::StructGridInterface::FaceEnum`: texts changed to `POS_I` etc. with the old spaced strings kept as UI texts; the display call sites in `RiuResultTextBuilder`, `RiuSelectionChangedHandler`, `RiuFemResultTextBuilder` and `RimGridTimeHistoryCurve` now use `uiText()`/`uiTextFromIndex()` so user-visible strings are unchanged. This enum is not serialized in any PDM field.
- `AppEnumMapperBase::addItem()`: new `CAF_ASSERT` that the trimmed serialization text and all aliases contain no whitespace, so this class of bug cannot be reintroduced.

Projects saved with the broken texts loaded as the default value both before and after this change, so there is no additional compatibility break. The token-based read itself cannot be changed to read the full stream, as `PdmField<std::vector<AppEnum<T>>>` fields serialize multiple tokens whitespace-separated into one stream.
