### PR TITLE
#14460 Keep MSW cell intersections sorted by measured depth

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathIntersectionTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathIntersectionTools.cpp
@@ -163,6 +163,8 @@ std::vector<WellPathCellIntersectionInfo>
         const WellPathCellIntersectionInfo& current = originalIntersections[i];
         const WellPathCellIntersectionInfo& next    = originalIntersections[i + 1];
 
+        intersectionsNoGap.push_back( current );
+
         double distance           = std::fabs( current.endMD - next.startMD );
         double gapInGridThreshold = 0.1;
         if ( distance > gapInGridThreshold )
@@ -214,10 +216,10 @@ std::vector<WellPathCellIntersectionInfo>
             extraIntersection.intersectedCellFaceOut      = cvf::StructGridInterface::oppositeFace( next.intersectedCellFaceIn );
             extraIntersection.intersectionLengthsInCellCS = cvf::Vec3d::ZERO;
 
+            // The gap spans [current.endMD, next.startMD], and must be inserted after current to keep the
+            // intersections sorted by measured depth.
             intersectionsNoGap.push_back( extraIntersection );
         }
-
-        intersectionsNoGap.push_back( current );
     }
 
     if ( !originalIntersections.empty() )

--- a/ApplicationLibCode/UnitTests/RigWellPathIntersectionTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigWellPathIntersectionTools-Test.cpp
@@ -18,10 +18,13 @@
 
 #include "gtest/gtest.h"
 
+#include "Well/RigWellLogExtractor.h"
 #include "Well/RigWellPath.h"
+#include "Well/RigWellPathIntersectionTools.h"
 
 #include "cvfVector3.h"
 
+#include <limits>
 #include <vector>
 
 //--------------------------------------------------------------------------------------------------
@@ -83,5 +86,46 @@ TEST( RigWellPathTest, FindWellPathCoordsIncludingIntersectionPoint )
     {
         auto wellPathPoints = wellPathGeometry.wellPathPointsIncludingInterpolatedIntersectionPoint( 10.0 );
         EXPECT_EQ( 5u, wellPathPoints.size() );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigWellPathIntersectionToolsTest, BuildContinuousIntersectionsIsSortedByMeasuredDepth )
+{
+    auto createIntersection = []( size_t globCellIndex, double startMD, double endMD )
+    {
+        WellPathCellIntersectionInfo intersection;
+        intersection.globCellIndex               = globCellIndex;
+        intersection.startPoint                  = cvf::Vec3d( 0.0, 0.0, -startMD );
+        intersection.endPoint                    = cvf::Vec3d( 0.0, 0.0, -endMD );
+        intersection.startMD                     = startMD;
+        intersection.endMD                       = endMD;
+        intersection.intersectionLengthsInCellCS = cvf::Vec3d::ZERO;
+        intersection.intersectedCellFaceIn       = cvf::StructGridInterface::NEG_K;
+        intersection.intersectedCellFaceOut      = cvf::StructGridInterface::POS_K;
+        return intersection;
+    };
+
+    // Two cells, then a gap where the well path is outside the grid, then a third cell
+    std::vector<WellPathCellIntersectionInfo> intersections;
+    intersections.push_back( createIntersection( 0, 100.0, 110.0 ) );
+    intersections.push_back( createIntersection( 1, 110.0, 120.0 ) );
+    intersections.push_back( createIntersection( 2, 200.0, 210.0 ) );
+
+    auto continuousIntersections = RigWellPathIntersectionTools::buildContinuousIntersections( intersections, nullptr );
+
+    ASSERT_EQ( 4u, continuousIntersections.size() );
+
+    // The gap intersection is inserted between the second and third cell
+    EXPECT_EQ( std::numeric_limits<size_t>::max(), continuousIntersections[2].globCellIndex );
+    EXPECT_DOUBLE_EQ( 120.0, continuousIntersections[2].startMD );
+    EXPECT_DOUBLE_EQ( 200.0, continuousIntersections[2].endMD );
+
+    for ( size_t i = 1; i < continuousIntersections.size(); i++ )
+    {
+        EXPECT_GE( continuousIntersections[i].startMD, continuousIntersections[i - 1].startMD );
+        EXPECT_GE( continuousIntersections[i].endMD, continuousIntersections[i - 1].endMD );
     }
 }


### PR DESCRIPTION
Fixes #14460

`RigWellPathIntersectionTools::buildContinuousIntersections()` inserts an extra "no cell" intersection spanning `[current.endMD, next.startMD]` wherever the well path leaves the grid. That extra intersection was pushed to the result vector before `current`, so the returned list was not sorted by measured depth.

`RicMswBranchBuilder::buildMainBoreBranch()` walks this list in order and writes the sub-segment midpoint MD directly as the WELSEGS `Length` column for `LengthAndDepth = ABS`, so the misordering ended up in the exported file:

```
-- First Seg     Last Seg     Branch No     Outlet Seg     Length         Depth Change
   4             4            1             3              2460.40302     1631.94714
   5             5            1             4              2809.74155     1639.04603   <- gap segment
   6             6            1             5              2517.54304     1633.04659
   7             7            1             6              3167.07917     1643.08640
```

Segment 5 is the midpoint of the gap `[2534.48369, 3084.99941]` and was emitted ahead of the cell `[2500.60240, 2534.48369]` (segment 6). Segment 6 also got segment 5 as its outlet, i.e. an outlet deeper along the well than the segment itself.

`current` is now pushed before the gap that follows it. Added a unit test verifying that the returned intersections are sorted by MD and that the gap is placed between the cells it separates.

`buildContinuousIntersections` has a single caller, `RicWellPathExportMswTableData::generateCellSegments`, so the change is limited to the MSW export.
