### PR TITLE
#14431 Guard against zero active cells in validKeywordsForPorosityModel

### DIFF
--- a/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp
@@ -836,6 +836,11 @@ std::vector<RifEclipseKeywordValueCount>
         return {};
     }
 
+    if ( porosityModel == RiaDefines::PorosityModelType::MATRIX_MODEL && ( matrixActiveCellInfo->reservoirActiveCellCount() == 0 ) )
+    {
+        return {};
+    }
+
     std::vector<RifEclipseKeywordValueCount> keywordsWithCorrectNumberOfDataItems;
 
     for ( const auto& keywordValueCount : keywordItemCounts )
@@ -848,15 +853,18 @@ std::vector<RifEclipseKeywordValueCount>
         auto matrixActiveCellCount   = matrixActiveCellInfo->reservoirActiveCellCount();
         auto fractureActiveCellCount = fractureActiveCellInfo->reservoirActiveCellCount();
 
-        size_t timeStepsAllCellsRest = valueCount % matrixActiveCellCount;
-        if ( timeStepsAllCellsRest == 0 && valueCount <= timeStepCount * matrixActiveCellCount )
+        if ( matrixActiveCellCount > 0 && ( valueCount % matrixActiveCellCount ) == 0 && valueCount <= timeStepCount * matrixActiveCellCount )
         {
             // Found result for all cells for N time steps, usually a static dataset for one time step
             validKeyword = true;
         }
         else
         {
-            size_t timeStepsMatrixRest = valueCount % matrixActiveCellCount;
+            size_t timeStepsMatrixRest = 0;
+            if ( matrixActiveCellCount > 0 )
+            {
+                timeStepsMatrixRest = valueCount % matrixActiveCellCount;
+            }
 
             size_t timeStepsFractureRest = 0;
             if ( fractureActiveCellCount > 0 )
@@ -895,7 +903,7 @@ std::vector<RifEclipseKeywordValueCount>
         if ( !validKeyword )
         {
             if ( valueCount > 0 && ( porosityModel == RiaDefines::PorosityModelType::MATRIX_MODEL ) &&
-                 ( valueCount % matrixActiveCellInfo->reservoirCellCount() == 0 ) )
+                 matrixActiveCellInfo->reservoirCellCount() > 0 && ( valueCount % matrixActiveCellInfo->reservoirCellCount() == 0 ) )
             {
                 validKeyword = true;
             }

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigBoundingBoxIjk-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifcCommandCore-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifEclipseInputFileTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RifEclipseOutputFileTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifOpmFlowDeckFile-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifReaderEclipseOutput-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifReaderEclipseSummary-Test.cpp

--- a/ApplicationLibCode/UnitTests/RifEclipseOutputFileTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RifEclipseOutputFileTools-Test.cpp
@@ -1,0 +1,86 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RifEclipseOutputFileTools.h"
+#include "RifEclipseReportKeywords.h"
+
+#include "RiaDefines.h"
+
+#include "RigActiveCellInfo.h"
+
+//--------------------------------------------------------------------------------------------------
+/// A grid with no active matrix cells must not cause division by zero
+//--------------------------------------------------------------------------------------------------
+TEST( RifEclipseOutputFileTools, ValidKeywordsNoActiveMatrixCells )
+{
+    std::vector<RifEclipseKeywordValueCount> keywordItemCounts;
+    keywordItemCounts.emplace_back( "PRESSURE", 50, RifEclipseKeywordValueCount::KeywordDataType::FLOAT );
+
+    RigActiveCellInfo matrixActiveCellInfo;
+    matrixActiveCellInfo.setReservoirCellCount( 100 );
+
+    RigActiveCellInfo fractureActiveCellInfo;
+    fractureActiveCellInfo.setReservoirCellCount( 100 );
+    fractureActiveCellInfo.setGridCount( 1 );
+    fractureActiveCellInfo.setGridActiveCellCounts( 0, 50 );
+    fractureActiveCellInfo.computeDerivedData();
+
+    EXPECT_EQ( size_t( 0 ), matrixActiveCellInfo.reservoirActiveCellCount() );
+
+    auto matrixKeywords = RifEclipseOutputFileTools::validKeywordsForPorosityModel( keywordItemCounts,
+                                                                                    &matrixActiveCellInfo,
+                                                                                    &fractureActiveCellInfo,
+                                                                                    RiaDefines::PorosityModelType::MATRIX_MODEL,
+                                                                                    1 );
+    EXPECT_TRUE( matrixKeywords.empty() );
+
+    auto fractureKeywords = RifEclipseOutputFileTools::validKeywordsForPorosityModel( keywordItemCounts,
+                                                                                      &matrixActiveCellInfo,
+                                                                                      &fractureActiveCellInfo,
+                                                                                      RiaDefines::PorosityModelType::FRACTURE_MODEL,
+                                                                                      1 );
+    EXPECT_EQ( size_t( 1 ), fractureKeywords.size() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Empty active cell info for both porosity models must not cause division by zero
+//--------------------------------------------------------------------------------------------------
+TEST( RifEclipseOutputFileTools, ValidKeywordsNoActiveCells )
+{
+    std::vector<RifEclipseKeywordValueCount> keywordItemCounts;
+    keywordItemCounts.emplace_back( "PRESSURE", 100, RifEclipseKeywordValueCount::KeywordDataType::FLOAT );
+
+    RigActiveCellInfo matrixActiveCellInfo;
+    RigActiveCellInfo fractureActiveCellInfo;
+
+    EXPECT_TRUE( RifEclipseOutputFileTools::validKeywordsForPorosityModel( keywordItemCounts,
+                                                                           &matrixActiveCellInfo,
+                                                                           &fractureActiveCellInfo,
+                                                                           RiaDefines::PorosityModelType::MATRIX_MODEL,
+                                                                           1 )
+                     .empty() );
+
+    EXPECT_TRUE( RifEclipseOutputFileTools::validKeywordsForPorosityModel( keywordItemCounts,
+                                                                           &matrixActiveCellInfo,
+                                                                           &fractureActiveCellInfo,
+                                                                           RiaDefines::PorosityModelType::FRACTURE_MODEL,
+                                                                           1 )
+                     .empty() );
+}


### PR DESCRIPTION
Fixes #14431

## Problem
`validKeywordsForPorosityModel` divides `valueCount` by the number of active matrix cells without checking it. A grid with no active matrix cells (fracture-only dual porosity, or ACTNUM all zero) makes `reservoirActiveCellCount()` return 0, and the modulo traps with SIGFPE during grid import.

The function already returns early when the fracture model has zero active cells; the matrix case was not handled.

## Fix
Return early when the requested porosity model has no active cells, and guard the remaining matrix divisors, matching the existing `fractureActiveCellCount > 0` pattern in the same function.

The sum `matrixActiveCellCount + fractureActiveCellCount` needs no guard: the early returns make it provably positive for both porosity models.

Adds unit tests that trap with `STATUS_INTEGER_DIVIDE_BY_ZERO` without the fix and pass with it.
