### PR TITLE
#14414 Block gRPC idle processing while crash handling is in progress

### DIFF
--- a/ApplicationExeCode/RiaGrpcConsoleApplication.cpp
+++ b/ApplicationExeCode/RiaGrpcConsoleApplication.cpp
@@ -17,6 +17,8 @@
 /////////////////////////////////////////////////////////////////////////////////
 #include "RiaGrpcConsoleApplication.h"
 
+#include "RiaMainTools.h"
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -30,6 +32,11 @@ QProcessEnvironment RiaGrpcConsoleApplication::pythonProcessEnvironment() const
 //--------------------------------------------------------------------------------------------------
 void RiaGrpcConsoleApplication::doIdleProcessing()
 {
+    // The crash handler pumps the event loop while flushing telemetry, so this timer slot can fire
+    // mid-crash. Processing requests or closing the project would then destroy objects the crashed
+    // code still uses, causing a nested crash.
+    if ( RiaMainTools::isCrashHandlingInProgress() ) return;
+
     int processCount = processRequests();
     if ( processCount == -1 )
     {

--- a/ApplicationExeCode/RiaGrpcGuiApplication.cpp
+++ b/ApplicationExeCode/RiaGrpcGuiApplication.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 #include "RiaGrpcGuiApplication.h"
 
+#include "RiaMainTools.h"
 #include "RiaPreferences.h"
 
 #include "cafProgressInfo.h"
@@ -55,6 +56,11 @@ QProcessEnvironment RiaGrpcGuiApplication::pythonProcessEnvironment() const
 //--------------------------------------------------------------------------------------------------
 void RiaGrpcGuiApplication::doIdleProcessing()
 {
+    // The crash handler pumps the event loop while flushing telemetry, so this timer slot can fire
+    // mid-crash. Processing requests or closing the project would then destroy objects the crashed
+    // code still uses, causing a nested crash.
+    if ( RiaMainTools::isCrashHandlingInProgress() ) return;
+
     if ( !caf::ProgressInfoStatic::isRunning() )
     {
         int processCount = processRequests();

--- a/ApplicationExeCode/RiaMainTools.cpp
+++ b/ApplicationExeCode/RiaMainTools.cpp
@@ -32,6 +32,7 @@
 
 #include <QDir>
 
+#include <atomic>
 #include <csignal>
 #include <exception>
 #include <map>
@@ -156,6 +157,8 @@ static std::string signalCodeDescription( int signo, int siCode )
 #endif
 } // namespace internal
 
+static std::atomic<bool> s_crashHandlingInProgress( false );
+
 //--------------------------------------------------------------------------------------------------
 /// Shared crash logging: writes to file logger and OpenTelemetry.
 /// extraAttrs may include platform-specific context like fault address and signal code description.
@@ -166,6 +169,11 @@ static std::string signalCodeDescription( int signo, int siCode )
 //--------------------------------------------------------------------------------------------------
 static void performCrashLogging( int signalCode, const std::map<std::string, std::string>& extraAttrs )
 {
+    // Block timer-driven application logic (e.g. gRPC idle processing) for the rest of the process
+    // lifetime: the telemetry flush below pumps the event loop, and a timer slot firing there could
+    // close the project and destroy objects the crashed code still uses, causing a nested crash.
+    s_crashHandlingInProgress = true;
+
 #if RIA_HAS_STD_STACKTRACE
     auto st = std::stacktrace::current();
 #endif
@@ -306,6 +314,14 @@ void manageSegFailureSA( int signalCode, siginfo_t* info, void* ucontext )
 
 namespace RiaMainTools
 {
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool isCrashHandlingInProgress()
+{
+    return s_crashHandlingInProgress;
+}
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationExeCode/RiaMainTools.h
+++ b/ApplicationExeCode/RiaMainTools.h
@@ -22,4 +22,9 @@ namespace RiaMainTools
 void initializeSingletons();
 void releaseSingletonAndFactoryObjects();
 void deleteStaleSettingsLockFiles();
+
+// True once crash logging has started. The crash handler pumps the Qt event loop while flushing
+// telemetry, so timer-driven application logic must check this flag and stay idle to avoid
+// re-entering or tearing down objects the crashed code still uses.
+bool isCrashHandlingInProgress();
 }; // namespace RiaMainTools


### PR DESCRIPTION
Fixes #14414

## Problem
When a crash is reported, `RiaOpenTelemetryManager::reportCrash` pumps the Qt event loop to let the telemetry HTTP POST finish. Timer events still flow there, so the gRPC applications' 5 ms idle timer can fire inside the crash handler. If the client has disconnected, `doIdleProcessing` calls `closeProject()` mid-crash; teardown then trips `CVF_ASSERT(eclipseCaseData()->refCount() == 1)` in `~RimEclipseCase`, aborting inside the handler. The nested crash pollutes the reported signature and can drop the original crash report.

## Fix
Set an atomic crash-in-progress flag at the start of `performCrashLogging` and return early from both gRPC `doIdleProcessing` slots while it is set. No requests are processed and no project teardown runs during crash reporting; the process still exits via the handler's `exit(1)` as before.
