### PR TITLE
#14452 Guard against fracture without fracture template

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimFracture.cpp
@@ -363,7 +363,7 @@ cvf::Color3f RimFracture::defaultComponentColor() const
 //--------------------------------------------------------------------------------------------------
 double RimFracture::startMD() const
 {
-    if ( fractureTemplate()->orientationType() == RimFractureTemplate::ALONG_WELL_PATH )
+    if ( fractureTemplate() && fractureTemplate()->orientationType() == RimFractureTemplate::ALONG_WELL_PATH )
     {
         return fractureMD() - 0.5 * perforationLength();
     }
@@ -378,6 +378,8 @@ double RimFracture::startMD() const
 //--------------------------------------------------------------------------------------------------
 double RimFracture::endMD() const
 {
+    if ( !fractureTemplate() ) return startMD();
+
     if ( fractureTemplate()->orientationType() == RimFractureTemplate::ALONG_WELL_PATH )
     {
         return startMD() + perforationLength();

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/Intersect-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifPerforationIntervalReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathCompletions-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimWellPathFracture-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathValve-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathGeometryDef-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDataFilterCollection-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimWellPathFracture-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimWellPathFracture-Test.cpp
@@ -1,0 +1,33 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RimWellPathFracture.h"
+
+//--------------------------------------------------------------------------------------------------
+/// A fracture without a fracture template must report a measured depth range without crashing
+//--------------------------------------------------------------------------------------------------
+TEST( RimWellPathFractureTest, MeasuredDepthWithoutFractureTemplate )
+{
+    RimWellPathFracture fracture;
+    fracture.setMeasuredDepth( 100.0 );
+
+    EXPECT_DOUBLE_EQ( 100.0, fracture.startMD() );
+    EXPECT_DOUBLE_EQ( 100.0, fracture.endMD() );
+}


### PR DESCRIPTION
Fixes #14452

## Problem

`RimFracture::startMD()` and `endMD()` dereference `fractureTemplate()` without a null check. The fracture template is a `PdmPtrField` and is null for a fracture with no template assigned. MSW completion export calls `startMD()` for every completion on a well path, so a single fracture without a template crashes the export.

## Fix

Guard both functions, using the `if ( fractureTemplate() )` pattern already used elsewhere in the same file. A unit test verifies that a fracture without a template reports its measured depth range without crashing.

`RimFracture::isEclipseCellOpenForFlow()` also dereferences the template unguarded, but there it is a documented precondition (`CVF_ASSERT( fractureTemplate() )`) and not on this crash path, so it is left unchanged.
