### PR TITLE
#14343 Add context menu for toggling selected cases in ensemble import dialog

### DIFF
--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
@@ -33,9 +33,7 @@
 
 #include "cafAppEnum.h"
 
-#include <QApplication>
 #include <QCheckBox>
-#include <QClipboard>
 #include <QCollator>
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -849,11 +847,6 @@ void RicImportGridAndSummaryEnsembleDialog::slotFileListCustomMenuRequested( con
     QMenu    menu;
     QAction* action;
 
-    action = new QAction( QIcon( ":/Copy.svg" ), "&Copy", this );
-    connect( action, SIGNAL( triggered() ), SLOT( slotCopyFileItemText() ) );
-    menu.addAction( action );
-    menu.addSeparator();
-
     action = new QAction( "On", this );
     connect( action, SIGNAL( triggered() ), SLOT( slotTurnOnFileListItems() ) );
     menu.addAction( action );
@@ -868,22 +861,6 @@ void RicImportGridAndSummaryEnsembleDialog::slotFileListCustomMenuRequested( con
 
     QPoint globalPoint = m_fileTreeView->mapToGlobal( point );
     menu.exec( globalPoint );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RicImportGridAndSummaryEnsembleDialog::slotCopyFileItemText()
-{
-    auto index = m_fileTreeView->currentIndex();
-    if ( index.isValid() )
-    {
-        auto item = m_filePathModel.itemFromIndex( index );
-        if ( item )
-        {
-            QApplication::clipboard()->setText( item->text() );
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
@@ -33,7 +33,9 @@
 
 #include "cafAppEnum.h"
 
+#include <QApplication>
 #include <QCheckBox>
+#include <QClipboard>
 #include <QCollator>
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -44,6 +46,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QRegularExpression>
@@ -248,6 +251,10 @@ RicImportGridAndSummaryEnsembleDialog::RicImportGridAndSummaryEnsembleDialog( QW
     connect( m_createGridEnsembleCheckBox, &QCheckBox::toggled, this, updateOkFromCheckboxes );
     connect( m_createSummaryEnsembleCheckBox, &QCheckBox::toggled, this, updateOkFromCheckboxes );
     connect( m_treeFilterButton, SIGNAL( clicked() ), this, SLOT( slotFilterTreeViewClicked() ) );
+    connect( m_fileTreeView,
+             SIGNAL( customContextMenuRequested( const QPoint& ) ),
+             this,
+             SLOT( slotFileListCustomMenuRequested( const QPoint& ) ) );
     connect( m_treeFilterLineEdit, &QLineEdit::returnPressed, m_treeFilterButton, &QPushButton::click );
     connect( m_treeFilterLineEdit, &QLineEdit::textEdited, m_treeFilterButton, &QPushButton::click );
 
@@ -829,6 +836,111 @@ void RicImportGridAndSummaryEnsembleDialog::slotFilterTreeViewClicked()
                 {
                     matchedItem->setCheckState( Qt::Checked );
                 }
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotFileListCustomMenuRequested( const QPoint& point )
+{
+    QMenu    menu;
+    QAction* action;
+
+    action = new QAction( QIcon( ":/Copy.svg" ), "&Copy", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotCopyFileItemText() ) );
+    menu.addAction( action );
+    menu.addSeparator();
+
+    action = new QAction( "On", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotTurnOnFileListItems() ) );
+    menu.addAction( action );
+
+    action = new QAction( "Off", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotTurnOffFileListItems() ) );
+    menu.addAction( action );
+
+    action = new QAction( "Toggle", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotToggleFileListItems() ) );
+    menu.addAction( action );
+
+    QPoint globalPoint = m_fileTreeView->mapToGlobal( point );
+    menu.exec( globalPoint );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotCopyFileItemText()
+{
+    auto index = m_fileTreeView->currentIndex();
+    if ( index.isValid() )
+    {
+        auto item = m_filePathModel.itemFromIndex( index );
+        if ( item )
+        {
+            QApplication::clipboard()->setText( item->text() );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotTurnOnFileListItems()
+{
+    auto selectionModel = m_fileTreeView->selectionModel();
+    auto indices        = selectionModel->selectedIndexes();
+    for ( auto& index : indices )
+    {
+        if ( index.isValid() )
+        {
+            auto item = m_filePathModel.itemFromIndex( index );
+            if ( item && item->isCheckable() )
+            {
+                item->setCheckState( Qt::Checked );
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotTurnOffFileListItems()
+{
+    auto selectionModel = m_fileTreeView->selectionModel();
+    auto indices        = selectionModel->selectedIndexes();
+    for ( auto& index : indices )
+    {
+        if ( index.isValid() )
+        {
+            auto item = m_filePathModel.itemFromIndex( index );
+            if ( item && item->isCheckable() )
+            {
+                item->setCheckState( Qt::Unchecked );
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotToggleFileListItems()
+{
+    auto selectionModel = m_fileTreeView->selectionModel();
+    auto indices        = selectionModel->selectedIndexes();
+    for ( auto& index : indices )
+    {
+        if ( index.isValid() )
+        {
+            auto item = m_filePathModel.itemFromIndex( index );
+            if ( item && item->isCheckable() )
+            {
+                item->setCheckState( item->checkState() == Qt::Checked ? Qt::Unchecked : Qt::Checked );
             }
         }
     }

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
@@ -84,7 +84,6 @@ private slots:
     void slotSearchClicked();
     void slotFilterTreeViewClicked();
     void slotFileListCustomMenuRequested( const QPoint& point );
-    void slotCopyFileItemText();
     void slotTurnOnFileListItems();
     void slotTurnOffFileListItems();
     void slotToggleFileListItems();

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
@@ -83,6 +83,11 @@ private slots:
     void slotUseRealizationStarClicked();
     void slotSearchClicked();
     void slotFilterTreeViewClicked();
+    void slotFileListCustomMenuRequested( const QPoint& point );
+    void slotCopyFileItemText();
+    void slotTurnOnFileListItems();
+    void slotTurnOffFileListItems();
+    void slotToggleFileListItems();
     void slotOkClicked();
     void slotCancelClicked();
     void showEvent( QShowEvent* event ) override;


### PR DESCRIPTION
Fixes #14343

The file tree in the "Import Grid and Summary Ensemble" dialog set `Qt::CustomContextMenu` as context menu policy, but the `customContextMenuRequested` signal was never connected, so right-clicking selected realizations did nothing.

Add the same context menu as in `RicRecursiveFileSearchDialog` with On, Off, and Toggle actions operating on the selected items.