### PR TITLE
Improve default source selection in Summary Plot Editor and fix truncated axis values

### DIFF
--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicOpenSummaryPlotEditorFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicOpenSummaryPlotEditorFeature.cpp
@@ -100,23 +100,27 @@ void RicOpenSummaryPlotEditorFeature::onActionTriggered( bool isChecked )
 
     if ( sourcesToSelect.empty() && selectedGroups.empty() )
     {
-        const auto                       ensembles = project->summaryEnsembles();
-        std::vector<RimSummaryEnsemble*> allEnsembles;
-        for ( const auto ensemble : ensembles )
-            if ( ensemble->isEnsemble() ) allEnsembles.push_back( ensemble );
-
+        std::vector<RimSummaryCase*> allSingleCases;
         if ( auto sumCaseMainColl = RiaSummaryTools::summaryCaseMainCollection() )
         {
-            const auto allSingleCases = sumCaseMainColl->topLevelSummaryCases();
-            if ( !allSingleCases.empty() )
-            {
-                sourcesToSelect.push_back( allSingleCases.front() );
-            }
+            allSingleCases = sumCaseMainColl->topLevelSummaryCases();
         }
 
-        else if ( !allEnsembles.empty() )
+        if ( !allSingleCases.empty() )
         {
-            sourcesToSelect.push_back( allEnsembles.front() );
+            sourcesToSelect.push_back( allSingleCases.front() );
+        }
+        else
+        {
+            // No single summary cases available, select the first ensemble
+            for ( const auto ensemble : project->summaryEnsembles() )
+            {
+                if ( ensemble->isEnsemble() )
+                {
+                    sourcesToSelect.push_back( ensemble );
+                    break;
+                }
+            }
         }
     }
 

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicSummaryPlotEditorUi.cpp
@@ -378,7 +378,7 @@ void RicSummaryPlotEditorUi::updatePreviewCurvesFromCurveDefinitions( const std:
             RimEnsembleCurveSet* curveSet = nullptr;
             for ( const auto& cs : m_previewPlot->ensembleCurveSetCollection()->curveSets() )
             {
-                if ( cs->summaryEnsemble() == curveDef.ensemble() && cs->summaryAddressY() == curveDef.summaryAddressY() )
+                if ( cs && cs->summaryEnsemble() == curveDef.ensemble() && cs->summaryAddressY() == curveDef.summaryAddressY() )
                 {
                     curveSet = cs;
                     break;
@@ -509,13 +509,9 @@ void RicSummaryPlotEditorUi::populateCurveCreator( const RimSummaryPlot& sourceS
 
     if ( curveDefs.empty() )
     {
-        auto sumCases = RimProject::current()->allSummaryCases();
-        if ( !sumCases.empty() )
-        {
-            RifEclipseSummaryAddress  defaultAdr;
-            RiaSummaryCurveDefinition curveDef( sumCases.front(), defaultAdr, false );
-            curveDefs.push_back( curveDef );
-        }
+        // No curves in the source plot, use the default source selection
+        setDefaultCurveSelection( {} );
+        return;
     }
 
     m_summaryCurveSelectionEditor->summaryAddressSelection()->setSelectedCurveDefinitions( curveDefs );

--- a/ApplicationLibCode/ProjectDataModel/Tools/RimPlotAxisTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Tools/RimPlotAxisTools.cpp
@@ -58,30 +58,7 @@ public:
         m_numberFormat     = numberFormat;
     }
 
-    QwtText label( double value ) const override
-    {
-        if ( qFuzzyCompare( scaledValue( value ) + 1.0, 1.0 ) ) value = 0.0;
-
-        return QString::number( scaledValue( value ), numberFormat(), m_numberOfDecimals );
-    }
-
-private:
-    char numberFormat() const
-    {
-        switch ( m_numberFormat )
-        {
-            case RimPlotAxisProperties::NUMBER_FORMAT_AUTO:
-                return 'g';
-            case RimPlotAxisProperties::NUMBER_FORMAT_DECIMAL:
-                return 'f';
-            case RimPlotAxisProperties::NUMBER_FORMAT_SCIENTIFIC:
-                return 'e';
-            default:
-                return 'g';
-        }
-    }
-
-    double scaledValue( double value ) const { return value / m_scaleFactor; }
+    QwtText label( double value ) const override { return axisValueText( value, m_scaleFactor, m_numberOfDecimals, m_numberFormat ); }
 
 private:
     double                                  m_scaleFactor;
@@ -211,6 +188,32 @@ void applyAxisScaleDraw( RiuPlotWidget* plotWidget, RiuPlotAxis axis, const RimP
                                                                               axisProperties->numberFormat() ) );
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Text for a single axis value, scaled by the given scale factor and formatted using the given number format
+//--------------------------------------------------------------------------------------------------
+QString axisValueText( double value, double scaleFactor, int numberOfDecimals, RimPlotAxisProperties::NumberFormatType numberFormat )
+{
+    double displayValue = scaleFactor != 0.0 ? value / scaleFactor : value;
+    if ( qFuzzyCompare( displayValue + 1.0, 1.0 ) ) displayValue = 0.0;
+
+    char format = 'g';
+    if ( numberFormat == RimPlotAxisProperties::NUMBER_FORMAT_DECIMAL ) format = 'f';
+    if ( numberFormat == RimPlotAxisProperties::NUMBER_FORMAT_SCIENTIFIC ) format = 'e';
+
+    int precision = numberOfDecimals;
+    if ( format == 'g' )
+    {
+        // The 'g' format interprets the precision as the number of significant digits, while the user specifies the
+        // number of decimals. Add the number of digits in the integer part to display the requested number of decimals.
+        const double absValue      = std::abs( displayValue );
+        const int    integerDigits = absValue >= 1.0 ? static_cast<int>( std::floor( std::log10( absValue ) ) ) + 1 : 1;
+
+        precision = integerDigits + numberOfDecimals;
+    }
+
+    return QString::number( displayValue, format, precision );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Tools/RimPlotAxisTools.h
+++ b/ApplicationLibCode/ProjectDataModel/Tools/RimPlotAxisTools.h
@@ -18,7 +18,8 @@
 
 #pragma once
 
-class RimPlotAxisProperties;
+#include "RimPlotAxisProperties.h"
+
 class RimPlotCurve;
 class RiuPlotAxis;
 class RiuPlotWidget;
@@ -39,6 +40,7 @@ void updatePlotWidgetFromAxisProperties( RiuPlotWidget*                         
 
 void        applyAxisScaleDraw( RiuPlotWidget* plotWidget, RiuPlotAxis axis, const RimPlotAxisProperties* const axisProperties );
 QString     scaleFactorText( const RimPlotAxisProperties* const axisProperties );
+QString     axisValueText( double value, double scaleFactor, int numberOfDecimals, RimPlotAxisProperties::NumberFormatType numberFormat );
 QString     axisTextForAddress( RifEclipseSummaryAddress address );
 std::string shortCalculationName( const std::string& calculationName );
 

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigStimPlanModelTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigWellPathIntersectionTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimHistogramDataSource-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimPlotAxisTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellLogExtractionCurveImpl-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivAnnotationTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivPipeGeometryGenerator-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimPlotAxisTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimPlotAxisTools-Test.cpp
@@ -1,0 +1,73 @@
+#include "gtest/gtest.h"
+
+#include "RimPlotAxisProperties.h"
+#include "Tools/RimPlotAxisTools.h"
+
+#include <vector>
+
+//--------------------------------------------------------------------------------------------------
+/// The tick values for the range 8e9 - 1.1e10 displayed using a scale factor of 1e9
+//--------------------------------------------------------------------------------------------------
+static std::vector<double> tickValuesForScaledRange()
+{
+    return { 8.0e9, 8.5e9, 9.0e9, 9.5e9, 10.0e9, 10.5e9, 11.0e9 };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The 'g' format used by the automatic number format interprets the precision as the number of
+/// significant digits. Using the number of decimals directly caused 10.5 to be displayed as 11, and
+/// the same label was displayed twice.
+//--------------------------------------------------------------------------------------------------
+TEST( RimPlotAxisTools, AutoFormatKeepsRequestedNumberOfDecimals )
+{
+    const std::vector<QString> expectedTexts = { "8", "8.5", "9", "9.5", "10", "10.5", "11" };
+
+    const auto tickValues = tickValuesForScaledRange();
+    ASSERT_EQ( expectedTexts.size(), tickValues.size() );
+
+    for ( size_t i = 0; i < tickValues.size(); i++ )
+    {
+        auto text = RimPlotAxisTools::axisValueText( tickValues[i], 1.0e9, 2, RimPlotAxisProperties::NUMBER_FORMAT_AUTO );
+
+        EXPECT_EQ( expectedTexts[i].toStdString(), text.toStdString() );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Trailing zeros are not displayed by the automatic number format, and increasing the number of
+/// decimals does not change the text for values that require fewer decimals
+//--------------------------------------------------------------------------------------------------
+TEST( RimPlotAxisTools, AutoFormatIsConcise )
+{
+    const auto autoFormat = RimPlotAxisProperties::NUMBER_FORMAT_AUTO;
+
+    EXPECT_EQ( "10", RimPlotAxisTools::axisValueText( 10.0e9, 1.0e9, 2, autoFormat ).toStdString() );
+    EXPECT_EQ( "10.5", RimPlotAxisTools::axisValueText( 10.5e9, 1.0e9, 4, autoFormat ).toStdString() );
+    EXPECT_EQ( "1234.5", RimPlotAxisTools::axisValueText( 1234.5, 1.0, 2, autoFormat ).toStdString() );
+    EXPECT_EQ( "0.25", RimPlotAxisTools::axisValueText( 0.25, 1.0, 2, autoFormat ).toStdString() );
+    EXPECT_EQ( "-10.5", RimPlotAxisTools::axisValueText( -10.5, 1.0, 2, autoFormat ).toStdString() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The decimal and scientific formats interpret the precision as the number of decimals
+//--------------------------------------------------------------------------------------------------
+TEST( RimPlotAxisTools, DecimalAndScientificFormat )
+{
+    EXPECT_EQ( "10.50", RimPlotAxisTools::axisValueText( 10.5e9, 1.0e9, 2, RimPlotAxisProperties::NUMBER_FORMAT_DECIMAL ).toStdString() );
+    EXPECT_EQ( "10.5", RimPlotAxisTools::axisValueText( 10.5e9, 1.0e9, 1, RimPlotAxisProperties::NUMBER_FORMAT_DECIMAL ).toStdString() );
+
+    EXPECT_EQ( "1.05e+01", RimPlotAxisTools::axisValueText( 10.5e9, 1.0e9, 2, RimPlotAxisProperties::NUMBER_FORMAT_SCIENTIFIC ).toStdString() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Values close to zero are displayed as zero, and a scale factor of one leaves the value unchanged
+//--------------------------------------------------------------------------------------------------
+TEST( RimPlotAxisTools, ZeroAndUnitScaleFactor )
+{
+    const auto autoFormat = RimPlotAxisProperties::NUMBER_FORMAT_AUTO;
+
+    EXPECT_EQ( "0", RimPlotAxisTools::axisValueText( 0.0, 1.0e9, 2, autoFormat ).toStdString() );
+    EXPECT_EQ( "0", RimPlotAxisTools::axisValueText( 1.0e-20, 1.0, 2, autoFormat ).toStdString() );
+
+    EXPECT_EQ( "8.5", RimPlotAxisTools::axisValueText( 8.5, 1.0, 2, autoFormat ).toStdString() );
+}

--- a/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
+++ b/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.cpp
@@ -533,33 +533,64 @@ void RiuSummaryVectorSelectionUi::setFieldChangedHandler( const std::function<vo
 //--------------------------------------------------------------------------------------------------
 void RiuSummaryVectorSelectionUi::setDefaultSelection( const std::vector<SummarySource*>& defaultSources )
 {
-    RimProject* proj        = RimProject::current();
-    auto        allSumCases = proj->allSummaryCases();
-
-    if ( !allSumCases.empty() )
+    std::vector<SummarySource*> selectTheseSources = defaultSources;
+    if ( selectTheseSources.empty() )
     {
-        RifEclipseSummaryAddress defaultAddress;
+        if ( auto defaultSource = defaultSummarySource() ) selectTheseSources.push_back( defaultSource );
+    }
 
-        std::vector<SummarySource*> selectTheseSources = defaultSources;
-        if ( selectTheseSources.empty() ) selectTheseSources.push_back( allSumCases[0] );
+    if ( selectTheseSources.empty() ) return;
 
-        std::vector<RiaSummaryCurveDefinition> curveDefs;
-        for ( SummarySource* s : selectTheseSources )
+    RifEclipseSummaryAddress defaultAddress;
+
+    std::vector<RiaSummaryCurveDefinition> curveDefs;
+    for ( SummarySource* s : selectTheseSources )
+    {
+        RimSummaryCase*     sumCase  = dynamic_cast<RimSummaryCase*>( s );
+        RimSummaryEnsemble* ensemble = dynamic_cast<RimSummaryEnsemble*>( s );
+        if ( ensemble )
         {
-            RimSummaryCase*     sumCase  = dynamic_cast<RimSummaryCase*>( s );
-            RimSummaryEnsemble* ensemble = dynamic_cast<RimSummaryEnsemble*>( s );
-            if ( ensemble )
-            {
-                curveDefs.push_back( RiaSummaryCurveDefinition( ensemble, defaultAddress ) );
-            }
-            else
-            {
-                curveDefs.push_back( RiaSummaryCurveDefinition( sumCase, defaultAddress, false ) );
-            }
+            curveDefs.push_back( RiaSummaryCurveDefinition( ensemble, defaultAddress ) );
+        }
+        else
+        {
+            curveDefs.push_back( RiaSummaryCurveDefinition( sumCase, defaultAddress, false ) );
+        }
+    }
+
+    setSelectedCurveDefinitions( curveDefs );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The default source is the first top level summary case. If no top level cases are available, the
+/// first ensemble is used. A realization of an ensemble is never used as default source.
+//--------------------------------------------------------------------------------------------------
+SummarySource* RiuSummaryVectorSelectionUi::defaultSummarySource() const
+{
+    RimProject* proj = RimProject::current();
+    if ( !proj ) return nullptr;
+
+    for ( RimOilField* oilField : proj->allOilFields() )
+    {
+        RimSummaryCaseMainCollection* sumCaseMainColl = oilField->summaryCaseMainCollection();
+        if ( !sumCaseMainColl ) continue;
+
+        if ( !m_hideSummaryCases )
+        {
+            const auto topLevelCases = sumCaseMainColl->topLevelSummaryCases();
+            if ( !topLevelCases.empty() ) return topLevelCases.front();
         }
 
-        setSelectedCurveDefinitions( curveDefs );
+        if ( !m_hideEnsembles )
+        {
+            for ( const auto& ensemble : sumCaseMainColl->summaryEnsembles() )
+            {
+                if ( ensemble->isEnsemble() ) return ensemble;
+            }
+        }
     }
+
+    return nullptr;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.h
+++ b/ApplicationLibCode/UserInterface/RiuSummaryVectorSelectionUi.h
@@ -103,6 +103,7 @@ private:
     bool isObservedData( const RimSummaryCase* sumCase ) const;
 
     std::vector<SummarySource*> selectedSummarySources() const;
+    SummarySource*              defaultSummarySource() const;
 
     void appendOptionItemsForSources( QList<caf::PdmOptionItemInfo>& options ) const;
     void appendOptionItemsForCategories( QList<caf::PdmOptionItemInfo>& options ) const;


### PR DESCRIPTION
Fixes #14562
Fixes #14563

**Default source selection in the Summary Plot Editor**

When no top level summary cases are available, the first ensemble is now selected by default. The ensemble fallback was previously chained to the summary case main collection pointer, so it was never reached.

A realization of an ensemble is never used as the default source. Both `RiuSummaryVectorSelectionUi::setDefaultSelection()` and `RicSummaryPlotEditorUi::populateCurveCreator()` used `RimProject::allSummaryCases().front()`, which is the first realization of the first ensemble when only ensembles are loaded. The default source is now resolved in one place by `RiuSummaryVectorSelectionUi::defaultSummarySource()`, honoring the hidden summary case and hidden ensemble settings of the dialog.

**Truncated display of axis values**

The `g` number format used by the automatic number format interprets the precision as the number of significant digits, while the user specifies the number of decimals. With 2 decimals and a scale factor of 1e9, the tick values for the range 8e9 - 1.1e10 were displayed as `8 8.5 9 9.5 10 11 11`, where 10.5 was rounded to 11 and the same label appeared twice. The number of integer digits is now added to the precision when the automatic number format is used, giving `8 8.5 9 9.5 10 10.5 11`.

The formatting was only reachable through a Qwt callback in a class local to the translation unit, and is extracted to `RimPlotAxisTools::axisValueText()` to make it testable. Unit tests are added in `RimPlotAxisTools-Test.cpp`.
