### PR TITLE
Give unit test helpers file-specific names so unity builds do not collide

### DIFF
--- a/ApplicationLibCode/UnitTests/RigEclipseCrossPlotDataExtractor-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigEclipseCrossPlotDataExtractor-Test.cpp
@@ -38,7 +38,7 @@
 
 namespace
 {
-struct MockCase
+struct CrossPlotMockCase
 {
     std::unique_ptr<RimEclipseResultCase> resultCase;
     cvf::ref<RigEclipseCaseData>          eclipseCase;
@@ -47,13 +47,13 @@ struct MockCase
 //--------------------------------------------------------------------------------------------------
 /// Build a regular ni x nj x nk box grid in memory (no file, no view)
 //--------------------------------------------------------------------------------------------------
-MockCase buildBoxGridCase( int ni, int nj, int nk )
+CrossPlotMockCase buildCrossPlotBoxGridCase( int ni, int nj, int nk )
 {
     RigReservoirBuilder builder;
     builder.setIJKCount( cvf::Vec3st( ni, nj, nk ) );
     builder.setWorldCoordinates( cvf::Vec3d( 0.0, 0.0, 0.0 ), cvf::Vec3d( ni, nj, -nk ) );
 
-    MockCase mockCase;
+    CrossPlotMockCase mockCase;
     mockCase.resultCase.reset( new RimEclipseResultCase );
     mockCase.eclipseCase = new RigEclipseCaseData( mockCase.resultCase.get() );
 
@@ -94,7 +94,7 @@ void setupResultDefinition( RimEclipseResultDefinition* resultDefinition, RimEcl
 //--------------------------------------------------------------------------------------------------
 TEST( RigEclipseCrossPlotDataExtractorTest, ExtractIgnoresEmptyCellVisibility )
 {
-    MockCase mockCase = buildBoxGridCase( 10, 10, 5 );
+    CrossPlotMockCase mockCase = buildCrossPlotBoxGridCase( 10, 10, 5 );
 
     RigCaseCellResultsData* resultsData = mockCase.eclipseCase->results( RiaDefines::PorosityModelType::MATRIX_MODEL );
     ASSERT_NE( resultsData, nullptr );
@@ -134,7 +134,7 @@ TEST( RigEclipseCrossPlotDataExtractorTest, ExtractIgnoresEmptyCellVisibility )
 //--------------------------------------------------------------------------------------------------
 TEST( RigEclipseCrossPlotDataExtractorTest, ExtractIgnoresTooShortCellVisibility )
 {
-    MockCase mockCase = buildBoxGridCase( 10, 10, 5 );
+    CrossPlotMockCase mockCase = buildCrossPlotBoxGridCase( 10, 10, 5 );
 
     RigCaseCellResultsData* resultsData = mockCase.eclipseCase->results( RiaDefines::PorosityModelType::MATRIX_MODEL );
     ASSERT_NE( resultsData, nullptr );

--- a/ApplicationLibCode/UnitTests/RimFormationNames-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimFormationNames-Test.cpp
@@ -36,7 +36,7 @@
 
 namespace
 {
-struct MockCase
+struct FormationNamesMockCase
 {
     std::unique_ptr<RimEclipseResultCase> resultCase;
     cvf::ref<RigEclipseCaseData>          eclipseCase;
@@ -45,13 +45,13 @@ struct MockCase
 //--------------------------------------------------------------------------------------------------
 /// Build a regular ni x nj x nk box grid in memory (no file, no view)
 //--------------------------------------------------------------------------------------------------
-MockCase buildBoxGridCase( int ni, int nj, int nk )
+FormationNamesMockCase buildFormationNamesBoxGridCase( int ni, int nj, int nk )
 {
     RigReservoirBuilder builder;
     builder.setIJKCount( cvf::Vec3st( ni, nj, nk ) );
     builder.setWorldCoordinates( cvf::Vec3d( 0.0, 0.0, 0.0 ), cvf::Vec3d( ni, nj, -nk ) );
 
-    MockCase mockCase;
+    FormationNamesMockCase mockCase;
     mockCase.resultCase.reset( new RimEclipseResultCase );
     mockCase.eclipseCase = new RigEclipseCaseData( mockCase.resultCase.get() );
 
@@ -96,8 +96,8 @@ std::string joinedFormationNames( const RigEclipseCaseData* eclipseCase )
 //--------------------------------------------------------------------------------------------------
 TEST( RimFormationNamesTest, CaseDataKeepsFormationNamesAliveAfterReloadAndDelete )
 {
-    MockCase mockCase       = buildBoxGridCase( 2, 2, 3 );
-    auto     formationNames = readNorneFormationNames();
+    FormationNamesMockCase mockCase       = buildFormationNamesBoxGridCase( 2, 2, 3 );
+    auto                   formationNames = readNorneFormationNames();
 
     mockCase.eclipseCase->setActiveFormationNames( formationNames->formationNamesData() );
 

--- a/ApplicationLibCode/UnitTests/RivIjkIntersectionGeometryGenerator-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RivIjkIntersectionGeometryGenerator-Test.cpp
@@ -38,7 +38,7 @@ namespace
 //--------------------------------------------------------------------------------------------------
 /// Build a regular ni x nj x nk box grid in memory (no file, no view)
 //--------------------------------------------------------------------------------------------------
-cvf::ref<RigEclipseCaseData> buildBoxGrid( int ni, int nj, int nk )
+cvf::ref<RigEclipseCaseData> buildBoxGridForIjkIntersection( int ni, int nj, int nk )
 {
     RigReservoirBuilder builder;
     builder.setIJKCount( cvf::Vec3st( ni, nj, nk ) );
@@ -61,7 +61,7 @@ TEST( RivIjkIntersectionGeometryGeneratorTest, FullRangeKSliceTriangleCount )
     const int nj = 3;
     const int nk = 5;
 
-    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( ni, nj, nk );
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGridForIjkIntersection( ni, nj, nk );
     RigMainGrid*                 mainGrid = caseData->mainGrid();
 
     cvf::ref<RivEclipseIntersectionGrid> hexGrid = new RivEclipseIntersectionGrid( mainGrid, nullptr, true );
@@ -91,7 +91,7 @@ TEST( RivIjkIntersectionGeometryGeneratorTest, KSliceVerticesAreCoplanar )
     const int nj = 3;
     const int nk = 4;
 
-    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( ni, nj, nk );
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGridForIjkIntersection( ni, nj, nk );
     RigMainGrid*                 mainGrid = caseData->mainGrid();
 
     cvf::ref<RivEclipseIntersectionGrid> hexGrid = new RivEclipseIntersectionGrid( mainGrid, nullptr, true );
@@ -123,7 +123,7 @@ TEST( RivIjkIntersectionGeometryGeneratorTest, NarrowedRangeISlice )
     const int nj = 4;
     const int nk = 6;
 
-    cvf::ref<RigEclipseCaseData> caseData = buildBoxGrid( ni, nj, nk );
+    cvf::ref<RigEclipseCaseData> caseData = buildBoxGridForIjkIntersection( ni, nj, nk );
     RigMainGrid*                 mainGrid = caseData->mainGrid();
 
     cvf::ref<RivEclipseIntersectionGrid> hexGrid = new RivEclipseIntersectionGrid( mainGrid, nullptr, true );


### PR DESCRIPTION
Several unit test files define helpers with the same name in an anonymous namespace. Each is internal to its own translation unit in a normal build, so they never meet, but the Windows CI job builds with unity enabled and merges several files into one translation unit. There the duplicates are a plain redefinition.