### PR TITLE
Surface intersection curves and bands for Intersection Box and I/J/K Intersection

### DIFF
--- a/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionBandFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionBandFeature.cpp
@@ -22,7 +22,7 @@
 
 #include "RimAnnotationLineAppearance.h"
 #include "RimEnsembleSurface.h"
-#include "RimExtrudedCurveIntersection.h"
+#include "RimIntersection.h"
 #include "RimSurface.h"
 #include "RimSurfaceCollection.h"
 #include "RimSurfaceIntersectionBand.h"
@@ -39,10 +39,20 @@ CAF_CMD_SOURCE_INIT( RicCreateSurfaceIntersectionBandFeature, "RicCreateSurfaceI
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicCreateSurfaceIntersectionBandFeature::isCommandEnabled() const
+{
+    auto* intersection = caf::SelectionManager::instance()->selectedItemAncestorOfType<RimIntersection>();
+
+    return intersection && intersection->supportsSurfaceIntersectionCurves();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicCreateSurfaceIntersectionBandFeature::onActionTriggered( bool isChecked )
 {
-    auto* intersection = caf::SelectionManager::instance()->selectedItemAncestorOfType<RimExtrudedCurveIntersection>();
-    if ( intersection )
+    auto* intersection = caf::SelectionManager::instance()->selectedItemAncestorOfType<RimIntersection>();
+    if ( intersection && intersection->supportsSurfaceIntersectionCurves() )
     {
         RimEnsembleSurface* firstEnsembleSurface = nullptr;
         {

--- a/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionBandFeature.h
+++ b/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionBandFeature.h
@@ -28,6 +28,7 @@ class RicCreateSurfaceIntersectionBandFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
+    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
 };

--- a/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionCurveFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionCurveFeature.cpp
@@ -18,7 +18,7 @@
 
 #include "RicCreateSurfaceIntersectionCurveFeature.h"
 
-#include "RimExtrudedCurveIntersection.h"
+#include "RimIntersection.h"
 #include "RimSurfaceIntersectionCurve.h"
 
 #include "Riu3DMainWindowTools.h"
@@ -32,10 +32,20 @@ CAF_CMD_SOURCE_INIT( RicCreateSurfaceIntersectionCurveFeature, "RicCreateSurface
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicCreateSurfaceIntersectionCurveFeature::isCommandEnabled() const
+{
+    auto* intersection = caf::SelectionManager::instance()->selectedItemAncestorOfType<RimIntersection>();
+
+    return intersection && intersection->supportsSurfaceIntersectionCurves();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicCreateSurfaceIntersectionCurveFeature::onActionTriggered( bool isChecked )
 {
-    auto* intersection = caf::SelectionManager::instance()->selectedItemAncestorOfType<RimExtrudedCurveIntersection>();
-    if ( intersection )
+    auto* intersection = caf::SelectionManager::instance()->selectedItemAncestorOfType<RimIntersection>();
+    if ( intersection && intersection->supportsSurfaceIntersectionCurves() )
     {
         auto curve = intersection->addIntersectionCurve();
         intersection->updateAllRequiredEditors();

--- a/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionCurveFeature.h
+++ b/ApplicationLibCode/Commands/RicCreateSurfaceIntersectionCurveFeature.h
@@ -28,6 +28,7 @@ class RicCreateSurfaceIntersectionCurveFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
+    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
 };

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivBoxIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivBoxIntersectionPartMgr.cpp
@@ -42,6 +42,7 @@
 #include "RivPartPriority.h"
 #include "RivResultToTextureMapper.h"
 #include "RivScalarMapperUtils.h"
+#include "RivSurfaceIntersectionCurveTools.h"
 #include "RivTernaryScalarMapper.h"
 #include "RivTernaryTextureCoordsCreator.h"
 
@@ -96,7 +97,7 @@ void RivBoxIntersectionPartMgr::updateCellResultColor( int timeStepIndex )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RivBoxIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCells )
+void RivBoxIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCells, cvf::Transform* scaleTransform )
 {
     bool useBufferObjects = true;
     // Surface geometry
@@ -151,6 +152,8 @@ void RivBoxIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCe
         }
     }
 
+    m_annotationParts = RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersectionBox, scaleTransform );
+
     updatePartEffect();
 }
 
@@ -203,6 +206,18 @@ void RivBoxIntersectionPartMgr::appendMeshLinePartsToModel( cvf::ModelBasicList*
     {
         m_intersectionBoxGridLines->setTransform( scaleTransform );
         model->addPart( m_intersectionBoxGridLines.p() );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RivBoxIntersectionPartMgr::appendAnnotationPartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform )
+{
+    for ( size_t i = 0; i < m_annotationParts.size(); i++ )
+    {
+        m_annotationParts[i]->setTransform( scaleTransform );
+        model->addPart( m_annotationParts.at( i ) );
     }
 }
 

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivBoxIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivBoxIntersectionPartMgr.cpp
@@ -152,7 +152,8 @@ void RivBoxIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCe
         }
     }
 
-    m_annotationParts = RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersectionBox, scaleTransform );
+    if ( scaleTransform )
+        m_annotationParts = RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersectionBox, *scaleTransform );
 
     updatePartEffect();
 }

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivBoxIntersectionPartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivBoxIntersectionPartMgr.h
@@ -20,6 +20,7 @@
 
 #include "RivBoxIntersectionGeometryGenerator.h"
 
+#include "cvfCollection.h"
 #include "cvfObject.h"
 
 namespace cvf
@@ -60,10 +61,11 @@ public:
 
     void appendNativeIntersectionFacesToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform );
     void appendMeshLinePartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform );
+    void appendAnnotationPartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform );
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const;
 
-    void generatePartGeometry( cvf::UByteArray* visibleCells );
+    void generatePartGeometry( cvf::UByteArray* visibleCells, cvf::Transform* scaleTransform );
 
 private:
     void updatePartEffect();
@@ -73,9 +75,10 @@ private:
 
     cvf::Color3f m_defaultColor;
 
-    cvf::ref<cvf::Part>       m_intersectionBoxFaces;
-    cvf::ref<cvf::Part>       m_intersectionBoxGridLines;
-    cvf::ref<cvf::Vec2fArray> m_intersectionBoxFacesTextureCoords;
+    cvf::ref<cvf::Part>        m_intersectionBoxFaces;
+    cvf::ref<cvf::Part>        m_intersectionBoxGridLines;
+    cvf::Collection<cvf::Part> m_annotationParts;
+    cvf::ref<cvf::Vec2fArray>  m_intersectionBoxFacesTextureCoords;
 
     cvf::ref<RivBoxIntersectionGeometryGenerator> m_intersectionBoxGenerator;
 };

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.cpp
@@ -165,8 +165,9 @@ void RivExtrudedCurveIntersectionGeometryGenerator::calculateSurfaceIntersection
     const auto surfaces = RivSurfaceIntersectionCurveTools::referencedSurfaces( m_intersection->surfaceIntersectionCollection() );
     if ( surfaces.empty() ) return;
 
-    // The curve is drawn along the whole intersection, so no depth clipping is applied here
-    const auto [minZ, maxZ] = m_intersection->surfaceCurtainZRange();
+    // Vertical pillars along the same polyline as the one used to build the geometry
+    const auto curtain = m_intersection->surfaceCurtain();
+    if ( !curtain.isValid() ) return;
 
     // The polyline is flattened when the curve is displayed in a 2D intersection view
     auto pointTransform = [this]( const cvf::Vec3d& point, size_t segmentIndex )
@@ -176,7 +177,7 @@ void RivExtrudedCurveIntersectionGeometryGenerator::calculateSurfaceIntersection
     };
 
     m_transformedSurfaceIntersectionPolylines =
-        RivSurfaceIntersectionCurveTools::computeSurfaceCurtainPolylines( surfaces, m_polylines.front(), minZ, maxZ, pointTransform );
+        RivSurfaceIntersectionCurveTools::computeSurfaceCurtainPolylines( surfaces, curtain, pointTransform );
 }
 
 class MeshLinesAccumulator

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.cpp
@@ -160,52 +160,23 @@ void RivExtrudedCurveIntersectionGeometryGenerator::calculateSurfaceIntersection
 {
     m_transformedSurfaceIntersectionPolylines.clear();
 
-    if ( !m_polylines.empty() )
+    if ( m_polylines.empty() ) return;
+
+    const auto surfaces = RivSurfaceIntersectionCurveTools::referencedSurfaces( m_intersection->surfaceIntersectionCollection() );
+    if ( surfaces.empty() ) return;
+
+    // The curve is drawn along the whole intersection, so no depth clipping is applied here
+    const auto [minZ, maxZ] = m_intersection->surfaceCurtainZRange();
+
+    // The polyline is flattened when the curve is displayed in a 2D intersection view
+    auto pointTransform = [this]( const cvf::Vec3d& point, size_t segmentIndex )
     {
-        auto firstPolyLine = m_polylines.front();
+        const size_t lineIndex = 0;
+        return transformPointByPolylineSegmentIndex( point, lineIndex, segmentIndex );
+    };
 
-        std::vector<RimSurface*> surfaces;
-        for ( auto curve : m_intersection->surfaceIntersectionCurves() )
-        {
-            if ( curve->surface() ) surfaces.push_back( curve->surface() );
-        }
-        for ( auto band : m_intersection->surfaceIntersectionBands() )
-        {
-            if ( band->surface1() ) surfaces.push_back( band->surface1() );
-            if ( band->surface2() ) surfaces.push_back( band->surface2() );
-        }
-
-        for ( auto rimSurface : surfaces )
-        {
-            if ( !rimSurface ) return;
-
-            rimSurface->loadDataIfRequired();
-            auto surface = rimSurface->surfaceData();
-            if ( !surface ) return;
-
-            std::vector<cvf::Vec3d> transformedSurfacePolyline;
-
-            // Resample polyline to required resolution
-            const double maxLineSegmentLength = 1.0;
-            const auto resampledPolyline = RigSurfaceResampler::computeResampledPolylineWithSegmentInfo( firstPolyLine, maxLineSegmentLength );
-
-            for ( const auto& [point, segmentIndex] : resampledPolyline )
-            {
-                cvf::Vec3d pointAbove = cvf::Vec3d( point.x(), point.y(), 10000.0 );
-                cvf::Vec3d pointBelow = cvf::Vec3d( point.x(), point.y(), -10000.0 );
-
-                cvf::Vec3d intersectionPoint;
-                bool foundMatch = RigSurfaceResampler::findClosestPointOnSurface( surface, pointAbove, pointBelow, intersectionPoint );
-                if ( foundMatch )
-                {
-                    const size_t lineIndex = 0;
-                    transformedSurfacePolyline.push_back( transformPointByPolylineSegmentIndex( intersectionPoint, lineIndex, segmentIndex ) );
-                }
-            }
-
-            if ( !transformedSurfacePolyline.empty() ) m_transformedSurfaceIntersectionPolylines[rimSurface] = transformedSurfacePolyline;
-        }
-    }
+    m_transformedSurfaceIntersectionPolylines =
+        RivSurfaceIntersectionCurveTools::computeSurfaceCurtainPolylines( surfaces, m_polylines.front(), minZ, maxZ, pointTransform );
 }
 
 class MeshLinesAccumulator
@@ -844,7 +815,7 @@ bool RivExtrudedCurveIntersectionGeometryGenerator::isAnyGeometryPresent() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::map<RimSurface*, std::vector<cvf::Vec3d>> RivExtrudedCurveIntersectionGeometryGenerator::transformedSurfaceIntersectionPolylines() const
+std::map<RimSurface*, RivSurfaceCurtainPolyline> RivExtrudedCurveIntersectionGeometryGenerator::transformedSurfaceIntersectionPolylines() const
 {
     return m_transformedSurfaceIntersectionPolylines;
 }

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.h
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.h
@@ -22,6 +22,7 @@
 #include "cafPdmPointer.h"
 
 #include "RivIntersectionGeometryGeneratorInterface.h"
+#include "RivSurfaceIntersectionCurveTools.h"
 
 #include "cvfArray.h"
 
@@ -76,7 +77,7 @@ public:
     // GeomGen Interface
     bool isAnyGeometryPresent() const override;
 
-    std::map<RimSurface*, std::vector<cvf::Vec3d>> transformedSurfaceIntersectionPolylines() const;
+    std::map<RimSurface*, RivSurfaceCurtainPolyline> transformedSurfaceIntersectionPolylines() const;
 
     const std::vector<size_t>&                       triangleToCellIndex() const override;
     const std::vector<RivIntersectionVertexWeights>& triangleVxToCellCornerInterpolationWeights() const override;
@@ -116,5 +117,5 @@ private:
 
     std::vector<std::pair<QString, cvf::Vec3d>> m_faultMeshLabelAndAnchorPositions;
 
-    std::map<RimSurface*, std::vector<cvf::Vec3d>> m_transformedSurfaceIntersectionPolylines;
+    std::map<RimSurface*, RivSurfaceCurtainPolyline> m_transformedSurfaceIntersectionPolylines;
 };

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp
@@ -326,7 +326,7 @@ void RivExtrudedCurveIntersectionPartMgr::generatePartGeometry( cvf::UByteArray*
 
     applySingleColorEffect();
 
-    createAnnotationSurfaceParts( scaleTransform );
+    if ( scaleTransform ) createAnnotationSurfaceParts( *scaleTransform );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -603,7 +603,7 @@ void RivExtrudedCurveIntersectionPartMgr::createExtrusionDirParts( bool useBuffe
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RivExtrudedCurveIntersectionPartMgr::createAnnotationSurfaceParts( cvf::Transform* scaleTransform )
+void RivExtrudedCurveIntersectionPartMgr::createAnnotationSurfaceParts( cvf::Transform& scaleTransform )
 {
     m_annotationParts =
         RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersection->surfaceIntersectionCollection(),

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp
@@ -64,6 +64,7 @@
 #include "RivResultToTextureMapper.h"
 #include "RivScalarMapperUtils.h"
 #include "RivSimWellPipeSourceInfo.h"
+#include "RivSurfaceIntersectionCurveTools.h"
 #include "RivTernaryScalarMapper.h"
 #include "RivTernaryTextureCoordsCreator.h"
 #include "RivWellPathSourceInfo.h"
@@ -325,7 +326,7 @@ void RivExtrudedCurveIntersectionPartMgr::generatePartGeometry( cvf::UByteArray*
 
     applySingleColorEffect();
 
-    createAnnotationSurfaceParts( useBufferObjects, scaleTransform );
+    createAnnotationSurfaceParts( scaleTransform );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -602,199 +603,12 @@ void RivExtrudedCurveIntersectionPartMgr::createExtrusionDirParts( bool useBuffe
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RivExtrudedCurveIntersectionPartMgr::createAnnotationSurfaceParts( bool useBufferObjects, cvf::Transform* scaleTransform )
+void RivExtrudedCurveIntersectionPartMgr::createAnnotationSurfaceParts( cvf::Transform* scaleTransform )
 {
-    m_annotationParts.clear();
-
-    auto surfPolys = m_intersectionGenerator->transformedSurfaceIntersectionPolylines();
-
-    for ( auto curve : m_rimIntersection->surfaceIntersectionCurves() )
-    {
-        if ( !curve->isChecked() ) continue;
-
-        auto surface = curve->surface();
-        if ( !surface ) continue;
-
-        if ( surfPolys.count( surface ) == 0 ) continue;
-        auto polylines = surfPolys[surface];
-
-        auto part = createCurvePart( polylines,
-                                     useBufferObjects,
-                                     surface->fullName(),
-                                     curve->lineAppearance()->color(),
-                                     curve->lineAppearance()->thickness(),
-                                     scaleTransform );
-
-        if ( part.notNull() ) m_annotationParts.push_back( part.p() );
-    }
-
-    for ( auto band : m_rimIntersection->surfaceIntersectionBands() )
-    {
-        if ( !band->isChecked() ) continue;
-
-        auto surface1 = band->surface1();
-        auto surface2 = band->surface2();
-
-        if ( !surface1 || !surface2 ) continue;
-
-        if ( surfPolys.count( surface1 ) == 0 ) continue;
-        if ( surfPolys.count( surface2 ) == 0 ) continue;
-
-        auto polylineA = surfPolys[surface1];
-        auto polylineB = surfPolys[surface2];
-
-        // Create curve parts
-        {
-            auto part = createCurvePart( polylineA,
-                                         useBufferObjects,
-                                         surface1->fullName(),
-                                         band->lineAppearance()->color(),
-                                         band->lineAppearance()->thickness(),
-                                         scaleTransform );
-
-            if ( part.notNull() ) m_annotationParts.push_back( part.p() );
-        }
-        {
-            auto part = createCurvePart( polylineB,
-                                         useBufferObjects,
-                                         surface2->fullName(),
-                                         band->lineAppearance()->color(),
-                                         band->lineAppearance()->thickness(),
-                                         scaleTransform );
-
-            if ( part.notNull() ) m_annotationParts.push_back( part.p() );
-        }
-
-        // Create a quad strip between the two polylines
-        size_t pointCount = std::min( polylineA.size(), polylineB.size() );
-        if ( pointCount > 1 )
-        {
-            cvf::GeometryBuilderDrawableGeo geoBuilder;
-
-            for ( size_t i = 1; i < pointCount; i++ )
-            {
-                const auto& pA0 = polylineA[i - 1];
-                const auto& pA1 = polylineA[i];
-                const auto& pB0 = polylineB[i - 1];
-                const auto& pB1 = polylineB[i];
-
-                geoBuilder.addQuadByVertices( cvf::Vec3f( pA0 ), cvf::Vec3f( pA1 ), cvf::Vec3f( pB1 ), cvf::Vec3f( pB0 ) );
-            }
-
-            cvf::ref<cvf::DrawableGeo> geo = geoBuilder.drawableGeo();
-            if ( geo.notNull() )
-            {
-                geo->computeNormals();
-
-                if ( useBufferObjects )
-                {
-                    geo->setRenderMode( cvf::DrawableGeo::BUFFER_OBJECT );
-                }
-
-                cvf::ref<cvf::Part> part = new cvf::Part;
-                part->setName( "Surface Intersection Band" );
-                part->setDrawable( geo.p() );
-                part->updateBoundingBox();
-                part->setEnableMask( intersectionCellFaceBit );
-                part->setPriority( RivPartPriority::PartType::Transparent );
-
-                auto                        color = cvf::Color4f( band->bandColor(), band->bandOpacity() );
-                caf::SurfaceEffectGenerator geometryEffgen( color, caf::PO_NEG_LARGE );
-
-                cvf::ref<cvf::Effect> geometryOnlyEffect = geometryEffgen.generateUnCachedEffect();
-
-                {
-                    cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
-
-                    polyOffset->enableFillMode( true );
-
-                    // The factor value is defined by enums in
-                    // EffectGenerator::createAndConfigurePolygonOffsetRenderState() Use a factor that is more negative
-                    // than the existing enums
-                    const double offsetFactor = -5;
-                    polyOffset->setFactor( offsetFactor );
-
-                    polyOffset->setUnits( band->polygonOffsetUnit() );
-
-                    geometryOnlyEffect->setRenderState( polyOffset.p() );
-                }
-
-                part->setEffect( geometryOnlyEffect.p() );
-
-                m_annotationParts.push_back( part.p() );
-            }
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-cvf::ref<cvf::Part> RivExtrudedCurveIntersectionPartMgr::createCurvePart( const std::vector<cvf::Vec3d>& polylines,
-                                                                          bool                           useBufferObjects,
-                                                                          const QString&                 description,
-                                                                          const cvf::Color3f&            color,
-                                                                          float                          lineWidth,
-                                                                          cvf::Transform*                scaleTransform )
-{
-    auto polylineGeo = RivPolylineGenerator::createLineAlongPolylineDrawable( polylines );
-    if ( polylineGeo.notNull() )
-    {
-        if ( useBufferObjects )
-        {
-            polylineGeo->setRenderMode( cvf::DrawableGeo::BUFFER_OBJECT );
-        }
-
-        cvf::ref<cvf::Part> part = new cvf::Part;
-        part->setName( "Intersection " + description.toStdString() );
-        part->setDrawable( polylineGeo.p() );
-
-        part->updateBoundingBox();
-        part->setPriority( RivPartPriority::PartType::FaultMeshLines );
-
-        caf::MeshEffectGenerator lineEffGen( color );
-        lineEffGen.setLineWidth( lineWidth );
-
-        cvf::ref<cvf::Effect> eff = lineEffGen.generateUnCachedEffect();
-
-        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
-        polyOffset->enableFillMode( true );
-        polyOffset->setFactor( -5 );
-        const double maxOffsetFactor = -1000;
-        polyOffset->setUnits( maxOffsetFactor );
-
-        eff->setRenderState( polyOffset.p() );
-
-        part->setEffect( eff.p() );
-
-        if ( part.notNull() && scaleTransform )
-        {
-            // The polylines are defined in the display coordinate system without Z-scaling. The z-scaling is applied to the visualization
-            // parts using Part::setTransform(Transform* transform)
-            // The annotation objects are defined by display coordinates, so apply the Z-scaling to the coordinates
-
-            std::vector<cvf::Vec3d> displayCoords;
-            const auto&             mat = scaleTransform->worldTransform();
-
-            for ( const auto& p : polylines )
-            {
-                displayCoords.push_back( p.getTransformedPoint( mat ) );
-            }
-
-            // Add annotation info to be used to display label in Rim3dView::onViewNavigationChanged()
-            // Set the source info on one part only, as this data is only used for display of labels
-            auto annoObj = new RivAnnotationSourceInfo( description.toStdString(), displayCoords );
-            annoObj->setLabelPositionStrategyHint( RivAnnotationTools::LabelPositionStrategy::RIGHT );
-            annoObj->setShowColor( true );
-            annoObj->setColor( color );
-
-            part->setSourceInfo( annoObj );
-        }
-
-        return part;
-    }
-
-    return nullptr;
+    m_annotationParts =
+        RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersection->surfaceIntersectionCollection(),
+                                                                 m_intersectionGenerator->transformedSurfaceIntersectionPolylines(),
+                                                                 scaleTransform );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.h
@@ -87,7 +87,7 @@ private:
     void createFaultLabelParts( const std::vector<std::pair<QString, cvf::Vec3d>>& labelAndAnchors );
     void createPolyLineParts( bool useBufferObjects );
     void createExtrusionDirParts( bool useBufferObjects );
-    void createAnnotationSurfaceParts( cvf::Transform* scaleTransform );
+    void createAnnotationSurfaceParts( cvf::Transform& scaleTransform );
 
 private:
     caf::PdmPointer<RimExtrudedCurveIntersection> m_rimIntersection;

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.h
@@ -87,14 +87,7 @@ private:
     void createFaultLabelParts( const std::vector<std::pair<QString, cvf::Vec3d>>& labelAndAnchors );
     void createPolyLineParts( bool useBufferObjects );
     void createExtrusionDirParts( bool useBufferObjects );
-    void createAnnotationSurfaceParts( bool useBufferObjects, cvf::Transform* scaleTransform );
-
-    cvf::ref<cvf::Part> createCurvePart( const std::vector<cvf::Vec3d>& polylines,
-                                         bool                           useBufferObjects,
-                                         const QString&                 description,
-                                         const cvf::Color3f&            color,
-                                         float                          lineWidth,
-                                         cvf::Transform*                scaleTransform );
+    void createAnnotationSurfaceParts( cvf::Transform* scaleTransform );
 
 private:
     caf::PdmPointer<RimExtrudedCurveIntersection> m_rimIntersection;

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionGeometryGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionGeometryGenerator.cpp
@@ -168,7 +168,7 @@ void RivIjkIntersectionGeometryGenerator::calculateArrays( cvf::UByteArray* visi
 
     const FaceType face = computeFace();
 
-    const auto visibleRange = m_intersectionDefinition->clampedCellRange();
+    const auto visibleRange = m_intersectionDefinition->clampedCellRange( m_mainGrid.p() );
     if ( !visibleRange ) return;
 
     cvf::ubyte faceVtxIdx[4];

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionGeometryGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionGeometryGenerator.cpp
@@ -148,42 +148,27 @@ void RivIjkIntersectionGeometryGenerator::calculateArrays( cvf::UByteArray* visi
     const size_t nk = m_mainGrid->cellCountK();
     if ( ni == 0 || nj == 0 || nk == 0 ) return;
 
-    // Determine which cell face the surface follows and the i/j/k loop bounds
+    // Determine which cell face the surface follows
     RimIjkIntersection::GridAxis axis = m_intersectionDefinition->axis();
     bool                         neg  = m_intersectionDefinition->useNegativeFace();
 
-    const RigBoundingBoxIjk<caf::VecIjk0> range = m_intersectionDefinition->ijkRange();
-
-    // Snap the fixed index into the grid so a stale project file still renders the border slice
-    const size_t fixed = static_cast<size_t>( std::max( 0, m_intersectionDefinition->fixedIndex() ) );
-
-    // Pick the cell face the surface follows and collapse the fixed axis of the range to the fixed index.
-    // The i()/j()/k() accessors are read-only, so the assignments must use x()/y()/z()
-    auto computeFaceAndRange = [&]() -> std::pair<FaceType, RigBoundingBoxIjk<caf::VecIjk0>>
+    auto computeFace = [&]() -> FaceType
     {
-        caf::VecIjk0 min = range.min();
-        caf::VecIjk0 max = range.max();
-
         switch ( axis )
         {
             case RimIjkIntersection::GridAxis::AXIS_I:
-                min.x() = max.x() = std::min( fixed, ni - 1 );
-                return { neg ? FaceType::NEG_I : FaceType::POS_I, { min, max } };
+                return neg ? FaceType::NEG_I : FaceType::POS_I;
             case RimIjkIntersection::GridAxis::AXIS_J:
-                min.y() = max.y() = std::min( fixed, nj - 1 );
-                return { neg ? FaceType::NEG_J : FaceType::POS_J, { min, max } };
+                return neg ? FaceType::NEG_J : FaceType::POS_J;
             case RimIjkIntersection::GridAxis::AXIS_K:
             default:
-                min.z() = max.z() = std::min( fixed, nk - 1 );
-                return { neg ? FaceType::NEG_K : FaceType::POS_K, { min, max } };
+                return neg ? FaceType::NEG_K : FaceType::POS_K;
         }
     };
 
-    const auto [face, requestedRange] = computeFaceAndRange();
+    const FaceType face = computeFace();
 
-    const RigBoundingBoxIjk<caf::VecIjk0> gridBounds( caf::VecIjk0::ZERO, caf::VecIjk0( ni - 1, nj - 1, nk - 1 ) );
-
-    const auto visibleRange = requestedRange.clamp( gridBounds );
+    const auto visibleRange = m_intersectionDefinition->clampedCellRange();
     if ( !visibleRange ) return;
 
     cvf::ubyte faceVtxIdx[4];

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionPartMgr.cpp
@@ -147,7 +147,7 @@ void RivIjkIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCe
         }
     }
 
-    m_annotationParts = RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersection, scaleTransform );
+    if ( scaleTransform ) m_annotationParts = RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersection, *scaleTransform );
 
     updatePartEffect();
 }

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionPartMgr.cpp
@@ -30,6 +30,7 @@
 #include "RivMeshLinesSourceInfo.h"
 #include "RivPartPriority.h"
 #include "RivScalarMapperUtils.h"
+#include "RivSurfaceIntersectionCurveTools.h"
 
 #include "cafEffectGenerator.h"
 
@@ -91,7 +92,7 @@ void RivIjkIntersectionPartMgr::updateCellResultColor( int timeStepIndex )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RivIjkIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCells )
+void RivIjkIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCells, cvf::Transform* scaleTransform )
 {
     bool useBufferObjects = true;
     // Surface geometry
@@ -146,6 +147,8 @@ void RivIjkIntersectionPartMgr::generatePartGeometry( cvf::UByteArray* visibleCe
         }
     }
 
+    m_annotationParts = RivSurfaceIntersectionCurveTools::createAnnotationParts( m_rimIntersection, scaleTransform );
+
     updatePartEffect();
 }
 
@@ -194,6 +197,18 @@ void RivIjkIntersectionPartMgr::appendMeshLinePartsToModel( cvf::ModelBasicList*
     {
         m_intersectionGridLines->setTransform( scaleTransform );
         model->addPart( m_intersectionGridLines.p() );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RivIjkIntersectionPartMgr::appendAnnotationPartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform )
+{
+    for ( size_t i = 0; i < m_annotationParts.size(); i++ )
+    {
+        m_annotationParts[i]->setTransform( scaleTransform );
+        model->addPart( m_annotationParts.at( i ) );
     }
 }
 

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionPartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivIjkIntersectionPartMgr.h
@@ -20,6 +20,7 @@
 
 #include "RivIjkIntersectionGeometryGenerator.h"
 
+#include "cvfCollection.h"
 #include "cvfObject.h"
 
 namespace cvf
@@ -46,10 +47,11 @@ public:
 
     void appendNativeIntersectionFacesToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform );
     void appendMeshLinePartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform );
+    void appendAnnotationPartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform );
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const;
 
-    void generatePartGeometry( cvf::UByteArray* visibleCells );
+    void generatePartGeometry( cvf::UByteArray* visibleCells, cvf::Transform* scaleTransform );
 
 private:
     void updatePartEffect();
@@ -59,9 +61,10 @@ private:
 
     cvf::Color3f m_defaultColor;
 
-    cvf::ref<cvf::Part>       m_intersectionFaces;
-    cvf::ref<cvf::Part>       m_intersectionGridLines;
-    cvf::ref<cvf::Vec2fArray> m_intersectionFacesTextureCoords;
+    cvf::ref<cvf::Part>        m_intersectionFaces;
+    cvf::ref<cvf::Part>        m_intersectionGridLines;
+    cvf::Collection<cvf::Part> m_annotationParts;
+    cvf::ref<cvf::Vec2fArray>  m_intersectionFacesTextureCoords;
 
     cvf::ref<RivIjkIntersectionGeometryGenerator> m_intersectionGenerator;
 };

--- a/ApplicationLibCode/ModelVisualization/Surfaces/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/CMakeLists_files.cmake
@@ -2,6 +2,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RivSurfacePartMgr.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivSurfaceIntersectionGeometryGenerator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivReservoirSurfaceIntersectionSourceInfo.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RivSurfaceIntersectionCurveTools.cpp
 )
 
 list(APPEND CODE_SOURCE_FILES ${SOURCE_GROUP_SOURCE_FILES})

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
@@ -45,30 +45,78 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <utility>
 
 namespace
 {
 // Distance between the points the footprint is resampled to before the surface is looked up
 const double maxLineSegmentLength = 1.0;
 
+// Added to the extent a pillar is continued to, to keep a surface touching the end inside the search
+const double pillarExtensionMargin = 1.0;
+
 //--------------------------------------------------------------------------------------------------
-/// Move a point onto the pillar at the depth of the point, and report whether the depth is within the
-/// pillar at all. The surface lookup falls back to a search in the XY plane when the pillar misses the
-/// surface triangles, and that fallback keeps the XY of the top of the pillar and ignores the extent
-/// of the pillar. Without this the point ends up beside a tilted pillar, or outside a pillar that is
-/// bounded by the extent of the intersection.
+/// Move a point onto the line through the pillar, at the depth of the point. The point is allowed to
+/// fall outside the pillar itself, so a surface above or below the intersection is placed along the
+/// continuation of the pillar rather than beside it.
 //--------------------------------------------------------------------------------------------------
-bool projectOntoPillar( const cvf::Vec3d& pillarTop, const cvf::Vec3d& pillarBottom, cvf::Vec3d& point )
+cvf::Vec3d projectOntoPillarLine( const cvf::Vec3d& pillarTop, const cvf::Vec3d& pillarBottom, const cvf::Vec3d& point )
 {
     const double pillarHeight = pillarTop.z() - pillarBottom.z();
-    if ( std::fabs( pillarHeight ) < 1.0e-9 ) return true;
+    if ( std::fabs( pillarHeight ) < 1.0e-9 ) return point;
 
     const double t = ( pillarTop.z() - point.z() ) / pillarHeight;
-    if ( t < 0.0 || t > 1.0 ) return false;
 
-    point = pillarTop + t * ( pillarBottom - pillarTop );
+    return pillarTop + t * ( pillarBottom - pillarTop );
+}
 
-    return true;
+//--------------------------------------------------------------------------------------------------
+/// The depth range covered by a surface, used to decide how far a pillar has to be continued
+//--------------------------------------------------------------------------------------------------
+std::pair<double, double> surfaceZRange( RigSurface* surface )
+{
+    double lowZ  = std::numeric_limits<double>::max();
+    double highZ = -std::numeric_limits<double>::max();
+
+    for ( const auto& vertex : surface->vertices() )
+    {
+        lowZ  = std::min( lowZ, vertex.z() );
+        highZ = std::max( highZ, vertex.z() );
+    }
+
+    return { lowZ, highZ };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Find where the surface crosses the pillar. A surface that does not cross the curtain is estimated
+/// by continuing the pillar in both directions, keeping the tilt of the pillar, so the curve carries
+/// on past the extent of the intersection instead of stopping. The pillar is continued only as far as
+/// the surface reaches, to keep the search for candidate triangles small.
+//--------------------------------------------------------------------------------------------------
+bool findSurfacePointOnPillar( RigSurface*       surface,
+                               const cvf::Vec3d& pillarTop,
+                               const cvf::Vec3d& pillarBottom,
+                               double            surfaceLowZ,
+                               double            surfaceHighZ,
+                               cvf::Vec3d&       point )
+{
+    if ( RigSurfaceResampler::computeIntersectionWithLine( surface, pillarTop, pillarBottom, point ) ) return true;
+
+    if ( std::fabs( pillarTop.z() - pillarBottom.z() ) > 1.0e-9 )
+    {
+        const double searchHighZ = std::max( std::max( pillarTop.z(), pillarBottom.z() ), surfaceHighZ + pillarExtensionMargin );
+        const double searchLowZ  = std::min( std::min( pillarTop.z(), pillarBottom.z() ), surfaceLowZ - pillarExtensionMargin );
+
+        const cvf::Vec3d extendedTop    = projectOntoPillarLine( pillarTop, pillarBottom, cvf::Vec3d( 0.0, 0.0, searchHighZ ) );
+        const cvf::Vec3d extendedBottom = projectOntoPillarLine( pillarTop, pillarBottom, cvf::Vec3d( 0.0, 0.0, searchLowZ ) );
+
+        if ( RigSurfaceResampler::computeIntersectionWithLine( surface, extendedTop, extendedBottom, point ) ) return true;
+    }
+
+    // The surface may not cover this position at all. Search in the XY plane around the pillar itself, as
+    // a continued pillar would move the search away from the intersection.
+    return RigSurfaceResampler::findClosestPointOnSurface( surface, pillarTop, pillarBottom, point );
 }
 } // namespace
 
@@ -187,6 +235,8 @@ std::map<RimSurface*, RivSurfaceCurtainPolyline>
         curtainPolyline.points.reserve( resampledPillars.size() );
         curtainPolyline.valid.reserve( resampledPillars.size() );
 
+        const auto [surfaceLowZ, surfaceHighZ] = surfaceZRange( surface );
+
         bool anyValidPoint = false;
 
         for ( size_t i = 0; i < resampledPillars.size(); i++ )
@@ -194,9 +244,9 @@ std::map<RimSurface*, RivSurfaceCurtainPolyline>
             const auto& [pillarTop, pillarBottom] = resampledPillars[i];
 
             cvf::Vec3d intersectionPoint;
-            bool       isValid = RigSurfaceResampler::findClosestPointOnSurface( surface, pillarTop, pillarBottom, intersectionPoint );
+            bool       isValid = findSurfacePointOnPillar( surface, pillarTop, pillarBottom, surfaceLowZ, surfaceHighZ, intersectionPoint );
 
-            if ( isValid ) isValid = projectOntoPillar( pillarTop, pillarBottom, intersectionPoint );
+            if ( isValid ) intersectionPoint = projectOntoPillarLine( pillarTop, pillarBottom, intersectionPoint );
 
             // A point is always appended, also when the surface was not hit, to keep the two curves of a band index aligned
             curtainPolyline.points.push_back( pointTransform( intersectionPoint, segmentIndices[i] ) );

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
@@ -23,6 +23,9 @@
 
 #include "Rim3dView.h"
 #include "RimAnnotationLineAppearance.h"
+#include "RimCase.h"
+#include "RimGridView.h"
+#include "RimIntersection.h"
 #include "RimSurface.h"
 #include "RimSurfaceIntersectionBand.h"
 #include "RimSurfaceIntersectionCollection.h"
@@ -232,6 +235,36 @@ cvf::Collection<cvf::Part>
     }
 
     return parts;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createAnnotationParts( const RimIntersection* intersection,
+                                                                                    cvf::Transform*        scaleTransform )
+{
+    if ( !intersection || !intersection->supportsSurfaceIntersectionCurves() ) return {};
+
+    const auto surfaces = referencedSurfaces( intersection->surfaceIntersectionCollection() );
+    if ( surfaces.empty() ) return {};
+
+    const auto footprint = intersection->surfaceCurtainFootprint();
+    if ( footprint.size() < 2 ) return {};
+
+    // The visualization parts are built in display coordinates
+    cvf::Vec3d displayOffset( 0.0, 0.0, 0.0 );
+    {
+        auto gridView = intersection->firstAncestorOrThisOfType<RimGridView>();
+        if ( gridView && gridView->ownerCase() ) displayOffset = gridView->ownerCase()->displayModelOffset();
+    }
+
+    const auto [minZ, maxZ] = intersection->surfaceCurtainZRange();
+
+    auto pointTransform = [displayOffset]( const cvf::Vec3d& point, size_t segmentIndex ) { return point - displayOffset; };
+
+    const auto surfacePolylines = computeSurfaceCurtainPolylines( surfaces, footprint, minZ, maxZ, pointTransform );
+
+    return createAnnotationParts( intersection->surfaceIntersectionCollection(), surfacePolylines, scaleTransform );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
@@ -74,12 +74,12 @@ cvf::Vec3d projectOntoPillarLine( const cvf::Vec3d& pillarTop, const cvf::Vec3d&
 //--------------------------------------------------------------------------------------------------
 /// The depth range covered by a surface, used to decide how far a pillar has to be continued
 //--------------------------------------------------------------------------------------------------
-std::pair<double, double> surfaceZRange( RigSurface* surface )
+std::pair<double, double> surfaceZRange( const RigSurface& surface )
 {
     double lowZ  = std::numeric_limits<double>::max();
     double highZ = -std::numeric_limits<double>::max();
 
-    for ( const auto& vertex : surface->vertices() )
+    for ( const auto& vertex : surface.vertices() )
     {
         lowZ  = std::min( lowZ, vertex.z() );
         highZ = std::max( highZ, vertex.z() );
@@ -94,14 +94,14 @@ std::pair<double, double> surfaceZRange( RigSurface* surface )
 /// on past the extent of the intersection instead of stopping. The pillar is continued only as far as
 /// the surface reaches, to keep the search for candidate triangles small.
 //--------------------------------------------------------------------------------------------------
-bool findSurfacePointOnPillar( RigSurface*       surface,
+bool findSurfacePointOnPillar( RigSurface&       surface,
                                const cvf::Vec3d& pillarTop,
                                const cvf::Vec3d& pillarBottom,
                                double            surfaceLowZ,
                                double            surfaceHighZ,
                                cvf::Vec3d&       point )
 {
-    if ( RigSurfaceResampler::computeIntersectionWithLine( surface, pillarTop, pillarBottom, point ) ) return true;
+    if ( RigSurfaceResampler::computeIntersectionWithLine( &surface, pillarTop, pillarBottom, point ) ) return true;
 
     if ( std::fabs( pillarTop.z() - pillarBottom.z() ) > 1.0e-9 )
     {
@@ -111,12 +111,12 @@ bool findSurfacePointOnPillar( RigSurface*       surface,
         const cvf::Vec3d extendedTop    = projectOntoPillarLine( pillarTop, pillarBottom, cvf::Vec3d( 0.0, 0.0, searchHighZ ) );
         const cvf::Vec3d extendedBottom = projectOntoPillarLine( pillarTop, pillarBottom, cvf::Vec3d( 0.0, 0.0, searchLowZ ) );
 
-        if ( RigSurfaceResampler::computeIntersectionWithLine( surface, extendedTop, extendedBottom, point ) ) return true;
+        if ( RigSurfaceResampler::computeIntersectionWithLine( &surface, extendedTop, extendedBottom, point ) ) return true;
     }
 
     // The surface may not cover this position at all. Search in the XY plane around the pillar itself, as
     // a continued pillar would move the search away from the intersection.
-    return RigSurfaceResampler::findClosestPointOnSurface( surface, pillarTop, pillarBottom, point );
+    return RigSurfaceResampler::findClosestPointOnSurface( &surface, pillarTop, pillarBottom, point );
 }
 } // namespace
 
@@ -128,11 +128,11 @@ std::vector<std::vector<cvf::Vec3d>> RivSurfaceCurtainPolyline::validRuns() cons
     std::vector<std::vector<cvf::Vec3d>> runs;
 
     std::vector<cvf::Vec3d> currentRun;
-    for ( size_t i = 0; i < points.size(); i++ )
+    for ( const auto& point : points )
     {
-        if ( valid[i] )
+        if ( !point.isUndefined() )
         {
-            currentRun.push_back( points[i] );
+            currentRun.push_back( point );
         }
         else if ( currentRun.size() > 1 )
         {
@@ -233,9 +233,8 @@ std::map<RimSurface*, RivSurfaceCurtainPolyline>
 
         RivSurfaceCurtainPolyline curtainPolyline;
         curtainPolyline.points.reserve( resampledPillars.size() );
-        curtainPolyline.valid.reserve( resampledPillars.size() );
 
-        const auto [surfaceLowZ, surfaceHighZ] = surfaceZRange( surface );
+        const auto [surfaceLowZ, surfaceHighZ] = surfaceZRange( *surface );
 
         bool anyValidPoint = false;
 
@@ -244,13 +243,19 @@ std::map<RimSurface*, RivSurfaceCurtainPolyline>
             const auto& [pillarTop, pillarBottom] = resampledPillars[i];
 
             cvf::Vec3d intersectionPoint;
-            bool       isValid = findSurfacePointOnPillar( surface, pillarTop, pillarBottom, surfaceLowZ, surfaceHighZ, intersectionPoint );
-
-            if ( isValid ) intersectionPoint = projectOntoPillarLine( pillarTop, pillarBottom, intersectionPoint );
+            const bool isValid = findSurfacePointOnPillar( *surface, pillarTop, pillarBottom, surfaceLowZ, surfaceHighZ, intersectionPoint );
 
             // A point is always appended, also when the surface was not hit, to keep the two curves of a band index aligned
-            curtainPolyline.points.push_back( pointTransform( intersectionPoint, segmentIndices[i] ) );
-            curtainPolyline.valid.push_back( isValid );
+            if ( isValid )
+            {
+                intersectionPoint = pointTransform( projectOntoPillarLine( pillarTop, pillarBottom, intersectionPoint ), segmentIndices[i] );
+            }
+            else
+            {
+                intersectionPoint = cvf::Vec3d::UNDEFINED;
+            }
+
+            curtainPolyline.points.push_back( intersectionPoint );
 
             anyValidPoint = anyValidPoint || isValid;
         }
@@ -267,7 +272,7 @@ std::map<RimSurface*, RivSurfaceCurtainPolyline>
 cvf::Collection<cvf::Part>
     RivSurfaceIntersectionCurveTools::createAnnotationParts( const RimSurfaceIntersectionCollection*                 surfaceIntersections,
                                                              const std::map<RimSurface*, RivSurfaceCurtainPolyline>& surfacePolylines,
-                                                             cvf::Transform*                                         scaleTransform )
+                                                             cvf::Transform&                                         scaleTransform )
 {
     cvf::Collection<cvf::Part> parts;
 
@@ -333,7 +338,7 @@ cvf::Collection<cvf::Part>
 ///
 //--------------------------------------------------------------------------------------------------
 cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createAnnotationParts( const RimIntersection* intersection,
-                                                                                    cvf::Transform*        scaleTransform )
+                                                                                    cvf::Transform&        scaleTransform )
 {
     if ( !intersection || !intersection->supportsSurfaceIntersectionCurves() ) return {};
 
@@ -364,7 +369,7 @@ cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createCurveParts( c
                                                                                const QString&                   description,
                                                                                const cvf::Color3f&              color,
                                                                                float                            lineWidth,
-                                                                               cvf::Transform*                  scaleTransform )
+                                                                               cvf::Transform&                  scaleTransform )
 {
     cvf::Collection<cvf::Part> parts;
 
@@ -378,17 +383,13 @@ cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createCurveParts( c
         part->setName( "Intersection " + description.toStdString() );
         parts.push_back( part.p() );
 
-        if ( scaleTransform )
+        // The polylines are defined in the display coordinate system without Z-scaling. The z-scaling is applied to the
+        // visualization parts using Part::setTransform(Transform* transform)
+        // The annotation objects are defined by display coordinates, so apply the Z-scaling to the coordinates
+        const auto& mat = scaleTransform.worldTransform();
+        for ( const auto& p : run )
         {
-            // The polylines are defined in the display coordinate system without Z-scaling. The z-scaling is applied to the
-            // visualization parts using Part::setTransform(Transform* transform)
-            // The annotation objects are defined by display coordinates, so apply the Z-scaling to the coordinates
-
-            const auto& mat = scaleTransform->worldTransform();
-            for ( const auto& p : run )
-            {
-                allDisplayCoords.push_back( p.getTransformedPoint( mat ) );
-            }
+            allDisplayCoords.push_back( p.getTransformedPoint( mat ) );
         }
     }
 
@@ -459,14 +460,14 @@ cvf::ref<cvf::Part> RivSurfaceIntersectionCurveTools::createBandPart( const RivS
     bool anyQuad = false;
     for ( size_t i = 1; i < pointCount; i++ )
     {
-        // A quad requires both surfaces to be present at both ends of the segment
-        if ( !polylineA.valid[i - 1] || !polylineA.valid[i] ) continue;
-        if ( !polylineB.valid[i - 1] || !polylineB.valid[i] ) continue;
-
         const auto& pA0 = polylineA.points[i - 1];
         const auto& pA1 = polylineA.points[i];
         const auto& pB0 = polylineB.points[i - 1];
         const auto& pB1 = polylineB.points[i];
+
+        // A quad requires both surfaces to be present at both ends of the segment
+        if ( pA0.isUndefined() || pA1.isUndefined() ) continue;
+        if ( pB0.isUndefined() || pB1.isUndefined() ) continue;
 
         geoBuilder.addQuadByVertices( cvf::Vec3f( pA0 ), cvf::Vec3f( pA1 ), cvf::Vec3f( pB1 ), cvf::Vec3f( pB0 ) );
         anyQuad = true;

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
@@ -1,0 +1,389 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RivSurfaceIntersectionCurveTools.h"
+
+#include "Surface/RigSurface.h"
+#include "Surface/RigSurfaceResampler.h"
+
+#include "Rim3dView.h"
+#include "RimAnnotationLineAppearance.h"
+#include "RimSurface.h"
+#include "RimSurfaceIntersectionBand.h"
+#include "RimSurfaceIntersectionCollection.h"
+#include "RimSurfaceIntersectionCurve.h"
+
+#include "RivAnnotationSourceInfo.h"
+#include "RivPartPriority.h"
+#include "RivPolylineGenerator.h"
+
+#include "cafEffectGenerator.h"
+
+#include "cvfDrawableGeo.h"
+#include "cvfGeometryBuilderDrawableGeo.h"
+#include "cvfPart.h"
+#include "cvfRenderStatePolygonOffset.h"
+#include "cvfTransform.h"
+
+#include <algorithm>
+
+namespace
+{
+// Distance between the points the footprint is resampled to before the surface is looked up
+const double maxLineSegmentLength = 1.0;
+
+// The vertical ray used to find the surface is made long enough to cover any reservoir depth
+const double verticalRayExtent = 10000.0;
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<std::vector<cvf::Vec3d>> RivSurfaceCurtainPolyline::validRuns() const
+{
+    std::vector<std::vector<cvf::Vec3d>> runs;
+
+    std::vector<cvf::Vec3d> currentRun;
+    for ( size_t i = 0; i < points.size(); i++ )
+    {
+        if ( valid[i] )
+        {
+            currentRun.push_back( points[i] );
+        }
+        else if ( currentRun.size() > 1 )
+        {
+            runs.push_back( currentRun );
+            currentRun.clear();
+        }
+        else
+        {
+            currentRun.clear();
+        }
+    }
+
+    if ( currentRun.size() > 1 ) runs.push_back( currentRun );
+
+    return runs;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimSurface*> RivSurfaceIntersectionCurveTools::referencedSurfaces( const RimSurfaceIntersectionCollection* surfaceIntersections )
+{
+    if ( !surfaceIntersections ) return {};
+
+    std::vector<RimSurface*> surfaces;
+
+    auto appendSurface = [&surfaces]( RimSurface* surface )
+    {
+        if ( !surface ) return;
+        if ( std::find( surfaces.begin(), surfaces.end(), surface ) != surfaces.end() ) return;
+
+        surfaces.push_back( surface );
+    };
+
+    for ( auto curve : surfaceIntersections->surfaceIntersectionCurves() )
+    {
+        appendSurface( curve->surface() );
+    }
+
+    for ( auto band : surfaceIntersections->surfaceIntersectionBands() )
+    {
+        appendSurface( band->surface1() );
+        appendSurface( band->surface2() );
+    }
+
+    return surfaces;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::map<RimSurface*, RivSurfaceCurtainPolyline>
+    RivSurfaceIntersectionCurveTools::computeSurfaceCurtainPolylines( const std::vector<RimSurface*>& surfaces,
+                                                                      const std::vector<cvf::Vec3d>&  footprintPolyline,
+                                                                      double                          minZ,
+                                                                      double                          maxZ,
+                                                                      const std::function<cvf::Vec3d( const cvf::Vec3d&, size_t )>& pointTransform )
+{
+    std::map<RimSurface*, RivSurfaceCurtainPolyline> surfacePolylines;
+
+    if ( footprintPolyline.size() < 2 ) return surfacePolylines;
+
+    const auto resampledPolyline = RigSurfaceResampler::computeResampledPolylineWithSegmentInfo( footprintPolyline, maxLineSegmentLength );
+    if ( resampledPolyline.empty() ) return surfacePolylines;
+
+    for ( auto rimSurface : surfaces )
+    {
+        if ( !rimSurface ) continue;
+
+        rimSurface->loadDataIfRequired();
+        auto surface = rimSurface->surfaceData();
+        if ( !surface ) continue;
+
+        RivSurfaceCurtainPolyline curtainPolyline;
+        curtainPolyline.points.reserve( resampledPolyline.size() );
+        curtainPolyline.valid.reserve( resampledPolyline.size() );
+
+        bool anyValidPoint = false;
+
+        for ( const auto& [point, segmentIndex] : resampledPolyline )
+        {
+            cvf::Vec3d pointAbove = cvf::Vec3d( point.x(), point.y(), verticalRayExtent );
+            cvf::Vec3d pointBelow = cvf::Vec3d( point.x(), point.y(), -verticalRayExtent );
+
+            cvf::Vec3d intersectionPoint;
+            bool       foundMatch = RigSurfaceResampler::findClosestPointOnSurface( surface, pointAbove, pointBelow, intersectionPoint );
+
+            bool isValid = foundMatch && intersectionPoint.z() >= minZ && intersectionPoint.z() <= maxZ;
+
+            // A point is always appended, also when the surface was not hit, to keep the two curves of a band index aligned
+            curtainPolyline.points.push_back( pointTransform( intersectionPoint, segmentIndex ) );
+            curtainPolyline.valid.push_back( isValid );
+
+            anyValidPoint = anyValidPoint || isValid;
+        }
+
+        if ( anyValidPoint ) surfacePolylines[rimSurface] = curtainPolyline;
+    }
+
+    return surfacePolylines;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+cvf::Collection<cvf::Part>
+    RivSurfaceIntersectionCurveTools::createAnnotationParts( const RimSurfaceIntersectionCollection*                 surfaceIntersections,
+                                                             const std::map<RimSurface*, RivSurfaceCurtainPolyline>& surfacePolylines,
+                                                             cvf::Transform*                                         scaleTransform )
+{
+    cvf::Collection<cvf::Part> parts;
+
+    if ( !surfaceIntersections ) return parts;
+
+    auto appendParts = [&parts]( cvf::Collection<cvf::Part>& partsToAppend )
+    {
+        for ( size_t i = 0; i < partsToAppend.size(); i++ )
+        {
+            parts.push_back( partsToAppend.at( i ) );
+        }
+    };
+
+    for ( auto curve : surfaceIntersections->surfaceIntersectionCurves() )
+    {
+        if ( !curve->isChecked() ) continue;
+
+        auto surface = curve->surface();
+        if ( !surface ) continue;
+
+        auto it = surfacePolylines.find( surface );
+        if ( it == surfacePolylines.end() ) continue;
+
+        auto curveParts = createCurveParts( it->second,
+                                            surface->fullName(),
+                                            curve->lineAppearance()->color(),
+                                            curve->lineAppearance()->thickness(),
+                                            scaleTransform );
+        appendParts( curveParts );
+    }
+
+    for ( auto band : surfaceIntersections->surfaceIntersectionBands() )
+    {
+        if ( !band->isChecked() ) continue;
+
+        auto surface1 = band->surface1();
+        auto surface2 = band->surface2();
+        if ( !surface1 || !surface2 ) continue;
+
+        auto it1 = surfacePolylines.find( surface1 );
+        auto it2 = surfacePolylines.find( surface2 );
+        if ( it1 == surfacePolylines.end() || it2 == surfacePolylines.end() ) continue;
+
+        const auto& polylineA = it1->second;
+        const auto& polylineB = it2->second;
+
+        auto curvePartsA =
+            createCurveParts( polylineA, surface1->fullName(), band->lineAppearance()->color(), band->lineAppearance()->thickness(), scaleTransform );
+        appendParts( curvePartsA );
+
+        auto curvePartsB =
+            createCurveParts( polylineB, surface2->fullName(), band->lineAppearance()->color(), band->lineAppearance()->thickness(), scaleTransform );
+        appendParts( curvePartsB );
+
+        auto bandPart = createBandPart( polylineA, polylineB, band->bandColor(), band->bandOpacity(), band->polygonOffsetUnit() );
+        if ( bandPart.notNull() ) parts.push_back( bandPart.p() );
+    }
+
+    return parts;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createCurveParts( const RivSurfaceCurtainPolyline& polyline,
+                                                                               const QString&                   description,
+                                                                               const cvf::Color3f&              color,
+                                                                               float                            lineWidth,
+                                                                               cvf::Transform*                  scaleTransform )
+{
+    cvf::Collection<cvf::Part> parts;
+
+    std::vector<cvf::Vec3d> allDisplayCoords;
+
+    for ( const auto& run : polyline.validRuns() )
+    {
+        auto part = createCurvePart( run, color, lineWidth );
+        if ( part.isNull() ) continue;
+
+        part->setName( "Intersection " + description.toStdString() );
+        parts.push_back( part.p() );
+
+        if ( scaleTransform )
+        {
+            // The polylines are defined in the display coordinate system without Z-scaling. The z-scaling is applied to the
+            // visualization parts using Part::setTransform(Transform* transform)
+            // The annotation objects are defined by display coordinates, so apply the Z-scaling to the coordinates
+
+            const auto& mat = scaleTransform->worldTransform();
+            for ( const auto& p : run )
+            {
+                allDisplayCoords.push_back( p.getTransformedPoint( mat ) );
+            }
+        }
+    }
+
+    if ( !parts.empty() && !allDisplayCoords.empty() )
+    {
+        // Add annotation info to be used to display label in Rim3dView::onViewNavigationChanged()
+        // Set the source info on one part only, as this data is only used for display of labels
+        auto annoObj = new RivAnnotationSourceInfo( description.toStdString(), allDisplayCoords );
+        annoObj->setLabelPositionStrategyHint( RivAnnotationTools::LabelPositionStrategy::RIGHT );
+        annoObj->setShowColor( true );
+        annoObj->setColor( color );
+
+        parts[0]->setSourceInfo( annoObj );
+    }
+
+    return parts;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+cvf::ref<cvf::Part>
+    RivSurfaceIntersectionCurveTools::createCurvePart( const std::vector<cvf::Vec3d>& polyline, const cvf::Color3f& color, float lineWidth )
+{
+    auto polylineGeo = RivPolylineGenerator::createLineAlongPolylineDrawable( polyline );
+    if ( polylineGeo.isNull() ) return nullptr;
+
+    polylineGeo->setRenderMode( cvf::DrawableGeo::BUFFER_OBJECT );
+
+    cvf::ref<cvf::Part> part = new cvf::Part;
+    part->setDrawable( polylineGeo.p() );
+
+    part->updateBoundingBox();
+    part->setPriority( RivPartPriority::PartType::FaultMeshLines );
+
+    caf::MeshEffectGenerator lineEffGen( color );
+    lineEffGen.setLineWidth( lineWidth );
+
+    cvf::ref<cvf::Effect> eff = lineEffGen.generateUnCachedEffect();
+
+    cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
+    polyOffset->enableFillMode( true );
+    polyOffset->setFactor( -5 );
+    const double maxOffsetFactor = -1000;
+    polyOffset->setUnits( maxOffsetFactor );
+
+    eff->setRenderState( polyOffset.p() );
+
+    part->setEffect( eff.p() );
+
+    return part;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+cvf::ref<cvf::Part> RivSurfaceIntersectionCurveTools::createBandPart( const RivSurfaceCurtainPolyline& polylineA,
+                                                                      const RivSurfaceCurtainPolyline& polylineB,
+                                                                      const cvf::Color3f&              color,
+                                                                      float                            opacity,
+                                                                      double                           polygonOffsetUnit )
+{
+    const size_t pointCount = std::min( polylineA.points.size(), polylineB.points.size() );
+    if ( pointCount < 2 ) return nullptr;
+
+    cvf::GeometryBuilderDrawableGeo geoBuilder;
+
+    bool anyQuad = false;
+    for ( size_t i = 1; i < pointCount; i++ )
+    {
+        // A quad requires both surfaces to be present at both ends of the segment
+        if ( !polylineA.valid[i - 1] || !polylineA.valid[i] ) continue;
+        if ( !polylineB.valid[i - 1] || !polylineB.valid[i] ) continue;
+
+        const auto& pA0 = polylineA.points[i - 1];
+        const auto& pA1 = polylineA.points[i];
+        const auto& pB0 = polylineB.points[i - 1];
+        const auto& pB1 = polylineB.points[i];
+
+        geoBuilder.addQuadByVertices( cvf::Vec3f( pA0 ), cvf::Vec3f( pA1 ), cvf::Vec3f( pB1 ), cvf::Vec3f( pB0 ) );
+        anyQuad = true;
+    }
+
+    if ( !anyQuad ) return nullptr;
+
+    cvf::ref<cvf::DrawableGeo> geo = geoBuilder.drawableGeo();
+    if ( geo.isNull() ) return nullptr;
+
+    geo->computeNormals();
+    geo->setRenderMode( cvf::DrawableGeo::BUFFER_OBJECT );
+
+    cvf::ref<cvf::Part> part = new cvf::Part;
+    part->setName( "Surface Intersection Band" );
+    part->setDrawable( geo.p() );
+    part->updateBoundingBox();
+    part->setEnableMask( intersectionCellFaceBit );
+    part->setPriority( RivPartPriority::PartType::Transparent );
+
+    caf::SurfaceEffectGenerator geometryEffgen( cvf::Color4f( color, opacity ), caf::PO_NEG_LARGE );
+
+    cvf::ref<cvf::Effect> geometryOnlyEffect = geometryEffgen.generateUnCachedEffect();
+
+    {
+        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
+
+        polyOffset->enableFillMode( true );
+
+        // The factor value is defined by enums in EffectGenerator::createAndConfigurePolygonOffsetRenderState()
+        // Use a factor that is more negative than the existing enums
+        const double offsetFactor = -5;
+        polyOffset->setFactor( offsetFactor );
+
+        polyOffset->setUnits( polygonOffsetUnit );
+
+        geometryOnlyEffect->setRenderState( polyOffset.p() );
+    }
+
+    part->setEffect( geometryOnlyEffect.p() );
+
+    return part;
+}

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.cpp
@@ -44,14 +44,32 @@
 #include "cvfTransform.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace
 {
 // Distance between the points the footprint is resampled to before the surface is looked up
 const double maxLineSegmentLength = 1.0;
 
-// The vertical ray used to find the surface is made long enough to cover any reservoir depth
-const double verticalRayExtent = 10000.0;
+//--------------------------------------------------------------------------------------------------
+/// Move a point onto the pillar at the depth of the point, and report whether the depth is within the
+/// pillar at all. The surface lookup falls back to a search in the XY plane when the pillar misses the
+/// surface triangles, and that fallback keeps the XY of the top of the pillar and ignores the extent
+/// of the pillar. Without this the point ends up beside a tilted pillar, or outside a pillar that is
+/// bounded by the extent of the intersection.
+//--------------------------------------------------------------------------------------------------
+bool projectOntoPillar( const cvf::Vec3d& pillarTop, const cvf::Vec3d& pillarBottom, cvf::Vec3d& point )
+{
+    const double pillarHeight = pillarTop.z() - pillarBottom.z();
+    if ( std::fabs( pillarHeight ) < 1.0e-9 ) return true;
+
+    const double t = ( pillarTop.z() - point.z() ) / pillarHeight;
+    if ( t < 0.0 || t > 1.0 ) return false;
+
+    point = pillarTop + t * ( pillarBottom - pillarTop );
+
+    return true;
+}
 } // namespace
 
 //--------------------------------------------------------------------------------------------------
@@ -120,17 +138,42 @@ std::vector<RimSurface*> RivSurfaceIntersectionCurveTools::referencedSurfaces( c
 //--------------------------------------------------------------------------------------------------
 std::map<RimSurface*, RivSurfaceCurtainPolyline>
     RivSurfaceIntersectionCurveTools::computeSurfaceCurtainPolylines( const std::vector<RimSurface*>& surfaces,
-                                                                      const std::vector<cvf::Vec3d>&  footprintPolyline,
-                                                                      double                          minZ,
-                                                                      double                          maxZ,
+                                                                      const RimIntersectionCurtain&   curtain,
                                                                       const std::function<cvf::Vec3d( const cvf::Vec3d&, size_t )>& pointTransform )
 {
     std::map<RimSurface*, RivSurfaceCurtainPolyline> surfacePolylines;
 
-    if ( footprintPolyline.size() < 2 ) return surfacePolylines;
+    if ( !curtain.isValid() ) return surfacePolylines;
 
-    const auto resampledPolyline = RigSurfaceResampler::computeResampledPolylineWithSegmentInfo( footprintPolyline, maxLineSegmentLength );
-    if ( resampledPolyline.empty() ) return surfacePolylines;
+    const auto resampledTrace = RigSurfaceResampler::computeResampledPolylineWithSegmentInfo( curtain.trace, maxLineSegmentLength );
+    if ( resampledTrace.empty() ) return surfacePolylines;
+
+    // Both ends of a pillar are interpolated using the position of the resampled point within its trace
+    // segment, so a resampled pillar stays on the curtain
+    std::vector<std::pair<cvf::Vec3d, cvf::Vec3d>> resampledPillars;
+    std::vector<size_t>                            segmentIndices;
+    resampledPillars.reserve( resampledTrace.size() );
+    segmentIndices.reserve( resampledTrace.size() );
+
+    for ( const auto& [point, segmentIndex] : resampledTrace )
+    {
+        if ( segmentIndex + 1 >= curtain.pillars.size() ) continue;
+
+        const auto& traceStart = curtain.trace[segmentIndex];
+        const auto& traceEnd   = curtain.trace[segmentIndex + 1];
+
+        const double segmentLength = ( traceEnd - traceStart ).length();
+        const double t             = segmentLength > 0.0 ? std::clamp( ( point - traceStart ).length() / segmentLength, 0.0, 1.0 ) : 0.0;
+
+        const auto& pillarStart = curtain.pillars[segmentIndex];
+        const auto& pillarEnd   = curtain.pillars[segmentIndex + 1];
+
+        const cvf::Vec3d top    = pillarStart.first + t * ( pillarEnd.first - pillarStart.first );
+        const cvf::Vec3d bottom = pillarStart.second + t * ( pillarEnd.second - pillarStart.second );
+
+        resampledPillars.emplace_back( top, bottom );
+        segmentIndices.push_back( segmentIndex );
+    }
 
     for ( auto rimSurface : surfaces )
     {
@@ -141,23 +184,22 @@ std::map<RimSurface*, RivSurfaceCurtainPolyline>
         if ( !surface ) continue;
 
         RivSurfaceCurtainPolyline curtainPolyline;
-        curtainPolyline.points.reserve( resampledPolyline.size() );
-        curtainPolyline.valid.reserve( resampledPolyline.size() );
+        curtainPolyline.points.reserve( resampledPillars.size() );
+        curtainPolyline.valid.reserve( resampledPillars.size() );
 
         bool anyValidPoint = false;
 
-        for ( const auto& [point, segmentIndex] : resampledPolyline )
+        for ( size_t i = 0; i < resampledPillars.size(); i++ )
         {
-            cvf::Vec3d pointAbove = cvf::Vec3d( point.x(), point.y(), verticalRayExtent );
-            cvf::Vec3d pointBelow = cvf::Vec3d( point.x(), point.y(), -verticalRayExtent );
+            const auto& [pillarTop, pillarBottom] = resampledPillars[i];
 
             cvf::Vec3d intersectionPoint;
-            bool       foundMatch = RigSurfaceResampler::findClosestPointOnSurface( surface, pointAbove, pointBelow, intersectionPoint );
+            bool       isValid = RigSurfaceResampler::findClosestPointOnSurface( surface, pillarTop, pillarBottom, intersectionPoint );
 
-            bool isValid = foundMatch && intersectionPoint.z() >= minZ && intersectionPoint.z() <= maxZ;
+            if ( isValid ) isValid = projectOntoPillar( pillarTop, pillarBottom, intersectionPoint );
 
             // A point is always appended, also when the surface was not hit, to keep the two curves of a band index aligned
-            curtainPolyline.points.push_back( pointTransform( intersectionPoint, segmentIndex ) );
+            curtainPolyline.points.push_back( pointTransform( intersectionPoint, segmentIndices[i] ) );
             curtainPolyline.valid.push_back( isValid );
 
             anyValidPoint = anyValidPoint || isValid;
@@ -248,8 +290,8 @@ cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createAnnotationPar
     const auto surfaces = referencedSurfaces( intersection->surfaceIntersectionCollection() );
     if ( surfaces.empty() ) return {};
 
-    const auto footprint = intersection->surfaceCurtainFootprint();
-    if ( footprint.size() < 2 ) return {};
+    const auto curtain = intersection->surfaceCurtain();
+    if ( !curtain.isValid() ) return {};
 
     // The visualization parts are built in display coordinates
     cvf::Vec3d displayOffset( 0.0, 0.0, 0.0 );
@@ -258,11 +300,9 @@ cvf::Collection<cvf::Part> RivSurfaceIntersectionCurveTools::createAnnotationPar
         if ( gridView && gridView->ownerCase() ) displayOffset = gridView->ownerCase()->displayModelOffset();
     }
 
-    const auto [minZ, maxZ] = intersection->surfaceCurtainZRange();
-
     auto pointTransform = [displayOffset]( const cvf::Vec3d& point, size_t segmentIndex ) { return point - displayOffset; };
 
-    const auto surfacePolylines = computeSurfaceCurtainPolylines( surfaces, footprint, minZ, maxZ, pointTransform );
+    const auto surfacePolylines = computeSurfaceCurtainPolylines( surfaces, curtain, pointTransform );
 
     return createAnnotationParts( intersection->surfaceIntersectionCollection(), surfacePolylines, scaleTransform );
 }

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "RimIntersection.h"
+
 #include "cvfCollection.h"
 #include "cvfColor3.h"
 #include "cvfObject.h"
@@ -29,7 +31,6 @@
 #include <map>
 #include <vector>
 
-class RimIntersection;
 class RimSurface;
 class RimSurfaceIntersectionCollection;
 
@@ -40,10 +41,10 @@ class Transform;
 } // namespace cvf
 
 //==================================================================================================
-/// The curve created when a surface is projected onto a vertical intersection. One entry per
-/// resampled footprint point, where valid[i] is false if the vertical ray missed the surface or the
-/// hit fell outside the depth extent of the intersection. Invalid points are kept in the array
-/// instead of being removed, so the two curves of a band stay index aligned.
+/// The curve created when a surface is projected onto an intersection. One entry per resampled
+/// position along the intersection, where valid[i] is false if the pillar at that position missed
+/// the surface. Invalid points are kept in the array instead of being removed, so the two curves of
+/// a band stay index aligned.
 //==================================================================================================
 class RivSurfaceCurtainPolyline
 {
@@ -57,30 +58,32 @@ public:
 
 //==================================================================================================
 /// Creation of surface intersection curves and bands. Shared by all intersection types that produce
-/// a vertical curtain, and that therefore can find the curve by shooting a vertical ray at the
-/// surface for each point along the footprint of the intersection.
+/// a curtain, and that therefore can find the curve by looking the surface up along the pillar the
+/// curtain is spanned between at each position along the intersection.
 //==================================================================================================
 class RivSurfaceIntersectionCurveTools
 {
 public:
     static std::vector<RimSurface*> referencedSurfaces( const RimSurfaceIntersectionCollection* surfaceIntersections );
 
-    /// pointTransform maps (worldPoint, footprintSegmentIndex) to the output coordinate system. Use
-    /// the identity for intersections drawn in 3D only, or the flattening transform when the curve
-    /// is also displayed in a 2D intersection view.
+    /// The surface is looked up along the pillars of the curtain, so the curve follows a tilted
+    /// curtain instead of a vertical plane through it. The curtain is resampled along its trace to
+    /// the resolution the curve is drawn at, and the pillars are interpolated to match.
+    ///
+    /// pointTransform maps (worldPoint, traceSegmentIndex) to the output coordinate system. Use the
+    /// identity for intersections drawn in 3D only, or the flattening transform when the curve is
+    /// also displayed in a 2D intersection view.
     static std::map<RimSurface*, RivSurfaceCurtainPolyline>
         computeSurfaceCurtainPolylines( const std::vector<RimSurface*>&                               surfaces,
-                                        const std::vector<cvf::Vec3d>&                                footprintPolyline,
-                                        double                                                        minZ,
-                                        double                                                        maxZ,
+                                        const RimIntersectionCurtain&                                 curtain,
                                         const std::function<cvf::Vec3d( const cvf::Vec3d&, size_t )>& pointTransform );
 
     static cvf::Collection<cvf::Part> createAnnotationParts( const RimSurfaceIntersectionCollection*                 surfaceIntersections,
                                                              const std::map<RimSurface*, RivSurfaceCurtainPolyline>& surfacePolylines,
                                                              cvf::Transform*                                         scaleTransform );
 
-    /// Curves and bands for an intersection that is drawn in 3D only, computed from the footprint and
-    /// the depth extent reported by the intersection itself
+    /// Curves and bands for an intersection that is drawn in 3D only, computed from the pillars
+    /// reported by the intersection itself
     static cvf::Collection<cvf::Part> createAnnotationParts( const RimIntersection* intersection, cvf::Transform* scaleTransform );
 
 private:

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <vector>
 
+class RimIntersection;
 class RimSurface;
 class RimSurfaceIntersectionCollection;
 
@@ -77,6 +78,10 @@ public:
     static cvf::Collection<cvf::Part> createAnnotationParts( const RimSurfaceIntersectionCollection*                 surfaceIntersections,
                                                              const std::map<RimSurface*, RivSurfaceCurtainPolyline>& surfacePolylines,
                                                              cvf::Transform*                                         scaleTransform );
+
+    /// Curves and bands for an intersection that is drawn in 3D only, computed from the footprint and
+    /// the depth extent reported by the intersection itself
+    static cvf::Collection<cvf::Part> createAnnotationParts( const RimIntersection* intersection, cvf::Transform* scaleTransform );
 
 private:
     static cvf::Collection<cvf::Part> createCurveParts( const RivSurfaceCurtainPolyline& polyline,

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
@@ -1,0 +1,95 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cvfCollection.h"
+#include "cvfColor3.h"
+#include "cvfObject.h"
+#include "cvfVector3.h"
+
+#include <QString>
+
+#include <functional>
+#include <map>
+#include <vector>
+
+class RimSurface;
+class RimSurfaceIntersectionCollection;
+
+namespace cvf
+{
+class Part;
+class Transform;
+} // namespace cvf
+
+//==================================================================================================
+/// The curve created when a surface is projected onto a vertical intersection. One entry per
+/// resampled footprint point, where valid[i] is false if the vertical ray missed the surface or the
+/// hit fell outside the depth extent of the intersection. Invalid points are kept in the array
+/// instead of being removed, so the two curves of a band stay index aligned.
+//==================================================================================================
+class RivSurfaceCurtainPolyline
+{
+public:
+    std::vector<cvf::Vec3d> points;
+    std::vector<bool>       valid;
+
+    /// The stretches of consecutive valid points that are long enough to draw a line
+    std::vector<std::vector<cvf::Vec3d>> validRuns() const;
+};
+
+//==================================================================================================
+/// Creation of surface intersection curves and bands. Shared by all intersection types that produce
+/// a vertical curtain, and that therefore can find the curve by shooting a vertical ray at the
+/// surface for each point along the footprint of the intersection.
+//==================================================================================================
+class RivSurfaceIntersectionCurveTools
+{
+public:
+    static std::vector<RimSurface*> referencedSurfaces( const RimSurfaceIntersectionCollection* surfaceIntersections );
+
+    /// pointTransform maps (worldPoint, footprintSegmentIndex) to the output coordinate system. Use
+    /// the identity for intersections drawn in 3D only, or the flattening transform when the curve
+    /// is also displayed in a 2D intersection view.
+    static std::map<RimSurface*, RivSurfaceCurtainPolyline>
+        computeSurfaceCurtainPolylines( const std::vector<RimSurface*>&                               surfaces,
+                                        const std::vector<cvf::Vec3d>&                                footprintPolyline,
+                                        double                                                        minZ,
+                                        double                                                        maxZ,
+                                        const std::function<cvf::Vec3d( const cvf::Vec3d&, size_t )>& pointTransform );
+
+    static cvf::Collection<cvf::Part> createAnnotationParts( const RimSurfaceIntersectionCollection*                 surfaceIntersections,
+                                                             const std::map<RimSurface*, RivSurfaceCurtainPolyline>& surfacePolylines,
+                                                             cvf::Transform*                                         scaleTransform );
+
+private:
+    static cvf::Collection<cvf::Part> createCurveParts( const RivSurfaceCurtainPolyline& polyline,
+                                                        const QString&                   description,
+                                                        const cvf::Color3f&              color,
+                                                        float                            lineWidth,
+                                                        cvf::Transform*                  scaleTransform );
+
+    static cvf::ref<cvf::Part> createCurvePart( const std::vector<cvf::Vec3d>& polyline, const cvf::Color3f& color, float lineWidth );
+
+    static cvf::ref<cvf::Part> createBandPart( const RivSurfaceCurtainPolyline& polylineA,
+                                               const RivSurfaceCurtainPolyline& polylineB,
+                                               const cvf::Color3f&              color,
+                                               float                            opacity,
+                                               double                           polygonOffsetUnit );
+};

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionCurveTools.h
@@ -42,15 +42,14 @@ class Transform;
 
 //==================================================================================================
 /// The curve created when a surface is projected onto an intersection. One entry per resampled
-/// position along the intersection, where valid[i] is false if the pillar at that position missed
-/// the surface. Invalid points are kept in the array instead of being removed, so the two curves of
-/// a band stay index aligned.
+/// position along the intersection, set to cvf::Vec3d::UNDEFINED where the pillar at that position
+/// missed the surface. The missing points are kept in the array instead of being removed, so the two
+/// curves of a band stay index aligned.
 //==================================================================================================
 class RivSurfaceCurtainPolyline
 {
 public:
     std::vector<cvf::Vec3d> points;
-    std::vector<bool>       valid;
 
     /// The stretches of consecutive valid points that are long enough to draw a line
     std::vector<std::vector<cvf::Vec3d>> validRuns() const;
@@ -80,18 +79,18 @@ public:
 
     static cvf::Collection<cvf::Part> createAnnotationParts( const RimSurfaceIntersectionCollection*                 surfaceIntersections,
                                                              const std::map<RimSurface*, RivSurfaceCurtainPolyline>& surfacePolylines,
-                                                             cvf::Transform*                                         scaleTransform );
+                                                             cvf::Transform&                                         scaleTransform );
 
     /// Curves and bands for an intersection that is drawn in 3D only, computed from the pillars
     /// reported by the intersection itself
-    static cvf::Collection<cvf::Part> createAnnotationParts( const RimIntersection* intersection, cvf::Transform* scaleTransform );
+    static cvf::Collection<cvf::Part> createAnnotationParts( const RimIntersection* intersection, cvf::Transform& scaleTransform );
 
 private:
     static cvf::Collection<cvf::Part> createCurveParts( const RivSurfaceCurtainPolyline& polyline,
                                                         const QString&                   description,
                                                         const cvf::Color3f&              color,
                                                         float                            lineWidth,
-                                                        cvf::Transform*                  scaleTransform );
+                                                        cvf::Transform&                  scaleTransform );
 
     static cvf::ref<cvf::Part> createCurvePart( const std::vector<cvf::Vec3d>& polyline, const cvf::Color3f& color, float lineWidth );
 

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
@@ -537,6 +537,14 @@ void RimBoxIntersection::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimBoxIntersection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    appendCommonMenuItems( menuBuilder );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimBoxIntersection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName )
 {
     appendSurfaceIntersectionsToTreeOrdering( uiTreeOrdering );

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
@@ -190,6 +190,41 @@ RimBoxIntersection::SinglePlaneState RimBoxIntersection::singlePlaneState() cons
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Only the single plane states X and Y give a vertical curtain. A depth slice, and the full box,
+/// would require the surface to be contoured instead of projected along a vertical ray.
+//--------------------------------------------------------------------------------------------------
+bool RimBoxIntersection::supportsSurfaceIntersectionCurves() const
+{
+    return m_singlePlaneState() == PLANE_STATE_X || m_singlePlaneState() == PLANE_STATE_Y;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<cvf::Vec3d> RimBoxIntersection::surfaceCurtainFootprint() const
+{
+    if ( m_singlePlaneState() == PLANE_STATE_X )
+    {
+        return { cvf::Vec3d( m_minXCoord, m_minYCoord, 0.0 ), cvf::Vec3d( m_minXCoord, m_maxYCoord, 0.0 ) };
+    }
+
+    if ( m_singlePlaneState() == PLANE_STATE_Y )
+    {
+        return { cvf::Vec3d( m_minXCoord, m_minYCoord, 0.0 ), cvf::Vec3d( m_maxXCoord, m_minYCoord, 0.0 ) };
+    }
+
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The depth fields are positive downwards, while z is positive upwards
+//--------------------------------------------------------------------------------------------------
+std::pair<double, double> RimBoxIntersection::surfaceCurtainZRange() const
+{
+    return { -m_maxDepth(), -m_minDepth() };
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RimBoxIntersection::setToDefaultSizeBox()

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
@@ -199,29 +199,23 @@ bool RimBoxIntersection::supportsSurfaceIntersectionCurves() const
 }
 
 //--------------------------------------------------------------------------------------------------
-///
+/// The pillars span the depth range of the box, so the curve is clipped to the box face. The depth
+/// fields are positive downwards, while z is positive upwards.
 //--------------------------------------------------------------------------------------------------
-std::vector<cvf::Vec3d> RimBoxIntersection::surfaceCurtainFootprint() const
+RimIntersectionCurtain RimBoxIntersection::surfaceCurtain() const
 {
+    std::vector<cvf::Vec3d> trace;
+
     if ( m_singlePlaneState() == PLANE_STATE_X )
     {
-        return { cvf::Vec3d( m_minXCoord, m_minYCoord, 0.0 ), cvf::Vec3d( m_minXCoord, m_maxYCoord, 0.0 ) };
+        trace = { cvf::Vec3d( m_minXCoord, m_minYCoord, 0.0 ), cvf::Vec3d( m_minXCoord, m_maxYCoord, 0.0 ) };
     }
-
-    if ( m_singlePlaneState() == PLANE_STATE_Y )
+    else if ( m_singlePlaneState() == PLANE_STATE_Y )
     {
-        return { cvf::Vec3d( m_minXCoord, m_minYCoord, 0.0 ), cvf::Vec3d( m_maxXCoord, m_minYCoord, 0.0 ) };
+        trace = { cvf::Vec3d( m_minXCoord, m_minYCoord, 0.0 ), cvf::Vec3d( m_maxXCoord, m_minYCoord, 0.0 ) };
     }
 
-    return {};
-}
-
-//--------------------------------------------------------------------------------------------------
-/// The depth fields are positive downwards, while z is positive upwards
-//--------------------------------------------------------------------------------------------------
-std::pair<double, double> RimBoxIntersection::surfaceCurtainZRange() const
-{
-    return { -m_maxDepth(), -m_minDepth() };
+    return verticalCurtain( trace, -m_minDepth(), -m_maxDepth() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
@@ -32,6 +32,7 @@
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
 #include "cafPdmUiSliderEditor.h"
+#include "cafPdmUiTreeOrdering.h"
 
 namespace caf
 {
@@ -502,6 +503,16 @@ void RimBoxIntersection::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
     uiOrdering.add( &m_show3DManipulator );
 
     defineSeparateDataSourceUi( uiConfigName, uiOrdering );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimBoxIntersection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName )
+{
+    appendSurfaceIntersectionsToTreeOrdering( uiTreeOrdering );
+
+    uiTreeOrdering.skipRemainingChildren( true );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.cpp
@@ -28,6 +28,7 @@
 
 #include "RivBoxIntersectionPartMgr.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafDisplayCoordTransform.h"
 #include "cafPdmUiDoubleSliderEditor.h"
 #include "cafPdmUiPushButtonEditor.h"
@@ -540,6 +541,8 @@ void RimBoxIntersection::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
 void RimBoxIntersection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
 {
     appendCommonMenuItems( menuBuilder );
+
+    menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
@@ -85,6 +85,8 @@ public:
 
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+
 protected:
     caf::PdmFieldHandle* userDescriptionField() final;
 

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
@@ -80,6 +80,10 @@ public:
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const override;
 
+    bool                      supportsSurfaceIntersectionCurves() const override;
+    std::vector<cvf::Vec3d>   surfaceCurtainFootprint() const override;
+    std::pair<double, double> surfaceCurtainZRange() const override;
+
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 
 protected:

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
@@ -80,12 +80,15 @@ public:
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const override;
 
+    void rebuildGeometryAndScheduleCreateDisplayModel() override;
+
 protected:
     caf::PdmFieldHandle* userDescriptionField() final;
 
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+    void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
     void initAfterRead() override;
 
 protected slots:
@@ -96,7 +99,6 @@ private:
     friend class RimIntersectionCollection;
     void updateBoxManipulatorGeometry();
 
-    void rebuildGeometryAndScheduleCreateDisplayModel();
     void updateVisibility();
     void clampSinglePlaneValues();
     void switchSingelPlaneState();

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimBoxIntersection.h
@@ -80,9 +80,8 @@ public:
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const override;
 
-    bool                      supportsSurfaceIntersectionCurves() const override;
-    std::vector<cvf::Vec3d>   surfaceCurtainFootprint() const override;
-    std::pair<double, double> surfaceCurtainZRange() const override;
+    bool                   supportsSurfaceIntersectionCurves() const override;
+    RimIntersectionCurtain surfaceCurtain() const override;
 
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
@@ -253,10 +253,6 @@ RimExtrudedCurveIntersection::RimExtrudedCurveIntersection()
     caf::PdmUiPushButtonEditor::configureEditorLabelLeft( &m_inputTwoAzimuthPointsFromViewerEnabled );
     m_inputTwoAzimuthPointsFromViewerEnabled = false;
 
-    CAF_PDM_InitFieldNoDefault( &m_surfaceIntersections, "SurfaceIntersections", "Surface Intersections" );
-    m_surfaceIntersections = new RimSurfaceIntersectionCollection;
-    m_surfaceIntersections->objectChanged.connect( this, &RimExtrudedCurveIntersection::onSurfaceIntersectionsChanged );
-
     CAF_PDM_InitField( &m_depthUpperThreshold, "UpperThreshold", -300000.0, "Upper Threshold" );
     m_depthUpperThreshold.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
 
@@ -736,14 +732,7 @@ QList<caf::PdmOptionItemInfo> RimExtrudedCurveIntersection::calculateValueOption
 //--------------------------------------------------------------------------------------------------
 void RimExtrudedCurveIntersection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName )
 {
-    for ( auto c : m_surfaceIntersections->surfaceIntersectionCurves() )
-    {
-        uiTreeOrdering.add( c );
-    }
-    for ( auto c : m_surfaceIntersections->surfaceIntersectionBands() )
-    {
-        uiTreeOrdering.add( c );
-    }
+    appendSurfaceIntersectionsToTreeOrdering( uiTreeOrdering );
 
     uiTreeOrdering.skipRemainingChildren( true );
 }
@@ -1298,33 +1287,21 @@ bool RimExtrudedCurveIntersection::showIntersectionGeometry() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSurfaceIntersectionCurve*> RimExtrudedCurveIntersection::surfaceIntersectionCurves() const
+bool RimExtrudedCurveIntersection::supportsSurfaceIntersectionCurves() const
 {
-    return m_surfaceIntersections->surfaceIntersectionCurves();
+    return true;
 }
 
 //--------------------------------------------------------------------------------------------------
-///
+/// The first polyline is used, as the surface intersection curve follows the same line as the
+/// intersection geometry itself
 //--------------------------------------------------------------------------------------------------
-std::vector<RimSurfaceIntersectionBand*> RimExtrudedCurveIntersection::surfaceIntersectionBands() const
+std::vector<cvf::Vec3d> RimExtrudedCurveIntersection::surfaceCurtainFootprint() const
 {
-    return m_surfaceIntersections->surfaceIntersectionBands();
-}
+    auto lines = polyLines();
+    if ( lines.empty() ) return {};
 
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RimSurfaceIntersectionCurve* RimExtrudedCurveIntersection::addIntersectionCurve()
-{
-    return m_surfaceIntersections->addIntersectionCurve();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RimSurfaceIntersectionBand* RimExtrudedCurveIntersection::addIntersectionBand()
-{
-    return m_surfaceIntersections->addIntersectionBand();
+    return lines.front();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1386,15 +1363,6 @@ void RimExtrudedCurveIntersection::appendOptionItemsForSources( int             
     {
         appendOptionItemsForSources( currentLevel, subColl, options );
     }
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimExtrudedCurveIntersection::onSurfaceIntersectionsChanged( const caf::SignalEmitter* emitter )
-{
-    updateAllRequiredEditors();
-    rebuildGeometryAndScheduleCreateDisplayModel();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
@@ -1294,14 +1294,17 @@ bool RimExtrudedCurveIntersection::supportsSurfaceIntersectionCurves() const
 
 //--------------------------------------------------------------------------------------------------
 /// The first polyline is used, as the surface intersection curve follows the same line as the
-/// intersection geometry itself
+/// intersection geometry itself. The curtain is treated as a vertical extrusion, also when the
+/// intersection has a tilted extrusion direction.
 //--------------------------------------------------------------------------------------------------
-std::vector<cvf::Vec3d> RimExtrudedCurveIntersection::surfaceCurtainFootprint() const
+RimIntersectionCurtain RimExtrudedCurveIntersection::surfaceCurtain() const
 {
     auto lines = polyLines();
     if ( lines.empty() ) return {};
 
-    return lines.front();
+    const double extent = defaultCurtainExtent();
+
+    return verticalCurtain( lines.front(), extent, -extent );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.cpp
@@ -47,6 +47,7 @@
 
 #include "RivExtrudedCurveIntersectionPartMgr.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmFieldScriptingCapabilityCvfVec3d.h"
 #include "cafPdmObjectScriptingCapability.h"
@@ -725,6 +726,20 @@ QList<caf::PdmOptionItemInfo> RimExtrudedCurveIntersection::calculateValueOption
     }
 
     return options;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimExtrudedCurveIntersection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    appendCommonMenuItems( menuBuilder );
+
+    menuBuilder << "RicSeismicSectionFromIntersectionFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicNewIntersectionViewFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.h
@@ -129,15 +129,13 @@ public:
     double     extentLength();
     bool       hasDefiningPoints() const;
 
-    std::vector<RimSurfaceIntersectionCurve*> surfaceIntersectionCurves() const;
-    std::vector<RimSurfaceIntersectionBand*>  surfaceIntersectionBands() const;
-    RimSurfaceIntersectionCurve*              addIntersectionCurve();
-    RimSurfaceIntersectionBand*               addIntersectionBand();
+    bool                    supportsSurfaceIntersectionCurves() const override;
+    std::vector<cvf::Vec3d> surfaceCurtainFootprint() const override;
 
     bool showIntersectionGeometry() const;
 
     int  branchIndex() const;
-    void rebuildGeometryAndScheduleCreateDisplayModel();
+    void rebuildGeometryAndScheduleCreateDisplayModel() override;
 
 private:
     caf::PdmFieldHandle* userDescriptionField() final;
@@ -158,8 +156,6 @@ private:
     static double               azimuthInRadians( cvf::Vec3d vec );
 
     void appendOptionItemsForSources( int currentLevel, RimSurfaceCollection* currentCollection, QList<caf::PdmOptionItemInfo>& options ) const;
-
-    void onSurfaceIntersectionsChanged( const caf::SignalEmitter* emitter );
 
     std::vector<cvf::Vec3d> pointsXYD() const;
     void                    setPointsFromXYD( const std::vector<cvf::Vec3d>& pointsXYD );
@@ -206,8 +202,6 @@ private:
     caf::PdmField<std::vector<cvf::Vec3d>> m_userPolylineXyz;
     caf::PdmField<std::vector<cvf::Vec3d>> m_customExtrusionPoints;
     caf::PdmField<std::vector<cvf::Vec3d>> m_twoAzimuthPoints;
-
-    caf::PdmChildField<RimSurfaceIntersectionCollection*> m_surfaceIntersections;
 
     cvf::ref<RivExtrudedCurveIntersectionPartMgr> m_crossSectionPartMgr;
 

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.h
@@ -129,8 +129,8 @@ public:
     double     extentLength();
     bool       hasDefiningPoints() const;
 
-    bool                    supportsSurfaceIntersectionCurves() const override;
-    std::vector<cvf::Vec3d> surfaceCurtainFootprint() const override;
+    bool                   supportsSurfaceIntersectionCurves() const override;
+    RimIntersectionCurtain surfaceCurtain() const override;
 
     bool showIntersectionGeometry() const;
 

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimExtrudedCurveIntersection.h
@@ -137,6 +137,8 @@ public:
     int  branchIndex() const;
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+
 private:
     caf::PdmFieldHandle* userDescriptionField() final;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
@@ -26,6 +26,7 @@
 #include "RivIjkIntersectionPartMgr.h"
 
 #include "cafPdmUiSliderEditor.h"
+#include "cafPdmUiTreeOrdering.h"
 
 #include <algorithm>
 
@@ -345,6 +346,16 @@ void RimIjkIntersection::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
     defineSeparateDataSourceUi( uiConfigName, uiOrdering );
 
     uiOrdering.skipRemainingFields( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIjkIntersection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName )
+{
+    appendSurfaceIntersectionsToTreeOrdering( uiTreeOrdering );
+
+    uiTreeOrdering.skipRemainingChildren( true );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
@@ -212,10 +212,11 @@ bool RimIjkIntersection::supportsSurfaceIntersectionCurves() const
 }
 
 //--------------------------------------------------------------------------------------------------
-/// Walk the cells of the index plane along the varying axis and pick the cell face corners, so the
-/// footprint follows the pillars and steps with the faults instead of being a straight line
+/// Walk the cells of the index plane along the varying axis and pick the cell face corners. Each
+/// pillar runs from the top of the first k layer to the bottom of the last k layer, so a tilted
+/// pillar gives a curve that lies on the curtain rather than on a vertical plane through it.
 //--------------------------------------------------------------------------------------------------
-std::vector<cvf::Vec3d> RimIjkIntersection::surfaceCurtainFootprint() const
+RimIntersectionCurtain RimIjkIntersection::surfaceCurtain() const
 {
     if ( !supportsSurfaceIntersectionCurves() ) return {};
 
@@ -228,7 +229,10 @@ std::vector<cvf::Vec3d> RimIjkIntersection::surfaceCurtainFootprint() const
     const bool alongJ = m_axis() == GridAxis::AXIS_I;
 
     // Corner indices of the cell face, see the hex vertex numbering in StructGridInterface::cellFaceVertexIndices().
-    // The first corner is at the start of the varying axis, the second at the end of the same axis.
+    // The first corner is at the start of the varying axis, the second at the end of the same axis. Corners 0-3 are
+    // the low k side of the cell, and adding 4 gives the corner on the same pillar at the high k side.
+    const int cornersPerKSide = 4;
+
     int startCorner = 0;
     int endCorner   = 0;
     if ( alongJ )
@@ -245,69 +249,43 @@ std::vector<cvf::Vec3d> RimIjkIntersection::surfaceCurtainFootprint() const
     // The fixed axis is collapsed to a single index by clampedCellRange()
     const size_t fixedI = cellRange->min().i();
     const size_t fixedJ = cellRange->min().j();
-    const size_t k      = cellRange->min().k();
+
+    const size_t firstK = cellRange->min().k();
+    const size_t lastK  = cellRange->max().k();
 
     const size_t varyingMin = alongJ ? cellRange->min().j() : cellRange->min().i();
     const size_t varyingMax = alongJ ? cellRange->max().j() : cellRange->max().i();
 
-    std::vector<cvf::Vec3d> footprint;
+    RimIntersectionCurtain curtain;
+
+    // The pillar at one position is spanned between the first and the last cell of the k range. The
+    // top of the pillar is used as the trace, so the curve is resampled along the top of the curtain.
+    auto appendPillar = [&]( size_t i, size_t j, int corner )
+    {
+        const size_t topCellIndex    = grid->cellIndexFromIJK( i, j, firstK );
+        const size_t bottomCellIndex = grid->cellIndexFromIJK( i, j, lastK );
+
+        if ( topCellIndex == cvf::UNDEFINED_SIZE_T || bottomCellIndex == cvf::UNDEFINED_SIZE_T ) return;
+        if ( grid->cell( topCellIndex ).isInvalid() || grid->cell( bottomCellIndex ).isInvalid() ) return;
+
+        const auto topCorners    = grid->cellCornerVertices( topCellIndex );
+        const auto bottomCorners = grid->cellCornerVertices( bottomCellIndex );
+
+        curtain.trace.push_back( topCorners[corner] );
+        curtain.pillars.emplace_back( topCorners[corner], bottomCorners[corner + cornersPerKSide] );
+    };
 
     for ( size_t varying = varyingMin; varying <= varyingMax; ++varying )
     {
         const size_t i = alongJ ? fixedI : varying;
         const size_t j = alongJ ? varying : fixedJ;
 
-        const size_t cellIndex = grid->cellIndexFromIJK( i, j, k );
-        if ( cellIndex == cvf::UNDEFINED_SIZE_T ) continue;
-        if ( grid->cell( cellIndex ).isInvalid() ) continue;
+        appendPillar( i, j, startCorner );
 
-        const auto corners = grid->cellCornerVertices( cellIndex );
-
-        footprint.push_back( corners[startCorner] );
-
-        if ( varying == varyingMax ) footprint.push_back( corners[endCorner] );
+        if ( varying == varyingMax ) appendPillar( i, j, endCorner );
     }
 
-    return footprint;
-}
-
-//--------------------------------------------------------------------------------------------------
-/// The extent is found from the first and the last layer of the index range only, as the pillars are
-/// monotonous in the k direction
-//--------------------------------------------------------------------------------------------------
-std::pair<double, double> RimIjkIntersection::surfaceCurtainZRange() const
-{
-    RigMainGrid* grid = mainGrid();
-    if ( !grid ) return RimIntersection::surfaceCurtainZRange();
-
-    const auto cellRange = clampedCellRange( grid );
-    if ( !cellRange ) return RimIntersection::surfaceCurtainZRange();
-
-    double minZ = std::numeric_limits<double>::max();
-    double maxZ = -std::numeric_limits<double>::max();
-
-    for ( size_t k : { cellRange->min().k(), cellRange->max().k() } )
-    {
-        for ( size_t j = cellRange->min().j(); j <= cellRange->max().j(); ++j )
-        {
-            for ( size_t i = cellRange->min().i(); i <= cellRange->max().i(); ++i )
-            {
-                const size_t cellIndex = grid->cellIndexFromIJK( i, j, k );
-                if ( cellIndex == cvf::UNDEFINED_SIZE_T ) continue;
-                if ( grid->cell( cellIndex ).isInvalid() ) continue;
-
-                for ( const auto& corner : grid->cellCornerVertices( cellIndex ) )
-                {
-                    minZ = std::min( minZ, corner.z() );
-                    maxZ = std::max( maxZ, corner.z() );
-                }
-            }
-        }
-    }
-
-    if ( minZ > maxZ ) return RimIntersection::surfaceCurtainZRange();
-
-    return { minZ, maxZ };
+    return curtain;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
@@ -203,6 +203,152 @@ void RimIjkIntersection::setToDefaultValues()
 }
 
 //--------------------------------------------------------------------------------------------------
+/// The I and J axes give a vertical curtain. A K slice is horizontal, and would require the surface
+/// to be contoured instead of projected along a vertical ray.
+//--------------------------------------------------------------------------------------------------
+bool RimIjkIntersection::supportsSurfaceIntersectionCurves() const
+{
+    return m_axis() != GridAxis::AXIS_K;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Walk the cells of the index plane along the varying axis and pick the cell face corners, so the
+/// footprint follows the pillars and steps with the faults instead of being a straight line
+//--------------------------------------------------------------------------------------------------
+std::vector<cvf::Vec3d> RimIjkIntersection::surfaceCurtainFootprint() const
+{
+    if ( !supportsSurfaceIntersectionCurves() ) return {};
+
+    RigMainGrid* grid = mainGrid();
+    if ( !grid ) return {};
+
+    const auto cellRange = clampedCellRange();
+    if ( !cellRange ) return {};
+
+    const bool alongJ = m_axis() == GridAxis::AXIS_I;
+
+    // Corner indices of the cell face, see the hex vertex numbering in StructGridInterface::cellFaceVertexIndices().
+    // The first corner is at the start of the varying axis, the second at the end of the same axis.
+    int startCorner = 0;
+    int endCorner   = 0;
+    if ( alongJ )
+    {
+        startCorner = m_useNegativeFace() ? 0 : 1;
+        endCorner   = m_useNegativeFace() ? 3 : 2;
+    }
+    else
+    {
+        startCorner = m_useNegativeFace() ? 0 : 3;
+        endCorner   = m_useNegativeFace() ? 1 : 2;
+    }
+
+    // The fixed axis is collapsed to a single index by clampedCellRange()
+    const size_t fixedI = cellRange->min().i();
+    const size_t fixedJ = cellRange->min().j();
+    const size_t k      = cellRange->min().k();
+
+    const size_t varyingMin = alongJ ? cellRange->min().j() : cellRange->min().i();
+    const size_t varyingMax = alongJ ? cellRange->max().j() : cellRange->max().i();
+
+    std::vector<cvf::Vec3d> footprint;
+
+    for ( size_t varying = varyingMin; varying <= varyingMax; ++varying )
+    {
+        const size_t i = alongJ ? fixedI : varying;
+        const size_t j = alongJ ? varying : fixedJ;
+
+        const size_t cellIndex = grid->cellIndexFromIJK( i, j, k );
+        if ( cellIndex == cvf::UNDEFINED_SIZE_T ) continue;
+        if ( grid->cell( cellIndex ).isInvalid() ) continue;
+
+        const auto corners = grid->cellCornerVertices( cellIndex );
+
+        footprint.push_back( corners[startCorner] );
+
+        if ( varying == varyingMax ) footprint.push_back( corners[endCorner] );
+    }
+
+    return footprint;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The extent is found from the first and the last layer of the index range only, as the pillars are
+/// monotonous in the k direction
+//--------------------------------------------------------------------------------------------------
+std::pair<double, double> RimIjkIntersection::surfaceCurtainZRange() const
+{
+    RigMainGrid* grid = mainGrid();
+    if ( !grid ) return RimIntersection::surfaceCurtainZRange();
+
+    const auto cellRange = clampedCellRange();
+    if ( !cellRange ) return RimIntersection::surfaceCurtainZRange();
+
+    double minZ = std::numeric_limits<double>::max();
+    double maxZ = -std::numeric_limits<double>::max();
+
+    for ( size_t k : { cellRange->min().k(), cellRange->max().k() } )
+    {
+        for ( size_t j = cellRange->min().j(); j <= cellRange->max().j(); ++j )
+        {
+            for ( size_t i = cellRange->min().i(); i <= cellRange->max().i(); ++i )
+            {
+                const size_t cellIndex = grid->cellIndexFromIJK( i, j, k );
+                if ( cellIndex == cvf::UNDEFINED_SIZE_T ) continue;
+                if ( grid->cell( cellIndex ).isInvalid() ) continue;
+
+                for ( const auto& corner : grid->cellCornerVertices( cellIndex ) )
+                {
+                    minZ = std::min( minZ, corner.z() );
+                    maxZ = std::max( maxZ, corner.z() );
+                }
+            }
+        }
+    }
+
+    if ( minZ > maxZ ) return RimIntersection::surfaceCurtainZRange();
+
+    return { minZ, maxZ };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The index range of the visible cells, with the fixed axis collapsed to the fixed index
+//--------------------------------------------------------------------------------------------------
+std::optional<RigBoundingBoxIjk<caf::VecIjk0>> RimIjkIntersection::clampedCellRange() const
+{
+    RigMainGrid* grid = mainGrid();
+    if ( !grid ) return {};
+
+    const size_t ni = grid->cellCountI();
+    const size_t nj = grid->cellCountJ();
+    const size_t nk = grid->cellCountK();
+    if ( ni == 0 || nj == 0 || nk == 0 ) return {};
+
+    const auto range = ijkRange();
+
+    caf::VecIjk0 min   = range.min();
+    caf::VecIjk0 max   = range.max();
+    const size_t fixed = static_cast<size_t>( std::max( 0, fixedIndex() ) );
+
+    switch ( m_axis() )
+    {
+        case GridAxis::AXIS_I:
+            min.x() = max.x() = std::min( fixed, ni - 1 );
+            break;
+        case GridAxis::AXIS_J:
+            min.y() = max.y() = std::min( fixed, nj - 1 );
+            break;
+        case GridAxis::AXIS_K:
+        default:
+            min.z() = max.z() = std::min( fixed, nk - 1 );
+            break;
+    }
+
+    const RigBoundingBoxIjk<caf::VecIjk0> gridBounds( caf::VecIjk0::ZERO, caf::VecIjk0( ni - 1, nj - 1, nk - 1 ) );
+
+    return RigBoundingBoxIjk<caf::VecIjk0>( min, max ).clamp( gridBounds );
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 RivIjkIntersectionPartMgr* RimIjkIntersection::intersectionPartMgr()

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
@@ -25,6 +25,7 @@
 
 #include "RivIjkIntersectionPartMgr.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmUiSliderEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 
@@ -477,6 +478,8 @@ void RimIjkIntersection::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
 void RimIjkIntersection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
 {
     appendCommonMenuItems( menuBuilder );
+
+    menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
@@ -474,6 +474,14 @@ void RimIjkIntersection::defineUiOrdering( QString uiConfigName, caf::PdmUiOrder
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimIjkIntersection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    appendCommonMenuItems( menuBuilder );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimIjkIntersection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName )
 {
     appendSurfaceIntersectionsToTreeOrdering( uiTreeOrdering );

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.cpp
@@ -222,7 +222,7 @@ std::vector<cvf::Vec3d> RimIjkIntersection::surfaceCurtainFootprint() const
     RigMainGrid* grid = mainGrid();
     if ( !grid ) return {};
 
-    const auto cellRange = clampedCellRange();
+    const auto cellRange = clampedCellRange( grid );
     if ( !cellRange ) return {};
 
     const bool alongJ = m_axis() == GridAxis::AXIS_I;
@@ -280,7 +280,7 @@ std::pair<double, double> RimIjkIntersection::surfaceCurtainZRange() const
     RigMainGrid* grid = mainGrid();
     if ( !grid ) return RimIntersection::surfaceCurtainZRange();
 
-    const auto cellRange = clampedCellRange();
+    const auto cellRange = clampedCellRange( grid );
     if ( !cellRange ) return RimIntersection::surfaceCurtainZRange();
 
     double minZ = std::numeric_limits<double>::max();
@@ -313,9 +313,8 @@ std::pair<double, double> RimIjkIntersection::surfaceCurtainZRange() const
 //--------------------------------------------------------------------------------------------------
 /// The index range of the visible cells, with the fixed axis collapsed to the fixed index
 //--------------------------------------------------------------------------------------------------
-std::optional<RigBoundingBoxIjk<caf::VecIjk0>> RimIjkIntersection::clampedCellRange() const
+std::optional<RigBoundingBoxIjk<caf::VecIjk0>> RimIjkIntersection::clampedCellRange( const RigMainGrid* grid ) const
 {
-    RigMainGrid* grid = mainGrid();
     if ( !grid ) return {};
 
     const size_t ni = grid->cellCountI();

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
@@ -75,16 +75,18 @@ public:
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const override;
 
+    void rebuildGeometryAndScheduleCreateDisplayModel() override;
+
 protected:
     caf::PdmFieldHandle* userDescriptionField() final;
 
     void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+    void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
 
 private:
-    int  axisCellCount() const;
-    void rebuildGeometryAndScheduleCreateDisplayModel();
+    int axisCellCount() const;
 
 private:
     caf::PdmField<QString>                m_name;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
@@ -26,6 +26,8 @@
 #include "cafPdmField.h"
 #include "cafVecIjk.h"
 
+#include <optional>
+
 class RigMainGrid;
 class RivIjkIntersectionPartMgr;
 
@@ -75,7 +77,14 @@ public:
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const override;
 
+    bool                      supportsSurfaceIntersectionCurves() const override;
+    std::vector<cvf::Vec3d>   surfaceCurtainFootprint() const override;
+    std::pair<double, double> surfaceCurtainZRange() const override;
+
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
+
+    /// The index range of the visible cells, with the fixed axis collapsed to the fixed index
+    std::optional<RigBoundingBoxIjk<caf::VecIjk0>> clampedCellRange() const;
 
 protected:
     caf::PdmFieldHandle* userDescriptionField() final;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
@@ -83,8 +83,9 @@ public:
 
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 
-    /// The index range of the visible cells, with the fixed axis collapsed to the fixed index
-    std::optional<RigBoundingBoxIjk<caf::VecIjk0>> clampedCellRange() const;
+    /// The index range of the visible cells, with the fixed axis collapsed to the fixed index. The
+    /// grid is passed in, as the intersection is not always reachable from a view.
+    std::optional<RigBoundingBoxIjk<caf::VecIjk0>> clampedCellRange( const RigMainGrid* grid ) const;
 
 protected:
     caf::PdmFieldHandle* userDescriptionField() final;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
@@ -77,9 +77,8 @@ public:
 
     const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const override;
 
-    bool                      supportsSurfaceIntersectionCurves() const override;
-    std::vector<cvf::Vec3d>   surfaceCurtainFootprint() const override;
-    std::pair<double, double> surfaceCurtainZRange() const override;
+    bool                   supportsSurfaceIntersectionCurves() const override;
+    RimIntersectionCurtain surfaceCurtain() const override;
 
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIjkIntersection.h
@@ -82,6 +82,8 @@ public:
 
     void rebuildGeometryAndScheduleCreateDisplayModel() override;
 
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+
     /// The index range of the visible cells, with the fixed axis collapsed to the fixed index. The
     /// grid is passed in, as the intersection is not always reachable from a view.
     std::optional<RigBoundingBoxIjk<caf::VecIjk0>> clampedCellRange( const RigMainGrid* grid ) const;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
@@ -28,11 +28,17 @@
 #include "RimGridView.h"
 #include "RimIntersectionResultDefinition.h"
 #include "RimIntersectionResultsDefinitionCollection.h"
+#include "RimSurfaceIntersectionBand.h"
+#include "RimSurfaceIntersectionCollection.h"
+#include "RimSurfaceIntersectionCurve.h"
 
 #include "RivEclipseIntersectionGrid.h"
 #include "RivFemIntersectionGrid.h"
 
 #include "cafPdmUiCheckBoxEditor.h"
+#include "cafPdmUiTreeOrdering.h"
+
+#include <limits>
 
 CAF_PDM_ABSTRACT_SOURCE_INIT( RimIntersection, "RimIntersectionHandle" );
 
@@ -49,6 +55,10 @@ RimIntersection::RimIntersection()
 
     CAF_PDM_InitField( &m_useSeparateDataSource, "UseSeparateIntersectionDataSource", true, "Enable" );
     CAF_PDM_InitFieldNoDefault( &m_separateDataSource, "SeparateIntersectionDataSource", "Source" );
+
+    CAF_PDM_InitFieldNoDefault( &m_surfaceIntersections, "SurfaceIntersections", "Surface Intersections" );
+    m_surfaceIntersections = new RimSurfaceIntersectionCollection;
+    m_surfaceIntersections->objectChanged.connect( this, &RimIntersection::onSurfaceIntersectionsChanged );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -182,6 +192,101 @@ void RimIntersection::updateDefaultSeparateDataSource()
             }
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceIntersectionCollection* RimIntersection::surfaceIntersectionCollection() const
+{
+    return m_surfaceIntersections();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimSurfaceIntersectionCurve*> RimIntersection::surfaceIntersectionCurves() const
+{
+    return m_surfaceIntersections->surfaceIntersectionCurves();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimSurfaceIntersectionBand*> RimIntersection::surfaceIntersectionBands() const
+{
+    return m_surfaceIntersections->surfaceIntersectionBands();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceIntersectionCurve* RimIntersection::addIntersectionCurve()
+{
+    return m_surfaceIntersections->addIntersectionCurve();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceIntersectionBand* RimIntersection::addIntersectionBand()
+{
+    return m_surfaceIntersections->addIntersectionBand();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RimIntersection::supportsSurfaceIntersectionCurves() const
+{
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<cvf::Vec3d> RimIntersection::surfaceCurtainFootprint() const
+{
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::pair<double, double> RimIntersection::surfaceCurtainZRange() const
+{
+    return { -std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Overridden by the intersection types that build their geometry from a part manager
+//--------------------------------------------------------------------------------------------------
+void RimIntersection::rebuildGeometryAndScheduleCreateDisplayModel()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIntersection::appendSurfaceIntersectionsToTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering )
+{
+    for ( auto c : m_surfaceIntersections->surfaceIntersectionCurves() )
+    {
+        uiTreeOrdering.add( c );
+    }
+    for ( auto c : m_surfaceIntersections->surfaceIntersectionBands() )
+    {
+        uiTreeOrdering.add( c );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIntersection::onSurfaceIntersectionsChanged( const caf::SignalEmitter* emitter )
+{
+    updateAllRequiredEditors();
+    rebuildGeometryAndScheduleCreateDisplayModel();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
@@ -38,8 +38,6 @@
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 
-#include <limits>
-
 CAF_PDM_ABSTRACT_SOURCE_INIT( RimIntersection, "RimIntersectionHandle" );
 
 //--------------------------------------------------------------------------------------------------
@@ -245,7 +243,7 @@ bool RimIntersection::supportsSurfaceIntersectionCurves() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<cvf::Vec3d> RimIntersection::surfaceCurtainFootprint() const
+RimIntersectionCurtain RimIntersection::surfaceCurtain() const
 {
     return {};
 }
@@ -253,9 +251,26 @@ std::vector<cvf::Vec3d> RimIntersection::surfaceCurtainFootprint() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::pair<double, double> RimIntersection::surfaceCurtainZRange() const
+double RimIntersection::defaultCurtainExtent()
 {
-    return { -std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
+    return 10000.0;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimIntersectionCurtain RimIntersection::verticalCurtain( const std::vector<cvf::Vec3d>& trace, double topZ, double bottomZ )
+{
+    RimIntersectionCurtain curtain;
+    curtain.trace = trace;
+    curtain.pillars.reserve( trace.size() );
+
+    for ( const auto& point : trace )
+    {
+        curtain.pillars.emplace_back( cvf::Vec3d( point.x(), point.y(), topZ ), cvf::Vec3d( point.x(), point.y(), bottomZ ) );
+    }
+
+    return curtain;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
@@ -35,6 +35,7 @@
 #include "RivEclipseIntersectionGrid.h"
 #include "RivFemIntersectionGrid.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiTreeOrdering.h"
 
@@ -293,6 +294,23 @@ void RimIntersection::appendSurfaceIntersectionsToTreeOrdering( caf::PdmUiTreeOr
     {
         uiTreeOrdering.add( c );
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIntersection::appendCommonMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicCreateSurfaceIntersectionBandFeature";
+    menuBuilder << "RicCreateSurfaceIntersectionCurveFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicPasteIntersectionsFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicAppendIntersectionFeature";
+    menuBuilder << "RicAppendIntersectionBoxFeature";
+    menuBuilder << "RicAppendIjkIntersectionFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.cpp
@@ -310,7 +310,6 @@ void RimIntersection::appendCommonMenuItems( caf::CmdFeatureMenuBuilder& menuBui
     menuBuilder << "RicAppendIntersectionBoxFeature";
     menuBuilder << "RicAppendIjkIntersectionFeature";
     menuBuilder.addSeparator();
-    menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
@@ -17,16 +17,29 @@
 /////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "cafPdmChildField.h"
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 #include "cafPdmPtrField.h"
 
 #include "cvfObject.h"
+#include "cvfVector3.h"
+
+#include <utility>
+#include <vector>
 
 class RimIntersectionResultDefinition;
 class RivIntersectionHexGridInterface;
 class RimIntersectionResultsDefinitionCollection;
+class RimSurfaceIntersectionBand;
+class RimSurfaceIntersectionCollection;
+class RimSurfaceIntersectionCurve;
 class RivIntersectionGeometryGeneratorInterface;
+
+namespace caf
+{
+class PdmUiTreeOrdering;
+}
 
 class RimIntersection : public caf::PdmObject
 {
@@ -47,6 +60,24 @@ public:
 
     virtual const RivIntersectionGeometryGeneratorInterface* intersectionGeometryGenerator() const = 0;
 
+    RimSurfaceIntersectionCollection*         surfaceIntersectionCollection() const;
+    std::vector<RimSurfaceIntersectionCurve*> surfaceIntersectionCurves() const;
+    std::vector<RimSurfaceIntersectionBand*>  surfaceIntersectionBands() const;
+    RimSurfaceIntersectionCurve*              addIntersectionCurve();
+    RimSurfaceIntersectionBand*               addIntersectionBand();
+
+    /// True if the intersection is a vertical curtain, and therefore can display surface intersection
+    /// curves and bands. Horizontal sections would require contouring instead of a vertical ray cast.
+    virtual bool supportsSurfaceIntersectionCurves() const;
+
+    /// The trace of the intersection in the XY plane, used to look up the surface below each point
+    virtual std::vector<cvf::Vec3d> surfaceCurtainFootprint() const;
+
+    /// The depth extent of the intersection, used to clip the surface intersection curves
+    virtual std::pair<double, double> surfaceCurtainZRange() const;
+
+    virtual void rebuildGeometryAndScheduleCreateDisplayModel();
+
 protected:
     virtual RimIntersectionResultsDefinitionCollection* findSeparateResultsCollection();
 
@@ -56,8 +87,15 @@ protected:
     void defineSeparateDataSourceUi( QString uiConfigName, caf::PdmUiOrdering& uiOrdering );
     void updateDefaultSeparateDataSource();
 
+    void appendSurfaceIntersectionsToTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering );
+
     caf::PdmField<bool>                                m_isActive;
     caf::PdmField<bool>                                m_showInactiveCells;
     caf::PdmField<bool>                                m_useSeparateDataSource;
     caf::PdmPtrField<RimIntersectionResultDefinition*> m_separateDataSource;
+
+    caf::PdmChildField<RimSurfaceIntersectionCollection*> m_surfaceIntersections;
+
+private:
+    void onSurfaceIntersectionsChanged( const caf::SignalEmitter* emitter );
 };

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
@@ -104,7 +104,8 @@ protected:
 
     void appendSurfaceIntersectionsToTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering );
 
-    /// The context menu shared by the intersection types that have no commands of their own
+    /// The context menu entries shared by all intersection types, ending with a separator so the
+    /// caller can add its own entries before the trailing copy-to-all-views command
     void appendCommonMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const;
 
     /// A curtain that is a vertical extrusion of the trace, spanning [bottomZ, topZ]

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
@@ -41,6 +41,24 @@ namespace caf
 class PdmUiTreeOrdering;
 }
 
+//==================================================================================================
+/// The curtain of an intersection, described at a set of positions along it
+//==================================================================================================
+class RimIntersectionCurtain
+{
+public:
+    /// The polyline the curve is resampled along, in 3D. Kept apart from the pillars so the samples
+    /// are distributed along the intersection itself, also where the pillars are long.
+    std::vector<cvf::Vec3d> trace;
+
+    /// For each point of the trace, the segment the surface is looked up along, from the top to the
+    /// bottom of the curtain. Tilted for an intersection that follows the grid pillars, which is
+    /// what puts the curve on the curtain instead of on a vertical plane through it.
+    std::vector<std::pair<cvf::Vec3d, cvf::Vec3d>> pillars;
+
+    bool isValid() const { return trace.size() == pillars.size() && trace.size() > 1; }
+};
+
 class RimIntersection : public caf::PdmObject
 {
     CAF_PDM_HEADER_INIT;
@@ -70,11 +88,7 @@ public:
     /// curves and bands. Horizontal sections would require contouring instead of a vertical ray cast.
     virtual bool supportsSurfaceIntersectionCurves() const;
 
-    /// The trace of the intersection in the XY plane, used to look up the surface below each point
-    virtual std::vector<cvf::Vec3d> surfaceCurtainFootprint() const;
-
-    /// The depth extent of the intersection, used to clip the surface intersection curves
-    virtual std::pair<double, double> surfaceCurtainZRange() const;
+    virtual RimIntersectionCurtain surfaceCurtain() const;
 
     virtual void rebuildGeometryAndScheduleCreateDisplayModel();
 
@@ -88,6 +102,12 @@ protected:
     void updateDefaultSeparateDataSource();
 
     void appendSurfaceIntersectionsToTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering );
+
+    /// A curtain that is a vertical extrusion of the trace, spanning [bottomZ, topZ]
+    static RimIntersectionCurtain verticalCurtain( const std::vector<cvf::Vec3d>& trace, double topZ, double bottomZ );
+
+    /// Reaches past any reservoir depth, used when the curtain has no defined vertical extent
+    static double defaultCurtainExtent();
 
     caf::PdmField<bool>                                m_isActive;
     caf::PdmField<bool>                                m_showInactiveCells;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersection.h
@@ -38,8 +38,9 @@ class RivIntersectionGeometryGeneratorInterface;
 
 namespace caf
 {
+class CmdFeatureMenuBuilder;
 class PdmUiTreeOrdering;
-}
+} // namespace caf
 
 //==================================================================================================
 /// The curtain of an intersection, described at a set of positions along it
@@ -102,6 +103,9 @@ protected:
     void updateDefaultSeparateDataSource();
 
     void appendSurfaceIntersectionsToTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering );
+
+    /// The context menu shared by the intersection types that have no commands of their own
+    void appendCommonMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const;
 
     /// A curtain that is a vertical extrusion of the trace, spanning [bottomZ, topZ]
     static RimIntersectionCurtain verticalCurtain( const std::vector<cvf::Vec3d>& trace, double topZ, double bottomZ );

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp
@@ -291,9 +291,10 @@ void RimIntersectionCollection::appendDynamicPartsToModel( cvf::ModelBasicList* 
     {
         if ( cs->isActive() )
         {
-            cs->intersectionBoxPartMgr()->generatePartGeometry( visibleCells );
+            cs->intersectionBoxPartMgr()->generatePartGeometry( visibleCells, scaleTransform );
             cs->intersectionBoxPartMgr()->appendNativeIntersectionFacesToModel( model, scaleTransform );
             cs->intersectionBoxPartMgr()->appendMeshLinePartsToModel( model, scaleTransform );
+            cs->intersectionBoxPartMgr()->appendAnnotationPartsToModel( model, scaleTransform );
         }
     }
 
@@ -301,9 +302,10 @@ void RimIntersectionCollection::appendDynamicPartsToModel( cvf::ModelBasicList* 
     {
         if ( cs->isActive() )
         {
-            cs->intersectionPartMgr()->generatePartGeometry( visibleCells );
+            cs->intersectionPartMgr()->generatePartGeometry( visibleCells, scaleTransform );
             cs->intersectionPartMgr()->appendNativeIntersectionFacesToModel( model, scaleTransform );
             cs->intersectionPartMgr()->appendMeshLinePartsToModel( model, scaleTransform );
+            cs->intersectionPartMgr()->appendAnnotationPartsToModel( model, scaleTransform );
         }
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp
@@ -41,6 +41,7 @@
 #include "RivExtrudedCurveIntersectionPartMgr.h"
 #include "RivIjkIntersectionPartMgr.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmObjectScriptingCapability.h"
 #include "cafPdmUiCheckBoxEditor.h"
 #include "cafPdmUiDoubleSliderEditor.h"
@@ -246,6 +247,20 @@ bool RimIntersectionCollection::hasAnyActiveSeparateResults()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIntersectionCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicPasteIntersectionsFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicAppendIntersectionFeature";
+    menuBuilder << "RicAppendIntersectionBoxFeature";
+    menuBuilder << "RicAppendIjkIntersectionFeature";
+    menuBuilder.addSeparator();
+    menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
+}
+
 void RimIntersectionCollection::appendPartsToModel( Rim3dView& view, cvf::ModelBasicList* model, cvf::Transform* scaleTransform )
 {
     if ( !isActive() ) return;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.h
@@ -36,6 +36,11 @@ class RimEclipseCellColors;
 class RimSimWellInView;
 class RivTernaryScalarMapper;
 
+namespace caf
+{
+class CmdFeatureMenuBuilder;
+}
+
 namespace cvf
 {
 class ModelBasicList;
@@ -92,6 +97,8 @@ public:
     void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
 
     void onChildAdded( caf::PdmFieldHandle* containerForNewObject ) override;
+
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
 
     bool isActive() const;
     void setActive( bool active );

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultDefinition.cpp
@@ -36,6 +36,7 @@
 
 #include "RiuViewer.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmUiTreeOrdering.h"
 
 CAF_PDM_SOURCE_INIT( RimIntersectionResultDefinition, "IntersectionResultDefinition" );
@@ -88,6 +89,14 @@ RimIntersectionResultDefinition::~RimIntersectionResultDefinition()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIntersectionResultDefinition::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicAppendSeparateIntersectionResultFeature";
+}
+
 bool RimIntersectionResultDefinition::isActive() const
 {
     return m_isActive();

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultDefinition.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultDefinition.h
@@ -31,6 +31,11 @@ class RimRegularLegendConfig;
 class RimTernaryLegendConfig;
 class RiuViewer;
 
+namespace caf
+{
+class CmdFeatureMenuBuilder;
+}
+
 class RimIntersectionResultDefinition : public caf::PdmObject
 {
     CAF_PDM_HEADER_INIT;
@@ -38,6 +43,8 @@ class RimIntersectionResultDefinition : public caf::PdmObject
 public:
     RimIntersectionResultDefinition();
     ~RimIntersectionResultDefinition() override;
+
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
 
     bool     isActive() const;
     bool     isInAction() const;

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultsDefinitionCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultsDefinitionCollection.cpp
@@ -22,6 +22,7 @@
 #include "RimGridView.h"
 #include "RimIntersectionCollection.h"
 #include "RimIntersectionResultDefinition.h"
+#include "cafCmdFeatureMenuBuilder.h"
 
 CAF_PDM_SOURCE_INIT( RimIntersectionResultsDefinitionCollection, "RimIntersectionResultsDefinitionCollection" );
 
@@ -50,6 +51,14 @@ RimIntersectionResultsDefinitionCollection::~RimIntersectionResultsDefinitionCol
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimIntersectionResultsDefinitionCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicAppendSeparateIntersectionResultFeature";
+}
+
 bool RimIntersectionResultsDefinitionCollection::isActive() const
 {
     return m_isActive();

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultsDefinitionCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionResultsDefinitionCollection.h
@@ -22,6 +22,11 @@
 
 class RimIntersectionResultDefinition;
 
+namespace caf
+{
+class CmdFeatureMenuBuilder;
+}
+
 class RimIntersectionResultsDefinitionCollection : public caf::PdmObjectCollection<RimIntersectionResultDefinition>
 {
     CAF_PDM_HEADER_INIT;
@@ -29,6 +34,8 @@ class RimIntersectionResultsDefinitionCollection : public caf::PdmObjectCollecti
 public:
     RimIntersectionResultsDefinitionCollection();
     ~RimIntersectionResultsDefinitionCollection() override;
+
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
 
     bool isActive() const;
 

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -41,7 +41,6 @@
 #include "RimAnnotationCollection.h"
 #include "RimAnnotationGroupCollection.h"
 #include "RimAnnotationInViewCollection.h"
-#include "RimBoxIntersection.h"
 #include "RimCalcScript.h"
 #include "RimCaseCollection.h"
 #include "RimCellEdgeColors.h"
@@ -90,7 +89,6 @@
 #include "RimGridCrossPlotCollection.h"
 #include "RimGridCrossPlotDataSet.h"
 #include "RimIdenticalGridCaseGroup.h"
-#include "RimIjkIntersection.h"
 #include "RimIntersectionCollection.h"
 #include "RimIntersectionResultDefinition.h"
 #include "RimIntersectionResultsDefinitionCollection.h"
@@ -788,32 +786,6 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
             menuBuilder << "RicSeismicSectionFromIntersectionFeature";
             menuBuilder.addSeparator();
             menuBuilder << "RicNewIntersectionViewFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
-        }
-        else if ( dynamic_cast<RimBoxIntersection*>( firstUiItem ) )
-        {
-            menuBuilder << "RicCreateSurfaceIntersectionBandFeature";
-            menuBuilder << "RicCreateSurfaceIntersectionCurveFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicPasteIntersectionsFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicAppendIntersectionFeature";
-            menuBuilder << "RicAppendIntersectionBoxFeature";
-            menuBuilder << "RicAppendIjkIntersectionFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
-        }
-        else if ( dynamic_cast<RimIjkIntersection*>( firstUiItem ) )
-        {
-            menuBuilder << "RicCreateSurfaceIntersectionBandFeature";
-            menuBuilder << "RicCreateSurfaceIntersectionCurveFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicPasteIntersectionsFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicAppendIntersectionFeature";
-            menuBuilder << "RicAppendIntersectionBoxFeature";
-            menuBuilder << "RicAppendIjkIntersectionFeature";
             menuBuilder.addSeparator();
             menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
         }

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -67,7 +67,6 @@
 #include "RimEnsembleCurveFilterCollection.h"
 #include "RimEnsembleCurveSetCollection.h"
 #include "RimEnsembleFractureStatisticsCollection.h"
-#include "RimExtrudedCurveIntersection.h"
 #include "RimFaultInView.h"
 #include "RimFaultReactivationModel.h"
 #include "RimFileWellPath.h"
@@ -89,9 +88,6 @@
 #include "RimGridCrossPlotCollection.h"
 #include "RimGridCrossPlotDataSet.h"
 #include "RimIdenticalGridCaseGroup.h"
-#include "RimIntersectionCollection.h"
-#include "RimIntersectionResultDefinition.h"
-#include "RimIntersectionResultsDefinitionCollection.h"
 #include "RimModeledWellPath.h"
 #include "RimMultiPlot.h"
 #include "RimObservedSummaryData.h"
@@ -761,38 +757,6 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         else if ( dynamic_cast<RimWellLogChannel*>( firstUiItem ) )
         {
             menuBuilder << "RicAddWellLogToPlotFeature";
-        }
-        else if ( dynamic_cast<RimIntersectionCollection*>( firstUiItem ) )
-        {
-            menuBuilder << "RicPasteIntersectionsFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicAppendIntersectionFeature";
-            menuBuilder << "RicAppendIntersectionBoxFeature";
-            menuBuilder << "RicAppendIjkIntersectionFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
-        }
-        else if ( dynamic_cast<RimExtrudedCurveIntersection*>( firstUiItem ) )
-        {
-            menuBuilder << "RicCreateSurfaceIntersectionBandFeature";
-            menuBuilder << "RicCreateSurfaceIntersectionCurveFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicPasteIntersectionsFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicAppendIntersectionFeature";
-            menuBuilder << "RicAppendIntersectionBoxFeature";
-            menuBuilder << "RicAppendIjkIntersectionFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicSeismicSectionFromIntersectionFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicNewIntersectionViewFeature";
-            menuBuilder.addSeparator();
-            menuBuilder << "RicCopyIntersectionsToAllViewsInCaseFeature";
-        }
-        else if ( dynamic_cast<RimIntersectionResultsDefinitionCollection*>( firstUiItem ) ||
-                  dynamic_cast<RimIntersectionResultDefinition*>( firstUiItem ) )
-        {
-            menuBuilder << "RicAppendSeparateIntersectionResultFeature";
         }
         else if ( dynamic_cast<RimSimWellInView*>( firstUiItem ) )
         {

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -793,6 +793,9 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         }
         else if ( dynamic_cast<RimBoxIntersection*>( firstUiItem ) )
         {
+            menuBuilder << "RicCreateSurfaceIntersectionBandFeature";
+            menuBuilder << "RicCreateSurfaceIntersectionCurveFeature";
+            menuBuilder.addSeparator();
             menuBuilder << "RicPasteIntersectionsFeature";
             menuBuilder.addSeparator();
             menuBuilder << "RicAppendIntersectionFeature";
@@ -803,6 +806,9 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         }
         else if ( dynamic_cast<RimIjkIntersection*>( firstUiItem ) )
         {
+            menuBuilder << "RicCreateSurfaceIntersectionBandFeature";
+            menuBuilder << "RicCreateSurfaceIntersectionCurveFeature";
+            menuBuilder.addSeparator();
             menuBuilder << "RicPasteIntersectionsFeature";
             menuBuilder.addSeparator();
             menuBuilder << "RicAppendIntersectionFeature";


### PR DESCRIPTION
Surface intersection curves and bands could only be created for an extruded curve intersection. The Intersection Box and the I/J/K Intersection had no way to display a surface horizon or a min/max uncertainty band, even though they render comparable curtain geometry.

The blocker was structural rather than algorithmic: the `RimSurfaceIntersectionCollection` child field, the ray cast onto the surface, and the part building all lived inside the extruded curve classes. They now live on the shared `RimIntersection` base and in `RivSurfaceIntersectionCurveTools`.

Fixes #14436

## What is supported

| Intersection | Supported | Reason |
| --- | --- | --- |
| Extruded curve | yes, unchanged | |
| Box, X or Y single plane | **new** | vertical curtain |
| Box, depth slice | no | horizontal, needs contouring rather than a pillar lookup |
| Box, full box | no | four faces, deferred |
| I/J/K on the I or J axis | **new** | curtain following the pillars |
| I/J/K on the K axis | no | horizontal, same as the depth slice |

Where unsupported, the two menu entries are disabled rather than hidden.

## How the curve is found

Each intersection describes its curtain as a trace plus the pillar segment at every point of the trace. The surface is looked up along that segment, using the existing segment/triangle intersection in `RigSurfaceResampler`.

Looking the surface up along the pillar instead of along a vertical ray is what makes the curve follow the tilt of the pillars of an I or J intersection. A vertical ray puts the curve on a vertical plane through the top of the curtain, and the error grows with both the tilt and the depth of the intersection.

The trace is kept apart from the pillars so the curve stays sampled along the intersection itself. Sampling along the pillar tops would collapse a near vertical section of a well path to a couple of points in the flattened 2D view.

A surface that does not cross the curtain is estimated by continuing the pillar in both directions, so a band does not disappear where the surface leaves the depth range of the intersection. The pillar is continued only as far as the surface reaches in depth, which keeps the search for candidate triangles close to the intersection.

## Behaviour changes to the existing feature

- A curve is drawn as separate line stretches where the surface does not cover the whole intersection, instead of a straight connector across the gap. The curve keeps one point per resampled position together with a validity flag rather than dropping the missing points, which is also what keeps the two curves of a band index aligned.
- A curve is drawn outside the extent of the intersection where the surface is outside it, following the continuation of the pillar.

## Project file compatibility

The `SurfaceIntersections` field keyword is unchanged, so existing project files load as before. Box and I/J/K intersections will write the same empty block on the next save.


