### PR TITLE
#14450 Guard against missing data source in RFT plot

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp
@@ -1897,7 +1897,7 @@ void RimWellRftPlot::initializeDataSources( RimWellRftPlot* source )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::variant<RimSummaryCase*, RimSummaryEnsemble*> RimWellRftPlot::dataSource() const
+std::variant<std::monostate, RimSummaryCase*, RimSummaryEnsemble*> RimWellRftPlot::dataSource() const
 {
     // Return the first selected ensemble, if any
     // If no ensemble is selected, return the first selected summary case, if any

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.h
@@ -88,7 +88,8 @@ public:
 
     int branchIndex() const;
 
-    std::variant<RimSummaryCase*, RimSummaryEnsemble*> dataSource() const;
+    // The monostate is used to indicate that no data source is selected
+    std::variant<std::monostate, RimSummaryCase*, RimSummaryEnsemble*> dataSource() const;
 
     static const char* plotNameFormatString();
 

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathCompletions-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathValve-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathGeometryDef-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellRftPlot-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDataFilterCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifActiveCellsReader-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimWellRftPlot-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellRftPlot-Test.cpp
@@ -1,0 +1,39 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RimSummaryCase.h"
+#include "RimSummaryEnsemble.h"
+#include "RimWellRftPlot.h"
+
+#include <variant>
+
+//--------------------------------------------------------------------------------------------------
+/// A plot with no selected sources must not report a summary case or ensemble data source
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellRftPlotTest, DataSourceWithoutSelectedSources )
+{
+    RimWellRftPlot plot;
+
+    auto dataSource = plot.dataSource();
+
+    EXPECT_TRUE( std::holds_alternative<std::monostate>( dataSource ) );
+    EXPECT_EQ( nullptr, std::get_if<RimSummaryCase*>( &dataSource ) );
+    EXPECT_EQ( nullptr, std::get_if<RimSummaryEnsemble*>( &dataSource ) );
+}


### PR DESCRIPTION
Fixes #14450

## Problem

`RimWellRftPlot::dataSource()` returns `std::variant<RimSummaryCase*, RimSummaryEnsemble*>` and ends with `return {};` when no source is selected. The default alternative is a null `RimSummaryCase*`, so `std::get_if<RimSummaryCase*>()` succeeds and `RicCreateRftPlotsFeature::onActionTriggered()` dereferences a null pointer.

## Fix

Add `std::monostate` as the first alternative to represent "no data source". The single caller then correctly sees that no summary case is available. A unit test verifies that a plot without selected sources reports neither a summary case nor an ensemble.
