### PR TITLE
#14420 Viewer: Guard against non-finite near/far clipping planes

### DIFF
--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -606,7 +606,18 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
         }
     }
 
-    if ( ( *farPlaneDist ) <= ( *nearPlaneDist ) ) ( *farPlaneDist ) = ( *nearPlaneDist ) + 1.0;
+    // The distances above are derived from scene geometry and camera coordinates. If either
+    // contains non-finite values, the guards above let them through, as any comparison involving
+    // NaN is false. cvf::Camera::setProjectionAsPerspective asserts on nearPlane > 0 and
+    // farPlane > nearPlane, and the assert handler aborts also in release builds.
+    const double maxPerspectiveNearPlaneDistance = 1.0e15;
+    if ( rendering->camera()->projection() == cvf::Camera::PERSPECTIVE &&
+         !( ( *nearPlaneDist ) > 0.0 && ( *nearPlaneDist ) < maxPerspectiveNearPlaneDistance ) )
+    {
+        ( *nearPlaneDist ) = m_defaultPerspectiveNearPlaneDistance;
+    }
+
+    if ( !( ( *farPlaneDist ) > ( *nearPlaneDist ) ) ) ( *farPlaneDist ) = ( *nearPlaneDist ) + 1.0;
 
     // Enforce a maximum far/near ratio to preserve depth buffer precision.
     // A 24-bit depth buffer has ~16 M discrete depth values; a far/near ratio of N


### PR DESCRIPTION
Fixes #14420

## Problem

`caf::Viewer::calculateNearFarPlanes` guards the near/far planes with plain comparisons. A NaN near plane passes through, since any comparison with NaN is false, and an infinite one makes `near + 1.0 == near`. `cvf::Camera::setProjectionAsPerspective` then asserts on `nearPlane > 0` / `farPlane > nearPlane`, and the assert handler aborts also in release builds.

Reachable when scene geometry or camera coordinates are non-finite. The source of the non-finite value is not identified, so this removes the abort but not the underlying defect.

## Fix

Reject non-finite and absurdly large near planes for perspective projection and fall back to the default distance, and make the far-plane guard NaN-safe. The `!( x > y )` form is the idiom already used in `Camera::computeFitViewEyePosition`. The orthographic branch is untouched, as `setProjectionAsOrtho` only asserts on `height > 0`.
