### PR TITLE
MSW: Restore fishbones export behaviour lost with the legacy code

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -62,26 +62,38 @@ namespace RicMswBranchBuilder
 //--------------------------------------------------------------------------------------------------
 void applyEffectiveDiameters( const FishbonesExportContext& context, RigMswWellExportData& exportData )
 {
-    if ( context.lateralSegments.empty() ) return;
+    if ( context.laterals.empty() ) return;
 
-    // Deff = sqrt(d1^2 + d2^2 + ..) for all lateral segments sharing a grid cell
+    // Deff = sqrt(d1^2 + d2^2 + ..) for all cell intersections sharing a grid cell. A cell
+    // intersection contributes once, no matter how many WELSEGS rows it was split into.
     std::map<size_t, double> sumOfSquaresPerCell;
-    for ( const auto& lateralSegment : context.lateralSegments )
+    for ( const auto& lateral : context.laterals )
     {
-        sumOfSquaresPerCell[lateralSegment.globalCellIndex] += lateralSegment.equivalentDiameter * lateralSegment.equivalentDiameter;
+        for ( const auto& lateralSegment : lateral.segments )
+        {
+            sumOfSquaresPerCell[lateralSegment.globalCellIndex] += lateralSegment.equivalentDiameter * lateralSegment.equivalentDiameter;
+        }
     }
 
     std::map<int, double> effectiveDiameterPerSegment;
-    for ( const auto& lateralSegment : context.lateralSegments )
+    for ( const auto& lateral : context.laterals )
     {
-        effectiveDiameterPerSegment[lateralSegment.segmentNumber] = std::sqrt( sumOfSquaresPerCell[lateralSegment.globalCellIndex] );
-    }
+        std::vector<double> effectiveDiameters;
+        for ( const auto& lateralSegment : lateral.segments )
+        {
+            effectiveDiameters.push_back( std::sqrt( sumOfSquaresPerCell[lateralSegment.globalCellIndex] ) );
+        }
 
-    // Reduce the diameter of the segment sharing a cell with the main bore
-    for ( const auto& [firstSegment, secondSegment] : context.firstAndSecondSegments )
-    {
-        auto it = effectiveDiameterPerSegment.find( secondSegment );
-        if ( it != effectiveDiameterPerSegment.end() ) effectiveDiameterPerSegment[firstSegment] = it->second;
+        // Reduce the diameter of the cell intersection shared with the main bore
+        if ( effectiveDiameters.size() > 1 ) effectiveDiameters[0] = effectiveDiameters[1];
+
+        for ( size_t i = 0; i < lateral.segments.size(); i++ )
+        {
+            for ( auto segmentNumber : lateral.segments[i].segmentNumbers )
+            {
+                effectiveDiameterPerSegment[segmentNumber] = effectiveDiameters[i];
+            }
+        }
     }
 
     for ( auto& branch : exportData.branches )
@@ -842,6 +854,8 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                                                   const std::string&                               wellNameForExport,
                                                   int&                                             segmentNumber,
                                                   int&                                             branchNumber,
+                                                  double                                           maxSegmentLength,
+                                                  const std::vector<std::pair<double, double>>&    customSegmentIntervals,
                                                   RiaDefines::EclipseUnitSystem                    unitSystem,
                                                   FishbonesExportContext&                          fishbonesContext )
 {
@@ -998,52 +1012,80 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                 const auto lateralLabel = QString( "Lateral %1" ).arg( lateralIndex + 1 ).toStdString();
 
                 std::vector<RigMswSegment> latSegs;
+                FishbonesLateral           lateralContext;
                 for ( const auto& cellIntInfo : lateralIntersections )
                 {
                     if ( auto mci = toMswCellIntersection( cellIntInfo, mainGrid, cellIntInfo.startMD, cellIntInfo.endMD ) )
                     {
-                        double len = 0.0;
-                        double dep = 0.0;
-                        if ( infoType == "INC" )
-                        {
-                            len = cellIntInfo.endMD - prevMD;
-                            dep = cellIntInfo.endTVD() - prevTVD;
-                        }
-                        else
-                        {
-                            len = cellIntInfo.endMD;
-                            dep = cellIntInfo.endTVD();
-                        }
-
                         // Deduplicate COMPSEGS: skip cells already connected (matching tree intersectedCells logic)
                         const bool isNewCell = usedGlobalCellIndices.insert( cellIntInfo.globCellIndex ).second;
 
-                        RigMswSegment latSeg;
-                        latSeg.segmentNumber       = segmentNumber++;
-                        latSeg.outletSegmentNumber = latOutletSeg;
-                        latSeg.length              = len;
-                        latSeg.depth               = dep;
-                        latSeg.diameter            = subs->equivalentDiameter( unitSystem );
-                        latSeg.roughness           = subs->openHoleRoughnessFactor( unitSystem );
-                        latSeg.sourceWellName      = wellPath->name().toStdString();
-                        if ( firstLatSeg ) latSeg.description = lateralLabel;
-                        latSeg.intersections = isNewCell ? std::vector<RigMswCellIntersection>{ *mci } : std::vector<RigMswCellIntersection>{};
+                        const double startMD  = prevMD;
+                        const double endMD    = cellIntInfo.endMD;
+                        const double startTVD = prevTVD;
+                        const double endTVD   = cellIntInfo.endTVD();
 
-                        fishbonesContext.lateralSegments.push_back(
-                            { latSeg.segmentNumber, cellIntInfo.globCellIndex, subs->equivalentDiameter( unitSystem ) } );
+                        FishbonesLateralSegment lateralSegmentContext;
+                        lateralSegmentContext.globalCellIndex    = cellIntInfo.globCellIndex;
+                        lateralSegmentContext.equivalentDiameter = subs->equivalentDiameter( unitSystem );
 
-                        latOutletSeg = latSeg.segmentNumber;
-                        prevMD       = cellIntInfo.endMD;
-                        prevTVD      = cellIntInfo.endTVD();
-                        firstLatSeg  = false;
-                        latSegs.push_back( std::move( latSeg ) );
+                        const auto subSegs =
+                            RicMswTableDataTools::createSubSegmentMDPairs( startMD, endMD, maxSegmentLength, customSegmentIntervals );
+
+                        bool firstSubSeg = true;
+                        for ( const auto& [subStartMD, subEndMD] : subSegs )
+                        {
+                            // The lateral geometry is not part of the well path, so the TVD of a sub-segment
+                            // cannot be interpolated along the well path. Interpolate linearly instead.
+                            const double mdRange     = endMD - startMD;
+                            const double startWeight = mdRange > 0.0 ? ( subStartMD - startMD ) / mdRange : 0.0;
+                            const double endWeight   = mdRange > 0.0 ? ( subEndMD - startMD ) / mdRange : 1.0;
+
+                            const double subStartTVD = startTVD * ( 1.0 - startWeight ) + endTVD * startWeight;
+                            const double subEndTVD   = startTVD * ( 1.0 - endWeight ) + endTVD * endWeight;
+
+                            double len = 0.0;
+                            double dep = 0.0;
+                            if ( infoType == "INC" )
+                            {
+                                len = subEndMD - subStartMD;
+                                dep = subEndTVD - subStartTVD;
+                            }
+                            else
+                            {
+                                len = subEndMD;
+                                dep = subEndTVD;
+                            }
+
+                            RigMswSegment latSeg;
+                            latSeg.segmentNumber       = segmentNumber++;
+                            latSeg.outletSegmentNumber = latOutletSeg;
+                            latSeg.length              = len;
+                            latSeg.depth               = dep;
+                            latSeg.diameter            = subs->equivalentDiameter( unitSystem );
+                            latSeg.roughness           = subs->openHoleRoughnessFactor( unitSystem );
+                            latSeg.sourceWellName      = wellPath->name().toStdString();
+                            if ( firstLatSeg ) latSeg.description = lateralLabel;
+
+                            // The cell is connected by the first sub-segment only
+                            if ( firstSubSeg && isNewCell ) latSeg.intersections = { *mci };
+
+                            lateralSegmentContext.segmentNumbers.push_back( latSeg.segmentNumber );
+
+                            latOutletSeg = latSeg.segmentNumber;
+                            firstLatSeg  = false;
+                            firstSubSeg  = false;
+                            latSegs.push_back( std::move( latSeg ) );
+                        }
+
+                        lateralContext.segments.push_back( std::move( lateralSegmentContext ) );
+
+                        prevMD  = cellIntInfo.endMD;
+                        prevTVD = cellIntInfo.endTVD();
                     }
                 }
 
-                if ( latSegs.size() > 1 )
-                {
-                    fishbonesContext.firstAndSecondSegments.emplace_back( latSegs[0].segmentNumber, latSegs[1].segmentNumber );
-                }
+                fishbonesContext.laterals.push_back( std::move( lateralContext ) );
 
                 result.push_back( RigMswBranch{ latBranch, std::nullopt, std::move( latSegs ) } );
             }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -844,10 +844,11 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
             icdSeg.outletSegmentNumber = outletSeg;
             icdSeg.length              = icdLength;
             icdSeg.depth               = icdDepth;
-            // Use RigMswSegment defaults for diameter/roughness (matching tree approach for fishbones ICD)
-            icdSeg.sourceWellName = wellPath->name().toStdString();
-            icdSeg.description    = QString( "ICD sub %1" ).arg( subIndex + 1 ).toStdString();
-            icdSeg.intersections  = std::move( icdCompsegs );
+            icdSeg.diameter            = 0.15; // default segment diameter
+            icdSeg.roughness           = 5.0e-5; // default segment roughness
+            icdSeg.sourceWellName      = wellPath->name().toStdString();
+            icdSeg.description         = QString( "ICD sub %1" ).arg( subIndex + 1 ).toStdString();
+            icdSeg.intersections       = std::move( icdCompsegs );
 
             WsegvalvRow wv;
             wv.well             = wellNameForExport;

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -49,12 +49,50 @@
 #include "Well/RigWellPath.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <map>
 #include <set>
 
 namespace RicMswBranchBuilder
 {
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void applyEffectiveDiameters( const FishbonesDiameterContext& context, RigMswWellExportData& exportData )
+{
+    if ( context.lateralSegments.empty() ) return;
+
+    // Deff = sqrt(d1^2 + d2^2 + ..) for all lateral segments sharing a grid cell
+    std::map<size_t, double> sumOfSquaresPerCell;
+    for ( const auto& lateralSegment : context.lateralSegments )
+    {
+        sumOfSquaresPerCell[lateralSegment.globalCellIndex] += lateralSegment.equivalentDiameter * lateralSegment.equivalentDiameter;
+    }
+
+    std::map<int, double> effectiveDiameterPerSegment;
+    for ( const auto& lateralSegment : context.lateralSegments )
+    {
+        effectiveDiameterPerSegment[lateralSegment.segmentNumber] = std::sqrt( sumOfSquaresPerCell[lateralSegment.globalCellIndex] );
+    }
+
+    // Reduce the diameter of the segment sharing a cell with the main bore
+    for ( const auto& [firstSegment, secondSegment] : context.firstAndSecondSegments )
+    {
+        auto it = effectiveDiameterPerSegment.find( secondSegment );
+        if ( it != effectiveDiameterPerSegment.end() ) effectiveDiameterPerSegment[firstSegment] = it->second;
+    }
+
+    for ( auto& branch : exportData.branches )
+    {
+        for ( auto& segment : branch.segments )
+        {
+            auto it = effectiveDiameterPerSegment.find( segment.segmentNumber );
+            if ( it != effectiveDiameterPerSegment.end() && it->second > 0.0 ) segment.diameter = it->second;
+        }
+    }
+}
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -739,7 +777,8 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                                                   const std::string&                               wellNameForExport,
                                                   int&                                             segmentNumber,
                                                   int&                                             branchNumber,
-                                                  RiaDefines::EclipseUnitSystem                    unitSystem )
+                                                  RiaDefines::EclipseUnitSystem                    unitSystem,
+                                                  FishbonesDiameterContext&                        diameterContext )
 {
     std::vector<RigMswBranch> result;
 
@@ -921,6 +960,9 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                         if ( firstLatSeg ) latSeg.description = lateralLabel;
                         latSeg.intersections = isNewCell ? std::vector<RigMswCellIntersection>{ *mci } : std::vector<RigMswCellIntersection>{};
 
+                        diameterContext.lateralSegments.push_back(
+                            { latSeg.segmentNumber, cellIntInfo.globCellIndex, subs->equivalentDiameter( unitSystem ) } );
+
                         latOutletSeg = latSeg.segmentNumber;
                         prevMD       = cellIntInfo.endMD;
                         prevTVD      = cellIntInfo.endTVD();
@@ -928,6 +970,12 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                         latSegs.push_back( std::move( latSeg ) );
                     }
                 }
+
+                if ( latSegs.size() > 1 )
+                {
+                    diameterContext.firstAndSecondSegments.emplace_back( latSegs[0].segmentNumber, latSegs[1].segmentNumber );
+                }
+
                 result.push_back( RigMswBranch{ latBranch, std::nullopt, std::move( latSegs ) } );
             }
         }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -60,7 +60,7 @@ namespace RicMswBranchBuilder
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void applyEffectiveDiameters( const FishbonesDiameterContext& context, RigMswWellExportData& exportData )
+void applyEffectiveDiameters( const FishbonesExportContext& context, RigMswWellExportData& exportData )
 {
     if ( context.lateralSegments.empty() ) return;
 
@@ -90,6 +90,70 @@ void applyEffectiveDiameters( const FishbonesDiameterContext& context, RigMswWel
         {
             auto it = effectiveDiameterPerSegment.find( segment.segmentNumber );
             if ( it != effectiveDiameterPerSegment.end() && it->second > 0.0 ) segment.diameter = it->second;
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void applyIcdAreaPerCell( const FishbonesExportContext& context, RigMswWellExportData& exportData )
+{
+    if ( context.icdSegments.empty() ) return;
+
+    std::map<size_t, std::set<int>> icdSegmentsPerCell;
+    for ( const auto& icdSegment : context.icdSegments )
+    {
+        for ( auto globalCellIndex : icdSegment.globalCellIndices )
+        {
+            icdSegmentsPerCell[globalCellIndex].insert( icdSegment.segmentNumber );
+        }
+    }
+
+    std::set<int> icdSegmentNumbers;
+    for ( const auto& icdSegment : context.icdSegments )
+    {
+        icdSegmentNumbers.insert( icdSegment.segmentNumber );
+    }
+
+    std::map<int, double> areaPerSegment;
+    for ( const auto& branch : exportData.branches )
+    {
+        for ( const auto& segment : branch.segments )
+        {
+            if ( !segment.wsegvalvData.has_value() ) continue;
+            if ( !icdSegmentNumbers.count( segment.segmentNumber ) ) continue;
+
+            areaPerSegment[segment.segmentNumber] = segment.wsegvalvData->area;
+        }
+    }
+
+    // An ICD sub connected to several cells is summed once per cell, in ascending cell order, and
+    // ends up with the sum of the last cell it takes part in. This matches the tree implementation.
+    for ( const auto& [globalCellIndex, segmentNumbers] : icdSegmentsPerCell )
+    {
+        double areaSum = 0.0;
+        for ( auto segmentNumber : segmentNumbers )
+        {
+            auto it = areaPerSegment.find( segmentNumber );
+            if ( it != areaPerSegment.end() ) areaSum += it->second;
+        }
+
+        for ( auto segmentNumber : segmentNumbers )
+        {
+            auto it = areaPerSegment.find( segmentNumber );
+            if ( it != areaPerSegment.end() ) it->second = areaSum;
+        }
+    }
+
+    for ( auto& branch : exportData.branches )
+    {
+        for ( auto& segment : branch.segments )
+        {
+            if ( !segment.wsegvalvData.has_value() ) continue;
+
+            auto it = areaPerSegment.find( segment.segmentNumber );
+            if ( it != areaPerSegment.end() ) segment.wsegvalvData->area = it->second;
         }
     }
 }
@@ -778,7 +842,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                                                   int&                                             segmentNumber,
                                                   int&                                             branchNumber,
                                                   RiaDefines::EclipseUnitSystem                    unitSystem,
-                                                  FishbonesDiameterContext&                        diameterContext )
+                                                  FishbonesExportContext&                          fishbonesContext )
 {
     std::vector<RigMswBranch> result;
 
@@ -852,6 +916,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                 icdCellIndices.insert( cellIntersectionContainingSubIndex[subIndex] );
 
             std::vector<RigMswCellIntersection> icdCompsegs;
+            std::set<size_t>                    icdGlobalCellIndices;
             for ( auto idx : icdCellIndices )
             {
                 const auto&  ci           = filteredIntersections[idx];
@@ -861,6 +926,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                 if ( auto mci = toMswCellIntersection( ci, mainGrid, overlapStart, overlapEnd ) )
                 {
                     icdCompsegs.push_back( *mci );
+                    icdGlobalCellIndices.insert( ci.globCellIndex );
                     usedGlobalCellIndices.insert( ci.globCellIndex );
                 }
             }
@@ -897,6 +963,8 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
             wv.status           = "OPEN";
             wv.description      = QString( "ICD sub %1" ).arg( subIndex + 1 ).toStdString();
             icdSeg.wsegvalvData = wv;
+
+            fishbonesContext.icdSegments.push_back( { icdSegNum, std::move( icdGlobalCellIndices ) } );
 
             result.push_back( RigMswBranch{ icdBranch, std::nullopt, { std::move( icdSeg ) } } );
 
@@ -960,7 +1028,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                         if ( firstLatSeg ) latSeg.description = lateralLabel;
                         latSeg.intersections = isNewCell ? std::vector<RigMswCellIntersection>{ *mci } : std::vector<RigMswCellIntersection>{};
 
-                        diameterContext.lateralSegments.push_back(
+                        fishbonesContext.lateralSegments.push_back(
                             { latSeg.segmentNumber, cellIntInfo.globCellIndex, subs->equivalentDiameter( unitSystem ) } );
 
                         latOutletSeg = latSeg.segmentNumber;
@@ -973,7 +1041,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
 
                 if ( latSegs.size() > 1 )
                 {
-                    diameterContext.firstAndSecondSegments.emplace_back( latSegs[0].segmentNumber, latSegs[1].segmentNumber );
+                    fishbonesContext.firstAndSecondSegments.emplace_back( latSegs[0].segmentNumber, latSegs[1].segmentNumber );
                 }
 
                 result.push_back( RigMswBranch{ latBranch, std::nullopt, std::move( latSegs ) } );

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -101,22 +101,13 @@ void applyIcdAreaPerCell( const FishbonesExportContext& context, RigMswWellExpor
 {
     if ( context.icdSegments.empty() ) return;
 
-    std::map<size_t, std::set<int>> icdSegmentsPerCell;
-    for ( const auto& icdSegment : context.icdSegments )
-    {
-        for ( auto globalCellIndex : icdSegment.globalCellIndices )
-        {
-            icdSegmentsPerCell[globalCellIndex].insert( icdSegment.segmentNumber );
-        }
-    }
-
     std::set<int> icdSegmentNumbers;
     for ( const auto& icdSegment : context.icdSegments )
     {
         icdSegmentNumbers.insert( icdSegment.segmentNumber );
     }
 
-    std::map<int, double> areaPerSegment;
+    std::map<int, double> originalAreaPerSegment;
     for ( const auto& branch : exportData.branches )
     {
         for ( const auto& segment : branch.segments )
@@ -124,26 +115,36 @@ void applyIcdAreaPerCell( const FishbonesExportContext& context, RigMswWellExpor
             if ( !segment.wsegvalvData.has_value() ) continue;
             if ( !icdSegmentNumbers.count( segment.segmentNumber ) ) continue;
 
-            areaPerSegment[segment.segmentNumber] = segment.wsegvalvData->area;
+            originalAreaPerSegment[segment.segmentNumber] = segment.wsegvalvData->area;
         }
     }
 
-    // An ICD sub connected to several cells is summed once per cell, in ascending cell order, and
-    // ends up with the sum of the last cell it takes part in. This matches the tree implementation.
-    for ( const auto& [globalCellIndex, segmentNumbers] : icdSegmentsPerCell )
+    // Every sum is computed from the original areas, so the result does not depend on the order the
+    // cells are visited in.
+    std::map<size_t, double> areaSumPerCell;
+    for ( const auto& icdSegment : context.icdSegments )
     {
-        double areaSum = 0.0;
-        for ( auto segmentNumber : segmentNumbers )
+        auto it = originalAreaPerSegment.find( icdSegment.segmentNumber );
+        if ( it == originalAreaPerSegment.end() ) continue;
+
+        for ( auto globalCellIndex : icdSegment.globalCellIndices )
         {
-            auto it = areaPerSegment.find( segmentNumber );
-            if ( it != areaPerSegment.end() ) areaSum += it->second;
+            areaSumPerCell[globalCellIndex] += it->second;
+        }
+    }
+
+    // An ICD sub spans a 0.1 m valve segment and normally connects to a single cell. When it reaches
+    // into more than one, it reports the largest of the sums it takes part in.
+    std::map<int, double> areaPerSegment;
+    for ( const auto& icdSegment : context.icdSegments )
+    {
+        double area = 0.0;
+        for ( auto globalCellIndex : icdSegment.globalCellIndices )
+        {
+            area = std::max( area, areaSumPerCell[globalCellIndex] );
         }
 
-        for ( auto segmentNumber : segmentNumbers )
-        {
-            auto it = areaPerSegment.find( segmentNumber );
-            if ( it != areaPerSegment.end() ) it->second = areaSum;
-        }
+        if ( area > 0.0 ) areaPerSegment[icdSegment.segmentNumber] = area;
     }
 
     for ( auto& branch : exportData.branches )

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
@@ -26,6 +26,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <QDateTime>
@@ -56,6 +57,42 @@ struct CellSegmentEntry
     double cellEndMD;
     int    lastSubSegmentNumber;
 };
+
+//--------------------------------------------------------------------------------------------------
+/// One fishbones lateral segment, recorded while the lateral branches are built so that effective
+/// diameters can be computed once all laterals of the well are known.
+//--------------------------------------------------------------------------------------------------
+struct FishbonesLateralSegment
+{
+    int    segmentNumber;
+    size_t globalCellIndex;
+    double equivalentDiameter;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// Data collected across all fishbones of a well, used by applyEffectiveDiameters().
+//--------------------------------------------------------------------------------------------------
+struct FishbonesDiameterContext
+{
+    std::vector<FishbonesLateralSegment> lateralSegments;
+
+    /// Segment numbers of the first and second segment of each lateral having more than one segment.
+    std::vector<std::pair<int, int>> firstAndSecondSegments;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// Replace the WELSEGS diameter of fishbones lateral segments with an effective diameter.
+///
+/// Several laterals may run through the same grid cell. The combined flow area is represented by
+/// Deff = sqrt(d1^2 + d2^2 + ..) over the lateral segments in that cell, see
+/// https://github.com/OPM/ResInsight/issues/7686
+///
+/// The first segment of a lateral shares its cell with the main bore and with the first segment of
+/// every other lateral on the same sub, which inflates Deff. It therefore inherits the effective
+/// diameter of the second segment of the same lateral, see
+/// https://github.com/OPM/ResInsight/issues/7731
+//--------------------------------------------------------------------------------------------------
+void applyEffectiveDiameters( const FishbonesDiameterContext& context, RigMswWellExportData& exportData );
 
 //--------------------------------------------------------------------------------------------------
 /// Convert a WellPathCellIntersectionInfo global-cell index to a RigMswCellIntersection (1-based i,j,k).
@@ -136,6 +173,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                                                   const std::string&                               wellNameForExport,
                                                   int&                                             segmentNumber,
                                                   int&                                             branchNumber,
-                                                  RiaDefines::EclipseUnitSystem                    unitSystem );
+                                                  RiaDefines::EclipseUnitSystem                    unitSystem,
+                                                  FishbonesDiameterContext&                        diameterContext );
 
 } // namespace RicMswBranchBuilder

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
@@ -70,14 +70,25 @@ struct FishbonesLateralSegment
 };
 
 //--------------------------------------------------------------------------------------------------
-/// Data collected across all fishbones of a well, used by applyEffectiveDiameters().
+/// One fishbones ICD sub segment, recorded with the grid cells it connects to.
 //--------------------------------------------------------------------------------------------------
-struct FishbonesDiameterContext
+struct FishbonesIcdSegment
+{
+    int              segmentNumber;
+    std::set<size_t> globalCellIndices;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// Data collected across all fishbones of a well, used by the apply functions below.
+//--------------------------------------------------------------------------------------------------
+struct FishbonesExportContext
 {
     std::vector<FishbonesLateralSegment> lateralSegments;
 
     /// Segment numbers of the first and second segment of each lateral having more than one segment.
     std::vector<std::pair<int, int>> firstAndSecondSegments;
+
+    std::vector<FishbonesIcdSegment> icdSegments;
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -92,7 +103,13 @@ struct FishbonesDiameterContext
 /// diameter of the second segment of the same lateral, see
 /// https://github.com/OPM/ResInsight/issues/7731
 //--------------------------------------------------------------------------------------------------
-void applyEffectiveDiameters( const FishbonesDiameterContext& context, RigMswWellExportData& exportData );
+void applyEffectiveDiameters( const FishbonesExportContext& context, RigMswWellExportData& exportData );
+
+//--------------------------------------------------------------------------------------------------
+/// Replace the WSEGVALV area of fishbones ICD subs connected to the same grid cell with the sum of
+/// their areas, so that the cell sees the total flow area of the ICDs completing it.
+//--------------------------------------------------------------------------------------------------
+void applyIcdAreaPerCell( const FishbonesExportContext& context, RigMswWellExportData& exportData );
 
 //--------------------------------------------------------------------------------------------------
 /// Convert a WellPathCellIntersectionInfo global-cell index to a RigMswCellIntersection (1-based i,j,k).
@@ -174,6 +191,6 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                                                   int&                                             segmentNumber,
                                                   int&                                             branchNumber,
                                                   RiaDefines::EclipseUnitSystem                    unitSystem,
-                                                  FishbonesDiameterContext&                        diameterContext );
+                                                  FishbonesExportContext&                          fishbonesContext );
 
 } // namespace RicMswBranchBuilder

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
@@ -108,6 +108,9 @@ void applyEffectiveDiameters( const FishbonesExportContext& context, RigMswWellE
 //--------------------------------------------------------------------------------------------------
 /// Replace the WSEGVALV area of fishbones ICD subs connected to the same grid cell with the sum of
 /// their areas, so that the cell sees the total flow area of the ICDs completing it.
+///
+/// The sums are computed from the original areas only. An ICD sub reaching into more than one cell
+/// reports the largest of the sums it takes part in.
 //--------------------------------------------------------------------------------------------------
 void applyIcdAreaPerCell( const FishbonesExportContext& context, RigMswWellExportData& exportData );
 

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.h
@@ -59,14 +59,26 @@ struct CellSegmentEntry
 };
 
 //--------------------------------------------------------------------------------------------------
-/// One fishbones lateral segment, recorded while the lateral branches are built so that effective
-/// diameters can be computed once all laterals of the well are known.
+/// One grid-cell intersection of a fishbones lateral, recorded while the lateral branches are built
+/// so that effective diameters can be computed once all laterals of the well are known.
+///
+/// A cell intersection longer than the max segment length is split into several WELSEGS rows. They
+/// all belong to the same intersection and share one effective diameter, so the segment numbers are
+/// kept together here.
 //--------------------------------------------------------------------------------------------------
 struct FishbonesLateralSegment
 {
-    int    segmentNumber;
-    size_t globalCellIndex;
-    double equivalentDiameter;
+    std::vector<int> segmentNumbers;
+    size_t           globalCellIndex;
+    double           equivalentDiameter;
+};
+
+//--------------------------------------------------------------------------------------------------
+/// The cell intersections of one fishbones lateral, in order from the ICD sub and outwards.
+//--------------------------------------------------------------------------------------------------
+struct FishbonesLateral
+{
+    std::vector<FishbonesLateralSegment> segments;
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -83,11 +95,7 @@ struct FishbonesIcdSegment
 //--------------------------------------------------------------------------------------------------
 struct FishbonesExportContext
 {
-    std::vector<FishbonesLateralSegment> lateralSegments;
-
-    /// Segment numbers of the first and second segment of each lateral having more than one segment.
-    std::vector<std::pair<int, int>> firstAndSecondSegments;
-
+    std::vector<FishbonesLateral>    laterals;
     std::vector<FishbonesIcdSegment> icdSegments;
 };
 
@@ -98,9 +106,9 @@ struct FishbonesExportContext
 /// Deff = sqrt(d1^2 + d2^2 + ..) over the lateral segments in that cell, see
 /// https://github.com/OPM/ResInsight/issues/7686
 ///
-/// The first segment of a lateral shares its cell with the main bore and with the first segment of
-/// every other lateral on the same sub, which inflates Deff. It therefore inherits the effective
-/// diameter of the second segment of the same lateral, see
+/// The first cell intersection of a lateral shares its cell with the main bore and with the first
+/// intersection of every other lateral on the same sub, which inflates Deff. It therefore inherits
+/// the effective diameter of the second intersection of the same lateral, see
 /// https://github.com/OPM/ResInsight/issues/7731
 //--------------------------------------------------------------------------------------------------
 void applyEffectiveDiameters( const FishbonesExportContext& context, RigMswWellExportData& exportData );
@@ -193,6 +201,8 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
                                                   const std::string&                               wellNameForExport,
                                                   int&                                             segmentNumber,
                                                   int&                                             branchNumber,
+                                                  double                                           maxSegmentLength,
+                                                  const std::vector<std::pair<double, double>>&    customSegmentIntervals,
                                                   RiaDefines::EclipseUnitSystem                    unitSystem,
                                                   FishbonesExportContext&                          fishbonesContext );
 

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
@@ -49,15 +49,16 @@ using CompletionType = RicWellPathExportMswTableData::CompletionType;
 /// Recursively build all WELSEGS/COMPSEGS/valve segments for one lateral (child well path)
 /// and any of its own child laterals.
 //--------------------------------------------------------------------------------------------------
-std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 eclipseCase,
-                                                const RimWellPath*              wellPath,
-                                                const RigMainGrid*              mainGrid,
-                                                int                             outletSegNum,
-                                                CompletionType                  completionType,
-                                                const std::optional<QDateTime>& exportDate,
-                                                int&                            segmentNumber,
-                                                int&                            branchNumber,
-                                                RiaDefines::EclipseUnitSystem   unitSystem )
+std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                                eclipseCase,
+                                                const RimWellPath*                             wellPath,
+                                                const RigMainGrid*                             mainGrid,
+                                                int                                            outletSegNum,
+                                                CompletionType                                 completionType,
+                                                const std::optional<QDateTime>&                exportDate,
+                                                int&                                           segmentNumber,
+                                                int&                                           branchNumber,
+                                                RiaDefines::EclipseUnitSystem                  unitSystem,
+                                                RicMswBranchBuilder::FishbonesDiameterContext& diameterContext )
 {
     std::vector<RigMswBranch> result;
     auto                      mswParameters = wellPath->mswCompletionParameters();
@@ -235,7 +236,8 @@ std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 
                                                                          wellNameForExport,
                                                                          segmentNumber,
                                                                          branchNumber,
-                                                                         unitSystem );
+                                                                         unitSystem,
+                                                                         diameterContext );
         result.insert( result.end(), std::make_move_iterator( fishBranches.begin() ), std::make_move_iterator( fishBranches.end() ) );
     }
 
@@ -244,8 +246,16 @@ std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 
     {
         const int grandchildOutlet =
             RicMswBranchBuilder::findOutletSegmentForMD( childCellSegMap, grandchild->wellPathTieIn()->branchValveMeasuredDepth() );
-        auto grandchildBranches =
-            buildLateralBranches( eclipseCase, grandchild, mainGrid, grandchildOutlet, completionType, exportDate, segmentNumber, branchNumber, unitSystem );
+        auto grandchildBranches = buildLateralBranches( eclipseCase,
+                                                        grandchild,
+                                                        mainGrid,
+                                                        grandchildOutlet,
+                                                        completionType,
+                                                        exportDate,
+                                                        segmentNumber,
+                                                        branchNumber,
+                                                        unitSystem,
+                                                        diameterContext );
         result.insert( result.end(), std::make_move_iterator( grandchildBranches.begin() ), std::make_move_iterator( grandchildBranches.end() ) );
     }
 
@@ -313,6 +323,9 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
     int                                                segmentNumber = 2; // Segment 1 is the implicit well heel.
     int                                                branchNumber  = 1; // Incremented for each new branch.
     std::vector<RicMswBranchBuilder::CellSegmentEntry> cellSegMap;
+
+    // Collected across the main bore and all tie-in laterals, applied once the branches are assembled.
+    RicMswBranchBuilder::FishbonesDiameterContext diameterContext;
 
     const RigActiveCellInfo* activeCellInfo = eclipseCase->eclipseCaseData()->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
 
@@ -396,7 +409,8 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
                                                                          wellNameForExport,
                                                                          segmentNumber,
                                                                          branchNumber,
-                                                                         unitSystem );
+                                                                         unitSystem,
+                                                                         diameterContext );
     }
 
     // Tie-in child laterals (recursive)
@@ -405,8 +419,16 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
     {
         const int childOutlet =
             RicMswBranchBuilder::findOutletSegmentForMD( cellSegMap, childWellPath->wellPathTieIn()->branchValveMeasuredDepth() );
-        auto childBranches =
-            buildLateralBranches( eclipseCase, childWellPath, mainGrid, childOutlet, completionType, exportDate, segmentNumber, branchNumber, unitSystem );
+        auto childBranches = buildLateralBranches( eclipseCase,
+                                                   childWellPath,
+                                                   mainGrid,
+                                                   childOutlet,
+                                                   completionType,
+                                                   exportDate,
+                                                   segmentNumber,
+                                                   branchNumber,
+                                                   unitSystem,
+                                                   diameterContext );
         lateralBranches.insert( lateralBranches.end(),
                                 std::make_move_iterator( childBranches.begin() ),
                                 std::make_move_iterator( childBranches.end() ) );
@@ -427,6 +449,9 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
     result.branches.insert( result.branches.end(),
                             std::make_move_iterator( lateralBranches.begin() ),
                             std::make_move_iterator( lateralBranches.end() ) );
+
+    RicMswBranchBuilder::applyEffectiveDiameters( diameterContext, result );
+
     return result;
 }
 

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
@@ -174,7 +174,11 @@ std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 
                                                                    unitSystem,
                                                                    &childCellSegMap,
                                                                    activeCellInfo );
-    if ( tieInValve && !lateralBranch.segments.empty() ) lateralBranch.segments.front().description.clear();
+    // Identify the segments of this lateral by name in the exported comment line
+    if ( !lateralBranch.segments.empty() )
+    {
+        lateralBranch.segments.front().description = QString( "Segments on lateral %1" ).arg( wellPath->name() ).toStdString();
+    }
     lateralBranch.tieInValve = std::move( tieInValve );
 
     // Standalone valves (from valveCollection, not inside perforation intervals)

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
@@ -236,6 +236,8 @@ std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 
                                                                          wellNameForExport,
                                                                          segmentNumber,
                                                                          branchNumber,
+                                                                         mswParameters->maxSegmentLength(),
+                                                                         {},
                                                                          unitSystem,
                                                                          fishbonesContext );
         result.insert( result.end(), std::make_move_iterator( fishBranches.begin() ), std::make_move_iterator( fishBranches.end() ) );
@@ -409,6 +411,8 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
                                                                          wellNameForExport,
                                                                          segmentNumber,
                                                                          branchNumber,
+                                                                         maxSegmentLength,
+                                                                         customSegmentIntervals,
                                                                          unitSystem,
                                                                          fishbonesContext );
     }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
@@ -49,16 +49,16 @@ using CompletionType = RicWellPathExportMswTableData::CompletionType;
 /// Recursively build all WELSEGS/COMPSEGS/valve segments for one lateral (child well path)
 /// and any of its own child laterals.
 //--------------------------------------------------------------------------------------------------
-std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                                eclipseCase,
-                                                const RimWellPath*                             wellPath,
-                                                const RigMainGrid*                             mainGrid,
-                                                int                                            outletSegNum,
-                                                CompletionType                                 completionType,
-                                                const std::optional<QDateTime>&                exportDate,
-                                                int&                                           segmentNumber,
-                                                int&                                           branchNumber,
-                                                RiaDefines::EclipseUnitSystem                  unitSystem,
-                                                RicMswBranchBuilder::FishbonesDiameterContext& diameterContext )
+std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                              eclipseCase,
+                                                const RimWellPath*                           wellPath,
+                                                const RigMainGrid*                           mainGrid,
+                                                int                                          outletSegNum,
+                                                CompletionType                               completionType,
+                                                const std::optional<QDateTime>&              exportDate,
+                                                int&                                         segmentNumber,
+                                                int&                                         branchNumber,
+                                                RiaDefines::EclipseUnitSystem                unitSystem,
+                                                RicMswBranchBuilder::FishbonesExportContext& fishbonesContext )
 {
     std::vector<RigMswBranch> result;
     auto                      mswParameters = wellPath->mswCompletionParameters();
@@ -237,7 +237,7 @@ std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 
                                                                          segmentNumber,
                                                                          branchNumber,
                                                                          unitSystem,
-                                                                         diameterContext );
+                                                                         fishbonesContext );
         result.insert( result.end(), std::make_move_iterator( fishBranches.begin() ), std::make_move_iterator( fishBranches.end() ) );
     }
 
@@ -255,7 +255,7 @@ std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                 
                                                         segmentNumber,
                                                         branchNumber,
                                                         unitSystem,
-                                                        diameterContext );
+                                                        fishbonesContext );
         result.insert( result.end(), std::make_move_iterator( grandchildBranches.begin() ), std::make_move_iterator( grandchildBranches.end() ) );
     }
 
@@ -325,7 +325,7 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
     std::vector<RicMswBranchBuilder::CellSegmentEntry> cellSegMap;
 
     // Collected across the main bore and all tie-in laterals, applied once the branches are assembled.
-    RicMswBranchBuilder::FishbonesDiameterContext diameterContext;
+    RicMswBranchBuilder::FishbonesExportContext fishbonesContext;
 
     const RigActiveCellInfo* activeCellInfo = eclipseCase->eclipseCaseData()->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL );
 
@@ -410,7 +410,7 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
                                                                          segmentNumber,
                                                                          branchNumber,
                                                                          unitSystem,
-                                                                         diameterContext );
+                                                                         fishbonesContext );
     }
 
     // Tie-in child laterals (recursive)
@@ -428,7 +428,7 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
                                                    segmentNumber,
                                                    branchNumber,
                                                    unitSystem,
-                                                   diameterContext );
+                                                   fishbonesContext );
         lateralBranches.insert( lateralBranches.end(),
                                 std::make_move_iterator( childBranches.begin() ),
                                 std::make_move_iterator( childBranches.end() ) );
@@ -450,7 +450,8 @@ RigMswWellExportData buildMswWellExportData( RimEclipseCase*                    
                             std::make_move_iterator( lateralBranches.begin() ),
                             std::make_move_iterator( lateralBranches.end() ) );
 
-    RicMswBranchBuilder::applyEffectiveDiameters( diameterContext, result );
+    RicMswBranchBuilder::applyEffectiveDiameters( fishbonesContext, result );
+    RicMswBranchBuilder::applyIcdAreaPerCell( fishbonesContext, result );
 
     return result;
 }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "RicMswBranchBuilder.h"
 #include "RicWellPathExportMswTableData.h"
 
 #include "CompletionsMsw/RigMswSegment.h"
@@ -39,15 +40,16 @@ class RigMainGrid;
 namespace RicWellPathExportMswGeometryPath
 {
 
-std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                               eclipseCase,
-                                                const RimWellPath*                            wellPath,
-                                                const RigMainGrid*                            mainGrid,
-                                                int                                           outletSegNum,
-                                                RicWellPathExportMswTableData::CompletionType completionType,
-                                                const std::optional<QDateTime>&               exportDate,
-                                                int&                                          segmentNumber,
-                                                int&                                          branchNumber,
-                                                RiaDefines::EclipseUnitSystem                 unitSystem );
+std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                                eclipseCase,
+                                                const RimWellPath*                             wellPath,
+                                                const RigMainGrid*                             mainGrid,
+                                                int                                            outletSegNum,
+                                                RicWellPathExportMswTableData::CompletionType  completionType,
+                                                const std::optional<QDateTime>&                exportDate,
+                                                int&                                           segmentNumber,
+                                                int&                                           branchNumber,
+                                                RiaDefines::EclipseUnitSystem                  unitSystem,
+                                                RicMswBranchBuilder::FishbonesDiameterContext& diameterContext );
 
 RigMswWellExportData buildMswWellExportData( RimEclipseCase*                               eclipseCase,
                                              const RimWellPath*                            wellPath,

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.h
@@ -40,16 +40,16 @@ class RigMainGrid;
 namespace RicWellPathExportMswGeometryPath
 {
 
-std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                                eclipseCase,
-                                                const RimWellPath*                             wellPath,
-                                                const RigMainGrid*                             mainGrid,
-                                                int                                            outletSegNum,
-                                                RicWellPathExportMswTableData::CompletionType  completionType,
-                                                const std::optional<QDateTime>&                exportDate,
-                                                int&                                           segmentNumber,
-                                                int&                                           branchNumber,
-                                                RiaDefines::EclipseUnitSystem                  unitSystem,
-                                                RicMswBranchBuilder::FishbonesDiameterContext& diameterContext );
+std::vector<RigMswBranch> buildLateralBranches( RimEclipseCase*                               eclipseCase,
+                                                const RimWellPath*                            wellPath,
+                                                const RigMainGrid*                            mainGrid,
+                                                int                                           outletSegNum,
+                                                RicWellPathExportMswTableData::CompletionType completionType,
+                                                const std::optional<QDateTime>&               exportDate,
+                                                int&                                          segmentNumber,
+                                                int&                                          branchNumber,
+                                                RiaDefines::EclipseUnitSystem                 unitSystem,
+                                                RicMswBranchBuilder::FishbonesExportContext&  fishbonesContext );
 
 RigMswWellExportData buildMswWellExportData( RimEclipseCase*                               eclipseCase,
                                              const RimWellPath*                            wellPath,

--- a/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
@@ -258,3 +258,164 @@ TEST( RicMswBranchBuilder, ToMswCellIntersection_DualPorosity_KShifted )
     ASSERT_TRUE( result.has_value() );
     EXPECT_EQ( 1u + cellCountK, result->k );
 }
+
+//==================================================================================================
+// applyEffectiveDiameters / applyIcdAreaPerCell tests
+//==================================================================================================
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Build export data with one branch holding the given segment numbers, each with a WSEGVALV area.
+//--------------------------------------------------------------------------------------------------
+RigMswWellExportData makeExportData( const std::vector<std::pair<int, double>>& segmentNumberAndArea )
+{
+    RigMswWellExportData exportData;
+    RigMswBranch         branch;
+    branch.branchNumber = 1;
+
+    for ( const auto& [segmentNumber, area] : segmentNumberAndArea )
+    {
+        RigMswSegment segment;
+        segment.segmentNumber       = segmentNumber;
+        segment.outletSegmentNumber = 1;
+        segment.length              = 1.0;
+        segment.depth               = 1.0;
+
+        WsegvalvRow row;
+        row.segmentNumber    = segmentNumber;
+        row.cv               = 1.5;
+        row.area             = area;
+        segment.wsegvalvData = row;
+
+        branch.segments.push_back( segment );
+    }
+
+    exportData.branches.push_back( branch );
+    return exportData;
+}
+
+double areaOfSegment( const RigMswWellExportData& exportData, int segmentNumber )
+{
+    for ( const auto& branch : exportData.branches )
+    {
+        for ( const auto& segment : branch.segments )
+        {
+            if ( segment.segmentNumber == segmentNumber && segment.wsegvalvData.has_value() ) return segment.wsegvalvData->area;
+        }
+    }
+    return -1.0;
+}
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+/// A single ICD sub in a cell keeps its own area.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, IcdAreaPerCell_SingleIcdIsUnchanged )
+{
+    FishbonesExportContext context;
+    context.icdSegments.push_back( { 10, { 100 } } );
+
+    auto exportData = makeExportData( { { 10, 0.002 } } );
+    applyIcdAreaPerCell( context, exportData );
+
+    EXPECT_DOUBLE_EQ( 0.002, areaOfSegment( exportData, 10 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Two ICD subs connected to the same cell both report the sum of their areas.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, IcdAreaPerCell_SharedCellGetsAreaSum )
+{
+    FishbonesExportContext context;
+    context.icdSegments.push_back( { 10, { 100 } } );
+    context.icdSegments.push_back( { 20, { 100 } } );
+
+    auto exportData = makeExportData( { { 10, 0.002 }, { 20, 0.003 } } );
+    applyIcdAreaPerCell( context, exportData );
+
+    EXPECT_DOUBLE_EQ( 0.005, areaOfSegment( exportData, 10 ) );
+    EXPECT_DOUBLE_EQ( 0.005, areaOfSegment( exportData, 20 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// ICD subs in different cells are not combined.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, IcdAreaPerCell_SeparateCellsAreIndependent )
+{
+    FishbonesExportContext context;
+    context.icdSegments.push_back( { 10, { 100 } } );
+    context.icdSegments.push_back( { 20, { 200 } } );
+
+    auto exportData = makeExportData( { { 10, 0.002 }, { 20, 0.003 } } );
+    applyIcdAreaPerCell( context, exportData );
+
+    EXPECT_DOUBLE_EQ( 0.002, areaOfSegment( exportData, 10 ) );
+    EXPECT_DOUBLE_EQ( 0.003, areaOfSegment( exportData, 20 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Valve segments that are not fishbones ICD subs are left alone.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, IcdAreaPerCell_NonIcdValveIsUntouched )
+{
+    FishbonesExportContext context;
+    context.icdSegments.push_back( { 10, { 100 } } );
+    context.icdSegments.push_back( { 20, { 100 } } );
+
+    auto exportData = makeExportData( { { 10, 0.002 }, { 20, 0.003 }, { 30, 0.007 } } );
+    applyIcdAreaPerCell( context, exportData );
+
+    EXPECT_DOUBLE_EQ( 0.007, areaOfSegment( exportData, 30 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Three laterals in the same cell give Deff = sqrt(3) * d.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, EffectiveDiameters_SharedCellCombinesDiameters )
+{
+    FishbonesExportContext context;
+    context.lateralSegments.push_back( { 10, 100, 0.0096 } );
+    context.lateralSegments.push_back( { 20, 100, 0.0096 } );
+    context.lateralSegments.push_back( { 30, 100, 0.0096 } );
+
+    auto exportData = makeExportData( { { 10, 0.0 }, { 20, 0.0 }, { 30, 0.0 } } );
+    applyEffectiveDiameters( context, exportData );
+
+    const double expected = std::sqrt( 3.0 ) * 0.0096;
+    for ( int segmentNumber : { 10, 20, 30 } )
+    {
+        for ( const auto& segment : exportData.branches[0].segments )
+        {
+            if ( segment.segmentNumber != segmentNumber ) continue;
+            ASSERT_TRUE( segment.diameter.has_value() );
+            EXPECT_NEAR( expected, *segment.diameter, 1.0e-12 );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The first segment of a lateral inherits the effective diameter of the second segment.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, EffectiveDiameters_FirstSegmentInheritsSecond )
+{
+    FishbonesExportContext context;
+
+    // Two laterals start in cell 100, only the first one continues into cell 200.
+    context.lateralSegments.push_back( { 10, 100, 0.0096 } );
+    context.lateralSegments.push_back( { 11, 200, 0.0096 } );
+    context.lateralSegments.push_back( { 20, 100, 0.0096 } );
+    context.firstAndSecondSegments.emplace_back( 10, 11 );
+
+    auto exportData = makeExportData( { { 10, 0.0 }, { 11, 0.0 }, { 20, 0.0 } } );
+    applyEffectiveDiameters( context, exportData );
+
+    const auto& segments = exportData.branches[0].segments;
+
+    // Segment 10 is alone with segment 20 in cell 100, but takes the value of segment 11.
+    EXPECT_NEAR( 0.0096, *segments[0].diameter, 1.0e-12 );
+    EXPECT_NEAR( 0.0096, *segments[1].diameter, 1.0e-12 );
+
+    // Segment 20 has no second segment and keeps the combined value of cell 100.
+    EXPECT_NEAR( std::sqrt( 2.0 ) * 0.0096, *segments[2].diameter, 1.0e-12 );
+}

--- a/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
@@ -425,22 +425,40 @@ TEST( RicMswBranchBuilder, IcdAreaPerCell_NonIcdValveIsUntouched )
 TEST( RicMswBranchBuilder, EffectiveDiameters_SharedCellCombinesDiameters )
 {
     FishbonesExportContext context;
-    context.lateralSegments.push_back( { 10, 100, 0.0096 } );
-    context.lateralSegments.push_back( { 20, 100, 0.0096 } );
-    context.lateralSegments.push_back( { 30, 100, 0.0096 } );
+    context.laterals.push_back( { { { { 10 }, 100, 0.0096 } } } );
+    context.laterals.push_back( { { { { 20 }, 100, 0.0096 } } } );
+    context.laterals.push_back( { { { { 30 }, 100, 0.0096 } } } );
 
     auto exportData = makeExportData( { { 10, 0.0 }, { 20, 0.0 }, { 30, 0.0 } } );
     applyEffectiveDiameters( context, exportData );
 
     const double expected = std::sqrt( 3.0 ) * 0.0096;
-    for ( int segmentNumber : { 10, 20, 30 } )
+    for ( const auto& segment : exportData.branches[0].segments )
     {
-        for ( const auto& segment : exportData.branches[0].segments )
-        {
-            if ( segment.segmentNumber != segmentNumber ) continue;
-            ASSERT_TRUE( segment.diameter.has_value() );
-            EXPECT_NEAR( expected, *segment.diameter, 1.0e-12 );
-        }
+        ASSERT_TRUE( segment.diameter.has_value() );
+        EXPECT_NEAR( expected, *segment.diameter, 1.0e-12 );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A cell intersection split into several WELSEGS rows contributes once to the sum, and all its rows
+/// get the same effective diameter.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, EffectiveDiameters_SplitIntersectionCountsOnce )
+{
+    FishbonesExportContext context;
+    context.laterals.push_back( { { { { 10, 11, 12 }, 100, 0.0096 } } } );
+    context.laterals.push_back( { { { { 20 }, 100, 0.0096 } } } );
+
+    auto exportData = makeExportData( { { 10, 0.0 }, { 11, 0.0 }, { 12, 0.0 }, { 20, 0.0 } } );
+    applyEffectiveDiameters( context, exportData );
+
+    // Two intersections in cell 100, not four rows.
+    const double expected = std::sqrt( 2.0 ) * 0.0096;
+    for ( const auto& segment : exportData.branches[0].segments )
+    {
+        ASSERT_TRUE( segment.diameter.has_value() );
+        EXPECT_NEAR( expected, *segment.diameter, 1.0e-12 );
     }
 }
 
@@ -452,10 +470,8 @@ TEST( RicMswBranchBuilder, EffectiveDiameters_FirstSegmentInheritsSecond )
     FishbonesExportContext context;
 
     // Two laterals start in cell 100, only the first one continues into cell 200.
-    context.lateralSegments.push_back( { 10, 100, 0.0096 } );
-    context.lateralSegments.push_back( { 11, 200, 0.0096 } );
-    context.lateralSegments.push_back( { 20, 100, 0.0096 } );
-    context.firstAndSecondSegments.emplace_back( 10, 11 );
+    context.laterals.push_back( { { { { 10 }, 100, 0.0096 }, { { 11 }, 200, 0.0096 } } } );
+    context.laterals.push_back( { { { { 20 }, 100, 0.0096 } } } );
 
     auto exportData = makeExportData( { { 10, 0.0 }, { 11, 0.0 }, { 20, 0.0 } } );
     applyEffectiveDiameters( context, exportData );
@@ -466,6 +482,6 @@ TEST( RicMswBranchBuilder, EffectiveDiameters_FirstSegmentInheritsSecond )
     EXPECT_NEAR( 0.0096, *segments[0].diameter, 1.0e-12 );
     EXPECT_NEAR( 0.0096, *segments[1].diameter, 1.0e-12 );
 
-    // Segment 20 has no second segment and keeps the combined value of cell 100.
+    // The second lateral has a single intersection and keeps the combined value of cell 100.
     EXPECT_NEAR( std::sqrt( 2.0 ) * 0.0096, *segments[2].diameter, 1.0e-12 );
 }

--- a/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicMswBranchBuilder-Test.cpp
@@ -355,6 +355,56 @@ TEST( RicMswBranchBuilder, IcdAreaPerCell_SeparateCellsAreIndependent )
 }
 
 //--------------------------------------------------------------------------------------------------
+/// An ICD sub reaching into two cells reports the largest sum, computed from the original areas.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, IcdAreaPerCell_MultipleCellsUseLargestSum )
+{
+    FishbonesExportContext context;
+    context.icdSegments.push_back( { 10, { 100, 200 } } );
+    context.icdSegments.push_back( { 20, { 100 } } );
+    context.icdSegments.push_back( { 30, { 200 } } );
+    context.icdSegments.push_back( { 40, { 200 } } );
+
+    auto exportData = makeExportData( { { 10, 0.001 }, { 20, 0.002 }, { 30, 0.003 }, { 40, 0.004 } } );
+    applyIcdAreaPerCell( context, exportData );
+
+    // Cell 100 sums to 0.003, cell 200 to 0.008. Segment 10 takes part in both and reports the larger.
+    EXPECT_DOUBLE_EQ( 0.008, areaOfSegment( exportData, 10 ) );
+    EXPECT_DOUBLE_EQ( 0.003, areaOfSegment( exportData, 20 ) );
+    EXPECT_DOUBLE_EQ( 0.008, areaOfSegment( exportData, 30 ) );
+    EXPECT_DOUBLE_EQ( 0.008, areaOfSegment( exportData, 40 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The result does not depend on the order the ICD subs are recorded in.
+//--------------------------------------------------------------------------------------------------
+TEST( RicMswBranchBuilder, IcdAreaPerCell_IsIndependentOfRecordingOrder )
+{
+    FishbonesExportContext forward;
+    forward.icdSegments.push_back( { 10, { 100, 200 } } );
+    forward.icdSegments.push_back( { 20, { 100 } } );
+    forward.icdSegments.push_back( { 30, { 200 } } );
+
+    FishbonesExportContext reversed;
+    reversed.icdSegments.push_back( { 30, { 200 } } );
+    reversed.icdSegments.push_back( { 20, { 100 } } );
+    reversed.icdSegments.push_back( { 10, { 200, 100 } } );
+
+    const std::vector<std::pair<int, double>> segments = { { 10, 0.001 }, { 20, 0.002 }, { 30, 0.003 } };
+
+    auto forwardData = makeExportData( segments );
+    applyIcdAreaPerCell( forward, forwardData );
+
+    auto reversedData = makeExportData( segments );
+    applyIcdAreaPerCell( reversed, reversedData );
+
+    for ( int segmentNumber : { 10, 20, 30 } )
+    {
+        EXPECT_DOUBLE_EQ( areaOfSegment( forwardData, segmentNumber ), areaOfSegment( reversedData, segmentNumber ) );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 /// Valve segments that are not fishbones ICD subs are left alone.
 //--------------------------------------------------------------------------------------------------
 TEST( RicMswBranchBuilder, IcdAreaPerCell_NonIcdValveIsUntouched )


### PR DESCRIPTION
Fixes #14477

Restores the fishbones behaviour of the legacy tree path in the geometry path, after the tree code was removed in 313ed1e4fc9c8ce269f6a17ef23d170372a9daff. The `useImprovedMswDataStructures` preference defaulted to false, so all users were on the tree path until that commit moved them to the geometry path and exposed four unreconciled differences at once.

## Changes

- ICD subs export 0.15 and 5.0e-5 for diameter and roughness again, instead of the `1*` default marker. `RigMswSegment` has never had the defaults the tree `RicMswSegment` constructor provided.
- Fishbones laterals get an effective diameter, `Deff = sqrt(d1^2 + d2^2 + ..)` over the cell intersections sharing a grid cell (#7686), with the first intersection of a lateral inheriting the value of the second (#7731). A lateral contained in a single grid cell has no second intersection and keeps the combined value, which is where the difference was most visible.
- ICD subs connected to the same grid cell report the sum of their areas in WSEGVALV. The sums are computed from the original areas, so the result does not depend on the order the cells are visited in, which the tree implementation did. An ICD sub reaching into more than one cell reports the largest of the sums it takes part in.
- The max segment length and the custom segment intervals are applied to fishbones laterals. The lateral geometry is not part of the well path, so sub-segment TVD is interpolated linearly between the start and end TVD of the intersection, as the tree path did. The cell is connected by the first sub-segment only, leaving COMPSEGS unchanged.

## Verification

Exported all twelve projects in `TestModels/msw-export` and compared against the tree output stored in `compare-output`. Every well with a stored reference matches, including the fishbones laterals and ICD subs that previously differed.

`fishbones.rsp` WELSEGS, before and after:

```
              tree      before    after
ICD sub 1     0.15000   1*        0.15000
Lateral 1     0.01664   0.00960   0.01664
Lateral 2     0.00960   0.00960   0.00960
              0.00960   0.00960   0.00960
Lateral 3     0.01664   0.00960   0.01664
```

The MSW unit tests go from 47 to 56. `applyEffectiveDiameters` and `applyIcdAreaPerCell` had no coverage before.

Splitting and the area summation are not reachable from the stored projects, since none of them enforces a max segment length or has more than one ICD sub per cell. Splitting was verified with a copy of `fishbones.rsp` with the max segment length enforced at 4 m, where the laterals are split into three or four rows each with evenly interpolated depths, unchanged effective diameters and identical COMPSEGS. The area summation is covered by unit tests.

## Not addressed

- `perf-lgr-two-wells/Well-1` differs from its stored reference in the header `Tlen 1` and in the main bore lengths and depths, not in diameters. Building without these changes produces the same output, so it predates them. Either a stale reference or a separate issue.
- `perf_lateral`, `standalone-valve` and `tie-in-custom-valve-location` are unverified. Their well paths are not named `Well-1`, so `exportMsw` could not resolve them from the command file.
