### PR TITLE
#14344 Update ensemble grid model views on polygon import

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -892,6 +892,16 @@ std::vector<Rim3dView*> RimProject::allViews() const
                     views.push_back( view );
                 }
             }
+
+            for ( auto gridEnsemble : oilField->analysisModels()->reservoirGridEnsembles.childrenByType() )
+            {
+                if ( !gridEnsemble ) continue;
+
+                for ( auto view : gridEnsemble->allViews() )
+                {
+                    views.push_back( view );
+                }
+            }
         }
     }
 

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -503,20 +503,30 @@ std::vector<RimEclipseView*> RimReservoirGridEnsemble::allViews() const
 {
     std::vector<RimEclipseView*> views;
 
-    for ( auto view : m_viewCollection->views() )
-    {
-        views.push_back( view );
-    }
+    // Use childrenByType() and null checks here, as this function can be called while child objects
+    // are being deleted during project close. PdmPointer entries in the child array fields are
+    // nulled one by one as the objects are destroyed.
 
-    for ( auto statCase : m_statisticsCaseCollection->reservoirs() )
+    if ( m_viewCollection )
     {
-        for ( auto view : statCase->reservoirViews() )
+        for ( auto view : m_viewCollection->views() )
         {
             views.push_back( view );
         }
     }
 
-    for ( auto cmap : m_statisticsContourMaps )
+    if ( m_statisticsCaseCollection )
+    {
+        for ( auto statCase : m_statisticsCaseCollection->reservoirs.childrenByType() )
+        {
+            for ( auto view : statCase->reservoirViews() )
+            {
+                views.push_back( view );
+            }
+        }
+    }
+
+    for ( auto cmap : m_statisticsContourMaps.childrenByType() )
     {
         for ( auto view : cmap->views() )
         {


### PR DESCRIPTION
Fixes OPM/ResInsight#14344

## Changes

**RimProject::allViews()**: Include views from reservoir grid ensembles (ensemble view collection, statistics case views, and statistics contour map views). Previously these views were not part of the project view traversal, so importing a polygon (or surface) did not update the Project Tree items or schedule a redraw for ensemble grid model views until a manual 3D view update was triggered.

**RimReservoirGridEnsemble::allViews()**: Iterate child array fields with childrenByType() and add null guards. This function can now be called re-entrantly during project close (a dying view triggers a command enabled-state refresh via RiuMainWindow::onViewerRemoved), and direct range-for iteration over the child array fields yields entries that are nulled one by one during deleteChildren(), causing an access violation when dereferenced. This mirrors the existing null-safe pattern in RimEclipseCaseEnsemble::allViews().