### PR TITLE
#14423 Fix crash when closing summary cases referred by a delta ensemble

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -56,6 +56,7 @@
 
 #include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldReorderCapability.h"
+#include "cafPdmPointer.h"
 #include "cafProgressInfo.h"
 
 #include <QCoreApplication>
@@ -228,14 +229,25 @@ void RimSummaryCaseMainCollection::removeCase( RimSummaryCase* summaryCase, bool
 //--------------------------------------------------------------------------------------------------
 void RimSummaryCaseMainCollection::removeCases( std::vector<RimSummaryCase*>& cases )
 {
-    for ( auto sumCase : cases )
+    // Removing one case can delete other cases in the list. A delta ensemble recreates its derived cases when a source
+    // case is removed, and deletes the derived cases no longer in use. Use guarded pointers to avoid touching deleted
+    // cases, and return only the cases that are still alive.
+    std::vector<caf::PdmPointer<RimSummaryCase>> guardedCases( cases.begin(), cases.end() );
+
+    for ( const auto& sumCase : guardedCases )
     {
-        removeCase( sumCase, false );
+        if ( sumCase.notNull() ) removeCase( sumCase, false );
     }
 
     for ( RimSummaryEnsemble* ensemble : m_ensembles )
     {
         ensemble->updateReferringCurveSetsZoomAll();
+    }
+
+    cases.clear();
+    for ( const auto& sumCase : guardedCases )
+    {
+        if ( sumCase.notNull() ) cases.push_back( sumCase );
     }
 
     dataSourceHasChanged.send();

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
@@ -60,6 +60,7 @@ public:
     void addCases( const std::vector<RimSummaryCase*> cases );
     void addCase( RimSummaryCase* summaryCase );
     void removeCase( RimSummaryCase* summaryCase, bool notifyChange = true );
+    // Cases deleted as a side effect of the removal are erased from the input vector
     void removeCases( std::vector<RimSummaryCase*>& cases );
     void moveCase( RimSummaryCase* summaryCase, int destinationIndex );
 

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimWellRftPlot-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDataFilterCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseCollection-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseMainCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifActiveCellsReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifCsvDataTableFormatter-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaSummaryAddressAnalyzer-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimSummaryCaseMainCollection-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimSummaryCaseMainCollection-Test.cpp
@@ -1,0 +1,88 @@
+#include "gtest/gtest.h"
+
+#include "Summary/RiaSummaryTools.h"
+
+#include "RigCaseRealizationParameters.h"
+
+#include "RimDeltaSummaryEnsemble.h"
+#include "RimMockSummaryCase.h"
+#include "RimSummaryCaseMainCollection.h"
+#include "RimSummaryEnsemble.h"
+
+#include "cafPdmPointer.h"
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+namespace
+{
+RimSummaryCase* createMockCase( int realizationNumber )
+{
+    auto* summaryCase = new RimMockSummaryCase();
+
+    auto parameters = std::make_shared<RigCaseRealizationParameters>();
+    parameters->setRealizationNumber( realizationNumber );
+    summaryCase->setCaseRealizationParameters( parameters );
+
+    return summaryCase;
+}
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+/// Removing a source case makes a delta ensemble recreate and delete derived cases. The derived cases
+/// are part of the list of cases to remove, and must not be left as dangling pointers in that list.
+//--------------------------------------------------------------------------------------------------
+TEST( RimSummaryCaseMainCollection, RemoveCasesReferredByDeltaEnsemble )
+{
+    RimSummaryCaseMainCollection* mainCollection = RiaSummaryTools::summaryCaseMainCollection();
+
+    auto* ensemble1 = mainCollection->addEnsemble( { createMockCase( 0 ), createMockCase( 1 ) }, "Ensemble 1", true );
+    auto* ensemble2 = mainCollection->addEnsemble( { createMockCase( 0 ), createMockCase( 1 ) }, "Ensemble 2", true );
+
+    auto* deltaEnsemble = new RimDeltaSummaryEnsemble();
+    mainCollection->addEnsemble( deltaEnsemble );
+    deltaEnsemble->setEnsemble1( ensemble1 );
+    deltaEnsemble->setEnsemble2( ensemble2 );
+    deltaEnsemble->createDerivedEnsembleCases();
+
+    EXPECT_EQ( size_t( 2 ), deltaEnsemble->allSummaryCases().size() );
+
+    auto cases = mainCollection->allSummaryCases();
+    EXPECT_EQ( size_t( 6 ), cases.size() );
+
+    // Guarded pointers are set to null when the object is deleted
+    std::vector<caf::PdmPointer<RimSummaryCase>> guardedCases( cases.begin(), cases.end() );
+
+    mainCollection->removeCases( cases );
+
+    size_t aliveCount = 0;
+    for ( const auto& guardedCase : guardedCases )
+    {
+        if ( guardedCase.notNull() ) aliveCount++;
+    }
+
+    // The two derived cases are deleted by the delta ensemble during removal
+    EXPECT_EQ( size_t( 4 ), aliveCount );
+    EXPECT_EQ( aliveCount, cases.size() );
+
+    // No deleted case is left behind in the list
+    for ( auto* summaryCase : cases )
+    {
+        auto isAlive = [summaryCase]( const caf::PdmPointer<RimSummaryCase>& guardedCase )
+        { return guardedCase.notNull() && guardedCase.p() == summaryCase; };
+        EXPECT_TRUE( std::any_of( guardedCases.begin(), guardedCases.end(), isAlive ) );
+    }
+
+    for ( auto* summaryCase : cases )
+    {
+        delete summaryCase;
+    }
+
+    mainCollection->removeEnsemble( deltaEnsemble );
+    mainCollection->removeEnsemble( ensemble1 );
+    mainCollection->removeEnsemble( ensemble2 );
+    delete deltaEnsemble;
+    delete ensemble1;
+    delete ensemble2;
+}


### PR DESCRIPTION
Fixes #14423

## Problem

`RimSummaryCaseMainCollection::allSummaryCases()` includes the derived cases of a delta ensemble. When a source case is removed, the delta ensemble recreates its derived cases and deletes the ones no longer in use. Those objects are still present in the list being removed, so `RicCloseSummaryCaseFeature::deleteSummaryCases` passes dangling pointers to `AsyncPdmObjectVectorDeleter`, crashing in `PdmObjectHandle::prepareForDelete()`.

## Fix

Use guarded `caf::PdmPointer` in `removeCases()` to skip cases deleted as a side effect, and return only the surviving cases. Adds a unit test that reproduces the crash.
