### PR TITLE
#14434 Guard against missing perforation interval in templateUpdated

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathValve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathValve.cpp
@@ -549,8 +549,11 @@ void RimWellPathValve::templateUpdated()
 {
     applyValveLabelAndIcon();
 
-    auto perforationInterval = firstAncestorOrThisOfType<RimPerforationInterval>();
-    perforationInterval->updateAllReferringTracks();
+    // A valve can also be a stand-alone valve or a tie-in outlet valve, and then has no perforation interval
+    if ( auto perforationInterval = firstAncestorOrThisOfType<RimPerforationInterval>() )
+    {
+        perforationInterval->updateAllReferringTracks();
+    }
 
     RimProject* proj = RimProject::current();
     proj->reloadCompletionTypeResultsInAllViews();

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/Intersect-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifPerforationIntervalReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathCompletions-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellPathValve-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDataFilterCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifActiveCellsReader-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimWellPathValve-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellPathValve-Test.cpp
@@ -1,0 +1,39 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RimValveCollection.h"
+#include "RimWellPath.h"
+#include "RimWellPathValve.h"
+
+//--------------------------------------------------------------------------------------------------
+/// A stand-alone valve has no perforation interval ancestor, and must not crash on template update
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellPathValveTest, TemplateUpdatedWithoutPerforationInterval )
+{
+    RimWellPath wellPath;
+
+    RimValveCollection* valveCollection = wellPath.valveCollection();
+    ASSERT_TRUE( valveCollection != nullptr );
+
+    RimWellPathValve* valve = valveCollection->addIcvValve( 100.0 );
+    ASSERT_TRUE( valve != nullptr );
+
+    valve->templateUpdated();
+}


### PR DESCRIPTION
Fixes #14434

## Problem

`RimWellPathValve::templateUpdated()` dereferences `firstAncestorOrThisOfType<RimPerforationInterval>()` without a null check. Stand-alone valves (`RimValveCollection`), tie-in outlet valves and well path group valves have no such ancestor, so changing the type of a valve template crashes.

## Fix

Guard the call, matching the existing pattern in `RimWellPathValve::fieldChangedByUi`. Added a unit test covering a stand-alone valve.

Related: `RimValveTemplate::fieldChangedByUi` calls through an unchecked `dynamic_cast<RimWellPathValve*>`, which can now be null since `RimWellEventValve` also refers to valve templates.
