### PR TITLE
Guard against null case and view when painting overlay and creating intersections

### DIFF
--- a/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp
@@ -35,7 +35,8 @@ void RicIntersectionFeatureImpl::createIntersectionBoxSlize( const QString& name
     RimGridView* activeView                 = RiaApplication::instance()->activeGridView();
     RimGridView* activeMainOrComparisonView = RiaApplication::instance()->activeMainOrComparisonGridView();
 
-    if ( activeMainOrComparisonView )
+    // activeGridView() and activeMainOrComparisonGridView() are different objects, both must be checked
+    if ( activeMainOrComparisonView && activeView && activeView->viewer() )
     {
         RimIntersectionCollection* coll = activeMainOrComparisonView->intersectionCollection();
         CVF_ASSERT( coll );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp
@@ -210,7 +210,7 @@ void RimEclipseContourMapView::onCreateDisplayModel()
         updateGeometry();
     }
 
-    if ( viewer()->mainCamera()->viewMatrix() == sm_defaultViewMatrix )
+    if ( viewer() && viewer()->mainCamera() && viewer()->mainCamera()->viewMatrix() == sm_defaultViewMatrix )
     {
         zoomAll();
     }

--- a/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp
@@ -320,8 +320,9 @@ void RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToPlot( RimAb
         auto crossPlot = dynamic_cast<RimParameterResultCrossPlot*>( plot );
         if ( crossPlot )
         {
-            crossPlot->setEnsembleParameter(
-                RimSummaryEnsembleTools::alphabeticEnsembleParameters( ensembles.front()->allSummaryCases() ).front().name );
+            // An ensemble without realization parameters has no parameters to select
+            const auto parameters = RimSummaryEnsembleTools::alphabeticEnsembleParameters( ensembles.front()->allSummaryCases() );
+            if ( !parameters.empty() ) crossPlot->setEnsembleParameter( parameters.front().name );
         }
     }
 }

--- a/ApplicationLibCode/UserInterface/RiuViewer.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewer.cpp
@@ -432,9 +432,11 @@ void RiuViewer::paintOverlayItems( QPainter* painter )
 
     int columnPos = trueWidth - columnWidth - margin - edgeAxisFrameBorderWidth;
 
-    if ( isComparisonViewActive() )
+    Rim3dView* rimView = dynamic_cast<Rim3dView*>( m_rimView.p() );
+
+    if ( isComparisonViewActive() && rimView )
     {
-        Rim3dView* compView = dynamic_cast<Rim3dView*>( m_rimView.p() )->activeComparisonView();
+        Rim3dView* compView = rimView->activeComparisonView();
         if ( compView )
         {
             columnWidth = 200;
@@ -445,15 +447,17 @@ void RiuViewer::paintOverlayItems( QPainter* painter )
 
             if ( m_showInfoText )
             {
+                // The owner case is nullptr while the case is being closed
+                if ( rimView->ownerCase() )
                 {
-                    Rim3dView* view = dynamic_cast<Rim3dView*>( m_rimView.p() );
-                    m_shortInfoLabel->setText( "<center>" + view->ownerCase()->caseUserDescription() + "</center>" );
+                    m_shortInfoLabel->setText( "<center>" + rimView->ownerCase()->caseUserDescription() + "</center>" );
 
                     QPoint topLeft = QPoint( columnPos, yPos );
                     m_shortInfoLabel->resize( columnWidth, m_shortInfoLabel->sizeHint().height() );
                     m_shortInfoLabel->render( painter, topLeft );
                 }
 
+                if ( compView->ownerCase() )
                 {
                     m_shortInfoLabelCompView->setText( "<center>" + compView->ownerCase()->caseUserDescription() + "</center>" );
                     QPoint topLeft = QPoint( compViewItemsXPos, yPos );


### PR DESCRIPTION
## Problem

Four crash signatures from release builds share the same shape: a pointer that is null during teardown, or before a view is fully created, is dereferenced without a check.

**`RiuViewer::paintOverlayItems()`** — the crash line resolves to `view->ownerCase()->caseUserDescription()`. `ownerCase()` is null while a case is being closed, and a repaint of a comparison view can land in that window. The same unguarded pattern is used for `compView->ownerCase()` two lines below, and the `dynamic_cast<Rim3dView*>` on the line above is dereferenced without checking the result.

**`RicIntersectionFeatureImpl::createIntersectionBoxSlize()`** — the guard tests `activeMainOrComparisonGridView()` but the body dereferences `activeGridView()`, a different object from a different accessor. It can be null, or have no viewer, while the first is valid.

**`RimEclipseContourMapView::onCreateDisplayModel()`** — `viewer()->mainCamera()` is called without checking `viewer()`, which is null before the widget exists.

**`RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToPlot()`** — `alphabeticEnsembleParameters( ... ).front().name` calls `front()` on a vector that is empty for an ensemble without realization parameters. The resulting garbage string is then assigned to a `PdmField<QString>`, which is where the crash surfaces.

## Fix

Add the missing null and empty checks at each site. All four guards are behaviour-preserving on the healthy path — they only skip work that would otherwise read through a null pointer.

No unit tests: every one of these paths needs live GUI state (an active view, a `RiuViewer` with a GL context, `RiaApplication::instance()`), so verification here is root-cause reasoning plus a clean build. The full unit test suite passes (973 tests).

## Call stacks

### RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToPlot (`5070fc941337`)

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[4] caf::PdmField<QString>::operator=(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h:107
[5] RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToPlot(RimAbstractCorrelationPlot*, std::vector<QString, std::allocator<QString> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp:251
[6] RimCorrelationPlotCollection::createParameterResultCrossPlot(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp:123
[7] RicNewParameterResultCrossPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CorrelationPlotCommands/RicNewParameterResultCrossPlotFeature.cpp:83
[8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[35] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[60] __libc_start_main at :0
```

### RicIntersectionFeatureImpl::createIntersectionBoxSlize (`ac28fab768b4`)

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[3] RiuViewer::viewerCommands() const at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1219
[4] RicIntersectionFeatureImpl::createIntersectionBoxSlize(QString const&, RimBoxIntersection::SinglePlaneState) at ResInsight/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp:43
[5] RicIntersectionBoxXSliceFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionBoxXSliceFeature.cpp:46
[6] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[33] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:648
[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[54] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[55] __libc_start_main at :0
```

### RiuViewer::paintOverlayItems (`af4f93095db7`)

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[4] RiuViewer::paintOverlayItems(QPainter*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:440
[5] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:841
[9] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[56] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[57] __libc_start_main at :0
```

### RimEclipseContourMapView::onCreateDisplayModel (`bba5f7476970`)

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[3] caf::Viewer::mainCamera() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:303
[4] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:213
[5] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
[6] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:731
[7] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[22] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[23] __libc_start_main at :0
```
