### PR TITLE
Copy Qt pdb files to the build folder when present

### DIFF
--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -396,7 +396,8 @@ if(RESINSIGHT_PRIVATE_INSTALL)
       POST_BUILD
       COMMAND
         ${WINDEPLOYQT_EXECUTABLE} $<TARGET_FILE:ResInsight>
-        "$<IF:$<CONFIG:Debug>,--debug,--release>" --no-translations >NUL 2>NUL
+        "$<IF:$<CONFIG:Debug>,--debug,--release>"
+        "$<$<CONFIG:Debug,RelWithDebInfo>:--pdb>" --no-translations >NUL 2>NUL
       COMMENT
         "Running windeployqt to deploy Qt dependencies to the build folder, required by install()"
     )

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/CMakeLists.txt
@@ -59,6 +59,18 @@ foreach(qtlib ${QT_LIBRARIES})
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${qtlib}>
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
   )
+
+  # Copy the matching pdb file, if present, to get symbols when debugging
+  if(MSVC)
+    add_custom_command(
+      TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND
+        ${CMAKE_COMMAND} -DBINARY_FILE=$<TARGET_FILE:${qtlib}>
+        -DDESTINATION_DIR=$<TARGET_FILE_DIR:${PROJECT_NAME}> -P
+        ${CMAKE_CURRENT_LIST_DIR}/../../../cmake/CopyPdbIfExists.cmake
+    )
+  endif()
 endforeach(qtlib)
 
 # Install

--- a/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
@@ -104,6 +104,18 @@ foreach(qtlib ${QT_LIBRARIES})
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${qtlib}>
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
   )
+
+  # Copy the matching pdb file, if present, to get symbols when debugging
+  if(MSVC)
+    add_custom_command(
+      TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND
+        ${CMAKE_COMMAND} -DBINARY_FILE=$<TARGET_FILE:${qtlib}>
+        -DDESTINATION_DIR=$<TARGET_FILE_DIR:${PROJECT_NAME}> -P
+        ${CMAKE_CURRENT_LIST_DIR}/../../cmake/CopyPdbIfExists.cmake
+    )
+  endif()
 endforeach(qtlib)
 
 # Install

--- a/Fwk/AppFwk/cafTests/cafTestCvfApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestCvfApplication/CMakeLists.txt
@@ -47,4 +47,16 @@ foreach(qtlib ${QT_LIBRARIES})
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${qtlib}>
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
   )
+
+  # Copy the matching pdb file, if present, to get symbols when debugging
+  if(MSVC)
+    add_custom_command(
+      TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND
+        ${CMAKE_COMMAND} -DBINARY_FILE=$<TARGET_FILE:${qtlib}>
+        -DDESTINATION_DIR=$<TARGET_FILE_DIR:${PROJECT_NAME}> -P
+        ${CMAKE_CURRENT_LIST_DIR}/../../cmake/CopyPdbIfExists.cmake
+    )
+  endif()
 endforeach(qtlib)

--- a/Fwk/AppFwk/cmake/CopyPdbIfExists.cmake
+++ b/Fwk/AppFwk/cmake/CopyPdbIfExists.cmake
@@ -1,0 +1,16 @@
+# Copy the .pdb file matching a binary file into a destination folder, if the
+# .pdb file is present. Used to get symbols when debugging into prebuilt
+# libraries like Qt, as these libraries are distributed with and without .pdb
+# files.
+#
+# Invoke using: cmake -DBINARY_FILE=<file> -DDESTINATION_DIR=<dir> -P
+# CopyPdbIfExists.cmake
+
+get_filename_component(_folder "${BINARY_FILE}" DIRECTORY)
+get_filename_component(_baseName "${BINARY_FILE}" NAME_WLE)
+
+set(_pdbFile "${_folder}/${_baseName}.pdb")
+
+if(EXISTS "${_pdbFile}")
+  file(COPY "${_pdbFile}" DESTINATION "${DESTINATION_DIR}")
+endif()


### PR DESCRIPTION
Qt is distributed both with and without pdb files. When they are present, copy them next to the Qt dlls in the build folder, so symbols are available when debugging into Qt.

- `ApplicationExeCode`: pass `--pdb` to `windeployqt` for the configurations built with debug information (Debug and RelWithDebInfo). The install step uses `RUNTIME_DEPENDENCIES`, which resolves dlls only, so the pdb files are not added to the installer.
- AppFwk test applications and unit tests: copy the pdb file matching each Qt dll. `$<TARGET_PDB_FILE:...>` is not available for imported targets, and `cmake -E copy_if_different` fails on a missing source file, so the copy is done by a small helper script, `Fwk/AppFwk/cmake/CopyPdbIfExists.cmake`, that derives the pdb name from the dll and skips the copy if the file is not present.
