### PR TITLE
#14409 Fix crash when creating h5 file from summary file without TIME vector

### DIFF
--- a/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp
@@ -130,16 +130,33 @@ bool RifHdf5SummaryExporter::ensureHdf5FileIsCreated( const std::string& smspecF
             // performance penalty
             sourceSummaryData.loadData();
 
+            std::string exportErrorText;
+
 #pragma omp critical( critical_section_HDF5_export )
             {
                 // HDF5 file access is not thread-safe, always make sure we use the HDF5 library from a single thread
 
-                RifHdf5Exporter exporter( h5FileName );
+                // NB! An exception must never escape an OpenMP structured block, as this will terminate the application
+                try
+                {
+                    RifHdf5Exporter exporter( h5FileName );
 
-                writeGeneralSection( exporter, sourceSummaryData );
-                writeSummaryVectors( exporter, sourceSummaryData );
+                    writeGeneralSection( exporter, sourceSummaryData );
+                    writeSummaryVectors( exporter, sourceSummaryData );
 
-                hdfFilesCreatedCount++;
+                    hdfFilesCreatedCount++;
+                }
+                catch ( std::exception& e )
+                {
+                    exportErrorText = e.what();
+                }
+            }
+
+            if ( !exportErrorText.empty() )
+            {
+                RiaLogging::error( std::format( "HDF export to file {} failed : {}", smspecFileName, exportErrorText ) );
+
+                return false;
             }
         }
         catch ( std::exception& e )
@@ -158,8 +175,6 @@ bool RifHdf5SummaryExporter::ensureHdf5FileIsCreated( const std::string& smspecF
 //--------------------------------------------------------------------------------------------------
 bool RifHdf5SummaryExporter::writeGeneralSection( RifHdf5Exporter& exporter, Opm::EclIO::ESmry& sourceSummaryData )
 {
-    auto timesteps = sourceSummaryData.dates();
-
     auto group = exporter.createGroup( nullptr, "general" );
 
     {

--- a/ApplicationLibCode/UnitTests/HDF5FileWriter-Test.cpp
+++ b/ApplicationLibCode/UnitTests/HDF5FileWriter-Test.cpp
@@ -24,7 +24,50 @@
 #include "opm/io/eclipse/ESmry.hpp"
 #include <numeric>
 
+#include <QByteArray>
+#include <QFile>
+#include <QTemporaryDir>
+
 static const QString H5_TEST_DATA_DIRECTORY_2 = QString( "%1/h5-file/" ).arg( TEST_DATA_DIR );
+
+//--------------------------------------------------------------------------------------------------
+/// A summary file without a TIME vector must be reported as a failed export, not terminate the
+/// application. Opm::EclIO::ESmry::dates() throws when the TIME vector is missing.
+//--------------------------------------------------------------------------------------------------
+TEST( HDFTests, ExportSummaryFileWithoutTimeKeyword )
+{
+    const QString sourceFolder = QString( "%1/SummaryData/Reek/" ).arg( TEST_DATA_DIR );
+
+    QTemporaryDir tempDir;
+    ASSERT_TRUE( tempDir.isValid() );
+
+    ASSERT_TRUE( QFile::copy( sourceFolder + "3_R001_REEK-1.UNSMRY", tempDir.filePath( "3_R001_REEK-1.UNSMRY" ) ) );
+
+    // Copy the SMSPEC file and rename the TIME keyword, making ESmry load without a TIME vector
+    const QString smspecFileName = tempDir.filePath( "3_R001_REEK-1.SMSPEC" );
+    {
+        QFile sourceFile( sourceFolder + "3_R001_REEK-1.SMSPEC" );
+        ASSERT_TRUE( sourceFile.open( QIODevice::ReadOnly ) );
+
+        QByteArray content = sourceFile.readAll();
+
+        const QByteArray timeKeyword( "TIME    " );
+        ASSERT_EQ( 1, content.count( timeKeyword ) );
+        content.replace( timeKeyword, QByteArray( "TIMX    " ) );
+
+        QFile destinationFile( smspecFileName );
+        ASSERT_TRUE( destinationFile.open( QIODevice::WriteOnly ) );
+        ASSERT_EQ( content.size(), destinationFile.write( content ) );
+    }
+
+    const std::string h5FileName = tempDir.filePath( "3_R001_REEK-1.h5" ).toStdString();
+
+    size_t hdfFilesCreatedCount = 0;
+    EXPECT_TRUE( RifHdf5SummaryExporter::ensureHdf5FileIsCreated( smspecFileName.toStdString(), h5FileName, true, hdfFilesCreatedCount ) );
+
+    EXPECT_EQ( size_t( 1 ), hdfFilesCreatedCount );
+    EXPECT_TRUE( QFile::exists( QString::fromStdString( h5FileName ) ) );
+}
 
 //--------------------------------------------------------------------------------------------------
 ///


### PR DESCRIPTION
Fixes #14409

## Problem
`ESmry::dates()` throws when the summary file has no TIME vector. The call was made from
inside `#pragma omp critical`, and GCC terminates the application when an exception leaves
an OpenMP structured block, so the surrounding try/catch never ran.

The `dates()` result was never used.

## Fix
Remove the unused `dates()` call, and move the exception handling inside the critical
section so no exception can escape the OpenMP structured block. Same guard pattern as
`writeSummaryVectors()`.

Note: this applies to all OpenMP structured blocks in the code base - an exception must be
caught inside the block.
