### PR TITLE
Add runner image version to vcpkg binary cache key

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -223,11 +223,25 @@ jobs:
           echo "Using compiler: $cl_path"
           echo "hash=$(sha1sum "$cl_path" | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
+      - name: Get runner image version
+        # vcpkg's ABI hash covers more of the runner image than cl.exe alone: on
+        # Windows every port's ABI includes the PowerShell version, and other
+        # image-provided tools feed it as well. A PowerShell 7.6.3 -> 7.6.4 bump
+        # in image 20260728 changed all 102 ABIs while cl.exe, the vcpkg
+        # submodule and vcpkg.json stayed fixed, so the cache restored but vcpkg
+        # rejected every archive ("Restored 0 package(s)"). Since the key was
+        # unchanged the action then skipped saving, leaving the stale entry in
+        # place for good. Track the image version so any image bump gives one
+        # cold rebuild followed by a save under the new key.
+        id: image-version
+        shell: bash
+        run: echo "version=${ImageVersion:-unknown}" >> $GITHUB_OUTPUT
+
       - name: Restore vcpkg cache
         id: vcpkg-cache
         uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.compiler-hash.outputs.hash }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.image-version.outputs.version }}-${{ steps.compiler-hash.outputs.hash }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           prefix: vcpkg-${{ matrix.config.cxx}}/
           
       - name: Print CMake version


### PR DESCRIPTION
## Summary

The Windows build rebuilds all 102 vcpkg dependencies on every run even though the vcpkg cache restores successfully:

```
Cache restored from 'vcpkg-cl/Windows-cl-76bc970e…'
Restored 0 package(s) from D:\a\ResInsight\ResInsight\.vcpkg-cache in 1.15 ms
Installing 1/102 vcpkg-cmake-config…
```

vcpkg's ABI hash covers more of the runner image than `cl.exe` does. On Windows every port's ABI includes the PowerShell version (`vcpkg-tool`, `src/vcpkg/commands.build.cpp`):

```cpp
#if defined(_WIN32)
    abi_tag_entries.emplace_back(AbiTagPowershell, paths.get_tool_version("powershell-core", out_sink));
#endif
```

Runner image `20260728.258` bumped PowerShell 7.6.3 → 7.6.4, which changed all 102 ABIs while `cl.exe`, the vcpkg submodule and `vcpkg.json` were unchanged — so the cache key stayed fixed and the restored archives were all rejected. The save step then skipped because the key already existed, so the stale entry never refreshed and the loop persisted across runs.

Runs on `dev` show the image version correlating exactly with the hit/miss pattern:

| Run | Runner image | Restored |
|---|---|---|
| Aug 1 | 20260728.258.1 | 0 |
| Aug 2 | 20260720.249.2 | 102 |
| Aug 3 | 20260728.258.1 | 0 |

Configure step: 98 min on a miss vs 1.6 min on a hit.

## Change

Read the runner's `ImageVersion` and include it in the vcpkg cache key, so an image bump gives one cold rebuild followed by a successful save under the new key. Applies to the Linux jobs as well, which had no compiler guard in the key at all. `${ImageVersion:-unknown}` keeps the step harmless on runners that do not set it.