### PR TITLE
#14451 Guard against well path without geometry

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFracture.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimWellPathFracture.cpp
@@ -245,7 +245,8 @@ void RimWellPathFracture::updatePositionFromMeasuredDepth()
     RigWellPath* wellPathGeometry = wellPath->wellPathGeometry();
     if ( wellPathGeometry )
     {
-        positionAlongWellpath = wellPathGeometry->interpolatedPointAlongWellPath( m_measuredDepth() );
+        auto position = wellPathGeometry->interpolatedPointAlongWellPath( m_measuredDepth() );
+        if ( !position.isUndefined() ) positionAlongWellpath = position;
     }
 
     setAnchorPosition( positionAlongWellpath );

--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPath.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPath.cpp
@@ -207,6 +207,8 @@ cvf::Vec3d RigWellPath::interpolatedVectorValuesAlongWellPath( const std::vector
 
     if ( horizontalLengthAlongWellToStartClipPoint ) *horizontalLengthAlongWellToStartClipPoint = 0.0;
 
+    if ( m_measuredDepths.empty() || vectorValuesAlongWellPath.empty() ) return cvf::Vec3d::UNDEFINED;
+
     size_t vxIdx = 0;
     while ( vxIdx < m_measuredDepths.size() && m_measuredDepths.at( vxIdx ) < measuredDepth )
     {

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaTextFileCompare-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifCaseRealizationParametersReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellLogExtractor-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigWellPath-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellPathGeometryTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifEclipseSummaryAddress-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaTimeHistoryCurveTools-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigWellPath-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellPath-Test.cpp
@@ -1,0 +1,53 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Well/RigWellPath.h"
+
+//--------------------------------------------------------------------------------------------------
+/// A well path without geometry must not throw, and must report the point as undefined
+//--------------------------------------------------------------------------------------------------
+TEST( RigWellPathTest, InterpolatedPointForEmptyGeometry )
+{
+    RigWellPath wellPath;
+
+    cvf::Vec3d point = wellPath.interpolatedPointAlongWellPath( 100.0 );
+    EXPECT_TRUE( point.isUndefined() );
+
+    double horizontalLength = -1.0;
+    point                   = wellPath.interpolatedPointAlongWellPath( 100.0, &horizontalLength );
+    EXPECT_TRUE( point.isUndefined() );
+    EXPECT_DOUBLE_EQ( 0.0, horizontalLength );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigWellPathTest, InterpolatedPointAlongWellPath )
+{
+    std::vector<cvf::Vec3d> points = { cvf::Vec3d( 0.0, 0.0, 0.0 ), cvf::Vec3d( 0.0, 0.0, -100.0 ), cvf::Vec3d( 0.0, 0.0, -200.0 ) };
+    std::vector<double>     mds    = { 0.0, 100.0, 200.0 };
+
+    RigWellPath wellPath( points, mds );
+
+    // Before, inside and after the measured depth range
+    EXPECT_EQ( cvf::Vec3d( 0.0, 0.0, 0.0 ), wellPath.interpolatedPointAlongWellPath( -10.0 ) );
+    EXPECT_EQ( cvf::Vec3d( 0.0, 0.0, -50.0 ), wellPath.interpolatedPointAlongWellPath( 50.0 ) );
+    EXPECT_EQ( cvf::Vec3d( 0.0, 0.0, -200.0 ), wellPath.interpolatedPointAlongWellPath( 500.0 ) );
+}


### PR DESCRIPTION
Fixes #14451

## Problem

`RigWellPath::interpolatedVectorValuesAlongWellPath()` takes the end-point branch when the well path has no measured depths, and evaluates `vectorValuesAlongWellPath.at( vxIdx - 1 )` with `vxIdx == 0`. The unsigned wrap-around makes `at()` throw `std::out_of_range`, which terminates the application.

The crash is reached from `RimWellPathFracture::updatePositionFromMeasuredDepth()`, which checks that the well path geometry pointer is valid but not that it holds any points.

## Fix

Return early when the well path has no geometry. A unit test covers the empty geometry case, plus interpolation before, inside and after the measured depth range.
