### PR TITLE
Contour Map: Always use an available cell result as data source

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaNumericalTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaNumericalTools.cpp
@@ -46,7 +46,8 @@ double RiaNumericalTools::roundToClosestPowerOfTenFloor( double value )
 //--------------------------------------------------------------------------------------------------
 double RiaNumericalTools::computeTenExponentCeil( double value )
 {
-    if ( value < 0.0 ) return 0.0;
+    // log10() is not defined for zero and negative values
+    if ( value <= 0.0 ) return 0.0;
 
     double logDecValueMax = log10( value );
     logDecValueMax        = cvf::Math::ceil( logDecValueMax );
@@ -59,7 +60,8 @@ double RiaNumericalTools::computeTenExponentCeil( double value )
 //--------------------------------------------------------------------------------------------------
 double RiaNumericalTools::computeTenExponentFloor( double value )
 {
-    if ( value < 0.0 ) return 0.0;
+    // log10() is not defined for zero and negative values
+    if ( value <= 0.0 ) return 0.0;
 
     double logDecValueMin = log10( value );
     logDecValueMin        = cvf::Math::floor( logDecValueMin );

--- a/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp
@@ -19,6 +19,7 @@
 #include "RicNewContourMapViewFeature.h"
 
 #include "RigActiveCellInfo.h"
+#include "RigCaseCellResultsData.h"
 #include "RigEclipseCaseData.h"
 #include "RigFemPartCollection.h"
 
@@ -51,7 +52,7 @@
 
 #include "RiaColorTools.h"
 #include "RiaLogging.h"
-#include "RiaPreferencesGrid.h"
+#include "RiaResultNames.h"
 
 #include "cafPdmDocument.h"
 #include "cafSelectionManager.h"
@@ -311,7 +312,11 @@ RimEclipseContourMapView* RicNewContourMapViewFeature::createEclipseContourMap( 
     contourMap->setEclipseCase( eclipseCase );
     contourMap->resetDockWindowId();
 
-    assignDefaultResultAndLegend( contourMap );
+    // Prefer the cell result of an existing view for this case, fall back to the default result of the case
+    if ( !assignResultFromExistingView( contourMap ) )
+    {
+        assignDefaultResultAndLegend( contourMap );
+    }
 
     caf::PdmDocument::updateUiIconStateRecursively( contourMap );
 
@@ -415,13 +420,35 @@ RimGeoMechContourMapView* RicNewContourMapViewFeature::createGeoMechContourMap( 
 //--------------------------------------------------------------------------------------------------
 void RicNewContourMapViewFeature::assignDefaultResultAndLegend( RimEclipseContourMapView* contourMap )
 {
-    if ( contourMap->cellResult() )
-    {
-        contourMap->cellResult()->setResultType( RiaDefines::ResultCatType::DYNAMIC_NATIVE );
+    if ( !contourMap->cellResult() ) return;
 
-        if ( RiaPreferencesGrid::current()->loadAndShowSoil() )
-        {
-            contourMap->cellResult()->setResultVariable( "SOIL" );
-        }
+    // Use the default result of the case, as this result is guaranteed to be available. See issue #14486.
+    if ( auto cellResultsData = contourMap->currentGridCellResults() )
+    {
+        contourMap->cellResult()->setFromEclipseResultAddress( cellResultsData->defaultResult() );
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Use the cell result of an existing view for the same case, if this result is available
+//--------------------------------------------------------------------------------------------------
+bool RicNewContourMapViewFeature::assignResultFromExistingView( RimEclipseContourMapView* contourMap )
+{
+    if ( !contourMap->cellResult() || !contourMap->eclipseCase() ) return false;
+
+    for ( auto view : contourMap->eclipseCase()->reservoirViews() )
+    {
+        if ( !view || view == contourMap ) continue;
+
+        auto sourceCellResult = view->cellResult();
+        if ( !sourceCellResult || sourceCellResult->isTernarySaturationSelected() || !sourceCellResult->hasResult() ) continue;
+
+        // Completion Type is a category result, and is not useful as a contour map data source
+        if ( sourceCellResult->resultVariable() == RiaResultNames::completionTypeResultName() ) continue;
+
+        contourMap->cellResult()->setFromEclipseResultAddress( sourceCellResult->eclipseResultAddress() );
+        return true;
+    }
+
+    return false;
 }

--- a/ApplicationLibCode/Commands/RicNewContourMapViewFeature.h
+++ b/ApplicationLibCode/Commands/RicNewContourMapViewFeature.h
@@ -51,4 +51,5 @@ protected:
     static RimGeoMechContourMapView* createGeoMechContourMap( RimGeoMechCase* geoMechCase );
 
     static void assignDefaultResultAndLegend( RimEclipseContourMapView* contourMap );
+    static bool assignResultFromExistingView( RimEclipseContourMapView* contourMap );
 };

--- a/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimRegularLegendConfig.cpp
@@ -381,6 +381,21 @@ auto computeAdjustedMinMax = []( double minimum, double maximum, double precisio
 };
 
 //--------------------------------------------------------------------------------------------------
+/// A logarithmic scale is not defined for zero, so the lower limit must always be larger than zero.
+/// Return the first candidate value above zero, and use one decade below the maximum value if no
+/// candidate value is above zero. The candidate values are given in prioritized order.
+//--------------------------------------------------------------------------------------------------
+auto lowerLimitForLogarithmicScale = []( const std::vector<double>& candidateValues, double maximumValue ) -> double
+{
+    for ( auto candidateValue : candidateValues )
+    {
+        if ( candidateValue > 0.0 ) return candidateValue;
+    }
+
+    return RiaNumericalTools::roundToClosestPowerOfTenFloor( maximumValue ) / 10.0;
+};
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RimRegularLegendConfig::updateLegend()
@@ -466,6 +481,12 @@ void RimRegularLegendConfig::updateLegend()
             {
                 adjustedMin = negClosestToZero;
             }
+        }
+
+        // The values closest to zero are not always available, make sure the lower limit is never zero
+        if ( adjustedMin <= 0.0 && adjustedMax > 0.0 )
+        {
+            adjustedMin = lowerLimitForLogarithmicScale( { posClosestToZero, m_globalAutoMin, m_localAutoMin }, adjustedMax );
         }
     }
 
@@ -816,8 +837,15 @@ void RimRegularLegendConfig::updateTickCountAndUserDefinedRange()
     {
         if ( m_mappingMode() == MappingType::LOG10_CONTINUOUS || m_mappingMode() == MappingType::LOG10_DISCRETE )
         {
+            // Use the closest power of ten below the lowest value. The value closest to zero is used when the lowest
+            // value is zero or negative, as a logarithmic scale is not defined for these values.
+            double minimumValue = lowerLimitForLogarithmicScale( { m_globalAutoMin, m_globalAutoPosClosestToZero }, m_globalAutoMax );
+
             double exponentMax = RiaNumericalTools::computeTenExponentCeil( m_globalAutoMax );
-            double exponentMin = RiaNumericalTools::computeTenExponentFloor( m_globalAutoPosClosestToZero );
+            double exponentMin = RiaNumericalTools::computeTenExponentFloor( minimumValue );
+
+            // Make sure the range spans at least one decade
+            if ( exponentMin >= exponentMax ) exponentMin = exponentMax - 1.0;
 
             m_userDefinedMaxValue = pow( 10, exponentMax );
             m_userDefinedMinValue = pow( 10, exponentMin );

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -830,6 +830,10 @@ RigEclipseResultAddress RigCaseCellResultsData::defaultResult() const
 {
     auto allResults = existingResults();
 
+    // Completion Type is a category result, and is not useful as a default result. See issue #14486.
+    auto isCandidateResult = []( const RigEclipseResultAddress& adr, RiaDefines::ResultCatType category )
+    { return adr.resultCatType() == category && adr.resultName() != RiaResultNames::completionTypeResultName(); };
+
     if ( maxTimeStepCount() > 0 )
     {
         auto prefs = RiaPreferencesGrid::current();
@@ -860,8 +864,8 @@ RigEclipseResultAddress RigCaseCellResultsData::defaultResult() const
 
         auto dynamicResult = std::find_if( allResults.begin(),
                                            allResults.end(),
-                                           []( const RigEclipseResultAddress& adr )
-                                           { return adr.resultCatType() == RiaDefines::ResultCatType::DYNAMIC_NATIVE; } );
+                                           [&isCandidateResult]( const RigEclipseResultAddress& adr )
+                                           { return isCandidateResult( adr, RiaDefines::ResultCatType::DYNAMIC_NATIVE ); } );
 
         if ( dynamicResult != allResults.end() ) return *dynamicResult;
     }
@@ -869,16 +873,16 @@ RigEclipseResultAddress RigCaseCellResultsData::defaultResult() const
     // If any input property exists, use that
     auto inputProperty = std::find_if( allResults.begin(),
                                        allResults.end(),
-                                       []( const RigEclipseResultAddress& adr )
-                                       { return adr.resultCatType() == RiaDefines::ResultCatType::INPUT_PROPERTY; } );
+                                       [&isCandidateResult]( const RigEclipseResultAddress& adr )
+                                       { return isCandidateResult( adr, RiaDefines::ResultCatType::INPUT_PROPERTY ); } );
 
     if ( inputProperty != allResults.end() ) return *inputProperty;
 
     // If any static property exists, use that
     auto staticResult = std::find_if( allResults.begin(),
                                       allResults.end(),
-                                      []( const RigEclipseResultAddress& adr )
-                                      { return adr.resultCatType() == RiaDefines::ResultCatType::STATIC_NATIVE; } );
+                                      [&isCandidateResult]( const RigEclipseResultAddress& adr )
+                                      { return isCandidateResult( adr, RiaDefines::ResultCatType::STATIC_NATIVE ); } );
 
     if ( staticResult != allResults.end() ) return *staticResult;
 

--- a/ApplicationLibCode/UnitTests/RiaNumericalTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaNumericalTools-Test.cpp
@@ -2,11 +2,24 @@
 
 #include "RiaNumericalTools.h"
 
+#include <cmath>
+
 TEST( RiaNumericalTools, LogTenFunctions )
 {
     {
         // Negative values will return zero
         double value = -0.0015;
+
+        auto exponentCeil = RiaNumericalTools::computeTenExponentCeil( value );
+        EXPECT_EQ( 0.0f, exponentCeil );
+
+        auto exponentFloor = RiaNumericalTools::computeTenExponentFloor( value );
+        EXPECT_EQ( 0.0f, exponentFloor );
+    }
+
+    {
+        // Zero will return zero, as log10() is not defined for zero
+        double value = 0.0;
 
         auto exponentCeil = RiaNumericalTools::computeTenExponentCeil( value );
         EXPECT_EQ( 0.0f, exponentCeil );
@@ -43,6 +56,45 @@ TEST( RiaNumericalTools, LogTenFunctions )
 
         auto exponentFloor = RiaNumericalTools::computeTenExponentFloor( value );
         EXPECT_EQ( 1.0f, exponentFloor );
+    }
+}
+
+TEST( RiaNumericalTools, ComputeTenExponentFloor )
+{
+    struct TestValues
+    {
+        double value;
+        double expectedExponent;
+    };
+
+    TestValues testValues[] = {
+        // Zero and negative values are not defined for log10(), and return zero
+        { -1150.0, 0.0 },
+        { -0.5, 0.0 },
+        { 0.0, 0.0 },
+        // Values below one give a negative exponent
+        { 0.0005, -4.0 },
+        { 0.05, -2.0 },
+        { 0.1, -1.0 },
+        { 0.5, -1.0 },
+        // Values above one give a positive exponent
+        { 1.0, 0.0 },
+        { 9.99, 0.0 },
+        { 10.0, 1.0 },
+        { 1150.0, 3.0 },
+    };
+
+    for ( const auto& testValue : testValues )
+    {
+        auto exponentFloor = RiaNumericalTools::computeTenExponentFloor( testValue.value );
+        EXPECT_EQ( testValue.expectedExponent, exponentFloor ) << "Failed for value " << testValue.value;
+
+        // The lower limit of a logarithmic range is the closest power of ten below the value
+        if ( testValue.value > 0.0 )
+        {
+            EXPECT_EQ( pow( 10.0, testValue.expectedExponent ), RiaNumericalTools::roundToClosestPowerOfTenFloor( testValue.value ) )
+                << "Failed for value " << testValue.value;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #14486

A new contour map created from the right-click menu on a case used a hardcoded SOIL result, resulting in an empty view when SOIL was not present in the case. The cell result of an existing view for the same case is now used if one is available, and otherwise the default result of the case is used. `RigCaseCellResultsData::defaultResult()` verifies that the result exists before selecting it, and falls back from dynamic to input property to static results. Completion Type is a category result, and is now excluded as a default result for both 3d views and contour maps.

Selecting a logarithmic result like PERMX exposed a related issue in the color legend. The lower limit of a logarithmic color range was computed from the value closest to zero, which is not always available. When this value was zero, `log10()` returned `-inf` and the lower limit ended up as zero. The closest power of ten below the lowest value is now used instead, and the value closest to zero is only used when the lowest value is zero or negative. For a PERMX result ranging from 0.5 to 1150 the range is now 0.1 to 10000. `computeTenExponentCeil()` and `computeTenExponentFloor()` are guarded against zero, and the range is guaranteed to span at least one decade.
