### PR TITLE
#14493 Speed up deleting a summary ensemble

### DIFF
--- a/ApplicationLibCode/Commands/RicCloseObservedDataFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCloseObservedDataFeature.cpp
@@ -60,7 +60,7 @@ void RicCloseObservedDataFeature::deleteObservedSummaryData( const std::vector<R
         {
             for ( RimSummaryPlot* summaryPlot : multiPlot->summaryPlots() )
             {
-                summaryPlot->deleteCurvesAssosiatedWithCase( observedData );
+                summaryPlot->deleteCurvesAssosiatedWithCases( { observedData } );
             }
             multiPlot->updateConnectedEditors();
         }

--- a/ApplicationLibCode/Commands/RicCloseSummaryCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCloseSummaryCaseFeature.cpp
@@ -42,6 +42,8 @@
 
 #include <QAction>
 
+#include <set>
+
 CAF_CMD_SOURCE_INIT( RicCloseSummaryCaseFeature, "RicCloseSummaryCaseFeature" );
 
 //--------------------------------------------------------------------------------------------------
@@ -66,16 +68,15 @@ void RicCloseSummaryCaseFeature::deleteSummaryCases( std::vector<RimSummaryCase*
 
     auto depthTrackPlots = caf::PdmObjectHandleTools::referringAncestorOfType<RimDepthTrackPlot, RimSummaryCase>( cases );
 
-    for ( RimSummaryCase* summaryCase : cases )
+    const std::set<RimSummaryCase*> casesToDelete( cases.begin(), cases.end() );
+
+    for ( RimSummaryMultiPlot* multiPlot : summaryPlotColl->multiPlots() )
     {
-        for ( RimSummaryMultiPlot* multiPlot : summaryPlotColl->multiPlots() )
+        for ( RimSummaryPlot* summaryPlot : multiPlot->summaryPlots() )
         {
-            for ( RimSummaryPlot* summaryPlot : multiPlot->summaryPlots() )
-            {
-                summaryPlot->deleteCurvesAssosiatedWithCase( summaryCase );
-            }
-            plotsToUpdate.insert( multiPlot );
+            summaryPlot->deleteCurvesAssosiatedWithCases( casesToDelete );
         }
+        plotsToUpdate.insert( multiPlot );
     }
 
     summaryCaseMainCollection->removeCases( cases );

--- a/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp
+++ b/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp
@@ -41,6 +41,8 @@
 #include <QAction>
 #include <QMessageBox>
 
+#include <set>
+
 CAF_CMD_SOURCE_INIT( RicDeleteSummaryCaseCollectionFeature, "RicDeleteSummaryCaseCollectionFeature" );
 
 //--------------------------------------------------------------------------------------------------
@@ -48,18 +50,25 @@ CAF_CMD_SOURCE_INIT( RicDeleteSummaryCaseCollectionFeature, "RicDeleteSummaryCas
 //--------------------------------------------------------------------------------------------------
 void RicDeleteSummaryCaseCollectionFeature::deleteSummaryCaseCollection( RimSummaryEnsemble* caseCollection )
 {
+    auto cases = caseCollection->allSummaryCases();
+    if ( cases.empty() ) return;
+
+    // Delete the curves for all the cases in one pass per plot, and update each multi plot only if it actually lost a
+    // curve. Doing this per case meant scanning every plot once per realization and updating the connected editors
+    // once per realization and multi plot.
+    const std::set<RimSummaryCase*> casesToDelete( cases.begin(), cases.end() );
+
     RimSummaryMultiPlotCollection* summaryPlotColl = RiaSummaryTools::summaryMultiPlotCollection();
 
-    for ( RimSummaryCase* summaryCase : caseCollection->allSummaryCases() )
+    for ( RimSummaryMultiPlot* multiPlot : summaryPlotColl->multiPlots() )
     {
-        for ( RimSummaryMultiPlot* multiPlot : summaryPlotColl->multiPlots() )
+        bool curvesDeleted = false;
+        for ( RimSummaryPlot* summaryPlot : multiPlot->summaryPlots() )
         {
-            for ( RimSummaryPlot* summaryPlot : multiPlot->summaryPlots() )
-            {
-                summaryPlot->deleteCurvesAssosiatedWithCase( summaryCase );
-            }
-            multiPlot->updateConnectedEditors();
+            if ( summaryPlot->deleteCurvesAssosiatedWithCases( casesToDelete ) ) curvesDeleted = true;
         }
+
+        if ( curvesDeleted ) multiPlot->updateConnectedEditors();
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.cpp
@@ -229,7 +229,7 @@ std::vector<RimSummaryCurve*> RimSummaryCurveCollection::curves() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryCurveCollection::deleteCurvesAssosiatedWithCase( RimSummaryCase* summaryCase )
+bool RimSummaryCurveCollection::deleteCurvesAssosiatedWithCases( const std::set<RimSummaryCase*>& summaryCases )
 {
     std::vector<RimSummaryCurve*> summaryCurvesToDelete;
 
@@ -238,7 +238,7 @@ void RimSummaryCurveCollection::deleteCurvesAssosiatedWithCase( RimSummaryCase* 
         if ( !summaryCurve ) continue;
         if ( !summaryCurve->summaryCaseY() ) continue;
 
-        if ( summaryCurve->summaryCaseY() == summaryCase )
+        if ( summaryCases.contains( summaryCurve->summaryCaseY() ) )
         {
             summaryCurvesToDelete.push_back( summaryCurve );
         }
@@ -248,6 +248,8 @@ void RimSummaryCurveCollection::deleteCurvesAssosiatedWithCase( RimSummaryCase* 
         m_curves.removeChild( summaryCurve );
         delete summaryCurve;
     }
+
+    return !summaryCurvesToDelete.empty();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCurveCollection.h
@@ -26,6 +26,8 @@
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
 
+#include <set>
+
 class RimSummaryCase;
 class RimSummaryCurve;
 class RimSummaryPlot;
@@ -75,7 +77,8 @@ private:
     void deleteCurve( RimSummaryCurve* curve );
     void removeCurve( RimSummaryCurve* curve );
 
-    void deleteCurvesAssosiatedWithCase( RimSummaryCase* summaryCase );
+    /// Delete the curves associated with any of the given cases. Returns true if any curve was deleted.
+    bool deleteCurvesAssosiatedWithCases( const std::set<RimSummaryCase*>& summaryCases );
     void deleteAllCurves();
     void updateCaseNameHasChanged();
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
@@ -53,6 +53,7 @@
 #include <QFileInfo>
 
 #include <cmath>
+#include <set>
 
 CAF_PDM_SOURCE_INIT( RimSummaryEnsemble, "SummaryCaseSubCollection" );
 
@@ -118,7 +119,8 @@ RimSummaryEnsemble::~RimSummaryEnsemble()
 {
     m_cases.deleteChildren();
 
-    updateReferringCurveSets();
+    // The cases are gone at this point, so the referring curve sets are cleared and their plots redrawn without data.
+    clearReferringCurveSets();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -785,6 +787,37 @@ void RimSummaryEnsemble::updateReferringCurveSets( bool doZoomAll )
 void RimSummaryEnsemble::updateReferringCurveSets()
 {
     updateReferringCurveSets( false );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Clear the curves of the curve sets referring to this ensemble, and redraw the affected plots.
+///
+/// Used when the summary cases have been deleted. Reloading the curve data has nothing to read at that point, so this
+/// deletes the curves directly instead of going through loadDataAndUpdate(). Each plot is updated once, even when it
+/// holds several curve sets referring to this ensemble.
+//--------------------------------------------------------------------------------------------------
+void RimSummaryEnsemble::clearReferringCurveSets()
+{
+    std::set<RimSummaryPlot*> plotsToUpdate;
+
+    for ( auto curveSet : objectsWithReferringPtrFieldsOfType<RimEnsembleCurveSet>() )
+    {
+        if ( !curveSet ) continue;
+
+        curveSet->deleteEnsembleCurves();
+        curveSet->deleteStatisticsCurves();
+        curveSet->filterChanged.send();
+
+        if ( auto parentPlot = curveSet->firstAncestorOrThisOfType<RimSummaryPlot>() )
+        {
+            plotsToUpdate.insert( parentPlot );
+        }
+    }
+
+    for ( auto plot : plotsToUpdate )
+    {
+        plot->updateAll();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.h
@@ -113,6 +113,7 @@ public:
 
     void updateReferringCurveSets();
     void updateReferringCurveSetsZoomAll();
+    void clearReferringCurveSets();
 
     RiaSummaryAddressAnalyzer* addressAnalyzer();
 

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp
@@ -1497,12 +1497,14 @@ void RimSummaryPlot::deleteCurves( const std::vector<RimSummaryCurve*>& curves )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimSummaryPlot::deleteCurvesAssosiatedWithCase( RimSummaryCase* summaryCase )
+bool RimSummaryPlot::deleteCurvesAssosiatedWithCases( const std::set<RimSummaryCase*>& summaryCases )
 {
     if ( m_summaryCurveCollection )
     {
-        m_summaryCurveCollection->deleteCurvesAssosiatedWithCase( summaryCase );
+        return m_summaryCurveCollection->deleteCurvesAssosiatedWithCases( summaryCases );
     }
+
+    return false;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.h
@@ -107,7 +107,8 @@ public:
 
     void deleteCurves( const std::vector<RimSummaryCurve*>& curves );
 
-    void deleteCurvesAssosiatedWithCase( RimSummaryCase* summaryCase );
+    /// Delete the curves associated with any of the given cases. Returns true if any curve was deleted.
+    bool deleteCurvesAssosiatedWithCases( const std::set<RimSummaryCase*>& summaryCases );
 
     RimEnsembleCurveSetCollection* ensembleCurveSetCollection() const;
 


### PR DESCRIPTION
Deleting a summary ensemble did work proportional to the number of realizations, in two independent places. Fixes #14493.

## Measured

Deleting an ensemble from a project with many plots, in the running application. Before is `2322d9e97f` on dev.

| Measurement | Before | After | Change |
| --- | --- | --- | --- |
| `deleteSummaryCaseCollection` | 2.1 s | 0 ms | eliminated |
| `~RimSummaryEnsemble` | 1.3 s | 704 ms | 1.85 x |
| Total | 3.5 s | 835 ms | 4.2 x, 2.7 s saved |

Before the change the two sections account for 3.4 s of the 3.5 s total, so nothing significant sits outside them. See https://github.com/OPM/ResInsight/issues/14493#issuecomment-5226263342 for the full notes.

## Delete curves for all cases in one pass

`deleteSummaryCaseCollection()` looped over every case, and for each case scanned every summary plot and called `updateConnectedEditors()` on every multi plot. Each plot was scanned once per realization, and the connected editors were updated once per realization and multi plot.

`deleteCurvesAssosiatedWithCase()` is replaced by `deleteCurvesAssosiatedWithCases()`, which takes a set of cases and returns whether anything was deleted. Each plot is scanned once, and the connected editors of a multi plot are updated only when that multi plot actually lost a curve.

This drops to 0 ms because nothing matches. The realization curves belong to `RimEnsembleCurveSet::m_realizationCurves`, not to the plot's `RimSummaryCurveCollection::m_curves`, so no curve is deleted and no editor is updated. Before the change, that same empty result cost 2.1 s.

`RicCloseSummaryCaseFeature` and `RicCloseObservedDataFeature` are updated to the new signature. `RicCloseSummaryCaseFeature` also scans each plot once instead of once per case.

## Clear the referring curve sets instead of reloading them

`~RimSummaryEnsemble()` deletes the cases and then calls `updateReferringCurveSets()`, which runs `RimEnsembleCurveSet::loadDataAndUpdate()` on every referring curve set. Calling it after the cases are deleted is intentional, the curve sets are meant to end up empty, but reloading the curve data has nothing to read at that point. The reload also syncs UI fields, reloads the curve filters, rebuilds the address list, recomputes statistics over an empty case set and updates three legends, and it calls `updateAll()` on the parent plot once per curve set instead of once per plot.

`clearReferringCurveSets()` deletes the ensemble and statistics curves directly and updates each affected plot once.

The referring objects are queried as `RimEnsembleCurveSet` instead of walking all referring objects and casting. The previous loop discarded everything that was not a curve set, so the behaviour is unchanged.

`curveSet->filterChanged.send()` is kept, so `RimAbstractCorrelationPlot`, `RimEnsembleWellLogCurveSet` and `RimEnsembleSurface` still get the same notification as before. Sending a filter change while the ensemble is being deleted is questionable and it is the first thing to try if the remaining 704 ms is worth chasing, but removing it is a behaviour change and is left out of this fix.

## Note

This touches `~RimSummaryEnsemble()` and so conflicts with #14492, which replaces `m_cases.deleteChildrenAsync()` with `m_cases.deleteChildren()` in the same destructor. The resolution is to keep both changes, they are independent.

A dozen other types hold a `PdmPtrField<RimSummaryEnsemble*>`, among them `RimAnalysisPlotDataEntry`, `RimParameterRftCrossPlot`, `RimRftTornadoPlot`, `RimOpmFlowJob` and the ensemble histogram data sources. None of them are notified when the ensemble is deleted, before or after this change.
