### PR TITLE
caf: Defer group box deletion to avoid use-after-free in property editor rebuild

### DIFF
--- a/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/CMakeLists.txt
@@ -64,6 +64,8 @@ set(PROJECT_FILES
     PdmObjects/OptionalFields.cpp
     PdmObjects/ValidationTest.h
     PdmObjects/ValidationTest.cpp
+    PdmObjects/ReentrantEditorRebuild.h
+    PdmObjects/ReentrantEditorRebuild.cpp
 )
 
 qt_add_executable(

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include "PdmObjects/LineEditAndPushButtons.h"
 #include "PdmObjects/ManyGroups.h"
 #include "PdmObjects/OptionalFields.h"
+#include "PdmObjects/ReentrantEditorRebuild.h"
 #include "PdmObjects/SingleEditorPdmObject.h"
 #include "PdmObjects/SmallDemoPdmObject.h"
 #include "PdmObjects/SmallDemoPdmObjectA.h"
@@ -196,6 +197,7 @@ void MainWindow::buildTestModel()
     m_testRoot->objects.push_back( new LineEditAndPushButtons );
     m_testRoot->objects.push_back( new LabelsAndHyperlinks );
     m_testRoot->objects.push_back( new OptionalFields );
+    m_testRoot->objects.push_back( new ReentrantEditorRebuild );
 
     auto tamComboBox = new TamComboBox;
     m_testRoot->objects.push_back( tamComboBox );

--- a/Fwk/AppFwk/cafTests/cafTestApplication/PdmObjects/ReentrantEditorRebuild.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/PdmObjects/ReentrantEditorRebuild.cpp
@@ -1,0 +1,89 @@
+#include "ReentrantEditorRebuild.h"
+
+#include "cafPdmUiLineEditor.h"
+#include "cafPdmUiOrdering.h"
+
+CAF_PDM_SOURCE_INIT( ReentrantEditorRebuild, "ReentrantEditorRebuild" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+ReentrantEditorRebuild::ReentrantEditorRebuild()
+    : m_hideFilterGroup( false )
+{
+    CAF_PDM_InitObject( "Reentrant Editor Rebuild", "", "", "" );
+
+    CAF_PDM_InitField( &m_realizationFilter,
+                       "RealizationFilter",
+                       QString(),
+                       "Realization Filter",
+                       "",
+                       "Type a value here and press Tab",
+                       "" );
+
+    CAF_PDM_InitField( &m_statusField, "Status", QString( "Type into Realization Filter, then press Tab" ), "Status", "", "", "" );
+    m_statusField.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitField( &m_rebuildLayoutOnChange,
+                       "RebuildLayoutOnChange",
+                       true,
+                       "Rebuild Layout On Change",
+                       "",
+                       "Rebuild all property editors from inside fieldChangedByUi()",
+                       "" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void ReentrantEditorRebuild::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
+                                               const QVariant&            oldValue,
+                                               const QVariant&            newValue )
+{
+    if ( changedField == &m_realizationFilter )
+    {
+        m_statusField = "Committed value: " + m_realizationFilter();
+
+        if ( m_rebuildLayoutOnChange )
+        {
+            // Drop the group that parents the line edit, and rebuild every property editor while
+            // still inside QLineEdit::focusOutEvent. This mirrors
+            // RimSumoDataSource::fieldChangedByUi() -> RimSummaryEnsembleSumo::onRealizationSelectionChanged().
+            m_hideFilterGroup = true;
+
+            updateAllRequiredEditors();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void ReentrantEditorRebuild::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    uiOrdering.add( &m_statusField );
+    uiOrdering.add( &m_rebuildLayoutOnChange );
+
+    if ( !m_hideFilterGroup )
+    {
+        // The line edit lives inside this group. When both the field and the group disappear from
+        // the ui ordering, PdmUiFormLayoutObjectEditor::configureAndUpdateUi() first deletes the
+        // field editor, whose destructor only calls deleteLater() on the QLineEdit, and then
+        // destroys the parent QMinimizePanel with a raw delete. ~QWidget destroys its children
+        // immediately, so the QLineEdit is gone before the pending deleteLater() can run.
+        auto group = uiOrdering.addNewGroup( "Filter" );
+        group->add( &m_realizationFilter );
+    }
+
+    uiOrdering.addNewButton( "Restore Filter Group", [this]() { restoreFilterGroup(); } );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void ReentrantEditorRebuild::restoreFilterGroup()
+{
+    m_hideFilterGroup = false;
+
+    updateAllRequiredEditors();
+}

--- a/Fwk/AppFwk/cafTests/cafTestApplication/PdmObjects/ReentrantEditorRebuild.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/PdmObjects/ReentrantEditorRebuild.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "cafPdmField.h"
+#include "cafPdmObject.h"
+
+//==================================================================================================
+/// Reproduction of https://github.com/OPM/ResInsight/issues/14505
+///
+/// Rebuilding the property editors from inside fieldChangedByUi() destroys widgets that Qt is
+/// still executing an event handler on, giving a use-after-free in QLineEdit::focusOutEvent.
+///
+/// Steps to reproduce:
+///   1. Select this object in the tree view so the property editor is shown.
+///   2. Type a value into "Realization Filter".
+///   3. Press Tab. Do not press Enter, the focus-out path is the dangerous one. Enter is handled
+///      by PdmUiLineEditor::eventFilter, which calls slotEditingFinished() outside focusOutEvent.
+///
+/// Uncheck "Rebuild Layout On Change" to get the same edit without the reentrant rebuild.
+//==================================================================================================
+class ReentrantEditorRebuild : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    ReentrantEditorRebuild();
+
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+
+private:
+    void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+
+    void restoreFilterGroup();
+
+private:
+    caf::PdmField<QString> m_realizationFilter;
+    caf::PdmField<QString> m_statusField;
+    caf::PdmField<bool>    m_rebuildLayoutOnChange;
+
+    bool m_hideFilterGroup;
+};

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp
@@ -60,6 +60,30 @@
 #include <QLabel>
 #include <QPushButton>
 
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Schedule deletion of a group box without destroying the widgets inside it synchronously.
+///
+/// A plain delete destroys the child widgets immediately, which defeats the deleteLater() used by
+/// PdmUiFieldEditorHandle to keep field editor widgets alive. When the rebuild is triggered from inside a
+/// widget event handler, Qt is still using those widgets further up the stack.
+/// See https://github.com/OPM/ResInsight/issues/14505
+///
+/// The group box is hidden and detached from its parent before the deferred delete is scheduled, so it is
+/// out of the layout, the visual tree and the focus chain immediately. This is what plain deleteLater()
+/// failed to do in https://github.com/OPM/ResInsight/issues/9719
+//--------------------------------------------------------------------------------------------------
+auto scheduleGroupBoxDeletion = []( QMinimizePanel* groupBox )
+{
+    if ( !groupBox ) return;
+
+    groupBox->hide();
+    groupBox->setParent( nullptr );
+    groupBox->deleteLater();
+};
+} // namespace
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -626,11 +650,7 @@ void caf::PdmUiFormLayoutObjectEditor::cleanupBeforeSettingPdmObject()
         QMinimizePanel* groupBox = groupIt->second;
         if ( groupBox )
         {
-            // https://github.com/OPM/ResInsight/issues/9719
-            // When opening a summary file from the command line, it seems like the groupBoxes are not deleted when
-            // using groupBox->deleteLater()
-
-            delete groupBox;
+            scheduleGroupBoxDeletion( groupBox );
         }
     }
 
@@ -721,7 +741,7 @@ void caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi( const QString& uiCo
         if ( itNew == m_newGroupBoxes.end() )
         {
             // The old groupBox is not present anymore, get rid of it
-            if ( !itOld->second.isNull() ) delete itOld->second;
+            if ( !itOld->second.isNull() ) scheduleGroupBoxDeletion( itOld->second );
         }
     }
     m_groupBoxes = m_newGroupBoxes;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
@@ -218,23 +218,29 @@ void PdmUiLineEditor::configureAndUpdateUi( const QString& uiConfigName )
                 m_lineEdit->setStyleSheet( "" );
             }
 
-            if ( uiField()->isAutoValueSupported() )
+            // The tool button and the layout are owned by m_placeholder, which is not returned as the editor widget
+            // when auto value is not supported. m_placeholder can then be destroyed by its parent widget while
+            // m_lineEdit survives, leaving these pointers null on a later update.
+            if ( !m_autoValueToolButton.isNull() )
             {
-                auto icon = UiIconFactory::twoStateChainIcon();
-                m_autoValueToolButton->setIcon( icon );
+                if ( uiField()->isAutoValueSupported() )
+                {
+                    auto icon = UiIconFactory::twoStateChainIcon();
+                    m_autoValueToolButton->setIcon( icon );
 
-                m_autoValueToolButton->setChecked( uiField()->isAutoValueEnabled() );
-                QString tooltipText = uiField()->isAutoValueEnabled() ? UiAppearanceSettings::globaleValueButtonText()
-                                                                      : UiAppearanceSettings::localValueButtonText();
-                m_autoValueToolButton->setToolTip( tooltipText );
+                    m_autoValueToolButton->setChecked( uiField()->isAutoValueEnabled() );
+                    QString tooltipText = uiField()->isAutoValueEnabled() ? UiAppearanceSettings::globaleValueButtonText()
+                                                                          : UiAppearanceSettings::localValueButtonText();
+                    m_autoValueToolButton->setToolTip( tooltipText );
 
-                m_layout->addWidget( m_autoValueToolButton );
-                m_autoValueToolButton->show();
-            }
-            else
-            {
-                m_layout->removeWidget( m_autoValueToolButton );
-                m_autoValueToolButton->hide();
+                    if ( !m_layout.isNull() ) m_layout->addWidget( m_autoValueToolButton );
+                    m_autoValueToolButton->show();
+                }
+                else
+                {
+                    if ( !m_layout.isNull() ) m_layout->removeWidget( m_autoValueToolButton );
+                    m_autoValueToolButton->hide();
+                }
             }
 
             if ( leab.validator )


### PR DESCRIPTION
Fixes #14505

`PdmUiFormLayoutObjectEditor` destroyed `QMinimizePanel` group boxes with a raw `delete`. Deleting a parent `QWidget` destroys its children immediately, so the `deleteLater()` that `PdmUiFieldEditorHandle` uses to keep field editor widgets alive never got a chance to run. When the rebuild is triggered from `fieldChangedByUi()`, Qt is still executing an event handler on those widgets further up the stack, giving a use-after-free.

Hide and detach the group box before scheduling a deferred delete, so it leaves the layout, the visual tree and the focus chain immediately. Detaching first is what plain `deleteLater()` did not do in #9719. The command line summary file case from #9719 has been retested and behaves correctly with this change.

Also guards `m_autoValueToolButton` and `m_layout` in `PdmUiLineEditor::configureAndUpdateUi()`, matching how `m_label` and `m_lineEdit` are already guarded in the same function. Both are owned by `m_placeholder`, which is not returned as the editor widget when auto value is not supported and is therefore tracked by nothing. It can be destroyed with a parent widget while the reparented `m_lineEdit` survives.

A `ReentrantEditorRebuild` demo object is added to `cafTestApplication` to reproduce the crash: select the object, type a value into Realization Filter and press Tab. This crashed reliably before the change and no longer does.
