### PR TITLE
Surface fixes: IRAP/GRI export folder, multiple properties and default property in views

### DIFF
--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriFeature.cpp
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriFeature.cpp
@@ -40,8 +40,30 @@
 
 #include <QAction>
 #include <cmath>
+#include <set>
 
 CAF_CMD_SOURCE_INIT( RicExportSurfaceToGriFeature, "RicExportSurfaceToGriFeature" );
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Returns the surface if it is a regular surface with a grid matching gridParams exactly, nullptr otherwise
+//--------------------------------------------------------------------------------------------------
+RimRegularSurface* regularSurfaceWithMatchingGrid( RimSurface* surf, const RigRegularSurfaceData& gridParams )
+{
+    auto* reg = dynamic_cast<RimRegularSurface*>( surf );
+    if ( !reg ) return nullptr;
+
+    if ( reg->nx() == gridParams.nx && reg->ny() == gridParams.ny && reg->originX() == gridParams.originX &&
+         reg->originY() == gridParams.originY && reg->incrementX() == gridParams.incrementX && reg->incrementY() == gridParams.incrementY &&
+         reg->rotation() == gridParams.rotation )
+    {
+        return reg;
+    }
+
+    return nullptr;
+}
+} // namespace
 
 //--------------------------------------------------------------------------------------------------
 /// For a RimRegularSurface whose stored grid matches gridParams exactly, depth values are returned
@@ -50,14 +72,9 @@ CAF_CMD_SOURCE_INIT( RicExportSurfaceToGriFeature, "RicExportSurfaceToGriFeature
 std::vector<float> RicExportSurfaceToGriFeature::resampleToGrid( RimSurface* surf, const RigRegularSurfaceData& gridParams )
 {
     // Regular surface with matching grid: use stored depth values directly (lossless)
-    if ( auto* reg = dynamic_cast<RimRegularSurface*>( surf ) )
+    if ( auto* reg = regularSurfaceWithMatchingGrid( surf, gridParams ) )
     {
-        if ( reg->nx() == gridParams.nx && reg->ny() == gridParams.ny && reg->originX() == gridParams.originX &&
-             reg->originY() == gridParams.originY && reg->incrementX() == gridParams.incrementX &&
-             reg->incrementY() == gridParams.incrementY && reg->rotation() == gridParams.rotation )
-        {
-            return reg->depthValues();
-        }
+        return reg->depthValues();
     }
 
     // Resample the surface onto the requested grid
@@ -83,6 +100,23 @@ std::vector<float> RicExportSurfaceToGriFeature::resampleToGrid( RimSurface* sur
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<float>
+    RicExportSurfaceToGriFeature::propertyValuesOnGrid( RimSurface* surf, const QString& propertyName, const RigRegularSurfaceData& gridParams )
+{
+    auto* reg = dynamic_cast<RimRegularSurface*>( surf );
+    if ( !reg ) return {};
+
+    // Property values are stored per node on the surface grid and are exported as they are. The export grid must
+    // therefore have the same number of nodes as the surface.
+    auto values = reg->getProperty( propertyName );
+    if ( values.size() != static_cast<size_t>( gridParams.nx * gridParams.ny ) ) return {};
+
+    return values;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*>& surfaces )
 {
     if ( surfaces.empty() ) return;
@@ -96,6 +130,18 @@ void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*
 
     RimRegularSurface* regularSurface = ( surfaces.size() == 1 ) ? dynamic_cast<RimRegularSurface*>( surfaces[0] ) : nullptr;
 
+    // Collect the properties available for export from all selected surfaces
+    std::set<QString> availableProperties;
+    for ( RimSurface* surf : surfaces )
+    {
+        if ( RigSurface* rig = surf->surfaceData() )
+        {
+            for ( const auto& name : rig->propertyNames() )
+                availableProperties.insert( name );
+        }
+    }
+    ui.setAvailableProperties( { availableProperties.begin(), availableProperties.end() } );
+
     if ( regularSurface )
     {
         ui.setGridDefaults( regularSurface->nx(),
@@ -103,7 +149,8 @@ void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*
                             regularSurface->originX(),
                             regularSurface->originY(),
                             regularSurface->incrementX(),
-                            regularSurface->incrementY() );
+                            regularSurface->incrementY(),
+                            regularSurface->rotation() );
     }
     else
     {
@@ -124,11 +171,12 @@ void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*
         const double spacing    = ( areaApprox > 0.0 ) ? std::sqrt( areaApprox / static_cast<double>( totalVertexCount ) ) : 1.0;
         const int    nx         = std::max( 2, static_cast<int>( std::ceil( bb.extent().x() / spacing ) ) + 1 );
         const int    ny         = std::max( 2, static_cast<int>( std::ceil( bb.extent().y() / spacing ) ) + 1 );
-        ui.setGridDefaults( nx, ny, bb.min().x(), bb.min().y(), spacing, spacing );
+        // The estimated grid is a starting point for the user, so round the values to something readable
+        ui.setGridDefaults( nx, ny, std::round( bb.min().x() ), std::round( bb.min().y() ), std::round( spacing ), std::round( spacing ), 0.0 );
     }
 
     caf::PdmUiPropertyViewDialog dialog( nullptr, &ui, "Export Surface to IRAP/GRI", "" );
-    dialog.resize( QSize( 400, 300 ) );
+    dialog.resize( QSize( 400, 450 ) );
     if ( dialog.exec() != QDialog::Accepted ) return;
 
     const QString exportDir = ui.exportFolder();
@@ -140,21 +188,54 @@ void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*
     const bool                  binary     = ( ui.exportFormat() == RicExportSurfaceToGriUi::ExportFormat::GRI );
     const QString               extension  = binary ? ".gri" : ".irap";
 
+    const auto selectedProperties = ui.selectedProperties();
+    if ( selectedProperties.empty() )
+    {
+        RiaLogging::error( "No values selected for export." );
+        return;
+    }
+
+    // IRAP/GRI files contain a single value per node, so each exported value is written to a separate file. When only
+    // depth values are exported, the file name is the surface name without any suffix.
+    const bool useValueNameSuffix = ( selectedProperties.size() > 1 ) ||
+                                    ( selectedProperties[0] != RicExportSurfaceToGriUi::depthEntryName() );
+
     for ( RimSurface* surf : surfaces )
     {
-        const QString fileName =
-            caf::Utils::constructFullFileName( exportDir, caf::Utils::makeValidFileBasename( surf->fullName() ), extension );
+        for ( const QString& valueName : selectedProperties )
+        {
+            const bool isDepth = ( valueName == RicExportSurfaceToGriUi::depthEntryName() );
+            const auto values  = isDepth ? resampleToGrid( surf, gridParams ) : propertyValuesOnGrid( surf, valueName, gridParams );
 
-        const auto depthValues = resampleToGrid( surf, gridParams );
-        if ( depthValues.empty() ) continue;
+            if ( values.empty() )
+            {
+                if ( isDepth )
+                {
+                    RiaLogging::warning( std::format( "No depth values found for surface '{}', skipping export.", surf->fullName() ) );
+                }
+                else
+                {
+                    RiaLogging::warning( std::format( "Skipping export of '{}' for surface '{}'. Properties can only be exported for a "
+                                                      "regular surface, and Nx and Ny must match the surface.",
+                                                      valueName,
+                                                      surf->fullName() ) );
+                }
+                continue;
+            }
 
-        bool ok = binary ? RifSurfio::exportToGri( fileName.toStdString(), gridParams, depthValues )
-                         : RifSurfio::exportToIrap( fileName.toStdString(), gridParams, depthValues );
+            QString baseName = caf::Utils::makeValidFileBasename( surf->fullName() );
+            if ( useValueNameSuffix ) baseName += "--" + caf::Utils::makeValidFileBasename( valueName );
 
-        if ( ok )
-            RiaLogging::info( std::format( "Exported surface to: {}", fileName ) );
-        else
-            RiaLogging::error( std::format( "Failed to export surface to: {}", fileName ) );
+            const QString fileName = caf::Utils::constructFullFileName( exportDir, baseName, extension );
+
+            bool ok = binary ? RifSurfio::exportToGri( fileName.toStdString(), gridParams, values )
+                             : RifSurfio::exportToIrap( fileName.toStdString(), gridParams, values );
+
+            if ( ok )
+                RiaLogging::info( std::format( "Exported surface to: {}", fileName ) );
+            else
+                RiaLogging::error( std::format( "Failed to export surface to: {}", fileName ) );
+        }
     }
 }
 

--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriFeature.cpp
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriFeature.cpp
@@ -92,13 +92,18 @@ void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*
 
     // Build default grid params
     RicExportSurfaceToGriUi ui;
+    ui.setExportFolder( defaultDir );
 
-    if ( surfaces.size() == 1 )
+    RimRegularSurface* regularSurface = ( surfaces.size() == 1 ) ? dynamic_cast<RimRegularSurface*>( surfaces[0] ) : nullptr;
+
+    if ( regularSurface )
     {
-        if ( auto* reg = dynamic_cast<RimRegularSurface*>( surfaces[0] ) )
-        {
-            ui.setDefaults( defaultDir, reg->nx(), reg->ny(), reg->originX(), reg->originY(), reg->incrementX(), reg->incrementY() );
-        }
+        ui.setGridDefaults( regularSurface->nx(),
+                            regularSurface->ny(),
+                            regularSurface->originX(),
+                            regularSurface->originY(),
+                            regularSurface->incrementX(),
+                            regularSurface->incrementY() );
     }
     else
     {
@@ -119,7 +124,7 @@ void RicExportSurfaceToGriFeature::exportSurfaces( const std::vector<RimSurface*
         const double spacing    = ( areaApprox > 0.0 ) ? std::sqrt( areaApprox / static_cast<double>( totalVertexCount ) ) : 1.0;
         const int    nx         = std::max( 2, static_cast<int>( std::ceil( bb.extent().x() / spacing ) ) + 1 );
         const int    ny         = std::max( 2, static_cast<int>( std::ceil( bb.extent().y() / spacing ) ) + 1 );
-        ui.setDefaults( defaultDir, nx, ny, bb.min().x(), bb.min().y(), spacing, spacing );
+        ui.setGridDefaults( nx, ny, bb.min().x(), bb.min().y(), spacing, spacing );
     }
 
     caf::PdmUiPropertyViewDialog dialog( nullptr, &ui, "Export Surface to IRAP/GRI", "" );

--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriFeature.h
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriFeature.h
@@ -41,6 +41,11 @@ public:
     // in row-major order (index = j * nx + i). Returns an empty vector on failure.
     static std::vector<float> resampleToGrid( RimSurface* surf, const RigRegularSurfaceData& gridParams );
 
+    // Returns the values of the named property in row-major order (index = j * nx + i). Property values are exported
+    // without resampling, so an empty vector is returned unless the surface is a regular surface with the same number
+    // of nodes as gridParams.
+    static std::vector<float> propertyValuesOnGrid( RimSurface* surf, const QString& propertyName, const RigRegularSurfaceData& gridParams );
+
     // Shows the export dialog, resamples and writes each surface. Format is chosen in the dialog.
     static void exportSurfaces( const std::vector<RimSurface*>& surfaces );
 

--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.cpp
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.cpp
@@ -58,15 +58,22 @@ RicExportSurfaceToGriUi::RicExportSurfaceToGriUi()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicExportSurfaceToGriUi::setDefaults( const QString& exportFolder, int nx, int ny, double originX, double originY, double incrementX, double incrementY )
+void RicExportSurfaceToGriUi::setExportFolder( const QString& exportFolder )
 {
     m_exportFolder = exportFolder;
-    m_nx           = nx;
-    m_ny           = ny;
-    m_originX      = std::round( originX );
-    m_originY      = std::round( originY );
-    m_incrementX   = std::round( incrementX );
-    m_incrementY   = std::round( incrementY );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicExportSurfaceToGriUi::setGridDefaults( int nx, int ny, double originX, double originY, double incrementX, double incrementY )
+{
+    m_nx         = nx;
+    m_ny         = ny;
+    m_originX    = std::round( originX );
+    m_originY    = std::round( originY );
+    m_incrementX = std::round( incrementX );
+    m_incrementY = std::round( incrementY );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.cpp
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.cpp
@@ -19,8 +19,7 @@
 #include "RicExportSurfaceToGriUi.h"
 
 #include "cafPdmUiFilePathEditor.h"
-
-#include <cmath>
+#include "cafPdmUiTreeSelectionEditor.h"
 
 namespace caf
 {
@@ -47,12 +46,25 @@ RicExportSurfaceToGriUi::RicExportSurfaceToGriUi()
     CAF_PDM_InitFieldNoDefault( &m_exportFolder, "ExportFolder", "Export Folder" );
     m_exportFolder.uiCapability()->setUiEditorTypeName( caf::PdmUiFilePathEditor::uiEditorTypeName() );
 
+    CAF_PDM_InitFieldNoDefault( &m_selectedProperties, "SelectedProperties", "Export Values" );
+    m_selectedProperties.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
+    m_selectedProperties = std::vector<QString>{ depthEntryName() };
+
     CAF_PDM_InitField( &m_nx, "Nx", 10, "Nx (columns)" );
     CAF_PDM_InitField( &m_ny, "Ny", 10, "Ny (rows)" );
     CAF_PDM_InitField( &m_originX, "OriginX", 0.0, "Origin X" );
     CAF_PDM_InitField( &m_originY, "OriginY", 0.0, "Origin Y" );
     CAF_PDM_InitField( &m_incrementX, "IncrementX", 1.0, "Increment X" );
     CAF_PDM_InitField( &m_incrementY, "IncrementY", 1.0, "Increment Y" );
+    CAF_PDM_InitField( &m_rotation, "Rotation", 0.0, "Rotation" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RicExportSurfaceToGriUi::depthEntryName()
+{
+    return "Depth";
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -66,14 +78,23 @@ void RicExportSurfaceToGriUi::setExportFolder( const QString& exportFolder )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicExportSurfaceToGriUi::setGridDefaults( int nx, int ny, double originX, double originY, double incrementX, double incrementY )
+void RicExportSurfaceToGriUi::setGridDefaults( int nx, int ny, double originX, double originY, double incrementX, double incrementY, double rotation )
 {
     m_nx         = nx;
     m_ny         = ny;
-    m_originX    = std::round( originX );
-    m_originY    = std::round( originY );
-    m_incrementX = std::round( incrementX );
-    m_incrementY = std::round( incrementY );
+    m_originX    = originX;
+    m_originY    = originY;
+    m_incrementX = incrementX;
+    m_incrementY = incrementY;
+    m_rotation   = rotation;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicExportSurfaceToGriUi::setAvailableProperties( const std::vector<QString>& propertyNames )
+{
+    m_availableProperties = propertyNames;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -88,8 +109,16 @@ RigRegularSurfaceData RicExportSurfaceToGriUi::gridParams() const
     p.originY    = m_originY;
     p.incrementX = m_incrementX;
     p.incrementY = m_incrementY;
-    p.rotation   = 0.0;
+    p.rotation   = m_rotation;
     return p;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<QString> RicExportSurfaceToGriUi::selectedProperties() const
+{
+    return m_selectedProperties();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -120,4 +149,27 @@ void RicExportSurfaceToGriUi::defineEditorAttribute( const caf::PdmFieldHandle* 
             attr->m_selectDirectory = true;
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QList<caf::PdmOptionItemInfo> RicExportSurfaceToGriUi::calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions )
+{
+    QList<caf::PdmOptionItemInfo> options;
+
+    if ( fieldNeedingOptions == &m_selectedProperties )
+    {
+        options.push_back( caf::PdmOptionItemInfo( depthEntryName(), depthEntryName() ) );
+
+        for ( const auto& name : m_availableProperties )
+        {
+            // A property with the same name as the depth entry is already represented in the list
+            if ( name == depthEntryName() ) continue;
+
+            options.push_back( caf::PdmOptionItemInfo( name, name ) );
+        }
+    }
+
+    return options;
 }

--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.h
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.h
@@ -24,6 +24,8 @@
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 
+#include <vector>
+
 //==================================================================================================
 /// PdmObject holding the parameters for resampling a surface onto a regular grid before export.
 //==================================================================================================
@@ -40,23 +42,33 @@ public:
 
     RicExportSurfaceToGriUi();
 
+    // Name of the entry representing the surface depth values in the list of exported values
+    static QString depthEntryName();
+
     void setExportFolder( const QString& exportFolder );
-    void setGridDefaults( int nx, int ny, double originX, double originY, double incrementX, double incrementY );
+    void setGridDefaults( int nx, int ny, double originX, double originY, double incrementX, double incrementY, double rotation );
+    void setAvailableProperties( const std::vector<QString>& propertyNames );
 
     RigRegularSurfaceData gridParams() const;
     QString               exportFolder() const;
     ExportFormat          exportFormat() const;
+    std::vector<QString>  selectedProperties() const;
 
 protected:
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
+    QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
 
 private:
     caf::PdmField<caf::AppEnum<ExportFormat>> m_exportFormat;
     caf::PdmField<QString>                    m_exportFolder;
+    caf::PdmField<std::vector<QString>>       m_selectedProperties;
     caf::PdmField<int>                        m_nx;
     caf::PdmField<int>                        m_ny;
     caf::PdmField<double>                     m_originX;
     caf::PdmField<double>                     m_originY;
     caf::PdmField<double>                     m_incrementX;
     caf::PdmField<double>                     m_incrementY;
+    caf::PdmField<double>                     m_rotation;
+
+    std::vector<QString> m_availableProperties;
 };

--- a/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.h
+++ b/ApplicationLibCode/Commands/SurfaceCommands/RicExportSurfaceToGriUi.h
@@ -40,7 +40,8 @@ public:
 
     RicExportSurfaceToGriUi();
 
-    void setDefaults( const QString& exportFolder, int nx, int ny, double originX, double originY, double incrementX, double incrementY );
+    void setExportFolder( const QString& exportFolder );
+    void setGridDefaults( int nx, int ny, double originX, double originY, double incrementX, double incrementY );
 
     RigRegularSurfaceData gridParams() const;
     QString               exportFolder() const;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp
@@ -253,6 +253,10 @@ void RimSurfaceInView::loadDataAndUpdate( int timeStep )
         {
             m_resultDefinition.uiCapability()->setUiTreeChildrenHidden( false );
             m_resultDefinition->setCheckState( true );
+
+            // Properties can be added after the surface was inserted into the view, as is the case when a regular
+            // surface is created and populated from Python. Select the first property when nothing is selected yet.
+            if ( m_resultDefinition->propertyName().isEmpty() ) m_resultDefinition->assignDefaultProperty();
         }
 
         m_resultDefinition->updateMinMaxValues( timeStep );


### PR DESCRIPTION
Fixes #14426

**Remember last used export folder**

The export folder in the IRAP/GRI export dialog is now always seeded from the last used `EXPORT_SURFACE` directory. It was previously only applied when a single regular surface was selected, so exporting any other single surface opened the dialog with an empty folder. A single non-regular surface also falls into the bounding box estimation branch instead of keeping the field defaults.

**Select first available surface property in all views**

`RimSurfaceInView::loadDataAndUpdate()` assigns the first available property when no property is selected yet. A regular surface created from Python is added to the views before any property is set, so the surface in view never got a default property and was rendered without result colors. An explicit `None` selection is not overridden.

**Export multiple properties**

IRAP/GRI files hold a single value per node, so the export dialog now has a multi-select list containing the surface depth and the properties available on the selected surfaces. Each selected value is written to a separate file named `<surface>--<value>`. Exporting depth only keeps the plain surface name.

Property values are exported without resampling and require a regular surface with matching Nx and Ny. Values that cannot be exported are reported as warnings. The grid defaults are no longer rounded when they come from a regular surface, and the grid rotation is added to the dialog, both needed to export a surface without resampling.

**Not included**

Resampling of property values onto a grid that differs from the surface grid. This needs the hit triangle and barycentric weights from `RigSurfaceResampler`, which currently only returns the intersection depth.
