### PR TITLE
Fix crashes reported by crash telemetry

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
@@ -608,9 +608,15 @@ void RimFlowCharacteristicsPlot::onLoadDataAndUpdate()
             m_currentlyPlottedTimeSteps = calculatedTimesteps;
         }
 
-        std::vector<QDateTime> timeStepDates   = m_case->timeStepDates();
-        QStringList            timeStepStrings = m_case->timeStepStrings();
-        std::vector<double>    lorenzVals( timeStepDates.size(), HUGE_VAL );
+        // The case can be missing, as the case field can be set to nothing from the UI
+        std::vector<QDateTime> timeStepDates;
+        QStringList            timeStepStrings;
+        if ( m_case() )
+        {
+            timeStepDates   = m_case()->timeStepDates();
+            timeStepStrings = m_case()->timeStepStrings();
+        }
+        std::vector<double> lorenzVals( timeStepDates.size(), HUGE_VAL );
 
         m_flowCharPlotWidget->removeAllCurves();
 
@@ -661,7 +667,11 @@ void RimFlowCharacteristicsPlot::onLoadDataAndUpdate()
                                                                                m_maxTof() );
                 timeStepToFlowResultMap[timeStepIdx] = flowCharResults;
             }
-            lorenzVals[timeStepIdx] = timeStepToFlowResultMap[timeStepIdx].m_lorenzCoefficient;
+            // The time step indices are given by the flow diagnostics solution, and can be out of range for the case
+            if ( timeStepIdx >= 0 && static_cast<size_t>( timeStepIdx ) < lorenzVals.size() )
+            {
+                lorenzVals[timeStepIdx] = timeStepToFlowResultMap[timeStepIdx].m_lorenzCoefficient;
+            }
         }
 
         m_timeStepToFlowResultMap = timeStepToFlowResultMap;
@@ -679,6 +689,8 @@ void RimFlowCharacteristicsPlot::onLoadDataAndUpdate()
 
         for ( int timeStepIdx : m_currentlyPlottedTimeSteps )
         {
+            if ( timeStepIdx < 0 || static_cast<size_t>( timeStepIdx ) >= timeStepDates.size() ) continue;
+
             const auto& flowCharResults = timeStepToFlowResultMap[timeStepIdx];
 
             m_flowCharPlotWidget->addFlowCapStorageCapCurve( timeStepDates[timeStepIdx],

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp
@@ -563,9 +563,10 @@ void RimFlowCharacteristicsPlot::fieldChangedByUi( const caf::PdmFieldHandle* ch
 
     if ( &m_case == changedField )
     {
-        m_flowDiagSolution = m_case->defaultFlowDiagSolution();
+        // The case field can be set to nothing from the UI
+        m_flowDiagSolution = m_case() ? m_case()->defaultFlowDiagSolution() : nullptr;
         m_currentlyPlottedTimeSteps.clear();
-        if ( !m_case()->reservoirViews().empty() )
+        if ( m_case() && !m_case()->reservoirViews().empty() )
         {
             m_cellFilterView = m_case()->reservoirViews()[0];
         }

--- a/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.cpp
@@ -186,15 +186,32 @@ size_t RigEclipseCaseData::gridCount() const
 }
 
 //--------------------------------------------------------------------------------------------------
+/// The cached well cell arrays are indexed by grid cell index, and are only valid as long as they
+/// have one array per grid sized to match the cell count of that grid.
+//--------------------------------------------------------------------------------------------------
+bool RigEclipseCaseData::isWellCellsPrGridUpToDate( const std::vector<RigGridBase*>& grids ) const
+{
+    if ( m_wellCellsInGrid.size() != grids.size() ) return false;
+
+    for ( size_t gIdx = 0; gIdx < grids.size(); ++gIdx )
+    {
+        if ( m_wellCellsInGrid[gIdx].isNull() || m_wellCellsInGrid[gIdx]->size() != grids[gIdx]->cellCount() ) return false;
+    }
+
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RigEclipseCaseData::computeWellCellsPrGrid()
 {
-    // If we have computed this already, return
-    if ( !m_wellCellsInGrid.empty() ) return;
-
     std::vector<RigGridBase*> grids;
     allGrids( &grids );
+
+    // If we have computed this already for the current set of grids, return. The cached arrays are indexed by grid
+    // cell index, and must be recomputed if the grids have changed after the previous computation.
+    if ( isWellCellsPrGridUpToDate( grids ) ) return;
 
     // Debug code used to display grid names and grid sizes
     /*

--- a/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.h
@@ -130,6 +130,7 @@ public:
 private:
     void computeActiveCellIJKBBox();
     void computeWellCellsPrGrid();
+    bool isWellCellsPrGridUpToDate( const std::vector<RigGridBase*>& grids ) const;
     void computeActiveCellsGeometryBoundingBoxSlow();
     void computeActiveCellsGeometryBoundingBoxOptimized();
 

--- a/ApplicationLibCode/UnitTests/RigReservoir-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigReservoir-Test.cpp
@@ -84,6 +84,30 @@ TEST( RigGridManager, EqualTests )
     EXPECT_TRUE( existingGrid.notNull() );
 }
 
+//--------------------------------------------------------------------------------------------------
+/// The well cell arrays are cached, and must be recomputed if the grid changes size after the first
+/// computation. A stale array is shorter than the cell count of the grid it is used with.
+//--------------------------------------------------------------------------------------------------
+TEST( RigEclipseCaseDataTest, WellCellsInGridIsRecomputedWhenGridSizeChanges )
+{
+    cvf::ref<RigMainGrid> mainGrid = new RigMainGrid;
+    mainGrid->setCellCounts( cvf::Vec3st( 2, 2, 2 ) );
+
+    cvf::ref<RigEclipseCaseData> eclipseCase = new RigEclipseCaseData( nullptr );
+    eclipseCase->setMainGrid( mainGrid.p() );
+
+    const cvf::UByteArray* wellCells = eclipseCase->wellCellsInGrid( 0 );
+    ASSERT_TRUE( wellCells != nullptr );
+    EXPECT_EQ( mainGrid->cellCount(), wellCells->size() );
+
+    // Grow the grid after the well cell arrays have been cached
+    mainGrid->setCellCounts( cvf::Vec3st( 3, 3, 3 ) );
+
+    wellCells = eclipseCase->wellCellsInGrid( 0 );
+    ASSERT_TRUE( wellCells != nullptr );
+    EXPECT_EQ( mainGrid->cellCount(), wellCells->size() );
+}
+
 /*
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuGuiTheme.cpp
+++ b/ApplicationLibCode/UserInterface/RiuGuiTheme.cpp
@@ -381,10 +381,13 @@ bool RiuGuiTheme::applyStyleSheet( RiaDefines::ThemeEnum theme )
     {
         if ( styleSheetFile.open( QIODevice::ReadOnly ) )
         {
-            RiaGuiApplication* app        = RiaGuiApplication::instance();
-            QString            styleSheet = styleSheetFile.readAll();
+            QString styleSheet = styleSheetFile.readAll();
             preparseStyleSheet( theme, styleSheet );
-            app->setStyleSheet( styleSheet );
+
+            if ( RiaGuiApplication* app = RiaGuiApplication::instance() )
+            {
+                app->setStyleSheet( styleSheet );
+            }
         }
         return true;
     }


### PR DESCRIPTION
Fixes four crashes reported by crash telemetry. One commit per crash.

### Recompute well cell arrays when the grids change

Problem: computeWellCellsPrGrid() returned early whenever the arrays had been computed once, so the size check below it was unreachable. A stale, too-short array was kept when the grids changed, tripping the assert in RivReservoirViewPartMgr::computeNativeVisibility.

Fix: Return early only when the cached arrays still match the current set of grids.

<details><summary>Crash stack (signature 1dd841454363, 2 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
[6] RivReservoirViewPartMgr::computeNativeVisibility(cvf::Array<unsigned char>*, RigGridBase const*, RigActiveCellInfo const*, cvf::Array<unsigned char> const*, bool, bool, bool) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:604
[7] RivReservoirViewPartMgr::computeVisibility(cvf::Array<unsigned char>*, RivCellSetEnum, RigGridBase*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:338
[8] RivReservoirViewPartMgr::createGeometry(RivCellSetEnum) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:278
[9] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:743
[10] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:770
[11] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1872
[25] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:422
[26] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:203
[27] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[31] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
[32] RivReservoirViewPartMgr::computeNativeVisibility(cvf::Array<unsigned char>*, RigGridBase const*, RigActiveCellInfo const*, cvf::Array<unsigned char> const*, bool, bool, bool) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:604
[33] RivReservoirViewPartMgr::computeVisibility(cvf::Array<unsigned char>*, RivCellSetEnum, RigGridBase*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:338
[34] RivReservoirViewPartMgr::createGeometry(RivCellSetEnum) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:278
[35] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:743
[36] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:770
[37] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
[42] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1872
[52] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[53] __libc_start_main at :0
```

</details>

### Guard against missing GUI application when applying style sheet

Problem: RiaGuiApplication::instance() does a dynamic_cast and returns null outside a GUI context. The assert guarding this is compiled out in release, so the null pointer was dereferenced.

Fix: Check the pointer before use.

<details><summary>Crash stack (signature 024f64fb61b2, 1 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[5] RiuGuiTheme::applyStyleSheet(RiaDefines::ThemeEnum) at ResInsight/ApplicationLibCode/UserInterface/RiuGuiTheme.cpp:387
[6] RiuGuiTheme::updateGuiTheme(RiaDefines::ThemeEnum) at ResInsight/ApplicationLibCode/UserInterface/RiuGuiTheme.cpp:355
[7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:75
[8] caf::PdmFieldUiCap<caf::PdmField<caf::AppEnum<RiaDefines::ThemeEnum> > >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:116
[9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
[11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
[12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
[13] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[41] RicEditPreferencesFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ApplicationCommands/RicEditPreferencesFeature.cpp:71
[42] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[68] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[69] __libc_start_main at :0
```

</details>

### Guard against missing case in flow characteristics plot field change

Problem: The case field can be set to nothing from the UI. RimEclipseResultCase::defaultFlowDiagSolution() and reservoirViews() were then called on a null pointer.

Fix: Check the case before use.

<details><summary>Crash stack (signature f58e9619efdf, 2 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[3] __gnu_cxx::__normal_iterator<caf::PdmPointer<RimFlowDiagSolution> const*, std::vector<caf::PdmPointer<RimFlowDiagSolution>, std::allocator<caf::PdmPointer<RimFlowDiagSolution> > > >::__normal_iterator(caf::PdmPointer<RimFlowDiagSolution> const* const&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_iterator.h:1077
[4] RimFlowCharacteristicsPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp:566
[5] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:75
[6] caf::PdmFieldUiCap<caf::PdmPtrField<RimEclipseResultCase*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:116
[7] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
[9] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
[10] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
[11] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[39] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[40] __libc_start_main at :0
```

</details>

### Guard against missing case and out of range time steps when updating flow characteristics plot

Problem: onLoadDataAndUpdate() dereferenced the case without checking, although the same function handles a missing case further down. The time step indices come from the flow diagnostics solution, and were used to index arrays sized by the number of case time steps without a range check.

Fix: Check the case before use, and skip time step indices that are out of range for the case.

<details><summary>Crash stack (signature 72e4129e054b, 3 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[6] RimFlowCharacteristicsPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp:721
[7] RimFlowCharacteristicsPlot::setFromFlowSolution(RimFlowDiagSolution*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimFlowCharacteristicsPlot.cpp:159
[8] RicShowFlowCharacteristicsPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/FlowCommands/RicShowFlowCharacteristicsPlotFeature.cpp:93
[9] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[36] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
[44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[60] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[61] __libc_start_main at :0
```

</details>

### Already fixed

Signature 4079489d1e3c (RifHdf5SummaryExporter, ESmry::dates() throwing out of an OpenMP block) was also in this batch. It is already fixed on dev by #14410, and needs no change here.
