### PR TITLE
#14441 Keep annotation labels inside the view frustum

### DIFF
--- a/ApplicationLibCode/ModelVisualization/RivAnnotationTools.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivAnnotationTools.cpp
@@ -105,6 +105,9 @@ cvf::ref<cvf::Part> RivAnnotationTools::createPartFromPolyline( const cvf::Color
     return part;
 }
 
+namespace
+{
+
 struct LabelTextAndPosition
 {
     std::string label;
@@ -139,12 +142,48 @@ auto computeScalingFactorFromZoom = []( const cvf::Camera* camera ) -> double
 };
 
 //--------------------------------------------------------------------------------------------------
+/// cvf::Camera::project() divides by the homogeneous w-coordinate, and coordinates behind the camera are mirrored into the viewport. Reject
+/// these coordinates before screen space coordinates are compared.
+//--------------------------------------------------------------------------------------------------
+auto isInFrontOfNearPlane = []( const cvf::Camera* camera, const cvf::Vec3d& displayCoord ) -> bool
+{
+    const double distanceAlongViewDir = ( displayCoord - camera->position() ) * camera->direction();
+
+    return distanceAlongViewDir > camera->nearPlane();
+};
+
+//--------------------------------------------------------------------------------------------------
+/// Move the label towards the camera to make sure the label is drawn in front of other geometry. The scaling factor is derived from the
+/// zoom level, and is not related to the distance between the camera and the anchor point. If the label is moved past the near plane, the
+/// label is silently discarded by the text renderer. Limit the offset to keep the label inside the view frustum.
+//--------------------------------------------------------------------------------------------------
+auto computeLabelPosition = []( const cvf::Camera* camera, const cvf::Vec3d& anchorPosition, const double anchorLineScalingFactor ) -> cvf::Vec3d
+{
+    const double distanceAlongViewDir = ( anchorPosition - camera->position() ) * camera->direction();
+
+    // Move the label at most half the way towards the camera. The label parts are part of the scene, and are used to compute the near and
+    // far clipping planes. Deriving the limit from the anchor point and not from the near plane avoids a feedback loop between the label
+    // positions and the clipping planes.
+    const double maxOffsetFromAnchorPoint = 0.5 * distanceAlongViewDir;
+
+    // If the near plane is close to the anchor point, the limit above is not sufficient to keep the label inside the frustum
+    const double maxOffsetFromNearPlane = distanceAlongViewDir - 1.1 * camera->nearPlane();
+
+    const double offset = std::max( 0.0, std::min( { anchorLineScalingFactor, maxOffsetFromAnchorPoint, maxOffsetFromNearPlane } ) );
+
+    const cvf::Vec3d directionPointToCam = ( camera->position() - anchorPosition ).getNormalized();
+
+    return anchorPosition + directionPointToCam * offset;
+};
+
+//--------------------------------------------------------------------------------------------------
 /// Project candidate coordinates to screen space, and compare with the normalized viewport position. Create a label item for the closest
 /// coordinate.
 //--------------------------------------------------------------------------------------------------
 auto createLabelForClosestCoordinate = []( const cvf::Camera*             camera,
                                            const RivAnnotationSourceInfo* annotationObject,
                                            const double                   viewportWidth,
+                                           const double                   viewportHeight,
                                            const double                   normalizedXPosition,
                                            const double                   anchorLineScalingFactor ) -> std::optional<LabelTextAndPosition>
 {
@@ -152,10 +191,18 @@ auto createLabelForClosestCoordinate = []( const cvf::Camera*             camera
 
     cvf::Vec3d anchorPosition;
     double     smallestDistance = std::numeric_limits<double>::max();
+
+    // Prefer coordinates inside the viewport, as a label attached to a coordinate outside the viewport can be positioned outside the
+    // visible area
+    cvf::Vec3d anchorPositionInViewport;
+    double     smallestDistanceInViewport = std::numeric_limits<double>::max();
+
     for ( const auto& displayCoord : annotationObject->anchorPointsInDisplayCoords() )
     {
+        if ( !isInFrontOfNearPlane( camera, displayCoord ) ) continue;
+
         cvf::Vec3d screenCoord;
-        camera->project( displayCoord, &screenCoord );
+        if ( !camera->project( displayCoord, &screenCoord ) ) continue;
 
         double horizontalDistance = std::fabs( normalizedXPosition * viewportWidth - screenCoord.x() );
 
@@ -164,13 +211,23 @@ auto createLabelForClosestCoordinate = []( const cvf::Camera*             camera
             smallestDistance = horizontalDistance;
             anchorPosition   = displayCoord;
         }
+
+        if ( screenCoord.y() > 0 && screenCoord.y() < viewportHeight && horizontalDistance < smallestDistanceInViewport )
+        {
+            smallestDistanceInViewport = horizontalDistance;
+            anchorPositionInViewport   = displayCoord;
+        }
+    }
+
+    if ( smallestDistanceInViewport != std::numeric_limits<double>::max() )
+    {
+        smallestDistance = smallestDistanceInViewport;
+        anchorPosition   = anchorPositionInViewport;
     }
 
     if ( smallestDistance == std::numeric_limits<double>::max() ) return std::nullopt;
 
-    const cvf::Vec3d directionPointToCam = ( camera->position() - anchorPosition ).getNormalized();
-
-    cvf::Vec3d labelPosition = anchorPosition + directionPointToCam * anchorLineScalingFactor;
+    cvf::Vec3d labelPosition = computeLabelPosition( camera, anchorPosition, anchorLineScalingFactor );
 
     const double maxScreenSpaceAdjustment = viewportWidth * 0.05;
     if ( smallestDistance < maxScreenSpaceAdjustment )
@@ -178,10 +235,11 @@ auto createLabelForClosestCoordinate = []( const cvf::Camera*             camera
         // Establish a fixed horizontal anchor point for the label in screen coordinates. Achieved through conversion to screen coordinates,
         // adjusting the x-coordinate, and then reverting to display coordinates.
         cvf::Vec3d screenCoord;
-        camera->project( labelPosition, &screenCoord );
-
-        screenCoord.x() = normalizedXPosition * viewportWidth;
-        camera->unproject( screenCoord, &labelPosition );
+        if ( camera->project( labelPosition, &screenCoord ) )
+        {
+            screenCoord.x() = normalizedXPosition * viewportWidth;
+            camera->unproject( screenCoord, &labelPosition );
+        }
     }
 
     LabelTextAndPosition info = { annotationObject->text(), anchorPosition, labelPosition };
@@ -213,8 +271,10 @@ auto createMultipleLabels = []( const cvf::Camera*             camera,
         {
             const auto& displayCoord = candidateCoords[i];
 
+            if ( !isInFrontOfNearPlane( camera, displayCoord ) ) continue;
+
             cvf::Vec3d screenCoord;
-            camera->project( displayCoord, &screenCoord );
+            if ( !camera->project( displayCoord, &screenCoord ) ) continue;
 
             if ( screenCoord.x() > 0 && screenCoord.x() < viewportWidth && screenCoord.y() > 0 && screenCoord.y() < viewportHeight )
             {
@@ -226,9 +286,8 @@ auto createMultipleLabels = []( const cvf::Camera*             camera,
 
         for ( size_t i = 0; i < labelCoords.size(); i++ )
         {
-            const cvf::Vec3d lineAnchorPosition  = labelCoords[i];
-            const cvf::Vec3d directionPointToCam = ( camera->position() - lineAnchorPosition ).getNormalized();
-            const cvf::Vec3d labelPosition       = lineAnchorPosition + directionPointToCam * anchorLineScalingFactor;
+            const cvf::Vec3d lineAnchorPosition = labelCoords[i];
+            const cvf::Vec3d labelPosition      = computeLabelPosition( camera, lineAnchorPosition, anchorLineScalingFactor );
 
             labelInfo.push_back( { labelTexts[i], lineAnchorPosition, labelPosition } );
         }
@@ -236,6 +295,8 @@ auto createMultipleLabels = []( const cvf::Camera*             camera,
 
     return labelInfo;
 };
+
+} // namespace
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -278,8 +339,12 @@ void RivAnnotationTools::addAnnotationLabels( const cvf::Collection<cvf::Part>& 
                     // Close to the right edge of the visible screen area
                     const auto normalizedXPosition = 0.9;
 
-                    auto labelCandidate =
-                        createLabelForClosestCoordinate( camera, annotationObject, viewportWidth, normalizedXPosition, anchorLineScalingFactor );
+                    auto labelCandidate = createLabelForClosestCoordinate( camera,
+                                                                           annotationObject,
+                                                                           viewportWidth,
+                                                                           viewportHeight,
+                                                                           normalizedXPosition,
+                                                                           anchorLineScalingFactor );
                     if ( labelCandidate.has_value() ) labels.push_back( labelCandidate.value() );
                 }
 
@@ -288,8 +353,12 @@ void RivAnnotationTools::addAnnotationLabels( const cvf::Collection<cvf::Part>& 
                     // Close to the left edge of the visible screen area
                     const auto normalizedXPosition = 0.1;
 
-                    auto labelCandidate =
-                        createLabelForClosestCoordinate( camera, annotationObject, viewportWidth, normalizedXPosition, anchorLineScalingFactor );
+                    auto labelCandidate = createLabelForClosestCoordinate( camera,
+                                                                           annotationObject,
+                                                                           viewportWidth,
+                                                                           viewportHeight,
+                                                                           normalizedXPosition,
+                                                                           anchorLineScalingFactor );
                     if ( labelCandidate.has_value() ) labels.push_back( labelCandidate.value() );
                 }
 
@@ -298,8 +367,10 @@ void RivAnnotationTools::addAnnotationLabels( const cvf::Collection<cvf::Part>& 
                     std::vector<cvf::Vec3d> visibleCoords;
                     for ( const auto& v : annotationObject->anchorPointsInDisplayCoords() )
                     {
+                        if ( !isInFrontOfNearPlane( camera, v ) ) continue;
+
                         cvf::Vec3d screenCoord;
-                        camera->project( v, &screenCoord );
+                        if ( !camera->project( v, &screenCoord ) ) continue;
 
                         if ( screenCoord.x() > 0 && screenCoord.x() < viewportWidth && screenCoord.y() > 0 && screenCoord.y() < viewportHeight )
                             visibleCoords.push_back( v );
@@ -315,9 +386,8 @@ void RivAnnotationTools::addAnnotationLabels( const cvf::Collection<cvf::Part>& 
                     {
                         size_t adjustedIndex = std::min( i, visibleCoords.size() - 1 );
 
-                        const cvf::Vec3d lineAnchorPosition  = visibleCoords[adjustedIndex];
-                        const cvf::Vec3d directionPointToCam = ( camera->position() - lineAnchorPosition ).getNormalized();
-                        const cvf::Vec3d labelPosition       = lineAnchorPosition + directionPointToCam * anchorLineScalingFactor;
+                        const cvf::Vec3d lineAnchorPosition = visibleCoords[adjustedIndex];
+                        const cvf::Vec3d labelPosition      = computeLabelPosition( camera, lineAnchorPosition, anchorLineScalingFactor );
 
                         labels.push_back( { annotationObject->text(), lineAnchorPosition, labelPosition } );
                     }

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigWellPathIntersectionTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimHistogramDataSource-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogExtractionCurveImpl-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RivAnnotationTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivPipeGeometryGenerator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivIjkIntersectionGeometryGenerator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivTernaryScalarMapper-Test.cpp

--- a/ApplicationLibCode/UnitTests/RivAnnotationTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RivAnnotationTools-Test.cpp
@@ -1,0 +1,165 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RivAnnotationSourceInfo.h"
+#include "RivAnnotationTools.h"
+
+#include "cvfCamera.h"
+#include "cvfDrawableText.h"
+#include "cvfModelBasicList.h"
+#include "cvfPart.h"
+#include "cvfViewport.h"
+
+#include <optional>
+
+namespace
+{
+const double viewportWidth  = 1000.0;
+const double viewportHeight = 800.0;
+
+//--------------------------------------------------------------------------------------------------
+/// Create a perspective camera using the near and far plane distances computed by caf::Viewer, see
+/// caf::Viewer::calculateNearFarPlanes()
+//--------------------------------------------------------------------------------------------------
+cvf::ref<cvf::Camera> createPerspectiveCamera( const cvf::Vec3d& eye, const cvf::Vec3d& viewRefPoint, double nearPlane, double farPlane )
+{
+    cvf::ref<cvf::Camera> camera = new cvf::Camera;
+    camera->setViewport( 0, 0, static_cast<int>( viewportWidth ), static_cast<int>( viewportHeight ) );
+    camera->setFromLookAt( eye, viewRefPoint, cvf::Vec3d::Z_AXIS );
+    camera->setProjectionAsPerspective( 40.0, nearPlane, farPlane );
+
+    return camera;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Create a part representing a surface intersection curve, with the annotation source info used to
+/// create labels
+//--------------------------------------------------------------------------------------------------
+cvf::ref<cvf::Part> createAnnotationPart( const std::vector<cvf::Vec3d>& displayCoords )
+{
+    auto annotationObject = new RivAnnotationSourceInfo( "Surface Name", displayCoords );
+    annotationObject->setLabelPositionStrategyHint( RivAnnotationTools::LabelPositionStrategy::RIGHT );
+
+    cvf::ref<cvf::Part> part = new cvf::Part;
+    part->setSourceInfo( annotationObject );
+
+    return part;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Find the position of the single label text created by RivAnnotationTools::addAnnotationLabels()
+//--------------------------------------------------------------------------------------------------
+std::optional<cvf::Vec3d> findLabelPosition( cvf::ModelBasicList* model )
+{
+    for ( cvf::uint i = 0; i < model->partCount(); i++ )
+    {
+        const auto* part = model->part( i );
+        if ( dynamic_cast<const cvf::DrawableText*>( part->drawable() ) )
+        {
+            return cvf::Vec3d( part->drawable()->boundingBox().center() );
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+/// The label is moved towards the camera to be drawn in front of other geometry. The offset is derived from the zoom level, and can be much
+/// larger than the distance between the camera and the curve. Labels outside the view frustum are silently discarded by the text renderer.
+//--------------------------------------------------------------------------------------------------
+TEST( RivAnnotationToolsTest, LabelIsInsideViewFrustum )
+{
+    const cvf::Vec3d eye( 0.0, -1500.0, 0.0 );
+
+    // The near plane is placed just in front of the closest geometry, and the far plane just behind
+    auto camera = createPerspectiveCamera( eye, cvf::Vec3d::ZERO, 0.8 * 1500.0, 1.2 * 1500.0 );
+
+    std::vector<cvf::Vec3d> curveCoords;
+    for ( int i = -10; i <= 10; i++ )
+    {
+        curveCoords.emplace_back( i * 50.0, 0.0, 0.0 );
+    }
+
+    cvf::Collection<cvf::Part> partCollection;
+    partCollection.push_back( createAnnotationPart( curveCoords ).p() );
+
+    cvf::ref<cvf::ModelBasicList> model = new cvf::ModelBasicList;
+
+    RivAnnotationTools annoTool;
+    annoTool.addAnnotationLabels( partCollection, camera.p(), model.p(), true );
+
+    auto labelPosition = findLabelPosition( model.p() );
+    ASSERT_TRUE( labelPosition.has_value() );
+
+    cvf::Vec3d screenCoord;
+    ASSERT_TRUE( camera->project( labelPosition.value(), &screenCoord ) );
+
+    // A label outside the near and far planes is not drawn
+    EXPECT_GT( screenCoord.z(), 0.0 );
+    EXPECT_LT( screenCoord.z(), 1.0 );
+
+    EXPECT_GT( screenCoord.x(), 0.0 );
+    EXPECT_LT( screenCoord.x(), viewportWidth );
+    EXPECT_GT( screenCoord.y(), 0.0 );
+    EXPECT_LT( screenCoord.y(), viewportHeight );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// cvf::Camera::project() divides by the homogeneous w-coordinate, and coordinates behind the camera are mirrored into the viewport. Such
+/// coordinates must not be used as anchor points for a label.
+//--------------------------------------------------------------------------------------------------
+TEST( RivAnnotationToolsTest, AnchorPointsBehindCameraAreIgnored )
+{
+    const cvf::Vec3d eye( 0.0, -100.0, 0.0 );
+
+    auto camera = createPerspectiveCamera( eye, cvf::Vec3d::ZERO, 10.0, 2000.0 );
+
+    // A curve along the view direction, where the first coordinates are behind the camera. The coordinates behind the camera are mirrored
+    // into the right part of the viewport, and are closer to the label position at 90% of the viewport width than any of the coordinates in
+    // front of the camera.
+    std::vector<cvf::Vec3d> curveCoords;
+    for ( int i = -10; i <= 10; i++ )
+    {
+        curveCoords.emplace_back( -300.0, i * 50.0, 0.0 );
+    }
+
+    cvf::Collection<cvf::Part> partCollection;
+    partCollection.push_back( createAnnotationPart( curveCoords ).p() );
+
+    cvf::ref<cvf::ModelBasicList> model = new cvf::ModelBasicList;
+
+    RivAnnotationTools annoTool;
+    annoTool.addAnnotationLabels( partCollection, camera.p(), model.p(), true );
+
+    auto labelPosition = findLabelPosition( model.p() );
+    ASSERT_TRUE( labelPosition.has_value() );
+
+    // The label must be located in front of the camera
+    const double distanceAlongViewDir = ( labelPosition.value() - camera->position() ) * camera->direction();
+    EXPECT_GT( distanceAlongViewDir, camera->nearPlane() );
+
+    cvf::Vec3d screenCoord;
+    ASSERT_TRUE( camera->project( labelPosition.value(), &screenCoord ) );
+
+    EXPECT_GT( screenCoord.z(), 0.0 );
+    EXPECT_LT( screenCoord.z(), 1.0 );
+}


### PR DESCRIPTION
Fixes #14441

The label for a surface intersection curve or band is moved from the anchor point towards the camera, to be drawn in front of other geometry. The offset was computed by `computeScalingFactorFromZoom()` as 10 times the near plane diagonal, a zoom dependent length that is not related to the distance between the camera and the anchor point. In a 3D view the offset is usually several times larger than this distance, and the label ends up behind the camera.

`cvf::DrawableText::renderText()` maps the projected depth to `1 - 2 * z` and clips anything outside `[-1, 1]`, so a label outside the view frustum is silently discarded. As the relation between the offset and the camera distance differs per curve and changes when the camera is moved, labels appear and disappear.

The flat 2D intersection view calls `addAnnotationLabels()` with `computeScalingFactor = false`, giving a fixed offset of 1.0. This is why the labels are displayed as expected in that view.

With the fix in this PR, the 3D view displays the labels as expected

<img width="733" height="528" alt="image" src="https://github.com/user-attachments/assets/cfad6f44-c930-4e65-90a6-059173e7bf96" />
