### PR TITLE
Fix crash when a grid case group references a missing grid file

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
@@ -285,6 +285,21 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
         return;
     }
 
+    // A case that failed to open is left in the collection by loadMainCaseAndActiveCellInfo(), and has no case data. Collect the cases
+    // that do have data, calling activeCellInfo() on a null case data crashes.
+    std::vector<RigEclipseCaseData*> sourceCaseData;
+    for ( auto* reservoir : caseCollection->reservoirs.childrenByType() )
+    {
+        if ( reservoir && reservoir->eclipseCaseData() ) sourceCaseData.push_back( reservoir->eclipseCaseData() );
+    }
+
+    if ( sourceCaseData.empty() )
+    {
+        clearActiveCellUnions();
+
+        return;
+    }
+
     m_unionOfMatrixActiveCells->setReservoirCellCount( m_mainGrid->totalCellCount() );
     m_unionOfFractureActiveCells->setReservoirCellCount( m_mainGrid->totalCellCount() );
     m_unionOfMatrixActiveCells->setGridCount( m_mainGrid->gridCount() );
@@ -302,14 +317,13 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
 
         for ( size_t gridLocalCellIndex = 0; gridLocalCellIndex < grid->cellCount(); gridLocalCellIndex++ )
         {
-            for ( size_t caseIdx = 0; caseIdx < caseCollection->reservoirs.size(); caseIdx++ )
+            for ( size_t caseIdx = 0; caseIdx < sourceCaseData.size(); caseIdx++ )
             {
                 size_t reservoirCellIndex = grid->reservoirCellIndex( gridLocalCellIndex );
 
                 if ( activeM[gridLocalCellIndex] == 0 )
                 {
-                    if ( caseCollection->reservoirs[caseIdx]
-                             ->eclipseCaseData()
+                    if ( sourceCaseData[caseIdx]
                              ->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL )
                              ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
@@ -319,8 +333,7 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
 
                 if ( activeF[gridLocalCellIndex] == 0 )
                 {
-                    if ( caseCollection->reservoirs[caseIdx]
-                             ->eclipseCaseData()
+                    if ( sourceCaseData[caseIdx]
                              ->activeCellInfo( RiaDefines::PorosityModelType::FRACTURE_MODEL )
                              ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {


### PR DESCRIPTION
### Skip source cases without case data when computing the union of active cells

Problem: `loadMainCaseAndActiveCellInfo()` calls `openAndReadActiveCellData()` for each source case in a grid case group. That function returns `false` before `setReservoirData()` when the grid file is missing, and the loop only does `continue`, so the case stays in `caseCollection->reservoirs` with a null `eclipseCaseData()`. `computeUnionOfActiveCells()` then iterates every reservoir and calls `eclipseCaseData()->activeCellInfo( ... )` on it. `activeCellInfo()` returns `m_activeCellInfo.p()`, so reading that member off a null case data segfaults, which is reported as `cvf::ref<RigActiveCellInfo>::p()`.

Reproduces by opening a saved project whose grid case group references a grid file that has been moved or deleted.

Fix: collect the source cases that actually have case data once, before the cell loops, and iterate those. Returns early, as the existing guards in this function do, when none of them have data. Collecting up front also removes the per-cell case lookup from the innermost loop.

<details><summary>Crash stack (signature 36a46843df47, 6 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
[3] cvf::ref<RigActiveCellInfo>::p() at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:307
[4] RimIdenticalGridCaseGroup::computeUnionOfActiveCells() at ResInsight/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp:297
[5] RimIdenticalGridCaseGroup::loadMainCaseAndActiveCellInfo() at ResInsight/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp:234
[6] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:609
[7] RiaApplication::openFile(QString const&) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:410
[8] RiuRecentFileActionProvider::slotOpenRecentFile() at ResInsight/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp:134
[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
[41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
[42] __libc_start_main at :0
```

</details>

<details><summary>Crash stack (signature 31aef0833d3f, 2 reports)</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[3] cvf::ref<RigActiveCellInfo>::p() at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:307
[4] RimIdenticalGridCaseGroup::computeUnionOfActiveCells() at ResInsight/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp:314
[5] RimIdenticalGridCaseGroup::loadMainCaseAndActiveCellInfo() at ResInsight/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp:235
[6] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:630
[7] RicOpenProjectFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ApplicationCommands/RicOpenProjectFeature.cpp:50
[8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[34] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[35] __libc_start_main at :0
```

</details>

### Related

`loadMainCaseAndActiveCellInfo()` leaves a case that failed to open in the collection with an empty `// Error message` comment where the failure should be reported. Other readers of `caseCollection->reservoirs` may make the same assumption about case data being present. Removing the failed case, or logging the failure, would be a better fix but changes behaviour beyond this crash.
