### PR TITLE
Fix crash on stale cell selection when creating highlight part

### DIFF
--- a/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp
@@ -228,8 +228,16 @@ cvf::ref<cvf::DrawableGeo> RivSingleCellPartGenerator::createMeshDrawable()
 {
     if ( m_rigCaseData && m_cellIndex != cvf::UNDEFINED_SIZE_T )
     {
+        auto mainGrid = m_rigCaseData->mainGrid();
+        if ( !mainGrid ) return nullptr;
+
+        if ( m_gridIndex >= mainGrid->gridCount() ) return nullptr;
+
         auto grid = m_rigCaseData->grid( m_gridIndex );
         if ( !grid ) return nullptr;
+
+        // The selection can be stale after the case data has been reloaded, and the cell index can be out of bounds
+        if ( m_cellIndex >= grid->cellCount() ) return nullptr;
 
         if ( m_showLgrMeshLines && RiaPreferencesGrid::current()->radialGridMode() == RiaGridDefines::RadialGridMode::CYLINDRICAL )
         {

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RivAnnotationTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivPipeGeometryGenerator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivIjkIntersectionGeometryGenerator-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RivSingleCellPartGenerator-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivTernaryScalarMapper-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ScalarMapper-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/WellPathAsciiFileReader-Test.cpp

--- a/ApplicationLibCode/UnitTests/RivSingleCellPartGenerator-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RivSingleCellPartGenerator-Test.cpp
@@ -1,0 +1,108 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RigEclipseCaseData.h"
+#include "RigMainGrid.h"
+#include "RigReservoirBuilder.h"
+
+#include "RivSingleCellPartGenerator.h"
+
+#include "cvfPart.h"
+#include "cvfVector3.h"
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Build a regular ni x nj x nk box grid in memory (no file, no view)
+//--------------------------------------------------------------------------------------------------
+cvf::ref<RigEclipseCaseData> buildBoxGrid( int ni, int nj, int nk )
+{
+    RigReservoirBuilder builder;
+    builder.setIJKCount( cvf::Vec3st( ni, nj, nk ) );
+    builder.setWorldCoordinates( cvf::Vec3d( 0.0, 0.0, 0.0 ), cvf::Vec3d( ni, nj, -nk ) );
+
+    cvf::ref<RigEclipseCaseData> caseData = new RigEclipseCaseData( nullptr );
+    builder.createGridsAndCells( caseData.p() );
+    caseData->mainGrid()->computeCachedData();
+
+    return caseData;
+}
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RivSingleCellPartGeneratorTest, ValidCellIndexCreatesDrawable )
+{
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( 2, 3, 4 );
+
+    RivSingleCellPartGenerator partGen( caseData.p(), 0, 5, cvf::Vec3d::ZERO );
+
+    cvf::ref<cvf::Part> part = partGen.createPart( cvf::Color3f::RED );
+    ASSERT_TRUE( part.notNull() );
+    EXPECT_TRUE( part->drawable() != nullptr );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A stale selection can reference a cell index no longer present in the grid
+//--------------------------------------------------------------------------------------------------
+TEST( RivSingleCellPartGeneratorTest, CellIndexOutOfBoundsIsIgnored )
+{
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( 2, 3, 4 );
+
+    const size_t cellCount = caseData->mainGrid()->cellCount();
+
+    for ( size_t cellIndex : { cellCount, cellCount + 1000 } )
+    {
+        RivSingleCellPartGenerator partGen( caseData.p(), 0, cellIndex, cvf::Vec3d::ZERO );
+
+        cvf::ref<cvf::Part> part = partGen.createPart( cvf::Color3f::RED );
+        ASSERT_TRUE( part.notNull() );
+        EXPECT_TRUE( part->drawable() == nullptr );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A stale selection can reference a grid no longer present in the case
+//--------------------------------------------------------------------------------------------------
+TEST( RivSingleCellPartGeneratorTest, GridIndexOutOfBoundsIsIgnored )
+{
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( 2, 3, 4 );
+
+    RivSingleCellPartGenerator partGen( caseData.p(), 1, 0, cvf::Vec3d::ZERO );
+
+    cvf::ref<cvf::Part> part = partGen.createPart( cvf::Color3f::RED );
+    ASSERT_TRUE( part.notNull() );
+    EXPECT_TRUE( part->drawable() == nullptr );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RivSingleCellPartGeneratorTest, UndefinedCellIndexIsIgnored )
+{
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( 2, 3, 4 );
+
+    RivSingleCellPartGenerator partGen( caseData.p(), 0, cvf::UNDEFINED_SIZE_T, cvf::Vec3d::ZERO );
+
+    cvf::ref<cvf::Part> part = partGen.createPart( cvf::Color3f::RED );
+    ASSERT_TRUE( part.notNull() );
+    EXPECT_TRUE( part->drawable() == nullptr );
+}


### PR DESCRIPTION
## Problem

`RivSingleCellPartGenerator` is created from the grid index and cell index stored in the 3D selection item (`RiuEclipseSelectionItem`). Only the view and the result definition are `PdmPointer`-guarded; the indices are plain values and are never revalidated when the case data is rebuilt behind a live selection.

Both lookups guard only with `CVF_ASSERT`, which is a no-op in release builds:

- `RigMainGrid::gridByIndex()` indexes `m_localGrids` out of range
- `RigGridBase::cell()` reads past `reservoirCells()`, and the resulting garbage corner indices then index `m_mainGrid->nodes()` out of range

The crash therefore surfaces in `RigGridBase::cellCornerVertices()`, two frames below the actual fault.

## Fix

Validate the grid index against `mainGrid()->gridCount()` and the cell index against `grid->cellCount()` in `RivSingleCellPartGenerator::createMeshDrawable()` before creating the drawable. A stale selection now draws no highlight instead of reading out of bounds. This matches the guard pattern already used in `createMeshDrawableFromLgrGridCells()` in the same file.

Unit tests in `RivSingleCellPartGenerator-Test.cpp` drive `createPart()` against an in-memory box grid. Without the fix, the out-of-range cell index test raises an access violation and the out-of-range grid index test kills the test process; with the fix all four pass.

## Related

The same release-time weakness exists elsewhere and is not addressed here:

- the geomech branch of `createMeshDrawable()` relies on `CVF_ASSERT` for `femParts()->partCount() > m_gridIndex`
- `RigMainGrid::gridByIndex()` and `RigGridBase::cell()` are unguarded in release for all callers

## Call stack

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[3] void cvf::Vector3<double>::set<cvf::Vector3<double> >(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:406
[4] cvf::StructGridGeometryGenerator::createMeshDrawableFromSingleCell(cvf::StructGridInterface const*, unsigned long, cvf::Vector3<double> const&) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGridGeometryGenerator.cpp:279
[5] RivSingleCellPartGenerator::createMeshDrawable() at ResInsight/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp:231
[6] RivSingleCellPartGenerator::createPart(cvf::Color3f) at ResInsight/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp:90
[7] RimGridView::onCreatePartCollectionFromSelection(cvf::Collection<cvf::Part>*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimGridView.cpp:392
[8] Rim3dView::createHighlightAndGridBoxDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1335
[9] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:719
[10] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
[15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[26] __libc_start_main at :0
```
