### PR TITLE
#14453 Guard against invalid model index in table view

### DIFF
--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewQModel.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewQModel.cpp
@@ -476,6 +476,9 @@ void PdmUiTableViewQModel::setArrayFieldAndBuildEditors( PdmChildArrayFieldHandl
 //--------------------------------------------------------------------------------------------------
 PdmFieldHandle* PdmUiTableViewQModel::getField( const QModelIndex& index ) const
 {
+    if ( !index.isValid() ) return nullptr;
+    if ( index.column() >= static_cast<int>( m_modelColumnIndexToFieldIndex.size() ) ) return nullptr;
+
     auto childArrayField = childArrayFieldHandle();
 
     if ( childArrayField && index.row() < static_cast<int>( childArrayField->size() ) )
@@ -610,6 +613,8 @@ caf::PdmUiFieldHandle* PdmUiTableViewQModel::getUiFieldHandle( const QModelIndex
 //--------------------------------------------------------------------------------------------------
 PdmObjectHandle* PdmUiTableViewQModel::pdmObjectForRow( int row ) const
 {
+    if ( row < 0 ) return nullptr;
+
     auto childArrayField = childArrayFieldHandle();
     if ( childArrayField && row < static_cast<int>( childArrayField->size() ) )
     {

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PROJECT_FILES
     cafUserInterface_UnitTests.cpp
     cafPdmUiTreeViewModelTest.cpp
     cafPdmUiTreeSelectionQModelTest.cpp
+    cafPdmUiTableViewQModelTest.cpp
     cafPdmUiNumberFormatTest.cpp
     cafPdmUiCheckBoxAndTextEditorTest.cpp
     cafPdmUiPropertyViewDialogTest.cpp

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiTableViewQModelTest.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiTableViewQModelTest.cpp
@@ -1,0 +1,61 @@
+
+#include "gtest/gtest.h"
+
+#include "cafPdmChildArrayField.h"
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+#include "cafPdmUiTableViewQModel.h"
+
+#include <QModelIndex>
+
+using namespace caf;
+
+class TableRowObject : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    TableRowObject()
+    {
+        CAF_PDM_InitObject( "TableRowObject" );
+        CAF_PDM_InitField( &m_value, "Value", 1.0, "Value" );
+    }
+
+    caf::PdmField<double> m_value;
+};
+CAF_PDM_SOURCE_INIT( TableRowObject, "TableRowObject" );
+
+class TableContainerObject : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    TableContainerObject()
+    {
+        CAF_PDM_InitObject( "TableContainerObject" );
+        CAF_PDM_InitFieldNoDefault( &m_rows, "Rows", "Rows" );
+    }
+
+    caf::PdmChildArrayField<TableRowObject*> m_rows;
+};
+CAF_PDM_SOURCE_INIT( TableContainerObject, "TableContainerObject" );
+
+//--------------------------------------------------------------------------------------------------
+/// An invalid model index has row and column set to -1, and must not be used to index the child array
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTableViewQModelTest, InvalidModelIndex )
+{
+    TableContainerObject container;
+    container.m_rows.push_back( new TableRowObject );
+
+    PdmUiTableViewQModel model( nullptr );
+    model.setArrayFieldAndBuildEditors( &container.m_rows, "" );
+
+    EXPECT_EQ( 1, model.rowCount() );
+
+    QModelIndex invalidIndex;
+    EXPECT_FALSE( invalidIndex.isValid() );
+
+    EXPECT_EQ( nullptr, model.getField( invalidIndex ) );
+    EXPECT_EQ( nullptr, model.pdmObjectForRow( invalidIndex.row() ) );
+}


### PR DESCRIPTION
Fixes #14453

## Problem

Dropping on an empty area of a table view calls `dropMimeData()` with an invalid parent index, where row and column are -1. `PdmUiTableViewQModel::getField()` only tested `index.row() < size`, so -1 passed the test, and `PdmChildArrayField::at()` does an unchecked `m_pointers[index]`. Converted to `size_t`, -1 reads far out of bounds and returns a garbage object pointer, which is then dereferenced. `pdmObjectForRow()` has the same hole and is called with the same -1.

## Fix

Reject invalid indices and out of range columns in `getField()`, and negative rows in `pdmObjectForRow()`. A unit test drives both functions with an invalid model index.
