### PR TITLE
MSW: Report a grid cell only once in COMPSEGS

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -360,7 +360,19 @@ RigMswBranch buildMainBoreBranch( const RimWellPath*                            
                 if ( !filterEval.includesGlobalCell( cellInfo.globCellIndex ) ) continue;
                 if ( auto ci = toMswCellIntersection( cellInfo, mainGrid, overlapStart, overlapEnd ) )
                 {
-                    cellCompsegs.push_back( *ci );
+                    // All candidates here describe the same grid cell, as they are derived from a single cellInfo.
+                    // Several perforation intervals may overlap that cell, but the cell must be connected only once,
+                    // matching the single COMPDAT connection. Widen the existing range instead of adding another row.
+                    if ( cellCompsegs.empty() )
+                    {
+                        cellCompsegs.push_back( *ci );
+                    }
+                    else
+                    {
+                        auto& existing         = cellCompsegs.front();
+                        existing.distanceStart = std::min( existing.distanceStart, ci->distanceStart );
+                        existing.distanceEnd   = std::max( existing.distanceEnd, ci->distanceEnd );
+                    }
                     emittedCountPerInterval[perf]++;
                 }
             }

--- a/TestModels/msw-export/project-files/perf_two_back_to_back.rsp
+++ b/TestModels/msw-export/project-files/perf_two_back_to_back.rsp
@@ -1,0 +1,2356 @@
+<?xml version="1.0"?>
+<ResInsightProject>
+    <DocumentFileName>C:/gitroot/ResInsight/TestModels/msw-export/project-files/perf_two_back_to_back.rsp</DocumentFileName>
+    <ProjectFileVersionString>2026.06.2-dev.02</ProjectFileVersionString>
+    <ReferencedExternalFiles>
+        $PathId_001$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.EGRID;
+        $PathId_002$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.SMSPEC;
+        $PathId_003$ C:/gitroot/ResInsight/TestModels/msw-export/opm-simulation-reference/BASE_MODEL_1.RFT;
+        $PathId_004$ $PathId_007$/BASE_MODEL_1.SMSPEC;
+        $PathId_005$ $PathId_007$/BASE_MODEL_1.RFT;
+        $PathId_006$ C:/gitroot/ResInsight/TestModels/msw-export/BASE_MODEL_1.DATA;
+        $PathId_007$ C:/gitroot/ResInsight/TestModels/msw-export/output;
+        $PathId_008$ C:/Users/MagneSjaastad;
+    </ReferencedExternalFiles>
+    <EnsembleFileSetCollection>
+        <EnsembleFileSetCollection>
+            <FileSets/>
+        </EnsembleFileSetCollection>
+    </EnsembleFileSetCollection>
+    <OilFields>
+        <ResInsightOilField>
+            <AnalysisModels>
+                <ResInsightAnalysisModels>
+                    <Reservoirs>
+                        <EclipseCase>
+                            <Name>BASE_MODEL_1</Name>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <Id>0</Id>
+                            <FilePath>$PathId_001$</FilePath>
+                            <DefaultFormationNames></DefaultFormationNames>
+                            <TimeStepFilter>
+                                <RimTimeStepFilter>
+                                    <FilterType>TS_ALL</FilterType>
+                                    <FirstTimeStep>0</FirstTimeStep>
+                                    <LastTimeStep>12</LastTimeStep>
+                                    <Interval>1</Interval>
+                                    <DateFormat>dd.MMM yyyy</DateFormat>
+                                    <TimeStepIndicesToImport>0 1 2 3 4 5 6 7 8 9 10 11 12 </TimeStepIndicesToImport>
+                                    <OnlyLastFrame>False </OnlyLastFrame>
+                                </RimTimeStepFilter>
+                            </TimeStepFilter>
+                            <IntersectionViewCollection>
+                                <Intersection2dViewCollection>
+                                    <IntersectionViews>
+                                        <Intersection2dView>
+                                            <WindowController>
+                                                <DockWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <ViewToControl>..</ViewToControl>
+                                                </DockWindowController>
+                                            </WindowController>
+                                            <ShowWindow>False </ShowWindow>
+                                            <DockWindowId></DockWindowId>
+                                            <Id>2</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View: Polyline</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>1 0 0 0 0 0 1 0 0 -1 0 1000 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>0 0 0</CameraPointOfInterest>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <Intersection>.. .. ViewCollection 0 Views 0 CrossSections 0 CrossSections 0</Intersection>
+                                            <ShowDefiningPoints>True </ShowDefiningPoints>
+                                            <ShowAxisLines>False </ShowAxisLines>
+                                        </Intersection2dView>
+                                    </IntersectionViews>
+                                </Intersection2dViewCollection>
+                            </IntersectionViewCollection>
+                            <ReservoirViews/>
+                            <MatrixModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </MatrixModelResults>
+                            <FractureModelResults>
+                                <ReservoirCellResultStorage>
+                                    <ResultCacheFileName></ResultCacheFileName>
+                                    <ResultCacheEntries/>
+                                </ReservoirCellResultStorage>
+                            </FractureModelResults>
+                            <FlipXAxis>False </FlipXAxis>
+                            <FlipYAxis>False </FlipYAxis>
+                            <ContourMaps>
+                                <Eclipse2dViewCollection>
+                                    <EclipseViews/>
+                                </Eclipse2dViewCollection>
+                            </ContourMaps>
+                            <InputPropertyCollection>
+                                <RimInputPropertyCollection>
+                                    <InputProperties/>
+                                </RimInputPropertyCollection>
+                            </InputPropertyCollection>
+                            <ViewCollection>
+                                <EclipseViewCollection>
+                                    <Views>
+                                        <ReservoirView>
+                                            <WindowController>
+                                                <DockWindowController>
+                                                    <MainWindowID>0</MainWindowID>
+                                                    <ViewToControl>..</ViewToControl>
+                                                </DockWindowController>
+                                            </WindowController>
+                                            <ShowWindow>True </ShowWindow>
+                                            <DockWindowId>{71da5736-e8ef-446f-8818-b87bb187d363}</DockWindowId>
+                                            <Id>0</Id>
+                                            <NameConfig>
+                                                <RimViewNameConfig>
+                                                    <CustomCurveName>3D View</CustomCurveName>
+                                                    <AddCaseName>False </AddCaseName>
+                                                    <AddAggregationType>True </AddAggregationType>
+                                                    <AddProperty>True </AddProperty>
+                                                    <AddSampleSpacing>False </AddSampleSpacing>
+                                                </RimViewNameConfig>
+                                            </NameConfig>
+                                            <CameraPosition>0.925339839789372 -0.320128379664994 0.203135426333383 -2440.99188803679 0.230904796197042 0.900796873422819 0.367760748211223 -1440.68301995879 -0.300714409351768 -0.293398727612683 0.907462412799271 -6236.46582513316 0 0 0 1</CameraPosition>
+                                            <CameraPointOfInterest>1254.1544091734 1572.15174297482 738.335830401848</CameraPointOfInterest>
+                                            <PerspectiveProjection>True </PerspectiveProjection>
+                                            <GridZScale>5</GridZScale>
+                                            <BackgroundColor>0.689997732639313 0.770000755786896 0.869993150234222</BackgroundColor>
+                                            <MaximumFrameRate>10</MaximumFrameRate>
+                                            <CurrentTimeStep>0</CurrentTimeStep>
+                                            <MeshMode>FULL_MESH</MeshMode>
+                                            <SurfaceMode>SURFACE</SurfaceMode>
+                                            <ShowGridBox>True </ShowGridBox>
+                                            <DisableLighting>False </DisableLighting>
+                                            <ShowZScale>True </ShowZScale>
+                                            <ComparisonView></ComparisonView>
+                                            <FontSize>Medium</FontSize>
+                                            <AnnotationStrategy>RIGHT</AnnotationStrategy>
+                                            <AnnotationCountHint>5</AnnotationCountHint>
+                                            <UseCustomAnnotationStrategy>False </UseCustomAnnotationStrategy>
+                                            <CrossSections>
+                                                <IntersectionCollection>
+                                                    <CrossSections>
+                                                        <CurveIntersection>
+                                                            <Active>True </Active>
+                                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                                            <UseSeparateIntersectionDataSource>True </UseSeparateIntersectionDataSource>
+                                                            <SeparateIntersectionDataSource>.. .. IntersectionResultDefColl 0 IntersectionResultDefinitions 0</SeparateIntersectionDataSource>
+                                                            <SurfaceIntersections>
+                                                                <RimSurfaceIntersectionCollection>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <IntersectionBands/>
+                                                                    <IntersectionCurves/>
+                                                                </RimSurfaceIntersectionCollection>
+                                                            </SurfaceIntersections>
+                                                            <UserDescription>Polyline</UserDescription>
+                                                            <ShowIntersectionGeometry>True </ShowIntersectionGeometry>
+                                                            <Type>CS_POLYLINE</Type>
+                                                            <Direction>CS_VERTICAL</Direction>
+                                                            <WellPath></WellPath>
+                                                            <SimulationWell></SimulationWell>
+                                                            <ProjectPolygon></ProjectPolygon>
+                                                            <Points>2178.14013712842 2279.31916920047 -2606.253254059 3346.04282521766 3705.68716983182 -2647.25015118923 4474.7336269588 5197.91817541397 -2686.87083859125 </Points>
+                                                            <AzimuthAngle>0</AzimuthAngle>
+                                                            <DipAngle>90</DipAngle>
+                                                            <CustomExtrusionPoints></CustomExtrusionPoints>
+                                                            <TwoAzimuthPoints></TwoAzimuthPoints>
+                                                            <Branch>-1</Branch>
+                                                            <ExtentLength>200</ExtentLength>
+                                                            <lengthUp>1000</lengthUp>
+                                                            <lengthDown>1000</lengthDown>
+                                                            <UpperThreshold>-300000</UpperThreshold>
+                                                            <LowerThreshold>300000</LowerThreshold>
+                                                            <DepthFilter>INTERSECT_SHOW_BELOW</DepthFilter>
+                                                            <CollectionUpperThreshold>0</CollectionUpperThreshold>
+                                                            <CollectionLowerThreshold>0</CollectionLowerThreshold>
+                                                            <ThresholdOverridden>False </ThresholdOverridden>
+                                                            <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                            <EnableKFilter>False </EnableKFilter>
+                                                            <KRangeFilter></KRangeFilter>
+                                                            <KFilterCollectionOverride>False </KFilterCollectionOverride>
+                                                            <KRangeCollectionFilter></KRangeCollectionFilter>
+                                                        </CurveIntersection>
+                                                    </CrossSections>
+                                                    <IntersectionBoxes/>
+                                                    <IjkIntersections/>
+                                                    <Active>True </Active>
+                                                    <UpperDepthThreshold>0</UpperDepthThreshold>
+                                                    <LowerDepthThreshold>0</LowerDepthThreshold>
+                                                    <DepthFilterOverride>False </DepthFilterOverride>
+                                                    <CollectionDepthFilterType>INTERSECT_SHOW_BELOW</CollectionDepthFilterType>
+                                                    <OverrideKFilter>False </OverrideKFilter>
+                                                    <KRangeFilter></KRangeFilter>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                </IntersectionCollection>
+                                            </CrossSections>
+                                            <IntersectionResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </IntersectionResultDefColl>
+                                            <ReservoirSurfaceResultDefColl>
+                                                <RimIntersectionResultsDefinitionCollection>
+                                                    <isActive>False </isActive>
+                                                    <IntersectionResultDefinitions>
+                                                        <IntersectionResultDefinition>
+                                                            <IsActive>True </IsActive>
+                                                            <Case>.. .. .. ..</Case>
+                                                            <TimeStep>0</TimeStep>
+                                                            <EclipseResultDef>
+                                                                <ResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                                    <ResultVariable>None</ResultVariable>
+                                                                    <FlowDiagSolution>.. .. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <DifferenceCase></DifferenceCase>
+                                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                                </ResultDefinition>
+                                                            </EclipseResultDef>
+                                                            <GeoMechResultDef>
+                                                                <GeoMechResultDefinition>
+                                                                    <IsChecked>True </IsChecked>
+                                                                    <ResultPositionType>NODAL</ResultPositionType>
+                                                                    <ResultFieldName></ResultFieldName>
+                                                                    <ResultComponentName></ResultComponentName>
+                                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                                    <ReferenceTimeStep>0</ReferenceTimeStep>
+                                                                    <CompactionRefLayer>0</CompactionRefLayer>
+                                                                    <NormalizeByHSP>False </NormalizeByHSP>
+                                                                    <NormalizationAirGap>0</NormalizationAirGap>
+                                                                </GeoMechResultDefinition>
+                                                            </GeoMechResultDef>
+                                                            <LegendConfig>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage></ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </LegendConfig>
+                                                            <TernaryLegendConfig>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendConfig>
+                                                        </IntersectionResultDefinition>
+                                                    </IntersectionResultDefinitions>
+                                                </RimIntersectionResultsDefinitionCollection>
+                                            </ReservoirSurfaceResultDefColl>
+                                            <GridCollection>
+                                                <GridCollection>
+                                                    <IsActive>False </IsActive>
+                                                    <MainGrid>
+                                                        <GridInfo>
+                                                            <IsActive>True </IsActive>
+                                                            <GridName>Main Grid</GridName>
+                                                            <GridIndex>0</GridIndex>
+                                                        </GridInfo>
+                                                    </MainGrid>
+                                                    <PersistentLgrs>
+                                                        <GridInfoCollection>
+                                                            <IsActive>True </IsActive>
+                                                            <GridInfos/>
+                                                        </GridInfoCollection>
+                                                    </PersistentLgrs>
+                                                </GridCollection>
+                                            </GridCollection>
+                                            <OverlayInfoConfig>
+                                                <View3dOverlayInfoConfig>
+                                                    <Active>True </Active>
+                                                    <ShowAnimProgress>True </ShowAnimProgress>
+                                                    <ShowInfoText>True </ShowInfoText>
+                                                    <ShowResultInfo>True </ShowResultInfo>
+                                                    <ShowHistogram>True </ShowHistogram>
+                                                    <ShowVolumeWeightedMean>True </ShowVolumeWeightedMean>
+                                                    <ShowVersionInfo>True </ShowVersionInfo>
+                                                    <StatisticsTimeRange>CURRENT_TIMESTEP</StatisticsTimeRange>
+                                                    <StatisticsCellRange>VISIBLE_CELLS</StatisticsCellRange>
+                                                </View3dOverlayInfoConfig>
+                                            </OverlayInfoConfig>
+                                            <WellMeasurements>
+                                                <WellMeasurementsInView>
+                                                    <Name>Well Measurements</Name>
+                                                    <IsChecked>False </IsChecked>
+                                                    <MeasurementKinds/>
+                                                    <linkWellVisibility>True </linkWellVisibility>
+                                                </WellMeasurementsInView>
+                                            </WellMeasurements>
+                                            <SurfaceInViewCollection/>
+                                            <SeismicSectionCollection>
+                                                <SeismicSectionCollection>
+                                                    <Name>Seismic Sections</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Seismic Sections</UserDescription>
+                                                    <SeismicSections/>
+                                                    <SurfaceIntersectionLinesScaleFactor>5</SurfaceIntersectionLinesScaleFactor>
+                                                    <SurfacesWithVisibleSurfaceLines></SurfacesWithVisibleSurfaceLines>
+                                                </SeismicSectionCollection>
+                                            </SeismicSectionCollection>
+                                            <PolygonInViewCollection>
+                                                <RimPolygonInViewCollection>
+                                                    <Name>Polygons</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Polygons/>
+                                                    <Collections/>
+                                                    <SourceCollection>.. .. .. .. .. PolygonCollection 0</SourceCollection>
+                                                </RimPolygonInViewCollection>
+                                            </PolygonInViewCollection>
+                                            <RangeFilters>
+                                                <CellFilterCollection>
+                                                    <Active>True </Active>
+                                                    <CombineFilterMode>AND</CombineFilterMode>
+                                                    <CellFilters/>
+                                                </CellFilterCollection>
+                                            </RangeFilters>
+                                            <CustomEclipseCase></CustomEclipseCase>
+                                            <EclipseCase>.. ..</EclipseCase>
+                                            <CaseChangeBehaviour>KEEP_CURRENT_SETTINGS</CaseChangeBehaviour>
+                                            <GridCellResult>
+                                                <ResultSlot>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                    <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                    <ResultVariable>SOIL</ResultVariable>
+                                                    <FlowDiagSolution>.. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                    <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                    <DifferenceCase></DifferenceCase>
+                                                    <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                    <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                    <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                    <SelectedProducerTracers></SelectedProducerTracers>
+                                                    <SelectedSouringTracers></SelectedSouringTracers>
+                                                    <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                    <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                    <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                    <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                    <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                    <ResultVarLegendDefinitionList>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>None</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>0.9073</UserDefinedMax>
+                                                            <UserDefinedMin>-2.981e-08</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>SOIL</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </ResultVarLegendDefinitionList>
+                                                    <TernaryLegendDefinition>
+                                                        <RimTernaryLegendConfig>
+                                                            <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                            <Precision>2</Precision>
+                                                            <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                            <ternaryRangeSummary></ternaryRangeSummary>
+                                                            <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                            <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                            <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                            <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                            <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                            <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                        </RimTernaryLegendConfig>
+                                                    </TernaryLegendDefinition>
+                                                    <LegendDefinitionPtrField>ResultVarLegendDefinitionList 1</LegendDefinitionPtrField>
+                                                </ResultSlot>
+                                            </GridCellResult>
+                                            <GridCellEdgeResult>
+                                                <CellEdgeResultSlot>
+                                                    <EnableCellEdgeColors>False </EnableCellEdgeColors>
+                                                    <propertyType>MULTI_AXIS_STATIC_PROPERTY</propertyType>
+                                                    <CellEdgeVariable>MULT</CellEdgeVariable>
+                                                    <UseXVariable>True </UseXVariable>
+                                                    <UseYVariable>True </UseYVariable>
+                                                    <UseZVariable>True </UseZVariable>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 3</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <SelectedProperties></SelectedProperties>
+                                                    <ShowTextValuesIfItemIsUnchecked>False </ShowTextValuesIfItemIsUnchecked>
+                                                    <SingleVarEdgeResult>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution></FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </SingleVarEdgeResult>
+                                                </CellEdgeResultSlot>
+                                            </GridCellEdgeResult>
+                                            <ElementVectorResult>
+                                                <RimElementVectorResult>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <ShowOil>True </ShowOil>
+                                                    <ShowGas>True </ShowGas>
+                                                    <ShowWater>True </ShowWater>
+                                                    <ShowResult>False </ShowResult>
+                                                    <VectorView>AGGREGATED</VectorView>
+                                                    <VectorSurfaceCrossingLocation>VECTOR_ANCHOR</VectorSurfaceCrossingLocation>
+                                                    <ShowVectorI>True </ShowVectorI>
+                                                    <ShowVectorJ>True </ShowVectorJ>
+                                                    <ShowVectorK>True </ShowVectorK>
+                                                    <ShowNncData>True </ShowNncData>
+                                                    <Threshold>0</Threshold>
+                                                    <VectorColor>RESULT_COLORS</VectorColor>
+                                                    <UniformVectorColor>0 0 0</UniformVectorColor>
+                                                    <SizeScale>1</SizeScale>
+                                                </RimElementVectorResult>
+                                            </ElementVectorResult>
+                                            <FaultResultSettings>
+                                                <RimFaultResultSlot>
+                                                    <ShowCustomFaultResult>False </ShowCustomFaultResult>
+                                                    <CustomResultSlot>
+                                                        <ResultSlot>
+                                                            <IsChecked>True </IsChecked>
+                                                            <ResultType>DYNAMIC_NATIVE</ResultType>
+                                                            <PorosityModelType>MATRIX_MODEL</PorosityModelType>
+                                                            <ResultVariable>None</ResultVariable>
+                                                            <FlowDiagSolution>.. .. .. .. FlowDiagSolutions 0</FlowDiagSolution>
+                                                            <TimeLapseBaseTimeStep>-1</TimeLapseBaseTimeStep>
+                                                            <DifferenceCase></DifferenceCase>
+                                                            <DivideByCellFaceArea>False </DivideByCellFaceArea>
+                                                            <ShowDualPorosityLabel>True </ShowDualPorosityLabel>
+                                                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                                                            <SelectedProducerTracers></SelectedProducerTracers>
+                                                            <SelectedSouringTracers></SelectedSouringTracers>
+                                                            <FlowTracerSelectionMode>FLOW_TR_INJ_AND_PROD</FlowTracerSelectionMode>
+                                                            <PhaseSelection>PHASE_ALL</PhaseSelection>
+                                                            <ShowOnlyVisibleCategoriesInLegend>True </ShowOnlyVisibleCategoriesInLegend>
+                                                            <MSyncSelectedInjProd>False </MSyncSelectedInjProd>
+                                                            <MSyncSelectedProdInj>False </MSyncSelectedProdInj>
+                                                            <ResultVarLegendDefinitionList>
+                                                                <Legend>
+                                                                    <ShowLegend>True </ShowLegend>
+                                                                    <NumberOfLevels>8</NumberOfLevels>
+                                                                    <Precision>4</Precision>
+                                                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                                    <MappingMode>LinearContinuous</MappingMode>
+                                                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                                    <UserDefinedMax>1</UserDefinedMax>
+                                                                    <UserDefinedMin>0</UserDefinedMin>
+                                                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                                    <ResultVariableUsage>None</ResultVariableUsage>
+                                                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                                </Legend>
+                                                            </ResultVarLegendDefinitionList>
+                                                            <TernaryLegendDefinition>
+                                                                <RimTernaryLegendConfig>
+                                                                    <ShowTernaryLegend>True </ShowTernaryLegend>
+                                                                    <Precision>2</Precision>
+                                                                    <RangeType>USER_DEFINED_MAX_MIN</RangeType>
+                                                                    <ternaryRangeSummary></ternaryRangeSummary>
+                                                                    <UserDefinedMaxSoil>1</UserDefinedMaxSoil>
+                                                                    <UserDefinedMinSoil>0</UserDefinedMinSoil>
+                                                                    <UserDefinedMaxSgas>1</UserDefinedMaxSgas>
+                                                                    <UserDefinedMinSgas>0</UserDefinedMinSgas>
+                                                                    <UserDefinedMaxSwat>1</UserDefinedMaxSwat>
+                                                                    <UserDefinedMinSwat>0</UserDefinedMinSwat>
+                                                                </RimTernaryLegendConfig>
+                                                            </TernaryLegendDefinition>
+                                                            <LegendDefinitionPtrField>ResultVarLegendDefinitionList 0</LegendDefinitionPtrField>
+                                                        </ResultSlot>
+                                                    </CustomResultSlot>
+                                                </RimFaultResultSlot>
+                                            </FaultResultSettings>
+                                            <StimPlanColors>
+                                                <RimStimPlanColors>
+                                                    <IsChecked>True </IsChecked>
+                                                    <ResultName>CONDUCTIVITY [md-m]</ResultName>
+                                                    <DefaultColor>0.647058844566345 0.164705887436867 0.164705887436867</DefaultColor>
+                                                    <LegendConfigurations>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 11</ColorLegend>
+                                                            <MappingMode>LinearDiscrete</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage>CONDUCTIVITY [md-m]</ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendConfigurations>
+                                                    <ShowStimPlanMesh>True </ShowStimPlanMesh>
+                                                    <StimPlanCellVizMode>COLOR_INTERPOLATION</StimPlanCellVizMode>
+                                                </RimStimPlanColors>
+                                            </StimPlanColors>
+                                            <VirtualPerforationResult>
+                                                <RimVirtualPerforationResults>
+                                                    <ShowConnectionFactors>False </ShowConnectionFactors>
+                                                    <ShowClosedConnections>True </ShowClosedConnections>
+                                                    <GeometryScaleFactor>2</GeometryScaleFactor>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>LinearContinuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                </RimVirtualPerforationResults>
+                                            </VirtualPerforationResult>
+                                            <WellCollection>
+                                                <Wells>
+                                                    <Active>True </Active>
+                                                    <ShowWellsIntersectingVisibleCells>False </ShowWellsIntersectingVisibleCells>
+                                                    <ShowOnlyActiveWells>False </ShowOnlyActiveWells>
+                                                    <WellHeadScale>1</WellHeadScale>
+                                                    <WellHeadPositionScaleFactor>0.1</WellHeadPositionScaleFactor>
+                                                    <WellPipeRadiusScale>0.1</WellPipeRadiusScale>
+                                                    <CellCenterSphereScale>0.2</CellCenterSphereScale>
+                                                    <WellLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellLabelColor>
+                                                    <ShowConnectionStatusColors>True </ShowConnectionStatusColors>
+                                                    <WellColorForApply>1 1 0</WellColorForApply>
+                                                    <WellPipeColors>WELLPIPE_COLOR_INDIDUALLY</WellPipeColors>
+                                                    <WellPipeVertexCount>12</WellPipeVertexCount>
+                                                    <WellPipeCoordType>WELLPIPE_INTERPOLATED</WellPipeCoordType>
+                                                    <DefaultWellFenceDirection>K_DIRECTION</DefaultWellFenceDirection>
+                                                    <WellCellTransparency>0.5</WellCellTransparency>
+                                                    <IsAutoDetectingBranches>True </IsAutoDetectingBranches>
+                                                    <WellHeadPosition>WELLHEAD_POS_ACTIVE_CELLS_BB</WellHeadPosition>
+                                                    <Wells>
+                                                        <Well>
+                                                            <Name>INJ-1</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.501960813999176 0.243137255311012 0.458823531866074</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-5</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.831372559070587 0.109803922474384 0.517647087574005</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>INJ-6</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.964705884456635 0.462745100259781 0.556862771511078</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-2</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.756862759590149 0 0.125490203499794</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-3</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.498039215803146 0.0941176488995552 0.0509803928434849</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                        <Well>
+                                                            <Name>PROD-4</Name>
+                                                            <ShowWell>True </ShowWell>
+                                                            <ShowWellLabel>True </ShowWellLabel>
+                                                            <ShowWellHead>True </ShowWellHead>
+                                                            <ShowWellPipe>True </ShowWellPipe>
+                                                            <ShowWellSpheres>False </ShowWellSpheres>
+                                                            <ShowWellDisks>False </ShowWellDisks>
+                                                            <WellHeadScaleFactor>1</WellHeadScaleFactor>
+                                                            <WellPipeRadiusScale>1</WellPipeRadiusScale>
+                                                            <WellPipeColor>0.945098042488098 0.227450981736183 0.0745098069310188</WellPipeColor>
+                                                            <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                            <ShowWellCells>False </ShowWellCells>
+                                                            <ShowWellCellFence>False </ShowWellCellFence>
+                                                        </Well>
+                                                    </Wells>
+                                                    <ShowWellValvesTristate>True </ShowWellValvesTristate>
+                                                    <WellDiskSummaryCase></WellDiskSummaryCase>
+                                                    <WellDiskQuantity>WOPT</WellDiskQuantity>
+                                                    <WellDiskPropertyType>PROPERTY_TYPE_PREDEFINED</WellDiskPropertyType>
+                                                    <WellDiskPropertyConfigType>PRODUCTION_RATES</WellDiskPropertyConfigType>
+                                                    <WellDiskShowQuantityLabels>True </WellDiskShowQuantityLabels>
+                                                    <WellDiskShowLabelsBackground>False </WellDiskShowLabelsBackground>
+                                                    <WellDiskScaleFactor>1</WellDiskScaleFactor>
+                                                    <WellDiskColor>0.501960813999176 0.501960813999176 0</WellDiskColor>
+                                                    <ShowWellCommunicationLines>False </ShowWellCommunicationLines>
+                                                </Wells>
+                                            </WellCollection>
+                                            <FaultCollection>
+                                                <Faults>
+                                                    <Active>True </Active>
+                                                    <ShowFaultFaces>True </ShowFaultFaces>
+                                                    <ShowOppositeFaultFaces>True </ShowOppositeFaultFaces>
+                                                    <ApplyCellFilters>True </ApplyCellFilters>
+                                                    <MeshLineThickness>1</MeshLineThickness>
+                                                    <OnlyShowWithDefNeighbor>False </OnlyShowWithDefNeighbor>
+                                                    <FaultFaceCulling>FAULT_BACK_FACE_CULLING</FaultFaceCulling>
+                                                    <ShowFaultLabel>False </ShowFaultLabel>
+                                                    <FaultLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</FaultLabelColor>
+                                                    <ShowNNCs>True </ShowNNCs>
+                                                    <HideNncsWhenNoResultIsAvailable>True </HideNncsWhenNoResultIsAvailable>
+                                                    <Faults>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults</FaultName>
+                                                            <ShowFault>True </ShowFault>
+                                                            <Color>0.396078437566757 0.517647087574005 0.376470595598221</Color>
+                                                        </Fault>
+                                                        <Fault>
+                                                            <FaultName>Undefined Grid Faults With Inactive</FaultName>
+                                                            <ShowFault>False </ShowFault>
+                                                            <Color>1 0.513725519180298 0.549019634723663</Color>
+                                                        </Fault>
+                                                    </Faults>
+                                                </Faults>
+                                            </FaultCollection>
+                                            <FaultReactivationModelCollection>
+                                                <FaultReactivationModelCollection>
+                                                    <Name>Fault Reactivation Models</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <UserDescription>Fault Reactivation Models</UserDescription>
+                                                    <FaultReactivationModels/>
+                                                </FaultReactivationModelCollection>
+                                            </FaultReactivationModelCollection>
+                                            <AnnotationCollection>
+                                                <Annotations>
+                                                    <IsChecked>True </IsChecked>
+                                                    <TextAnnotations>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsChecked>True </IsChecked>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotations>
+                                                    <AnnotationPlaneDepth>0</AnnotationPlaneDepth>
+                                                    <SnapAnnotations>False </SnapAnnotations>
+                                                    <TextAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsChecked>True </IsChecked>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </TextAnnotationsInView>
+                                                    <ReachCircleAnnotationsInView>
+                                                        <RimAnnotationGroupCollection>
+                                                            <IsChecked>True </IsChecked>
+                                                            <Annotations/>
+                                                        </RimAnnotationGroupCollection>
+                                                    </ReachCircleAnnotationsInView>
+                                                    <AnnotationFontSize>Medium</AnnotationFontSize>
+                                                </Annotations>
+                                            </AnnotationCollection>
+                                            <StreamlineCollection>
+                                                <StreamlineInViewCollection>
+                                                    <LegendDefinition>
+                                                        <Legend>
+                                                            <ShowLegend>True </ShowLegend>
+                                                            <NumberOfLevels>8</NumberOfLevels>
+                                                            <Precision>4</Precision>
+                                                            <TickNumberFormat>FIXED</TickNumberFormat>
+                                                            <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 0</ColorLegend>
+                                                            <MappingMode>Log10Continuous</MappingMode>
+                                                            <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                                            <UserDefinedMax>1</UserDefinedMax>
+                                                            <UserDefinedMin>0</UserDefinedMin>
+                                                            <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                                            <ResultVariableUsage></ResultVariableUsage>
+                                                            <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                                        </Legend>
+                                                    </LegendDefinition>
+                                                    <Name>Streamlines</Name>
+                                                    <FlowThreshold>0.01</FlowThreshold>
+                                                    <LengthThreshold>100</LengthThreshold>
+                                                    <Resolution>20</Resolution>
+                                                    <MaxDays>5000</MaxDays>
+                                                    <UseProducers>True </UseProducers>
+                                                    <UseInjectors>True </UseInjectors>
+                                                    <Phase>COMBINED</Phase>
+                                                    <isActive>False </isActive>
+                                                    <VisualizationMode>ANIMATION</VisualizationMode>
+                                                    <ColorMode>PHASE_COLORS</ColorMode>
+                                                    <AnimationSpeed>10</AnimationSpeed>
+                                                    <AnimationIndex>0</AnimationIndex>
+                                                    <ScaleFactor>100</ScaleFactor>
+                                                    <TracerLength>100</TracerLength>
+                                                </StreamlineInViewCollection>
+                                            </StreamlineCollection>
+                                            <PropertyFilters>
+                                                <CellPropertyFilters>
+                                                    <Active>True </Active>
+                                                    <PropertyFilters/>
+                                                </CellPropertyFilters>
+                                            </PropertyFilters>
+                                            <DataFiltersInView>
+                                                <DataFilterInViewCollection>
+                                                    <Name>Data Filters</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <Wrappers/>
+                                                    <SourceCollection>.. .. .. DataFilterCollection 0</SourceCollection>
+                                                </DataFilterInViewCollection>
+                                            </DataFiltersInView>
+                                            <FilterInViewCollection>
+                                                <FilterInViewCollection>
+                                                    <Name>Filters</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <CellFilters>.. RangeFilters 0</CellFilters>
+                                                    <PropertyFilters>.. PropertyFilters 0</PropertyFilters>
+                                                    <DataFiltersInView>.. DataFiltersInView 0</DataFiltersInView>
+                                                </FilterInViewCollection>
+                                            </FilterInViewCollection>
+                                            <ShowInactiveCells>False </ShowInactiveCells>
+                                            <ShowInvalidCells>False </ShowInvalidCells>
+                                            <AdditionalResultsForResultInfo>
+                                                <RimMultipleEclipseResults>
+                                                    <IsChecked>True </IsChecked>
+                                                    <showCenterCoordinates>False </showCenterCoordinates>
+                                                    <showCornerCoordinates>False </showCornerCoordinates>
+                                                    <SelectedProperties></SelectedProperties>
+                                                </RimMultipleEclipseResults>
+                                            </AdditionalResultsForResultInfo>
+                                            <CameraPositions/>
+                                            <RefinementRegions>
+                                                <RefinementRegionCollection>
+                                                    <IsActive>True </IsActive>
+                                                    <Regions/>
+                                                </RefinementRegionCollection>
+                                            </RefinementRegions>
+                                        </ReservoirView>
+                                    </Views>
+                                </EclipseViewCollection>
+                            </ViewCollection>
+                            <DataFilterCollection>
+                                <DataFilterCollection>
+                                    <Filters/>
+                                </DataFilterCollection>
+                            </DataFilterCollection>
+                            <DataAnalyticsCollection>
+                                <DataAnalyticsCollection>
+                                    <FaultDistanceCollection>
+                                        <RimFaultDistanceCollection>
+                                            <FaultDistances/>
+                                        </RimFaultDistanceCollection>
+                                    </FaultDistanceCollection>
+                                    <WellTargetMappings/>
+                                </DataAnalyticsCollection>
+                            </DataAnalyticsCollection>
+                            <ResultAliasNames/>
+                            <FlowDiagSolutions>
+                                <FlowDiagSolution>
+                                    <UserDescription>All Wells</UserDescription>
+                                </FlowDiagSolution>
+                            </FlowDiagSolutions>
+                            <SourSimFileName></SourSimFileName>
+                            <MswMergeThreshold>False  3</MswMergeThreshold>
+                        </EclipseCase>
+                    </Reservoirs>
+                    <CaseGroups/>
+                    <CaseEnsembles/>
+                    <ReservoirGridEnsembles/>
+                </ResInsightAnalysisModels>
+            </AnalysisModels>
+            <GeoMechModels/>
+            <WellPathCollection>
+                <WellPaths>
+                    <Active>True </Active>
+                    <ShowWellPathLabel>True </ShowWellPathLabel>
+                    <WellPathLabelColor>0.919996976852417 0.919996976852417 0.919996976852417</WellPathLabelColor>
+                    <GlobalWellPathVisibility>ALL_ON</GlobalWellPathVisibility>
+                    <WellPathRadiusScale>0.1</WellPathRadiusScale>
+                    <WellPathClip>True </WellPathClip>
+                    <WellPathClipZDistance>100</WellPathClipZDistance>
+                    <WellPaths>
+                        <ModeledWellPath>
+                            <Name>Well-1</Name>
+                            <UnitSystem>UNITS_METRIC</UnitSystem>
+                            <SimWellName>Well-1</SimWellName>
+                            <SimBranchIndex>0</SimBranchIndex>
+                            <ShowWellPathLabel>True </ShowWellPathLabel>
+                            <MeasuredDepthLabelInterval>False  50</MeasuredDepthLabelInterval>
+                            <ShowWellPath>True </ShowWellPath>
+                            <WellPathRadiusScale>1</WellPathRadiusScale>
+                            <WellPathColor>0.788235306739807 0.5686274766922 0.788235306739807</WellPathColor>
+                            <Completions>
+                                <WellPathCompletions>
+                                    <Perforations>
+                                        <PerforationCollection>
+                                            <Name>Perforations</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Perforations>
+                                                <Perforation>
+                                                    <Name>3100 - 3800</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>3100</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>3800</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                    <CellFilter></CellFilter>
+                                                </Perforation>
+                                                <Perforation>
+                                                    <Name>3800 - 3900</Name>
+                                                    <IsChecked>True </IsChecked>
+                                                    <StartMeasuredDepth>3800</StartMeasuredDepth>
+                                                    <EndMeasuredDepth>3900</EndMeasuredDepth>
+                                                    <Diameter>0.216</Diameter>
+                                                    <SkinFactor>0</SkinFactor>
+                                                    <CompletionNumber>0</CompletionNumber>
+                                                    <UseCustomStartDate>False </UseCustomStartDate>
+                                                    <StartDate>2000_01_01-00:00:00</StartDate>
+                                                    <UseCustomEndDate>False </UseCustomEndDate>
+                                                    <EndDate>2000_12_30-00:00:00</EndDate>
+                                                    <Valves/>
+                                                    <CellFilter></CellFilter>
+                                                </Perforation>
+                                            </Perforations>
+                                            <NonDarcyParameters>
+                                                <NonDarcyPerforationParameters>
+                                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                                    <GridPermeabilityScalingFactor>1</GridPermeabilityScalingFactor>
+                                                    <WellRadius>0.108</WellRadius>
+                                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                                    <GasViscosity>0.02</GasViscosity>
+                                                    <InertialCoefficientBeta0>883.9</InertialCoefficientBeta0>
+                                                    <PermeabilityScalingFactor>-1.1045</PermeabilityScalingFactor>
+                                                    <PorosityScalingFactor>0</PorosityScalingFactor>
+                                                </NonDarcyPerforationParameters>
+                                            </NonDarcyParameters>
+                                        </PerforationCollection>
+                                    </Perforations>
+                                    <Valves>
+                                        <ValveCollection>
+                                            <Name>Valves</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Valves/>
+                                        </ValveCollection>
+                                    </Valves>
+                                    <Fishbones>
+                                        <FishbonesCollection>
+                                            <Name>Fishbones</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <FishbonesSubs/>
+                                            <StartMDAuto>AUTOMATIC</StartMDAuto>
+                                            <StartMD>inf</StartMD>
+                                            <EndMDAuto>AUTOMATIC</EndMDAuto>
+                                            <EndMD>-inf</EndMD>
+                                            <MainBoreDiameter>0.216</MainBoreDiameter>
+                                            <MainBoreSkinFactor>0</MainBoreSkinFactor>
+                                        </FishbonesCollection>
+                                    </Fishbones>
+                                    <Fractures>
+                                        <WellPathFractureCollection>
+                                            <Name>Fractures</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Fractures/>
+                                        </WellPathFractureCollection>
+                                    </Fractures>
+                                    <StimPlanModels>
+                                        <StimPlanModelCollection>
+                                            <Name>StimPlan Models</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <StimPlanModels/>
+                                        </StimPlanModelCollection>
+                                    </StimPlanModels>
+                                    <MswSegments>
+                                        <RimMswSegmentCollection>
+                                            <Name>MSW Segments</Name>
+                                            <IsChecked>True </IsChecked>
+                                            <Segments/>
+                                        </RimMswSegmentCollection>
+                                    </MswSegments>
+                                </WellPathCompletions>
+                            </Completions>
+                            <CompletionSettings>
+                                <WellPathCompletionSettings>
+                                    <WellNameForExport>Well-1</WellNameForExport>
+                                    <ReferenceDepth></ReferenceDepth>
+                                    <DrainageRadius>0</DrainageRadius>
+                                    <WellGroupNameForExport>PROD_N</WellGroupNameForExport>
+                                    <WellTypeForExport>OIL</WellTypeForExport>
+                                    <GasInflowEq>STD</GasInflowEq>
+                                    <AutoWellShutIn>STOP</AutoWellShutIn>
+                                    <AllowWellCrossFlow>True </AllowWellCrossFlow>
+                                    <WellBoreFluidPVTTable>0</WellBoreFluidPVTTable>
+                                    <HydrostaticDensity>SEG</HydrostaticDensity>
+                                    <FluidInPlaceRegion>0</FluidInPlaceRegion>
+                                    <MswParameters>
+                                        <RimMswCompletionParameters>
+                                            <RefMDType>GridEntryPoint</RefMDType>
+                                            <RefMD>0</RefMD>
+                                            <CustomValuesForLateral>False </CustomValuesForLateral>
+                                            <LinerDiameter>0.152</LinerDiameter>
+                                            <RoughnessFactor>1e-05</RoughnessFactor>
+                                            <DiameterRoughnessMode>Uniform</DiameterRoughnessMode>
+                                            <DiameterRoughnessIntervals>
+                                                <DiameterRoughnessIntervalCollection>
+                                                    <Intervals/>
+                                                </DiameterRoughnessIntervalCollection>
+                                            </DiameterRoughnessIntervals>
+                                            <PressureDrop>HF-</PressureDrop>
+                                            <LengthAndDepth>ABS</LengthAndDepth>
+                                            <EnforceMaxSegmentLength>False </EnforceMaxSegmentLength>
+                                            <MaxSegmentLength>200</MaxSegmentLength>
+                                            <CustomSegmentIntervals>
+                                                <CustomSegmentIntervalCollection>
+                                                    <Intervals/>
+                                                </CustomSegmentIntervalCollection>
+                                            </CustomSegmentIntervals>
+                                        </RimMswCompletionParameters>
+                                    </MswParameters>
+                                </WellPathCompletionSettings>
+                            </CompletionSettings>
+                            <WellLogs/>
+                            <CollectionOf3dWellLogCurves>
+                                <Rim3dWellLogCurveCollection>
+                                    <Show3dWellLogCurves>True </Show3dWellLogCurves>
+                                    <PlaneWidthScaling>1</PlaneWidthScaling>
+                                    <Show3dWellLogGrid>True </Show3dWellLogGrid>
+                                    <Show3dWellLogBackground>False </Show3dWellLogBackground>
+                                    <ArrayOf3dWellLogCurves/>
+                                </Rim3dWellLogCurveCollection>
+                            </CollectionOf3dWellLogCurves>
+                            <WellPathFormationKeyInFile></WellPathFormationKeyInFile>
+                            <WellPathFormationFilePath></WellPathFormationFilePath>
+                            <WellPathAttributes>
+                                <WellPathAttributes>
+                                    <Name>Casing Design</Name>
+                                    <IsChecked>True </IsChecked>
+                                    <Attributes/>
+                                </WellPathAttributes>
+                            </WellPathAttributes>
+                            <WellPathTieIn>
+                                <RimWellPathTieIn>
+                                    <ParentWellPath></ParentWellPath>
+                                    <ChildWellPath>..</ChildWellPath>
+                                    <TieInMeasuredDepth>0</TieInMeasuredDepth>
+                                    <AddValveAtConnection>False </AddValveAtConnection>
+                                    <Valve>
+                                        <WellPathValve>
+                                            <Name></Name>
+                                            <IsChecked>True </IsChecked>
+                                            <ValveTemplate></ValveTemplate>
+                                            <StartMeasuredDepth>0</StartMeasuredDepth>
+                                            <IsOpen>True </IsOpen>
+                                            <ValveLocations>
+                                                <RimMultipleValveLocations>
+                                                    <LocationMode>VALVE_COUNT</LocationMode>
+                                                    <RangeStart>100</RangeStart>
+                                                    <RangeEnd>250</RangeEnd>
+                                                    <ValveSpacing>0</ValveSpacing>
+                                                    <RangeValveCount>13</RangeValveCount>
+                                                    <LocationOfValves></LocationOfValves>
+                                                </RimMultipleValveLocations>
+                                            </ValveLocations>
+                                            <UseCustomStartDate>False </UseCustomStartDate>
+                                            <StartDate>2026_08_09-08:38:26</StartDate>
+                                        </WellPathValve>
+                                    </Valve>
+                                    <CustomOutletValveMd>False  0</CustomOutletValveMd>
+                                </RimWellPathTieIn>
+                            </WellPathTieIn>
+                            <WellIASettings>
+                                <RimWellIASettingsCollection>
+                                    <WellIASettings/>
+                                </RimWellIASettingsCollection>
+                            </WellIASettings>
+                            <WellPathGeometryDef>
+                                <WellPathGeometryDef>
+                                    <ReferencePosUtmXyd>2396.76894299986 2546.33210593977 2633.21284797828</ReferencePosUtmXyd>
+                                    <AirGap>0</AirGap>
+                                    <MdAtFirstTarget>2892.81933283547</MdAtFirstTarget>
+                                    <WellPathTargets>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>-29.9498740653398 799.654971524146 34.569094276821</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.5764369959842</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>True </IsEnabled>
+                                            <TargetPoint>1236.9904202153 1260.26083230065 91.6253907017731</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>70.0208758408677</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>87.5764369959842</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>70.0208758408677</EstimatedAzimuth>
+                                            <EstimatedInclination>87.5764369959842</EstimatedInclination>
+                                        </WellPathTarget>
+                                        <WellPathTarget>
+                                            <IsEnabled>False </IsEnabled>
+                                            <TargetPoint>1929.51139254053 2455.31736287457 120.824833681511</TargetPoint>
+                                            <Dogleg1>3</Dogleg1>
+                                            <Dogleg2>3</Dogleg2>
+                                            <UseFixedAzimuth>False </UseFixedAzimuth>
+                                            <Azimuth>36.591018613603</Azimuth>
+                                            <UseFixedInclination>False </UseFixedInclination>
+                                            <Inclination>88.1528471139157</Inclination>
+                                            <EstimatedDogleg1>0</EstimatedDogleg1>
+                                            <EstimatedDogleg2>0</EstimatedDogleg2>
+                                            <EstimatedAzimuth>36.591018613603</EstimatedAzimuth>
+                                            <EstimatedInclination>88.1528471139157</EstimatedInclination>
+                                        </WellPathTarget>
+                                    </WellPathTargets>
+                                    <ShowAbsolutePosForWellTargets>False </ShowAbsolutePosForWellTargets>
+                                    <UseTopLevelWellReferencePoint>False </UseTopLevelWellReferencePoint>
+                                    <UseAutoGeneratedTargetAtSeaLevel>False </UseAutoGeneratedTargetAtSeaLevel>
+                                    <LinkReferencePointUpdates>False </LinkReferencePointUpdates>
+                                    <AttachedToParentWell>False </AttachedToParentWell>
+                                    <FixedWellPathPoints></FixedWellPathPoints>
+                                    <FixedMeasuredDepths></FixedMeasuredDepths>
+                                    <ShowSpheres>True </ShowSpheres>
+                                    <SphereColor>0.317647069692612 0.52549022436142 0.580392181873322</SphereColor>
+                                    <SphereRadiusFactor>0.15</SphereRadiusFactor>
+                                    <WellTargetHandleScalingFactor>2</WellTargetHandleScalingFactor>
+                                </WellPathGeometryDef>
+                            </WellPathGeometryDef>
+                        </ModeledWellPath>
+                    </WellPaths>
+                    <WellMeasurements>
+                        <WellMeasurements>
+                            <Measurements/>
+                            <ImportedFiles/>
+                        </WellMeasurements>
+                    </WellMeasurements>
+                    <EventTimeline>
+                        <WellEventTimeline>
+                            <Events/>
+                        </WellEventTimeline>
+                    </EventTimeline>
+                    <MswWellNameGrouping>USE_PREFERENCES</MswWellNameGrouping>
+                    <MswWellNameGroupingPattern>?*Y*</MswWellNameGroupingPattern>
+                    <MswEclipseCase></MswEclipseCase>
+                    <MswShowBands>True </MswShowBands>
+                    <MswAutoUpdateSegments>True </MswAutoUpdateSegments>
+                </WellPaths>
+            </WellPathCollection>
+            <CompletionTemplateCollection>
+                <CompletionTemplateCollection>
+                    <FractureTemplates>
+                        <FractureTemplateCollection>
+                            <DefaultUnitForTemplates>UNITS_METRIC</DefaultUnitForTemplates>
+                            <FractureDefinitions>
+                                <RimEllipseFractureTemplate>
+                                    <Id>0</Id>
+                                    <UserDescription>Ellipse Fracture Template</UserDescription>
+                                    <UnitSystem>UNITS_METRIC</UnitSystem>
+                                    <Orientation>Transverse</Orientation>
+                                    <UserDefinedPerforationLength>False </UserDefinedPerforationLength>
+                                    <AzimuthAngle>0</AzimuthAngle>
+                                    <SkinFactor>0</SkinFactor>
+                                    <PerforationLength>1</PerforationLength>
+                                    <PerforationEfficiency>1</PerforationEfficiency>
+                                    <WellDiameter>0.216</WellDiameter>
+                                    <ConductivityType>FiniteConductivity</ConductivityType>
+                                    <WellPathDepthAtFracture>25</WellPathDepthAtFracture>
+                                    <FractureContainmentField>
+                                        <FractureContainment>
+                                            <IsUsingFractureContainment>False </IsUsingFractureContainment>
+                                            <TopKLayer>0</TopKLayer>
+                                            <BaseKLayer>0</BaseKLayer>
+                                            <TruncateAtFaults>False </TruncateAtFaults>
+                                            <FaultThrowValue>0</FaultThrowValue>
+                                        </FractureContainment>
+                                    </FractureContainmentField>
+                                    <NonDarcyFlowType>None</NonDarcyFlowType>
+                                    <UserDefinedDFactor>1</UserDefinedDFactor>
+                                    <FractureWidthType>FractureWidth</FractureWidthType>
+                                    <FractureWidth>0.01</FractureWidth>
+                                    <BetaFactorType>UserDefinedBetaFactor</BetaFactorType>
+                                    <InertialCoefficient>0.006083236</InertialCoefficient>
+                                    <PermeabilityType>FractureConductivity</PermeabilityType>
+                                    <RelativePermeability>1</RelativePermeability>
+                                    <EffectivePermeability>0</EffectivePermeability>
+                                    <RelativeGasDensity>0.8</RelativeGasDensity>
+                                    <GasViscosity>0.02</GasViscosity>
+                                    <HeightScaleFactor>1</HeightScaleFactor>
+                                    <WidthScaleFactor>1</WidthScaleFactor>
+                                    <DFactorScaleFactor>1</DFactorScaleFactor>
+                                    <ConductivityFactor>1</ConductivityFactor>
+                                    <HalfLength>100</HalfLength>
+                                    <Height>75</Height>
+                                    <Width>0.01</Width>
+                                    <Permeability>100000</Permeability>
+                                </RimEllipseFractureTemplate>
+                            </FractureDefinitions>
+                        </FractureTemplateCollection>
+                    </FractureTemplates>
+                    <StimPlanModelTemplates>
+                        <StimPlanModelTemplateCollection>
+                            <StimPlanModelTemplates/>
+                        </StimPlanModelTemplateCollection>
+                    </StimPlanModelTemplates>
+                    <ValveTemplates>
+                        <ValveTemplateCollection>
+                            <ValveDefinitions>
+                                <ValveTemplate>
+                                    <Name>AICD: Valve Template #1</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>AICD</CompletionType>
+                                    <UserLabel>Valve Template #1</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD>1</StrengthAICD>
+                                            <DensityCalibrationFluid>2</DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid>3</ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent>4</VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent>5</ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate>12</MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICD: Valve Template #2</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICD</CompletionType>
+                                    <UserLabel>Valve Template #2</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                                <ValveTemplate>
+                                    <Name>ICV: Valve Template #3</Name>
+                                    <UnitSystem>UNITS_UNKNOWN</UnitSystem>
+                                    <CompletionType>ICV</CompletionType>
+                                    <UserLabel>Valve Template #3</UserLabel>
+                                    <OrificeDiameter>8</OrificeDiameter>
+                                    <FlowCoefficient>0.7</FlowCoefficient>
+                                    <AICDParameters>
+                                        <WellPathAicdParameters>
+                                            <DeviceOpen>True </DeviceOpen>
+                                            <StrengthAICD></StrengthAICD>
+                                            <DensityCalibrationFluid></DensityCalibrationFluid>
+                                            <ViscosityCalibrationFluid></ViscosityCalibrationFluid>
+                                            <VolumeFlowRateExponent></VolumeFlowRateExponent>
+                                            <ViscosityFunctionExponent></ViscosityFunctionExponent>
+                                            <CriticalWaterLiquidFractionEmul></CriticalWaterLiquidFractionEmul>
+                                            <ViscosityTransitionRegionEmul></ViscosityTransitionRegionEmul>
+                                            <MaxRatioOfEmulsionVisc></MaxRatioOfEmulsionVisc>
+                                            <MaxFlowRate></MaxFlowRate>
+                                            <ExponentOilDensity></ExponentOilDensity>
+                                            <ExponentWaterDensity></ExponentWaterDensity>
+                                            <ExponentGasDensity></ExponentGasDensity>
+                                            <ExponentOilViscosity></ExponentOilViscosity>
+                                            <ExponentWaterViscosity></ExponentWaterViscosity>
+                                            <ExponentGasViscosity></ExponentGasViscosity>
+                                        </WellPathAicdParameters>
+                                    </AICDParameters>
+                                    <SICDParameters>
+                                        <WellPathSicdParameters>
+                                            <Strength>1</Strength>
+                                            <CalibrationDensity></CalibrationDensity>
+                                            <CalibrationViscosity></CalibrationViscosity>
+                                            <EmlCrt></EmlCrt>
+                                            <EmlTrans></EmlTrans>
+                                            <EmlMax></EmlMax>
+                                            <MaxCalibRate></MaxCalibRate>
+                                            <DeviceOpen>True </DeviceOpen>
+                                        </WellPathSicdParameters>
+                                    </SICDParameters>
+                                </ValveTemplate>
+                            </ValveDefinitions>
+                            <ValveUnits>UNITS_METRIC</ValveUnits>
+                        </ValveTemplateCollection>
+                    </ValveTemplates>
+                    <FractureGroupStatisticsCollection>
+                        <FractureGroupStatisticsCollection>
+                            <FractureGroupStatistics/>
+                        </FractureGroupStatisticsCollection>
+                    </FractureGroupStatisticsCollection>
+                </CompletionTemplateCollection>
+            </CompletionTemplateCollection>
+            <SummaryCaseCollection>
+                <SummaryCaseCollection>
+                    <SummaryCases>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_002$</SummaryHeaderFilename>
+                            <Id>1</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_003$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                        <FileSummaryCase>
+                            <ShortName>BASE_MODEL_1</ShortName>
+                            <NameSetting>FULL_CASE_NAME</NameSetting>
+                            <ShowSubNodesInTree>True </ShowSubNodesInTree>
+                            <IncludeInAutoReload>False </IncludeInAutoReload>
+                            <SummaryHeaderFilename>$PathId_004$</SummaryHeaderFilename>
+                            <Id>2</Id>
+                            <IncludeRestartFiles>False </IncludeRestartFiles>
+                            <AdditionalSummaryFilePath></AdditionalSummaryFilePath>
+                            <RftCase>
+                                <RimRftCase>
+                                    <RftFilePath>$PathId_005$</RftFilePath>
+                                    <DataDeckFilePath></DataDeckFilePath>
+                                </RimRftCase>
+                            </RftCase>
+                        </FileSummaryCase>
+                    </SummaryCases>
+                    <SummaryCaseCollections/>
+                </SummaryCaseCollection>
+            </SummaryCaseCollection>
+            <FormationNamesCollection>
+                <FormationNamesCollectionObject>
+                    <FormationNamesList/>
+                </FormationNamesCollectionObject>
+            </FormationNamesCollection>
+            <ObservedDataCollection>
+                <ObservedDataCollection>
+                    <ObservedDataArray/>
+                    <ObservedFmuRftDataArray/>
+                    <PressureDepthDataArray/>
+                </ObservedDataCollection>
+            </ObservedDataCollection>
+            <AnnotationCollection>
+                <RimAnnotationCollection>
+                    <IsChecked>True </IsChecked>
+                    <TextAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsChecked>True </IsChecked>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </TextAnnotations>
+                    <ReachCircleAnnotations>
+                        <RimAnnotationGroupCollection>
+                            <IsChecked>True </IsChecked>
+                            <Annotations/>
+                        </RimAnnotationGroupCollection>
+                    </ReachCircleAnnotations>
+                </RimAnnotationCollection>
+            </AnnotationCollection>
+            <EnsembleWellLogsCollection>
+                <EnsembleWellLogsCollection>
+                    <EnsembleWellLogsCollection/>
+                </EnsembleWellLogsCollection>
+            </EnsembleWellLogsCollection>
+            <PolygonCollection>
+                <PolygonCollection>
+                    <SubCollections/>
+                    <Polygons/>
+                </PolygonCollection>
+            </PolygonCollection>
+            <SurfaceCollection>
+                <SurfaceCollection>
+                    <SubCollections/>
+                    <SurfacesField/>
+                </SurfaceCollection>
+            </SurfaceCollection>
+            <SeismicCollection>
+                <SeismicDataCollection>
+                    <SeismicData/>
+                    <DifferenceData/>
+                </SeismicDataCollection>
+            </SeismicCollection>
+            <SeismicViewCollection>
+                <SeismicViewCollection>
+                    <Views/>
+                </SeismicViewCollection>
+            </SeismicViewCollection>
+            <EclipseViewCollection>
+                <EclipseViewCollection>
+                    <Views/>
+                </EclipseViewCollection>
+            </EclipseViewCollection>
+            <ContourMaps>
+                <Eclipse2dViewCollection>
+                    <EclipseViews/>
+                </Eclipse2dViewCollection>
+            </ContourMaps>
+            <VfpDataCollection>
+                <RimVfpDataCollection>
+                    <VfpPlots/>
+                </RimVfpDataCollection>
+            </VfpDataCollection>
+            <CloudDataCollection>
+                <RimCloudDataSourceCollection>
+                    <SumoFieldId></SumoFieldId>
+                    <SumoCaseId></SumoCaseId>
+                    <SumoEnsembleNames></SumoEnsembleNames>
+                    <SumoDataSources/>
+                </RimCloudDataSourceCollection>
+            </CloudDataCollection>
+        </ResInsightOilField>
+    </OilFields>
+    <ColorLegendCollection>
+        <ColorLegendCollection>
+            <CustomColorLegends/>
+        </ColorLegendCollection>
+    </ColorLegendCollection>
+    <JobCollection>
+        <JobCollection>
+            <Jobs>
+                <OpmFlowJob>
+                    <Name>BASE_MODEL_1 - Opm Flow Simulation</Name>
+                    <DeckFile>$PathId_006$</DeckFile>
+                    <WorkDirectory>$PathId_007$</WorkDirectory>
+                    <WellPath>$ROOT$ OilFields 0 WellPathCollection 0 WellPaths 0</WellPath>
+                    <EclipseCase></EclipseCase>
+                    <GridEnsemble></GridEnsemble>
+                    <SummaryEnsemble></SummaryEnsemble>
+                    <PauseBeforeRun>False </PauseBeforeRun>
+                    <AddNewWell>True </AddNewWell>
+                    <OpenWellDeckPosition>-1</OpenWellDeckPosition>
+                    <IncludeMswData>False </IncludeMswData>
+                    <AddToEnsemble>False </AddToEnsemble>
+                    <UseRestart>False </UseRestart>
+                    <CurrentRunID>0</CurrentRunID>
+                    <WellGroupName>PROD_N</WellGroupName>
+                    <WellOpenType>AtSelectedDate</WellOpenType>
+                    <WconprodKeyword>
+                        <KeywordWconprod>
+                            <status>OPEN</status>
+                            <target>LRAT</target>
+                            <orat>100</orat>
+                            <wrat>100</wrat>
+                            <grat>100</grat>
+                            <lrat>100</lrat>
+                            <resv>100</resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <alqWell></alqWell>
+                        </KeywordWconprod>
+                    </WconprodKeyword>
+                    <WconinjeKeyword>
+                        <KeywordWconinje>
+                            <type>WAT</type>
+                            <status>OPEN</status>
+                            <target>RATE</target>
+                            <rate></rate>
+                            <resv></resv>
+                            <bhp></bhp>
+                            <thp></thp>
+                            <vfptab></vfptab>
+                            <rsrvinj></rsrvinj>
+                        </KeywordWconinje>
+                    </WconinjeKeyword>
+                    <JobSettings>
+                        <OpmFlowJobSettings>
+                            <mpiProcesses>2</mpiProcesses>
+                            <threadsPerProcess>2</threadsPerProcess>
+                            <enableEsmry>True </enableEsmry>
+                            <enableTerminalOutput>True </enableTerminalOutput>
+                            <enableTuning>False </enableTuning>
+                            <ignoreKeywords></ignoreKeywords>
+                            <newtonMaxIterations>False  20</newtonMaxIterations>
+                            <parsingStrictness>normal</parsingStrictness>
+                            <relaxedMaxPvFraction>False  0.03</relaxedMaxPvFraction>
+                            <solverMaxTimeStepInDays>False  365</solverMaxTimeStepInDays>
+                            <solverMinTimeStepInDays>False  1e-12</solverMinTimeStepInDays>
+                            <minStrictCnvIter>False  -1</minStrictCnvIter>
+                            <minStrictMbIter>False  -1</minStrictMbIter>
+                            <minTimeStepBasedOnNewtonIterations>False  0</minTimeStepBasedOnNewtonIterations>
+                            <minTimeStepBeforeShuttingProblematicWellsInDays>False  0.01</minTimeStepBeforeShuttingProblematicWellsInDays>
+                            <toleranceCnv>False  0.01</toleranceCnv>
+                            <toleranceCnvEnergy>False  0.01</toleranceCnvEnergy>
+                            <toleranceCnvEnergyRelaxed>False  1</toleranceCnvEnergyRelaxed>
+                            <toleranceCnvRelaxed>False  1</toleranceCnvRelaxed>
+                            <toleranceEnergyBalance>False  1e-07</toleranceEnergyBalance>
+                            <toleranceEnergyBalanceRelaxed>False  1e-06</toleranceEnergyBalanceRelaxed>
+                            <toleranceMb>False  1e-07</toleranceMb>
+                            <toleranceMbRelaxed>False  1e-06</toleranceMbRelaxed>
+                            <tolerancePressureMsWells>False  1000</tolerancePressureMsWells>
+                            <toleranceWellControl>False  1e-07</toleranceWellControl>
+                            <toleranceWells>False  0.0001</toleranceWells>
+                            <wellGroupConstraintsMaxIterations>False  1</wellGroupConstraintsMaxIterations>
+                        </OpmFlowJobSettings>
+                    </JobSettings>
+                    <OpenTimeStep>6</OpenTimeStep>
+                    <EndTimeStep>0</EndTimeStep>
+                    <EndTimeStepEnabled>False </EndTimeStepEnabled>
+                    <AppendNewDates>False </AppendNewDates>
+                    <NewDatesInterval>1</NewDatesInterval>
+                    <NumberOfNewDates>12</NumberOfNewDates>
+                    <DateAppendType>AppendMonths</DateAppendType>
+                </OpmFlowJob>
+            </Jobs>
+        </JobCollection>
+    </JobCollection>
+    <MainPlotCollection>
+        <MainPlotCollection>
+            <Show>True </Show>
+            <WellLogPlotCollection>
+                <WellLogPlotCollection>
+                    <WellLogPlots/>
+                </WellLogPlotCollection>
+            </WellLogPlotCollection>
+            <RftPlotCollection>
+                <WellRftPlotCollection>
+                    <RftPlots/>
+                </WellRftPlotCollection>
+            </RftPlotCollection>
+            <PltPlotCollection>
+                <WellPltPlotCollection>
+                    <PltPlots/>
+                </WellPltPlotCollection>
+            </PltPlotCollection>
+            <SummaryMultiPlotCollection>
+                <RimSummaryMultiPlotCollection>
+                    <MultiSummaryPlots/>
+                    <UseCommonReadoutSettings>False </UseCommonReadoutSettings>
+                    <ReadOutSettings>
+                        <RimSummaryPlotReadOut>
+                            <ReadOutType>NONE</ReadOutType>
+                            <LineAppearance>
+                                <RimAnnotationLineAppearance>
+                                    <LineFieldsHidden>False </LineFieldsHidden>
+                                    <Color>0.250980406999588 0.250980406999588 0.250980406999588</Color>
+                                    <Thickness>2</Thickness>
+                                    <Style>STYLE_DASH</Style>
+                                </RimAnnotationLineAppearance>
+                            </LineAppearance>
+                            <VerticalLineLabelAlignment>LEFT</VerticalLineLabelAlignment>
+                            <HorizontalLineLabelAlignment>LEFT</HorizontalLineLabelAlignment>
+                        </RimSummaryPlotReadOut>
+                    </ReadOutSettings>
+                </RimSummaryMultiPlotCollection>
+            </SummaryMultiPlotCollection>
+            <AnalysisPlotCollection>
+                <AnalysisPlotCollection>
+                    <AnalysisPlots/>
+                </AnalysisPlotCollection>
+            </AnalysisPlotCollection>
+            <CorrelationPlotCollection>
+                <CorrelationPlotCollection>
+                    <CorrelationPlots/>
+                    <CorrelationReports/>
+                    <RftCorrelationReports/>
+                </CorrelationPlotCollection>
+            </CorrelationPlotCollection>
+            <SummaryCrossPlotCollection>
+                <SummaryCrossPlotCollection>
+                    <SummaryCrossPlots/>
+                </SummaryCrossPlotCollection>
+            </SummaryCrossPlotCollection>
+            <SummaryTableCollection>
+                <RimSummaryTableCollection>
+                    <SummaryTables/>
+                </RimSummaryTableCollection>
+            </SummaryTableCollection>
+            <FlowPlotCollection>
+                <FlowPlotCollection>
+                    <FlowCharacteristicsPlot>
+                        <FlowCharacteristicsPlot>
+                            <WindowController>
+                                <DockWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <ViewToControl>..</ViewToControl>
+                                </DockWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <DockWindowId></DockWindowId>
+                            <FlowCase></FlowCase>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeSelectionType>SELECTED</TimeSelectionType>
+                            <SelectedTimeSteps></SelectedTimeSteps>
+                            <SelectedTimeStepsUi></SelectedTimeStepsUi>
+                            <CellPVThreshold>0.1</CellPVThreshold>
+                            <ShowLegend>True </ShowLegend>
+                            <CellFilter>CELLS_ACTIVE</CellFilter>
+                            <CellFilterView></CellFilterView>
+                            <TracerFilter></TracerFilter>
+                            <SelectedTracerNames></SelectedTracerNames>
+                            <MinCommunication>0</MinCommunication>
+                            <MaxTof>146000</MaxTof>
+                        </FlowCharacteristicsPlot>
+                    </FlowCharacteristicsPlot>
+                    <DefaultWellConnectivityTable>
+                        <RimWellConnectivityTable>
+                            <WindowController>
+                                <DockWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <ViewToControl>..</ViewToControl>
+                                </DockWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <DockWindowId></DockWindowId>
+                            <Id>0</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <CurveCase></CurveCase>
+                            <VisibleCellView></VisibleCellView>
+                            <ViewFilterType>FILTER_BY_VISIBLE_PRODUCERS</ViewFilterType>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <TimeStepSelectopn>SINGLE_TIME_STEP</TimeStepSelectopn>
+                            <SelectProducersAndInjectorsForTimeSteps>True </SelectProducersAndInjectorsForTimeSteps>
+                            <ThresholdValue>0</ThresholdValue>
+                            <TimeSampleValueType>FLOW_RATE_FRACTION</TimeSampleValueType>
+                            <TimeStep></TimeStep>
+                            <TimeRangeValueType>ACCUMULATED_FLOW_VOLUME_FRACTION</TimeRangeValueType>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <SelectedProducerTracers></SelectedProducerTracers>
+                            <SelectedInjectorTracers></SelectedInjectorTracers>
+                            <SyncSelectedProdInj>False </SyncSelectedProdInj>
+                            <SyncSelectedInjProd>False </SyncSelectedInjProd>
+                            <ShowValueLabels>False </ShowValueLabels>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisLabelFontSize>Medium</AxisLabelFontSize>
+                            <ValueLabelFontSize>Medium</ValueLabelFontSize>
+                            <LegendConfig>
+                                <Legend>
+                                    <ShowLegend>True </ShowLegend>
+                                    <NumberOfLevels>8</NumberOfLevels>
+                                    <Precision>4</Precision>
+                                    <TickNumberFormat>FIXED</TickNumberFormat>
+                                    <ColorLegend>$ROOT$ ColorLegendCollection 0 StandardColorLegends 18</ColorLegend>
+                                    <MappingMode>LinearContinuous</MappingMode>
+                                    <RangeType>AUTOMATIC_ALLTIMESTEPS</RangeType>
+                                    <UserDefinedMax>1</UserDefinedMax>
+                                    <UserDefinedMin>0</UserDefinedMin>
+                                    <CategoryColorMode>INTERPOLATE</CategoryColorMode>
+                                    <ResultVariableUsage></ResultVariableUsage>
+                                    <CenterLegendAroundZero>False </CenterLegendAroundZero>
+                                </Legend>
+                            </LegendConfig>
+                            <MappingType>LinearContinuous</MappingType>
+                            <RangeType>AUTOMATIC</RangeType>
+                        </RimWellConnectivityTable>
+                    </DefaultWellConnectivityTable>
+                    <DefaultWellAllocationOverTimePlot>
+                        <RimWellAllocationOverTimePlot>
+                            <WindowController>
+                                <DockWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <ViewToControl>..</ViewToControl>
+                                </DockWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <DockWindowId></DockWindowId>
+                            <Id>1</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Medium</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <RowSpan>ONE</RowSpan>
+                            <ColSpan>ONE</ColSpan>
+                            <PlotDescription>Default Well Allocation Over Time Plot</PlotDescription>
+                            <CurveCase></CurveCase>
+                            <WellName>None</WellName>
+                            <FromTimeStep></FromTimeStep>
+                            <ToTimeStep></ToTimeStep>
+                            <TimeStepRangeFilterMode>TIME_STEP_COUNT</TimeStepRangeFilterMode>
+                            <TimeStepCount>10</TimeStepCount>
+                            <ExcludeTimeSteps></ExcludeTimeSteps>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowValueType>FLOW_RATE</FlowValueType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AxisTitleFontSize>Large</AxisTitleFontSize>
+                            <AxisValueFontSize>Medium</AxisValueFontSize>
+                        </RimWellAllocationOverTimePlot>
+                    </DefaultWellAllocationOverTimePlot>
+                    <DefaultWellAllocationPlot>
+                        <WellAllocationPlot>
+                            <WindowController>
+                                <DockWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <ViewToControl>..</ViewToControl>
+                                </DockWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <DockWindowId></DockWindowId>
+                            <PlotDescription>Default Flow Diagnostics Plot</PlotDescription>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <BranchDetection>True </BranchDetection>
+                            <CurveCase></CurveCase>
+                            <PlotTimeStep>0</PlotTimeStep>
+                            <WellName>None</WellName>
+                            <FlowDiagSolution></FlowDiagSolution>
+                            <FlowType>ACCUMULATED</FlowType>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsThreshold>0.005</SmallContributionsThreshold>
+                            <AccumulatedWellFlowPlot>
+                                <WellLogPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <DockWindowId></DockWindowId>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>False </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>False </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <TemplateText>$CASE, $WELL</TemplateText>
+                                    <PlotNamingMethod>CUSTOM</PlotNamingMethod>
+                                    <DepthType>CONNECTION_NUMBER</DepthType>
+                                    <DepthUnit>UNIT_NONE</DepthUnit>
+                                    <MinimumDepth>0</MinimumDepth>
+                                    <MaximumDepth>1000</MaximumDepth>
+                                    <ShowDepthGridLines>GRID_X_MAJOR</ShowDepthGridLines>
+                                    <AutoScaleDepthEnabled>True </AutoScaleDepthEnabled>
+                                    <DepthAxisVisibility>ONE_VISIBLE</DepthAxisVisibility>
+                                    <ShowDepthMarkerLine>False </ShowDepthMarkerLine>
+                                    <AutoZoomMinDepthFactor>0</AutoZoomMinDepthFactor>
+                                    <AutoZoomMaxDepthFactor>0</AutoZoomMaxDepthFactor>
+                                    <DepthAnnotations/>
+                                    <SubTitleFontSize>Medium</SubTitleFontSize>
+                                    <AxisTitleFontSize>Medium</AxisTitleFontSize>
+                                    <AxisValueFontSize>Medium</AxisValueFontSize>
+                                    <NameConfig>
+                                        <RimWellLogPlotNameConfig>
+                                            <CustomCurveName>Accumulated Flow Chart</CustomCurveName>
+                                        </RimWellLogPlotNameConfig>
+                                    </NameConfig>
+                                    <FilterEnsembleCurveSet></FilterEnsembleCurveSet>
+                                    <DepthEqualization>NONE</DepthEqualization>
+                                    <Tracks/>
+                                    <DepthOrientation>VERTICAL</DepthOrientation>
+                                </WellLogPlot>
+                            </AccumulatedWellFlowPlot>
+                            <TotalWellFlowPlot>
+                                <TotalWellAllocationPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <DockWindowId></DockWindowId>
+                                    <PlotDescription>Total Allocation</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                </TotalWellAllocationPlot>
+                            </TotalWellFlowPlot>
+                            <WellAllocLegend>
+                                <WellAllocationPlotLegend>
+                                    <ShowPlotLegend>True </ShowPlotLegend>
+                                </WellAllocationPlotLegend>
+                            </WellAllocLegend>
+                            <TofAccumulatedPhaseFractionsPlot>
+                                <TofAccumulatedPhaseFractionsPlot>
+                                    <WindowController/>
+                                    <ShowWindow>False </ShowWindow>
+                                    <DockWindowId></DockWindowId>
+                                    <PlotDescription>Cumulative Saturation by Time of Flight</PlotDescription>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <MaxTof>50</MaxTof>
+                                </TofAccumulatedPhaseFractionsPlot>
+                            </TofAccumulatedPhaseFractionsPlot>
+                        </WellAllocationPlot>
+                    </DefaultWellAllocationPlot>
+                    <WellDistributionPlotCollection>
+                        <WellDistributionPlotCollection>
+                            <WindowController>
+                                <DockWindowController>
+                                    <MainWindowID>1</MainWindowID>
+                                    <ViewToControl>..</ViewToControl>
+                                </DockWindowController>
+                            </WindowController>
+                            <ShowWindow>False </ShowWindow>
+                            <DockWindowId></DockWindowId>
+                            <Id>2</Id>
+                            <ShowPlotTitle>True </ShowPlotTitle>
+                            <ShowTrackLegends>True </ShowTrackLegends>
+                            <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                            <LegendItemsClickable>True </LegendItemsClickable>
+                            <TitleFontSize>XX_Large</TitleFontSize>
+                            <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                            <LegendPosition>ABOVE</LegendPosition>
+                            <Case></Case>
+                            <TimeStepIndex>-1</TimeStepIndex>
+                            <WellName>None</WellName>
+                            <GroupSmallContributions>True </GroupSmallContributions>
+                            <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                            <MaximumTOF>20</MaximumTOF>
+                            <Plots>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <DockWindowId></DockWindowId>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>OIL_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <DockWindowId></DockWindowId>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>GAS_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                                <WellDistributionPlot>
+                                    <WindowController/>
+                                    <ShowWindow>True </ShowWindow>
+                                    <DockWindowId></DockWindowId>
+                                    <Id>-1</Id>
+                                    <ShowPlotTitle>True </ShowPlotTitle>
+                                    <ShowTrackLegends>False </ShowTrackLegends>
+                                    <TrackLegendsHorizontal>True </TrackLegendsHorizontal>
+                                    <LegendItemsClickable>True </LegendItemsClickable>
+                                    <TitleFontSize>XX_Large</TitleFontSize>
+                                    <LegendDeltaFontSize>Large</LegendDeltaFontSize>
+                                    <LegendPosition>ABOVE</LegendPosition>
+                                    <RowSpan>ONE</RowSpan>
+                                    <ColSpan>ONE</ColSpan>
+                                    <Case></Case>
+                                    <TimeStepIndex>-1</TimeStepIndex>
+                                    <WellName>None</WellName>
+                                    <Phase>WATER_PHASE</Phase>
+                                    <GroupSmallContributions>True </GroupSmallContributions>
+                                    <SmallContributionsRelativeThreshold>0.005</SmallContributionsRelativeThreshold>
+                                    <MaximumTOF>20</MaximumTOF>
+                                </WellDistributionPlot>
+                            </Plots>
+                            <ShowOil>True </ShowOil>
+                            <ShowGas>True </ShowGas>
+                            <ShowWater>True </ShowWater>
+                            <PlotDescription>Cumulative Phase Distribution Plots</PlotDescription>
+                        </WellDistributionPlotCollection>
+                    </WellDistributionPlotCollection>
+                    <StoredWellAllocationPlots/>
+                    <StoredFlowCharacteristicsPlots/>
+                </FlowPlotCollection>
+            </FlowPlotCollection>
+            <Rim3dCrossPlotCollection>
+                <RimGridCrossPlotCollection>
+                    <GridCrossPlots/>
+                </RimGridCrossPlotCollection>
+            </Rim3dCrossPlotCollection>
+            <RimSaturationPressurePlotCollection>
+                <RimSaturationPressurePlotCollection>
+                    <SaturationPressurePlots/>
+                </RimSaturationPressurePlotCollection>
+            </RimSaturationPressurePlotCollection>
+            <RimMultiPlotCollection>
+                <RimMultiPlotCollection>
+                    <MultiPlots/>
+                </RimMultiPlotCollection>
+            </RimMultiPlotCollection>
+            <StimPlanModelPlotCollection>
+                <StimPlanModelPlotCollection>
+                    <StimPlanModelPlots/>
+                </StimPlanModelPlotCollection>
+            </StimPlanModelPlotCollection>
+            <VfpPlotCollection>
+                <RimVfpPlotCollection>
+                    <CustomVfpPlots/>
+                </RimVfpPlotCollection>
+            </VfpPlotCollection>
+            <HistogramMultiPlotCollection>
+                <RimHistogramMultiPlotCollection>
+                    <HistogramMultiPlots/>
+                </RimHistogramMultiPlotCollection>
+            </HistogramMultiPlotCollection>
+        </MainPlotCollection>
+    </MainPlotCollection>
+    <PinnedFieldCollection>
+        <RimQuickAccessCollection>
+            <FieldReferencesGroup>
+                <RimFieldQuickAccessGroup>
+                    <Name></Name>
+                    <FieldReferences>
+                        <RimFieldQuickAccess>
+                            <FieldReference>
+                                <RimFieldReference>
+                                    <Object>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</Object>
+                                    <FieldKeyword>EclipseCase</FieldKeyword>
+                                </RimFieldReference>
+                            </FieldReference>
+                        </RimFieldQuickAccess>
+                    </FieldReferences>
+                    <OwnerView>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0 ViewCollection 0 Views 0</OwnerView>
+                </RimFieldQuickAccessGroup>
+            </FieldReferencesGroup>
+        </RimQuickAccessCollection>
+    </PinnedFieldCollection>
+    <LinkedViews>
+        <RimViewLinkerCollection>
+            <Active>True </Active>
+            <ViewLinkers/>
+        </RimViewLinkerCollection>
+    </LinkedViews>
+    <CalculationCollection>
+        <RimSummaryCalculationCollection>
+            <Calculations/>
+        </RimSummaryCalculationCollection>
+    </CalculationCollection>
+    <GridCalculationCollection>
+        <RimGridCalculationCollection>
+            <Calculations/>
+        </RimGridCalculationCollection>
+    </GridCalculationCollection>
+    <MultiSnapshotDefinitions/>
+    <TreeViewStates>-1-1100000;-1-11000;-1-110;-1-130002000;-1-1300020;-1-13000;-1-130||-1-110</TreeViewStates>
+    <TreeViewCurrentModelIndexPaths>3 0;0 0||1 0;0 0</TreeViewCurrentModelIndexPaths>
+    <PlotWindowTreeViewStates>-1-100|-1-100|||</PlotWindowTreeViewStates>
+    <PlotWindowTreeViewCurrentModelIndexPaths>||||</PlotWindowTreeViewCurrentModelIndexPaths>
+    <show3DWindow>True </show3DWindow>
+    <showPlotWindow>False </showPlotWindow>
+    <showPlotWindowOnTopOf3DWindow>False </showPlotWindowOnTopOf3DWindow>
+    <MainWindowDockState>AAAHf3jalVXLctowFN33KzTeu+AHWMwAGYY00y5oSUzCsiPkC1EjS4wkaJO2/95rkiEh9QMvPLauztE992UNL37lkuzBWKHVyAs+dj0CiutMqM3Iu11c+dS7GA+v3STbM8Uhu9T8AffSR+sgJ3dHokduLZjjOvbIVCvHhELLYXsKyhkmlyLbgBt5GZ6zBMl1Dik3AMobD48MciU1cwcJXbSnWymcQ/M3I/AU3Clc/Clc7BSeFVZi/BPMxAAjC7ZCQRFu7IwB9SJlbvQP4G6BSr7nqGEpVKZ/IudZL/nKcqhFkqnUFrJCcKeEdckcS/XOcGhJxOSIrbP1rE4R2Ul8wf/xbcG4x0+ZcNo0h1gBLnWbiiew42QQk5j2yLDzvMb3S0nOK845RX4TYPgmwN9JkLFeEvV9oLD247i/9ikNqL+iyWoV0CSL+tFfD7uKbQ65KYn5tBdrinKus5YFut4J/jDhHKxtqE4FsqY0QUIHJMLn/Nq85j2qznuh5gbsTrovaq0bZJcDG7p/ClKmIHHeUNVCa1nKDcpT3C+VOpfanSX1PbBpwmHr7ltybkDOweQtWfN9W20pCPtZ2DaUmb43dioMl1DprCLv71tkhp3KNtDU12WwpkwYXYzBTKsWP6o4HJAgjPqk16XlE3GwDJKERN2wBhElIQkDGpVCOsfLDL8rrs/xh3+uOoqH</MainWindowDockState>
+    <PlotWindowDockState>AAAFTXjapVTBTsMwDL3zFVHuox3jwKHbNHXsNhi0Y0cUGqtEpEmVpIMhPh63Q5U2dW03TnXt9+zn5CnB9CuTZAvGCq3GdHjtUwIq0VyodEzX8WJwR6eT4MnN+JapBPhcJx9Yi3bWQUZeaiIlawum/r+lJNTKMaEwU5VDUM4wuRE8BTemHPtsQCY6gygxAIpOgppBFlIzV0nwMR/lUjiH6UcjsAtWyhE/5YhCYa/RScygxtwgZmaAkZi92ZJCwsIYUH9SVlI7G6OO1xyjJarYCMX1J7L2iskDy6ADS0KpLfBStNfAiyHLJXNwCRfPSOR9pnrlkgerDo9XNToH43b3XDht+uzbSmgcH4lvsBOf+CTw9jF+/26oVdyhJdAHLK1QDbKOoI0yOkwxajfFnDkW6cIk0NMZ7YSOK8ZqwS+xRpFlzOxWFUmxFMw/LfEs0nd3ti8aWecKWYK1uIHtMf0UtMOPzY7sqnv104TxicdwcvULpZ/XBA==</PlotWindowDockState>
+    <DialogData>
+        <RimDialogData>
+            <ExportCarfin>
+                <RicExportCarfinUi>
+                    <CellRange>
+                        <RicCellRangeUi>
+                            <Case></Case>
+                            <GridIndex>0</GridIndex>
+                            <StartIndexI>1</StartIndexI>
+                            <StartIndexJ>1</StartIndexJ>
+                            <StartIndexK>1</StartIndexK>
+                            <CellCountI>1</CellCountI>
+                            <CellCountJ>1</CellCountJ>
+                            <CellCountK>1</CellCountK>
+                        </RicCellRangeUi>
+                    </CellRange>
+                    <ExportFileName></ExportFileName>
+                    <CaseToApply></CaseToApply>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <MaxWellCount>8</MaxWellCount>
+                </RicExportCarfinUi>
+            </ExportCarfin>
+            <ExportCompletionData>
+                <RicExportCompletionDataSettingsUi>
+                    <Folder>C:/gitroot/ResInsight/TestModels/msw-export/compare-output/perf_two_back_to_back</Folder>
+                    <CaseToApply>$ROOT$ OilFields 0 AnalysisModels 0 Reservoirs 0</CaseToApply>
+                    <FileSplit>SPLIT_ON_WELL</FileSplit>
+                    <compdatExport>TRANSMISSIBILITIES</compdatExport>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludeMSW>True </IncludeMSW>
+                    <UseLateralNTG>False </UseLateralNTG>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <IncludeFractures>True </IncludeFractures>
+                    <TransScalingType>False </TransScalingType>
+                    <TransScalingTimeStep>0</TransScalingTimeStep>
+                    <TransScalingWBHPSource>WBHP_SUMMARY</TransScalingWBHPSource>
+                    <TransScalingWBHP>200</TransScalingWBHP>
+                    <ExcludeMainBoreForFishbones>False </ExcludeMainBoreForFishbones>
+                    <ExportDataSourceAsComment>False </ExportDataSourceAsComment>
+                    <ExportWelspec>True </ExportWelspec>
+                    <CompletionWelspecAfterMainBore>True </CompletionWelspecAfterMainBore>
+                    <UseCustomFileName>False </UseCustomFileName>
+                    <CustomFileName></CustomFileName>
+                </RicExportCompletionDataSettingsUi>
+            </ExportCompletionData>
+            <MultipleFractionsData>
+                <RiuCreateMultipleFractionsUi>
+                    <SourceCase></SourceCase>
+                    <MinDistanceFromWellTd>10</MinDistanceFromWellTd>
+                    <MaxFracturesPerWell>10</MaxFracturesPerWell>
+                    <Options/>
+                </RiuCreateMultipleFractionsUi>
+            </MultipleFractionsData>
+            <HoloLenseExportToFolderData>
+                <RicHoloLensExportToFolderUi>
+                    <ViewForExport></ViewForExport>
+                    <ExportFolder></ExportFolder>
+                </RicHoloLensExportToFolderUi>
+            </HoloLenseExportToFolderData>
+            <ExportwellPathsData>
+                <RicExportWellPathsUi>
+                    <ExportFolder></ExportFolder>
+                    <MdStepSize>5</MdStepSize>
+                </RicExportWellPathsUi>
+            </ExportwellPathsData>
+            <ExportLgr>
+                <RicExportLgrUi>
+                    <ExportFolder></ExportFolder>
+                    <CaseToApply></CaseToApply>
+                    <TimeStepIndex>0</TimeStepIndex>
+                    <IncludePerforations>True </IncludePerforations>
+                    <IncludeFractures>True </IncludeFractures>
+                    <IncludeFishbones>True </IncludeFishbones>
+                    <CellCountI>2</CellCountI>
+                    <CellCountJ>2</CellCountJ>
+                    <CellCountK>2</CellCountK>
+                    <SplitType>LGR_PER_COMPLETION</SplitType>
+                </RicExportLgrUi>
+            </ExportLgr>
+            <ExportSectorModel>
+                <RicExportEclipseInputGridUi>
+                    <ExportGrid>True </ExportGrid>
+                    <ExportGridFilename>GRID.GRDECL</ExportGridFilename>
+                    <ExportInLocalCoords>False </ExportInLocalCoords>
+                    <InvisibleCellActnum>False </InvisibleCellActnum>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>2147483647</MinI>
+                    <MinJ>2147483647</MinJ>
+                    <MinK>2147483647</MinK>
+                    <MaxI>-2147483647</MaxI>
+                    <MaxJ>-2147483647</MaxJ>
+                    <MaxK>-2147483647</MaxK>
+                    <ExportFaults>TO_SINGLE_RESULT_FILE</ExportFaults>
+                    <ExportFaultsFilename>FAULTS.GRDECL</ExportFaultsFilename>
+                    <RefinementCountI>1</RefinementCountI>
+                    <RefinementCountJ>1</RefinementCountJ>
+                    <RefinementCountK>1</RefinementCountK>
+                    <ExportParams>TO_SEPARATE_RESULT_FILES</ExportParams>
+                    <ExportParamsFilename>RESULTS.GRDECL</ExportParamsFilename>
+                    <ExportMainKeywords></ExportMainKeywords>
+                    <WriteEchoInGrdeclFiles>False </WriteEchoInGrdeclFiles>
+                    <ExportFolder>$PathId_008$</ExportFolder>
+                </RicExportEclipseInputGridUi>
+            </ExportSectorModel>
+            <MockModelSettings>
+                <MockModelSettings>
+                    <CellCountX>100</CellCountX>
+                    <CellCountY>100</CellCountY>
+                    <CellCountZ>10</CellCountZ>
+                    <TotalCellCount>0</TotalCellCount>
+                    <ExtentX>6000</ExtentX>
+                    <ExtentY>12000</ExtentY>
+                    <ExtentZ>500</ExtentZ>
+                    <OffsetX>400000</OffsetX>
+                    <OffsetY>6000000</OffsetY>
+                    <ResultCount>3</ResultCount>
+                    <TimeStepCount>10</TimeStepCount>
+                </MockModelSettings>
+            </MockModelSettings>
+            <CreateEnsembleSurfaceUi>
+                <RicCreateEnsembleSurfaceUi>
+                    <Layers></Layers>
+                    <AutoCreateEnsembleSurfaces>False </AutoCreateEnsembleSurfaces>
+                    <MinLayer>0</MinLayer>
+                    <MaxLayer>0</MaxLayer>
+                </RicCreateEnsembleSurfaceUi>
+            </CreateEnsembleSurfaceUi>
+            <CreateEnsembleWellLogUi>
+                <RicCreateEnsembleWellLogUi>
+                    <AutoCreateEnsembleWellLogs>True </AutoCreateEnsembleWellLogs>
+                    <TimeStep>0</TimeStep>
+                    <WellPathSource>FILE</WellPathSource>
+                    <WellPath></WellPath>
+                    <WellFilePath></WellFilePath>
+                    <SelectedProperties></SelectedProperties>
+                </RicCreateEnsembleWellLogUi>
+            </CreateEnsembleWellLogUi>
+            <ExportSectorModelUi>
+                <RicExportSectorModelUi>
+                    <ExportFolder>$PathId_008$</ExportFolder>
+                    <ExportDeckName></ExportDeckName>
+                    <PorvMultiplier>1000000</PorvMultiplier>
+                    <BoundaryCondition>OPERNUM_OPERATER</BoundaryCondition>
+                    <GridBoxSelection>VISIBLE_CELLS</GridBoxSelection>
+                    <VisibleWellsPadding>2</VisibleWellsPadding>
+                    <MinI>1</MinI>
+                    <MinJ>1</MinJ>
+                    <MinK>1</MinK>
+                    <MaxI>1</MaxI>
+                    <MaxJ>1</MaxJ>
+                    <MaxK>1</MaxK>
+                    <RefinementSettings>
+                        <RicRefinementSettings>
+                            <NonUniformEnableI>True </NonUniformEnableI>
+                            <NonUniformIntervalsI>0.5, 0.5</NonUniformIntervalsI>
+                            <NonUniformEnableJ>True </NonUniformEnableJ>
+                            <NonUniformIntervalsJ>0.5, 0.5</NonUniformIntervalsJ>
+                            <NonUniformEnableK>True </NonUniformEnableK>
+                            <NonUniformIntervalsK>0.5, 0.5</NonUniformIntervalsK>
+                            <NonUniformSubMode>LINEAR_EQUAL_SPLIT</NonUniformSubMode>
+                            <NonUniformSubcellCountI>2</NonUniformSubcellCountI>
+                            <NonUniformSubcellCountJ>2</NonUniformSubcellCountJ>
+                            <NonUniformSubcellCountK>2</NonUniformSubcellCountK>
+                            <NonUniformTotalCellsI>10</NonUniformTotalCellsI>
+                            <NonUniformTotalCellsJ>10</NonUniformTotalCellsJ>
+                            <NonUniformTotalCellsK>10</NonUniformTotalCellsK>
+                        </RicRefinementSettings>
+                    </RefinementSettings>
+                    <SelectedRefinementRegions></SelectedRefinementRegions>
+                    <BcpropKeywords/>
+                    <KeywordsToRemove>ACTION ACTIONX ACTIONW BOX UDQ </KeywordsToRemove>
+                    <EnablePadding>False </EnablePadding>
+                    <PaddingNzUpper>0</PaddingNzUpper>
+                    <PaddingTopUpper>0</PaddingTopUpper>
+                    <PaddingUpperPorosity>0</PaddingUpperPorosity>
+                    <PaddingUpperEquilnum>1</PaddingUpperEquilnum>
+                    <PaddingNzLower>0</PaddingNzLower>
+                    <PaddingBottomLower>0</PaddingBottomLower>
+                    <PaddingMinThickness>0.1</PaddingMinThickness>
+                    <PaddingFillGaps>False </PaddingFillGaps>
+                    <PaddingMonotonicZcorn>False </PaddingMonotonicZcorn>
+                    <PaddingVerticalPillars>False </PaddingVerticalPillars>
+                    <CreateSimulationJob>False </CreateSimulationJob>
+                    <SimulationJobFolder></SimulationJobFolder>
+                    <SimulationJobName></SimulationJobName>
+                    <StartSimulationJobAfterExport>False </StartSimulationJobAfterExport>
+                    <EclipseCase></EclipseCase>
+                    <EclipseView></EclipseView>
+                </RicExportSectorModelUi>
+            </ExportSectorModelUi>
+        </RimDialogData>
+    </DialogData>
+    <AutomationSettings>
+        <RimAutomationSettings>
+            <CellSelectionDestination></CellSelectionDestination>
+            <CaseReloadIntervalSeconds>15</CaseReloadIntervalSeconds>
+        </RimAutomationSettings>
+    </AutomationSettings>
+</ResInsightProject>


### PR DESCRIPTION
Part of #14252 ("fix IJK in COMPSEGS reported twice, can be tested with two perforations back to back").

When several perforation intervals overlap the same grid cell, the main bore COMPSEGS table emitted one row per interval. Two perforations placed back to back therefore reported the same IJK twice, while COMPDAT correctly reported a single connection for that cell.

The candidate intersections collected for one cell all describe the same IJK, so they are now merged into a single COMPSEGS row spanning the union of the overlapping measured depth ranges.

`TestModels/msw-export/project-files/perf_two_back_to_back.rsp` is added to cover the case. Exporting `Well-1` from it changes COMPSEGS from

```
   3     4     5     1             3550.23345       3800.00000      /
   3     4     5     1             3800.00000       3900.00000      /
```

to

```
   3     4     5     1             3550.23345       3900.00000      /
```

which matches the single COMPDAT connection already reported for that cell.

Exports for `base`, `fishbones`, `fracture`, `perf_aicd`, `perf_valve`, `perf-lgr`, `perf-lgr-two-wells` and `two_wells` in `TestModels/msw-export` are byte identical before and after the change.
