### PR TITLE
Fix crashes reported by crash telemetry

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/VerticalFlowPerformance/RimCustomVfpPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/VerticalFlowPerformance/RimCustomVfpPlot.cpp
@@ -646,10 +646,11 @@ void RimCustomVfpPlot::onLoadDataAndUpdate()
 
     for ( const auto& table : tables )
     {
-        if ( !table ) continue;
+        if ( !table || !table->dataSource() ) continue;
 
         int  tableNumber = table->tableNumber();
         auto vfpTables   = table->dataSource()->vfpTables();
+        if ( !vfpTables ) continue;
 
         if ( table->tableType() == RimVfpDefines::TableType::INJECTION )
         {
@@ -1445,7 +1446,8 @@ void RimCustomVfpPlot::scheduleReplot()
 //--------------------------------------------------------------------------------------------------
 std::vector<double> RimCustomVfpPlot::familyValuesForTable( RimVfpTable* table ) const
 {
-    if ( !table || !m_mainDataSource || !m_mainDataSource->dataSource() || !m_mainDataSource->dataSource()->vfpTables() ) return {};
+    if ( !table || !table->dataSource() || !table->dataSource()->vfpTables() ) return {};
+    if ( !m_mainDataSource || !m_mainDataSource->dataSource() || !m_mainDataSource->dataSource()->vfpTables() ) return {};
 
     std::vector<double> mainTableFamilyValues = valuesForProductionType( m_familyVariable() );
 

--- a/ApplicationLibCode/ReservoirDataModel/RigEnsembleFractureStatisticsCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigEnsembleFractureStatisticsCalculator.cpp
@@ -157,6 +157,7 @@ std::vector<double> RigEnsembleFractureStatisticsCalculator::calculateGridStatis
 {
     std::vector<double> samples;
     if ( fractureDefinitions.empty() ) return samples;
+    if ( fractureDefinitions[0]->conductivityResultNames().isEmpty() ) return samples;
 
     // TODO: heuristic to find conductivity name?
     QString conductivityResultName = fractureDefinitions[0]->conductivityResultNames()[0];
@@ -255,6 +256,7 @@ std::vector<double> RigEnsembleFractureStatisticsCalculator::calculateAreaWeight
 {
     std::vector<double> samples;
     if ( fractureDefinitions.empty() ) return samples;
+    if ( fractureDefinitions[0]->conductivityResultNames().isEmpty() ) return samples;
 
     // TODO: heuristic to find conductivity name?
     QString conductivityResultName = fractureDefinitions[0]->conductivityResultNames()[0];

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigHexIntersectionTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ObservedDataParser-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicExpressionParser-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiuPlotUpdater-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuQwtLinearScaleEngine-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuSummaryVectorDescriptionMap-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FixedWidthDataParser-Test.cpp

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigEclipseCaseDataTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigEclipseCrossPlotDataExtractor-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigEclipseResultTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigEnsembleFractureStatisticsCalculator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigMobilePoreVolumeResultCalculator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigReservoir-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigResdataGridConverter-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigEnsembleFractureStatisticsCalculator-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigEnsembleFractureStatisticsCalculator-Test.cpp
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+
+#include "RigEnsembleFractureStatisticsCalculator.h"
+#include "RigStimPlanFractureDefinition.h"
+
+#include <QStringList>
+
+//--------------------------------------------------------------------------------------------------
+/// A fracture definition without any conductivity result must not be indexed out of range
+//--------------------------------------------------------------------------------------------------
+TEST( RigEnsembleFractureStatisticsCalculatorTest, NoConductivityResultNames )
+{
+    cvf::ref<RigStimPlanFractureDefinition> definition = new RigStimPlanFractureDefinition;
+    EXPECT_TRUE( definition->conductivityResultNames().isEmpty() );
+
+    std::vector<cvf::ref<RigStimPlanFractureDefinition>> definitions = { definition };
+
+    for ( auto propertyType : RigEnsembleFractureStatisticsCalculator::propertyTypes() )
+    {
+        if ( propertyType == RigEnsembleFractureStatisticsCalculator::PropertyType::FORMATION_DIP ) continue;
+
+        auto values = RigEnsembleFractureStatisticsCalculator::calculateProperty( definitions, propertyType );
+        EXPECT_TRUE( values.empty() );
+    }
+}

--- a/ApplicationLibCode/UnitTests/RiuPlotUpdater-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiuPlotUpdater-Test.cpp
@@ -1,0 +1,59 @@
+#include "gtest/gtest.h"
+
+#include "RimEclipseResultDefinition.h"
+
+#include "Riu3dSelectionManager.h"
+#include "RiuPlotUpdater.h"
+
+#include <QWidget>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+class TestPlotUpdater : public RiuPlotUpdater
+{
+public:
+    void storeSelection( const RiuEclipseSelectionItem* selectionItem ) { storeDelayedInformation( selectionItem ); }
+
+    int queryCount() const { return m_queryCount; }
+
+protected:
+    void     clearPlot() override {}
+    QWidget* plotPanel() override { return nullptr; }
+
+    bool queryDataAndUpdatePlot( const RimEclipseResultDefinition* eclipseResDef, size_t, size_t, size_t ) override
+    {
+        m_queryCount++;
+        return true;
+    }
+
+private:
+    int m_queryCount = 0;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// The result definition can be deleted between the selection change and the delayed update
+//--------------------------------------------------------------------------------------------------
+TEST( RiuPlotUpdaterTest, DelayedUpdateAfterResultDefinitionIsDeleted )
+{
+    auto* resultDefinition = new RimEclipseResultDefinition;
+
+    RiuEclipseSelectionItem selectionItem( nullptr,
+                                           resultDefinition,
+                                           0,
+                                           0,
+                                           0,
+                                           0,
+                                           cvf::Color3f( 1.0f, 0.0f, 0.0f ),
+                                           cvf::StructGridInterface::NO_FACE,
+                                           cvf::Vec3d::ZERO );
+
+    TestPlotUpdater plotUpdater;
+    plotUpdater.storeSelection( &selectionItem );
+
+    delete resultDefinition;
+
+    plotUpdater.doDelayedUpdate();
+
+    EXPECT_EQ( 0, plotUpdater.queryCount() );
+}

--- a/ApplicationLibCode/UserInterface/RiuPlotUpdater.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotUpdater.cpp
@@ -81,7 +81,7 @@ RiuEclipseSelectionItem* RiuPlotUpdater::extractEclipseSelectionItem( const RiuS
 //--------------------------------------------------------------------------------------------------
 void RiuPlotUpdater::doDelayedUpdate()
 {
-    if ( m_eclipseResultDef != nullptr )
+    if ( m_eclipseResultDef.notNull() )
     {
         if ( !queryDataAndUpdatePlot( m_eclipseResultDef, m_timeStepIndex, m_gridIndex, m_gridLocalCellIndex ) )
         {

--- a/ApplicationLibCode/UserInterface/RiuPlotUpdater.h
+++ b/ApplicationLibCode/UserInterface/RiuPlotUpdater.h
@@ -17,6 +17,8 @@
 /////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "cafPdmPointer.h"
+
 #include <QPointer>
 #include <QString>
 
@@ -61,8 +63,9 @@ protected:
     const Rim3dView* m_viewToFollowAnimationFrom;
 
     // cached values for delayed plot updates
-    const RimEclipseResultDefinition* m_eclipseResultDef;
-    size_t                            m_timeStepIndex;
-    size_t                            m_gridIndex;
-    size_t                            m_gridLocalCellIndex;
+    // Use a guarded pointer, as the result definition can be deleted before the delayed update is executed
+    caf::PdmPointer<RimEclipseResultDefinition> m_eclipseResultDef;
+    size_t                                      m_timeStepIndex;
+    size_t                                      m_gridIndex;
+    size_t                                      m_gridLocalCellIndex;
 };


### PR DESCRIPTION
Crashes found by inspecting reports from crash telemetry. Each section has the call stack that motivated the fix.

### Use guarded pointer for delayed plot updates

Problem: `RiuPlotUpdater` caches the selected result definition in a raw pointer while the plot panel is hidden, and dereferences it from `showEvent` after the object may have been deleted.

Fix: Store the cached result definition in a `caf::PdmPointer`, which is set to null when the object is deleted.

Unit test `RiuPlotUpdaterTest.DelayedUpdateAfterResultDefinitionIsDeleted` passes a dangling pointer to the plot query without the fix.

<details><summary>Crash stack (signature 32397cd21d29, 3 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[4] RiuPvtPlotUpdater::queryDataAndUpdatePlot(RimEclipseResultDefinition const*, unsigned long, unsigned long, unsigned long) at ResInsight/ApplicationLibCode/UserInterface/RiuPvtPlotUpdater.cpp:81
[5] RiuPlotUpdater::doDelayedUpdate() at ResInsight/ApplicationLibCode/UserInterface/RiuPlotUpdater.cpp:86
[6] RiuPvtPlotPanel::showEvent(QShowEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuPvtPlotPanel.cpp:344
[9] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[49] __libc_start_main at :0
```

</details>

### Guard against fracture definition without conductivity result

Problem: `conductivityResultNames()[0]` is an out of range access when a StimPlan fracture definition has no conductivity result.

Fix: Return no samples when the list of conductivity result names is empty, matching the `isEmpty()` check used by the other callers.

Unit test `RigEnsembleFractureStatisticsCalculatorTest.NoConductivityResultNames` crashes with an access violation without the fix.

<details><summary>Crash stack (signature 365d8f1357cb, 3 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[5] RigEnsembleFractureStatisticsCalculator::calculateAreaWeightedStatistics(std::vector<cvf::ref<RigStimPlanFractureDefinition>, std::allocator<cvf::ref<RigStimPlanFractureDefinition> > > const&, double (*)(cvf::cref<RigFractureGrid>, cvf::cref<RigFractureGrid>, RiaDefines::EclipseUnitSystem, QString const&)) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigEnsembleFractureStatisticsCalculator.cpp:275
[6] RigEnsembleFractureStatisticsCalculator::calculateProperty(std::vector<cvf::ref<RigStimPlanFractureDefinition>, std::allocator<cvf::ref<RigStimPlanFractureDefinition> > > const&, RigEnsembleFractureStatisticsCalculator::PropertyType) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigEnsembleFractureStatisticsCalculator.cpp:132
[7] RimStimPlanFractureTemplate::generatePropertiesTable() const at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimStimPlanFractureTemplate.cpp:788
[8] RimStimPlanFractureTemplate::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimStimPlanFractureTemplate.cpp:219
[9] RimFractureTemplateCollection::loadAndUpdateData() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.cpp:263
[10] RimCompletionTemplateCollection::loadAndUpdateData() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimCompletionTemplateCollection.cpp:161
[11] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:699
[12] RicOpenProjectFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ApplicationCommands/RicOpenProjectFeature.cpp:50
[13] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[41] __libc_start_main at :0
```

</details>

### Guard against missing data source in custom VFP plot

Problem: The data source of a VFP table can be null, and `vfpTables()` returns null until the data has been imported. Both are dereferenced unchecked when the plot is updated, also for the comparison tables in `familyValuesForTable()`.

Fix: Skip tables without a data source or without imported VFP tables.

No unit test: `onLoadDataAndUpdate()` returns early without a plot widget, so the crashing loop is not reachable outside GUI state.

<details><summary>Crash stack (signature 5ae2e6f0153b, 3 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[4] RimCustomVfpPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/VerticalFlowPerformance/RimCustomVfpPlot.cpp:704
[5] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
[6] RimCustomVfpPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/VerticalFlowPerformance/RimCustomVfpPlot.cpp:1401
[7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
[8] caf::PdmFieldUiCap<caf::PdmPtrArrayField<RimVfpTable*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
[9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
[11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
[12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
[13] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:538
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[42] __libc_start_main at :0
```

</details>

<details><summary>Crash stack (signature a92cb693a22d, 3 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
[4] RimCustomVfpPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/VerticalFlowPerformance/RimCustomVfpPlot.cpp:688
[5] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:90
[6] RimCustomVfpPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/VerticalFlowPerformance/RimCustomVfpPlot.cpp:1385
[7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:75
[8] caf::PdmFieldUiCap<caf::PdmField<std::vector<double, std::allocator<double> > > >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
[9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
[11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
[12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
[13] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:538
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
[41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
[42] __libc_start_main at :0
```

</details>
