### PR TITLE
Do not abort on failed texture setup and failed result loading

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1809,8 +1809,9 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
 
         if ( !resultLoadingSuccess )
         {
-            // Error logging
-            CAF_ASSERT( false );
+            // A result present in the meta data can still fail to load from file. This is a run-time condition, not a
+            // programming error, so report it instead of asserting.
+            RiaLogging::error( QString( "Failed to load result '%1' for time step %2" ).arg( resultName ).arg( timeStepIndex ).toStdString() );
         }
     }
 

--- a/Fwk/VizFwk/LibRender/cvfRenderStateTextureBindings.cpp
+++ b/Fwk/VizFwk/LibRender/cvfRenderStateTextureBindings.cpp
@@ -237,6 +237,14 @@ void RenderStateTextureBindings::applyOpenGL(OpenGLContext* oglContext) const
         const Sampler* sampler = m_bindings[i].sampler.p();
         CVF_ASSERT(texture && sampler);
 
+        // Texture setup in setupTextures() can fail at run-time, leaving the texture without a valid OpenGL id.
+        // Skip the binding in that case, as Texture::bind() asserts on an invalid id.
+        if (texture->textureOglId() == 0)
+        {
+            CVF_LOG_RENDER_ERROR(oglContext, "Skipping texture binding, texture has not been set up.");
+            continue;
+        }
+
         cvfGL->glActiveTexture(static_cast<GLenum>(GL_TEXTURE0 + i));
 
         texture->bind(oglContext);


### PR DESCRIPTION
Two crashes from the crash telemetry registry, both caused by an assert firing on a run-time condition rather than a programming error.

## Problem

**`cvf::Texture::bind`** — `RenderStateTextureBindings::setupTextures()` ignores the `bool` returned by `Texture::setupTexture()`. When setup fails, `setupTexture()` deletes the texture and the OpenGL id stays 0. `applyOpenGL()` then calls `Texture::bind()` regardless, where `CVF_ASSERT(OglRc::safeOglId(...) != 0)` aborts the application. VizFwk asserts are active in release builds, so a failed texture setup kills the running session.

**`RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep`** — the function asserted when the reader failed to return a result. A result listed in the meta data that cannot be read from file is a legitimate run-time condition (bad or truncated data), not a programming error. The `// Error logging` comment shows logging was the intent.

## Fix

Skip texture bindings that have no valid OpenGL id and emit `CVF_LOG_RENDER_ERROR`, matching how the same file already handles unsupported contexts. Rendering degrades instead of terminating.

Replace the assert on failed result loading with a `RiaLogging::error` naming the result and time step. The three other `CAF_ASSERT( false )` in `RigCaseCellResultsData` guard genuinely unreachable branches and are unchanged.

Both targets build clean. No unit tests: the texture path needs a live OpenGL context, and the result-loading path needs a reader stub that fails mid-load, where the change is error reporting rather than a behaviour fix.

## Call stack

`cvf::Texture::bind`:

```
[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
[6] cvf::Texture::bind(cvf::OpenGLContext*) const at ResInsight/Fwk/VizFwk/LibRender/cvfTexture.cpp:377
[7] cvf::RenderStateTextureBindings::applyOpenGL(cvf::OpenGLContext*) const at ResInsight/Fwk/VizFwk/LibRender/cvfRenderStateTextureBindings.cpp:242
[8] cvf::RenderStateTracker::applyRenderStates(cvf::OpenGLContext*, cvf::RenderStateSet const*, cvf::RenderStateSet const*) at ResInsight/Fwk/VizFwk/LibRender/cvfRenderStateTracker.cpp:205
[9] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:178
[10] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
[11] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
[12] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[55] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[66] __libc_start_main at :0
```

`RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep`:

```
[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
[6] RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep(RigEclipseResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1775
[7] RimEclipseStatisticsCaseEvaluator::evaluateForResults(QList<RimEclipseStatisticsCaseEvaluator::ResSpec> const&, RimEclipseView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCaseEvaluator.cpp:158
[8] RimEclipseStatisticsCase::computeStatistics() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCase.cpp:463
[9] RimEclipseStatisticsCase::computeStatisticsAndUpdateViews() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseStatisticsCase.cpp:1002
[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[36] __libc_start_main at :0
```
