### PR TITLE
Fix crashes in RFT curve creation and static NNC import

### DIFF
--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -357,11 +357,16 @@ RimWellLogRftCurve* RicWellLogTools::addRftCurve( RimWellLogTrack* plotTrack, co
     {
         curve->setEclipseCase( resultCase );
 
-        auto wellNames = resultCase->rftReader()->wellNames();
-        if ( !wellNames.empty() )
+        // The case selected above is the first Eclipse result case, which is not guaranteed to have an RFT reader. See
+        // hasRftData() that requires a reader to be present.
+        if ( auto* rftReader = resultCase->rftReader() )
         {
-            auto wellName = *( wellNames.begin() );
-            curve->setDefaultAddress( wellName );
+            auto wellNames = rftReader->wellNames();
+            if ( !wellNames.empty() )
+            {
+                auto wellName = *( wellNames.begin() );
+                curve->setDefaultAddress( wellName );
+            }
         }
     }
     else

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -62,6 +62,7 @@
 #include <QDateTime>
 #include <QFileInfo>
 
+#include <algorithm>
 #include <cmath> // Needed for HUGE_VAL on Linux
 #include <iostream>
 #include <map>
@@ -719,7 +720,18 @@ void RifReaderEclipseOutput::transferStaticNNCData( const ecl_grid_type* mainEcl
         {
             int numNNC       = ecl_nnc_data_get_size( tran_data );
             int geometrySize = ecl_nnc_geometry_size( nnc_geo );
-            CAF_ASSERT( numNNC == geometrySize );
+
+            if ( numNNC != geometrySize )
+            {
+                // The transmissibility data is read from the INIT file, the geometry from the grid file. If the two files are out of
+                // sync, iterating the geometry using the data count reads out of bounds. Use the smallest count.
+                RiaLogging::warning( std::format( "NNC data count ({}) does not match NNC geometry count ({}), importing {} connections.",
+                                                  numNNC,
+                                                  geometrySize,
+                                                  std::min( numNNC, geometrySize ) ) );
+
+                numNNC = std::min( numNNC, geometrySize );
+            }
 
             if ( numNNC > 0 )
             {


### PR DESCRIPTION
Two crash fixes from the stacktrace registry.

### Guard missing RFT reader when creating an RFT curve

Problem: `addRftCurve()` picks the first `RimEclipseResultCase` in the project without checking that it has an RFT reader, then dereferences `rftReader()`. The command is enabled by `hasRftData()`, which returns true if *any* case has a reader, so with several Eclipse cases loaded the enabled menu entry can select a case with no RFT data and crash.

Fix: null-check the reader before use, matching the guard already used in `hasRftData()` and `hasRftDataForWell()` in the same file.

<details><summary>Crash stack (signature 06099b707ff2, 2 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[3] RicWellLogTools::addRftCurve(RimWellLogTrack*, RimSimWellInView const*, bool) at ResInsight/ApplicationLibCode/Commands/RicWellLogTools.cpp:360
[4] RicNewWellLogRftCurveFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/WellLogCommands/RicNewWellLogRftCurveFeature.cpp:77
[5] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[32] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
[40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[45] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[56] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[57] __libc_start_main at :0
```

</details>

### Do not read NNC geometry out of bounds on INIT/grid mismatch

Problem: `transferStaticNNCData()` takes the connection count from the INIT file (`ecl_nnc_data_get_size`) but iterates the geometry from the grid file (`ecl_nnc_geometry_iget`). The two counts were only compared in a `CVF_ASSERT`, which is compiled out in release builds, so an INIT file out of sync with the grid reads past the end of the geometry vector inside resdata.

Fix: compare the two counts at runtime, log a warning and iterate the smaller of the two. Both `nncConnections` and `transmissibilityValuesTemp` are filled in the same loop, so they stay aligned.

<details><summary>Crash stack (signature 6efc152a9abd, 1 report)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[8] RifReaderEclipseOutput::transferStaticNNCData(ecl_grid_struct const*, ecl_file_struct*, RigMainGrid*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:714
[9] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:487
[10] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
[11] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1060
[12] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1188
[13] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
[14] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:782
[15] RicOpenProjectFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ApplicationCommands/RicOpenProjectFeature.cpp:50
[16] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[42] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[43] __libc_start_main at :0
```

</details>

### Related

`addRftCurve()` still selects the first Eclipse result case even when a later case is the one holding RFT data, so the created curve can end up empty. Selecting the first case that has a reader would be a better default, but changes behaviour for the sim-well branch and is left out of this fix.
