### PR TITLE
#14437 Guard against lateral without active well targets

### DIFF
--- a/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivWellPathPartMgr.cpp
@@ -928,14 +928,16 @@ void RivWellPathPartMgr::buildWellPathParts( const caf::DisplayCoordTransform* d
         {
             auto geoDef = modeledWellPath->geometryDefinition();
 
+            // A lateral gets its well path geometry from the parent well, and can have no active well targets
+            auto wellTargets = geoDef->activeWellTargets();
+            if ( wellTargets.empty() ) return;
+
             auto   sphereColor        = geoDef->sphereColor();
             double sphereRadiusFactor = geoDef->sphereRadiusFactor();
 
             cvf::ref<cvf::Vec3fArray>   vertices = new cvf::Vec3fArray;
             cvf::ref<cvf::Vec3fArray>   vecRes   = new cvf::Vec3fArray;
             cvf::ref<cvf::Color3fArray> colors   = new cvf::Color3fArray;
-
-            auto wellTargets = geoDef->activeWellTargets();
 
             size_t pointCount = wellTargets.size();
             vertices->reserve( pointCount );

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -75,6 +75,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RifPerforationIntervalReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathCompletions-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathValve-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellPathGeometryDef-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDataFilterCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifActiveCellsReader-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimWellPathGeometryDef-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellPathGeometryDef-Test.cpp
@@ -1,0 +1,50 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RimModeledWellPath.h"
+#include "RimWellPathGeometryDef.h"
+#include "Well/RigWellPath.h"
+
+//--------------------------------------------------------------------------------------------------
+/// A lateral gets its well path geometry from the parent well. The geometry is then long enough to be
+/// visualized, even if the lateral has no active well targets. Visualization code must not assume that
+/// a well path with geometry has at least one active well target.
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellPathGeometryDefTest, GeometryFromParentWellWithoutActiveTargets )
+{
+    RimModeledWellPath wellPath;
+
+    RimWellPathGeometryDef* geoDef = wellPath.geometryDefinition();
+    ASSERT_TRUE( geoDef != nullptr );
+
+    // Mimic a lateral tied in to a parent well, see RimModeledWellPath::updateTieInLocationFromParentWell()
+    geoDef->setIsAttachedToParentWell( true );
+    geoDef->setFixedWellPathPoints( { cvf::Vec3d( 0.0, 0.0, 0.0 ), cvf::Vec3d( 0.0, 0.0, -100.0 ) } );
+    geoDef->setFixedMeasuredDepths( { 0.0, 100.0 } );
+
+    EXPECT_TRUE( geoDef->activeWellTargets().empty() );
+    EXPECT_TRUE( geoDef->showSpheres() );
+
+    wellPath.createWellPathGeometry();
+
+    RigWellPath* wellPathGeometry = wellPath.wellPathGeometry();
+    ASSERT_TRUE( wellPathGeometry != nullptr );
+    EXPECT_GE( wellPathGeometry->wellPathPoints().size(), size_t( 2 ) );
+}


### PR DESCRIPTION
Fixes #14437

**Problem**

A lateral gets its well path geometry from the parent well, so it is visualized even when it has no active well targets. Building the well target spheres then calls `setVectors()` with empty arrays, which asserts.

**Fix**

Skip the sphere part when there are no active well targets.

A similar unguarded call exists in `RivPolylinePartMgr::buildPolylineParts()`, where a polyline with no points gives the same empty arrays.