### PR TITLE
Fix five crashes found by crash triage

### DIFF
--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -357,11 +357,16 @@ RimWellLogRftCurve* RicWellLogTools::addRftCurve( RimWellLogTrack* plotTrack, co
     {
         curve->setEclipseCase( resultCase );
 
-        auto wellNames = resultCase->rftReader()->wellNames();
-        if ( !wellNames.empty() )
+        // The case selected above is the first Eclipse result case, which is not guaranteed to have an RFT reader. See
+        // hasRftData() that requires a reader to be present.
+        if ( auto* rftReader = resultCase->rftReader() )
         {
-            auto wellName = *( wellNames.begin() );
-            curve->setDefaultAddress( wellName );
+            auto wellNames = rftReader->wellNames();
+            if ( !wellNames.empty() )
+            {
+                auto wellName = *( wellNames.begin() );
+                curve->setDefaultAddress( wellName );
+            }
         }
     }
     else

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -62,6 +62,7 @@
 #include <QDateTime>
 #include <QFileInfo>
 
+#include <algorithm>
 #include <cmath> // Needed for HUGE_VAL on Linux
 #include <iostream>
 #include <map>
@@ -719,7 +720,18 @@ void RifReaderEclipseOutput::transferStaticNNCData( const ecl_grid_type* mainEcl
         {
             int numNNC       = ecl_nnc_data_get_size( tran_data );
             int geometrySize = ecl_nnc_geometry_size( nnc_geo );
-            CAF_ASSERT( numNNC == geometrySize );
+
+            if ( numNNC != geometrySize )
+            {
+                // The transmissibility data is read from the INIT file, the geometry from the grid file. If the two files are out of
+                // sync, iterating the geometry using the data count reads out of bounds. Use the smallest count.
+                RiaLogging::warning( std::format( "NNC data count ({}) does not match NNC geometry count ({}), importing {} connections.",
+                                                  numNNC,
+                                                  geometrySize,
+                                                  std::min( numNNC, geometrySize ) ) );
+
+                numNNC = std::min( numNNC, geometrySize );
+            }
 
             if ( numNNC > 0 )
             {

--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
@@ -635,6 +635,7 @@ std::vector<double> RimGridCalculation::getActiveCellValues( const QString&     
     size_t gridIndex = 0;
     auto   resultAccessor =
         RigResultAccessorFactory::createFromResultAddress( eclipseCaseData, gridIndex, porosityModel, timeStepToUse, resAddr );
+    if ( resultAccessor.isNull() ) return {};
 
 #pragma omp parallel for
     for ( int i = 0; i < static_cast<int>( activeReservoirCells.size() ); i++ )

--- a/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimIdenticalGridCaseGroup.cpp
@@ -285,6 +285,21 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
         return;
     }
 
+    // A case that failed to open is left in the collection by loadMainCaseAndActiveCellInfo(), and has no case data. Collect the cases
+    // that do have data, calling activeCellInfo() on a null case data crashes.
+    std::vector<RigEclipseCaseData*> sourceCaseData;
+    for ( auto* reservoir : caseCollection->reservoirs.childrenByType() )
+    {
+        if ( reservoir && reservoir->eclipseCaseData() ) sourceCaseData.push_back( reservoir->eclipseCaseData() );
+    }
+
+    if ( sourceCaseData.empty() )
+    {
+        clearActiveCellUnions();
+
+        return;
+    }
+
     m_unionOfMatrixActiveCells->setReservoirCellCount( m_mainGrid->totalCellCount() );
     m_unionOfFractureActiveCells->setReservoirCellCount( m_mainGrid->totalCellCount() );
     m_unionOfMatrixActiveCells->setGridCount( m_mainGrid->gridCount() );
@@ -302,14 +317,13 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
 
         for ( size_t gridLocalCellIndex = 0; gridLocalCellIndex < grid->cellCount(); gridLocalCellIndex++ )
         {
-            for ( size_t caseIdx = 0; caseIdx < caseCollection->reservoirs.size(); caseIdx++ )
+            for ( size_t caseIdx = 0; caseIdx < sourceCaseData.size(); caseIdx++ )
             {
                 size_t reservoirCellIndex = grid->reservoirCellIndex( gridLocalCellIndex );
 
                 if ( activeM[gridLocalCellIndex] == 0 )
                 {
-                    if ( caseCollection->reservoirs[caseIdx]
-                             ->eclipseCaseData()
+                    if ( sourceCaseData[caseIdx]
                              ->activeCellInfo( RiaDefines::PorosityModelType::MATRIX_MODEL )
                              ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {
@@ -319,8 +333,7 @@ void RimIdenticalGridCaseGroup::computeUnionOfActiveCells()
 
                 if ( activeF[gridLocalCellIndex] == 0 )
                 {
-                    if ( caseCollection->reservoirs[caseIdx]
-                             ->eclipseCaseData()
+                    if ( sourceCaseData[caseIdx]
                              ->activeCellInfo( RiaDefines::PorosityModelType::FRACTURE_MODEL )
                              ->isActive( ReservoirCellIndex( reservoirCellIndex ) ) )
                     {

--- a/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigAllGridCellsResultAccessor.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigAllGridCellsResultAccessor.cpp
@@ -21,8 +21,6 @@
 
 #include "RigGridBase.h"
 
-#include "cafAssert.h"
-
 #include <cmath>
 
 //--------------------------------------------------------------------------------------------------
@@ -42,9 +40,9 @@ double RigAllGridCellsResultAccessor::cellScalar( size_t gridLocalCellIndex ) co
     if ( m_reservoirResultValues->empty() ) return HUGE_VAL;
 
     size_t reservoirCellIndex = m_grid->reservoirCellIndex( gridLocalCellIndex );
-    CAF_ASSERT( reservoirCellIndex < m_reservoirResultValues->size() );
+    if ( reservoirCellIndex >= m_reservoirResultValues->size() ) return HUGE_VAL;
 
-    return m_reservoirResultValues->at( reservoirCellIndex );
+    return ( *m_reservoirResultValues )[reservoirCellIndex];
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -62,9 +60,11 @@ double RigAllGridCellsResultAccessor::cellScalarGlobIdx( size_t globCellIndex ) 
 {
     if ( m_reservoirResultValues->empty() ) return HUGE_VAL;
 
-    CAF_ASSERT( globCellIndex < m_reservoirResultValues->size() );
+    // The cell index can come from another case, see RimGridCalculation::getActiveCellValues(). Avoid at(), which throws: an
+    // exception escaping an OpenMP loop calls std::terminate.
+    if ( globCellIndex >= m_reservoirResultValues->size() ) return HUGE_VAL;
 
-    return m_reservoirResultValues->at( globCellIndex );
+    return ( *m_reservoirResultValues )[globCellIndex];
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -2372,6 +2372,11 @@ void RigCaseCellResultsData::computeRiTransComponent( const QString& riTransComp
             size_t         neighborResvCellIdx = grid->reservoirCellIndex( gridLocalNeighborCellIdx );
             const RigCell& neighborCell        = m_ownerMainGrid->cell( neighborResvCellIdx );
 
+            // Do nothing if this cell has no permeability result. The transmissibility and the permeability results can use
+            // different indexing, so a defined transmissibility index does not imply a defined permeability index.
+            size_t nativeCellPermResIdx = ( *permIdxFunc )( activeCellInfo, nativeResvCellIndex );
+            if ( nativeCellPermResIdx == cvf::UNDEFINED_SIZE_T ) continue;
+
             // Do nothing if neighbor cell has no results
             size_t neighborCellPermResIdx = ( *permIdxFunc )( activeCellInfo, neighborResvCellIdx );
             if ( neighborCellPermResIdx == cvf::UNDEFINED_SIZE_T ) continue;
@@ -2402,8 +2407,7 @@ void RigCaseCellResultsData::computeRiTransComponent( const QString& riTransComp
             {
                 cvf::Vec3d centerToFace = nativeCell.faceCenter( faceId ) - nativeCell.center();
 
-                size_t permResIdx = ( *permIdxFunc )( activeCellInfo, nativeResvCellIndex );
-                double perm       = permResults[permResIdx];
+                double perm = permResults[nativeCellPermResIdx];
 
                 double ntg = 1.0;
                 if ( hasNTGResults && faceId != cvf::StructGridInterface::POS_K )

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -160,6 +160,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicWellPathExportMswGeometryPath-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicMswBranchBuilder-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigMswTableData-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigAllGridCellsResultAccessor-Test.cpp
 )
 
 if(RESINSIGHT_ENABLE_GRPC)

--- a/ApplicationLibCode/UnitTests/RigAllGridCellsResultAccessor-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigAllGridCellsResultAccessor-Test.cpp
@@ -1,0 +1,64 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "ResultAccessors/RigAllGridCellsResultAccessor.h"
+
+#include <cmath>
+#include <vector>
+
+//--------------------------------------------------------------------------------------------------
+/// The grid is only used by cellScalar(), the global index accessors read the result vector directly.
+//--------------------------------------------------------------------------------------------------
+TEST( RigAllGridCellsResultAccessorTest, CellScalarGlobIdxReturnsValueForValidIndex )
+{
+    std::vector<double> values = { 1.0, 2.0, 3.0 };
+
+    RigAllGridCellsResultAccessor accessor( nullptr, &values );
+
+    EXPECT_DOUBLE_EQ( 1.0, accessor.cellScalarGlobIdx( 0 ) );
+    EXPECT_DOUBLE_EQ( 3.0, accessor.cellScalarGlobIdx( 2 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A cell index beyond the result vector must not throw. The accessor is called from OpenMP loops,
+/// where an escaping exception terminates the application.
+//--------------------------------------------------------------------------------------------------
+TEST( RigAllGridCellsResultAccessorTest, CellScalarGlobIdxIsUndefinedForIndexBeyondResultVector )
+{
+    std::vector<double> values = { 1.0, 2.0, 3.0 };
+
+    RigAllGridCellsResultAccessor accessor( nullptr, &values );
+
+    EXPECT_NO_THROW( accessor.cellScalarGlobIdx( 3 ) );
+    EXPECT_DOUBLE_EQ( HUGE_VAL, accessor.cellScalarGlobIdx( 3 ) );
+    EXPECT_DOUBLE_EQ( HUGE_VAL, accessor.cellScalarGlobIdx( 1000 ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RigAllGridCellsResultAccessorTest, CellScalarGlobIdxIsUndefinedForEmptyResultVector )
+{
+    std::vector<double> values;
+
+    RigAllGridCellsResultAccessor accessor( nullptr, &values );
+
+    EXPECT_DOUBLE_EQ( HUGE_VAL, accessor.cellScalarGlobIdx( 0 ) );
+}


### PR DESCRIPTION
Combines five independent crash fixes from the crash triage worklist into a single branch. Supersedes #14485 and #14489, which have been closed.

### Guard against missing RFT reader when creating an RFT curve
`RicWellLogTools::addRftCurve()` picks the first Eclipse result case, which is not guaranteed to have an RFT reader, and then dereferenced `rftReader()` unconditionally. Guard the reader before reading well names, matching the requirement already expressed by `hasRftData()`.

### Do not read NNC geometry out of bounds on INIT and grid file mismatch
`transferStaticNNCData()` asserted that the NNC transmissibility count from the INIT file equals the NNC geometry count from the grid file. When the two files are out of sync the assert is disabled in release builds and the geometry is then iterated using the larger data count, reading out of bounds. Use the smaller of the two counts and log a warning.

### Skip source cases without case data when computing union of active cells
A case that fails to open is left in the collection by `loadMainCaseAndActiveCellInfo()` with no case data, so `computeUnionOfActiveCells()` crashed calling `activeCellInfo()` on null. Collect the cases that do have data up front, and clear the unions if none remain.

### Guard against undefined permeability index in riTRANS computation
`computeRiTransComponent()` checked the neighbor cell's permeability index but not the native cell's. Transmissibility and permeability results can use different indexing, so a defined transmissibility index does not imply a defined permeability index. Look up the native index once, skip the cell when undefined, and reuse the value further down.

### Do not terminate when a grid calculation reads a cell index out of range
`RigAllGridCellsResultAccessor` bounds checked the cell index with an assert that is compiled out in release builds, and then called `std::vector::at()`, which throws. `RimGridCalculation::getActiveCellValues()` calls the accessor from an OpenMP loop, using active cell indices from the destination case to read results from the source case, so an index beyond the source result vector threw an exception that could not escape the parallel region and called `std::terminate`. Return undefined for an out of range index instead, and guard against a null result accessor on the same call.

Covered by new unit tests in `RigAllGridCellsResultAccessor-Test.cpp`. Without the accessor fix the out of range test fails with `std::out_of_range`.

## Call stack

The terminate crash, from the stacktrace registry:

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[5] manageTerminate() at ResInsight/ApplicationExeCode/RiaMainTools.cpp:241
[14] RimGridCalculation::getActiveCellValues(QString const&, RiaDefines::ResultCatType, unsigned long, RiaDefines::PorosityModelType, RimEclipseCase*, RimEclipseCase*) const [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp:642
```