### PR TITLE
#14544 Make mime data hasFormat() consistent with formats()

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimMimeData.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMimeData.cpp
@@ -55,7 +55,7 @@ const QModelIndexList& MimeDataWithIndexes::indexes() const
 //--------------------------------------------------------------------------------------------------
 bool MimeDataWithIndexes::hasFormat( const QString& mimetype ) const
 {
-    return ( mimetype == formatName() );
+    return ( mimetype == formatName() ) || QMimeData::hasFormat( mimetype );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -114,7 +114,7 @@ const std::vector<QString>& MimeDataWithReferences::references() const
 //--------------------------------------------------------------------------------------------------
 bool MimeDataWithReferences::hasFormat( const QString& mimetype ) const
 {
-    return ( mimetype == formatName() );
+    return ( mimetype == formatName() ) || QMimeData::hasFormat( mimetype );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #14544

`MimeDataWithIndexes` and `MimeDataWithReferences` overrode `formats()` and `hasFormat()` in ways that contradicted each other. `formats()` returns `QMimeData::formats()` plus the own format name, so it includes every format stored on the object, while `hasFormat()` returned `mimetype == formatName()` only and therefore denied every format it had just advertised.

This matters for summary vector drag and drop. `PdmUiTreeViewQModel::mimeData()` stores the object reference paths under the `ObjectReferenceList` mime type, and `RiuDragDrop::convertToObjects()` reads them back. The payload was present but the object reported that it was not. It worked only because `QMimeData::data()` goes to `retrieveData()` and never consults the overridden `hasFormat()`, so any consumer following the normal `hasFormat()` then `data()` pattern, including Qt when it builds a Windows OLE `IDataObject` for a drag, would see nothing.

`hasFormat()` now falls back to `QMimeData::hasFormat()` so the two functions agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
