### PR TITLE
#14555 Allow statistical grid cases to be used as source for grid calculator expressions

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp
@@ -1406,6 +1406,13 @@ std::vector<RimEclipseView*> RimEclipseCase::reservoirViews() const
 
     addViewsFromViewCollection( views, viewCollection() );
     addViewsFromViewCollection( views, globalViewCollection() );
+
+    // A case in a grid ensemble is displayed by views in the view collection of the grid ensemble
+    if ( auto gridEnsemble = firstAncestorOrThisOfType<RimReservoirGridEnsemble>() )
+    {
+        addViewsFromViewCollection( views, gridEnsemble->viewCollection() );
+    }
+
     return views;
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculation.cpp
@@ -178,6 +178,13 @@ bool RimGridCalculation::calculate()
     bool checkIfGridSizeIsEqual = ( !allSourceCasesAreEqualToDestinationCase() || m_cellFilterView != nullptr ) &&
                                   m_additionalCasesType != AdditionalCasesType::ENSEMBLE;
 
+    // Grid dimensions are required to validate the calculation, and a source case is not necessarily opened. This is the case for a
+    // statistics case with no computed statistics.
+    for ( auto inputCase : inputCases() )
+    {
+        if ( inputCase && !inputCase->eclipseCaseData() ) inputCase->ensureReservoirCaseIsOpen();
+    }
+
     for ( auto calculationCase : outputEclipseCases() )
     {
         if ( !calculationCase ) continue;
@@ -524,7 +531,11 @@ void RimGridCalculation::onVariableUpdated( const SignalEmitter* emitter )
     {
         if ( auto variableCase = variable->eclipseCase() )
         {
-            if ( !m_destinationCase || !m_destinationCase->isGridSizeEqualTo( variableCase ) )
+            // A statistics case can be used as source, but never as destination. A calculated result stored in a statistics case is
+            // interpreted as computed statistics, and will block recomputation of the statistics.
+            const bool canBeDestinationCase = dynamic_cast<RimEclipseStatisticsCase*>( variableCase ) == nullptr;
+
+            if ( canBeDestinationCase && ( !m_destinationCase || !m_destinationCase->isGridSizeEqualTo( variableCase ) ) )
             {
                 m_destinationCase = variableCase;
             }
@@ -609,6 +620,9 @@ std::vector<double> RimGridCalculation::getActiveCellValues( const QString&     
 {
     if ( !sourceCase || !destinationCase ) return {};
 
+    // A statistics case is not necessarily opened when used as source for a calculation
+    if ( !sourceCase->eclipseCaseData() && !sourceCase->ensureReservoirCaseIsOpen() ) return {};
+
     size_t timeStepToUse = tsId;
     if ( resultCategoryType == RiaDefines::ResultCatType::STATIC_NATIVE )
     {
@@ -618,7 +632,9 @@ std::vector<double> RimGridCalculation::getActiveCellValues( const QString&     
 
     RigEclipseResultAddress resAddr( resultCategoryType, resultName );
 
-    auto eclipseCaseData        = sourceCase->eclipseCaseData();
+    auto eclipseCaseData = sourceCase->eclipseCaseData();
+    if ( !eclipseCaseData ) return {};
+
     auto rigCaseCellResultsData = eclipseCaseData->results( porosityModel );
     if ( rigCaseCellResultsData->findOrLoadKnownScalarResultForTimeStep( resAddr, timeStepToUse ) == cvf::UNDEFINED_SIZE_T ) return {};
 

--- a/ApplicationLibCode/ProjectDataModel/RimGridCalculationVariable.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridCalculationVariable.cpp
@@ -164,7 +164,11 @@ QList<caf::PdmOptionItemInfo> RimGridCalculationVariable::calculateValueOptions(
     }
     else if ( fieldNeedingOptions == &m_eclipseCase )
     {
-        RimTools::eclipseCaseOptionItems( &options );
+        // Include statistics cases, as a statistics result can be used as source in a grid calculation
+        for ( auto* c : RimEclipseCaseTools::allEclipseGridCases() )
+        {
+            options.push_back( caf::PdmOptionItemInfo( c->caseUserDescription(), c, false, c->uiIconProvider() ) );
+        }
     }
     else if ( fieldNeedingOptions == &m_timeStep )
     {

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -644,9 +644,19 @@ std::vector<RimCase*> RimProject::allGridCases() const
 
             for ( RimReservoirGridEnsemble* ensemble : analysisModels->reservoirGridEnsembles.childrenByType() )
             {
+                if ( ensemble == nullptr ) continue;
+
                 for ( RimEclipseCase* acase : ensemble->cases() )
                 {
                     cases.push_back( acase );
+                }
+
+                if ( ensemble->statisticsCaseCollection() )
+                {
+                    for ( RimEclipseCase* eclipseCase : ensemble->statisticsCaseCollection()->reservoirs )
+                    {
+                        cases.push_back( eclipseCase );
+                    }
                 }
             }
 

--- a/ApplicationLibCode/ProjectDataModel/RimResultSelectionUi.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimResultSelectionUi.cpp
@@ -109,7 +109,8 @@ QList<caf::PdmOptionItemInfo> RimResultSelectionUi::calculateValueOptions( const
 
     if ( fieldNeedingOptions == &m_eclipseCase )
     {
-        for ( auto* c : RimEclipseCaseTools::nativeEclipseGridCases() )
+        // Include statistics cases, as a statistics result can be used as source in a grid calculation
+        for ( auto* c : RimEclipseCaseTools::allEclipseGridCases() )
         {
             options.push_back( caf::PdmOptionItemInfo( c->caseUserDescription(), c, false, c->uiIconProvider() ) );
         }


### PR DESCRIPTION
## Summary

Fixes #14555.

Statistics cases can now be used as source for grid calculator expressions.

**Case lists**

Statistics cases were filtered out of the case lists used by the grid calculator, both in the "Grid Case" column of the variable table and in the case list of the "Select Result" dialog. Statistics cases belonging to a grid ensemble were in addition missing from `RimProject::allGridCases()`, as only the source cases of the ensemble were collected. Statistics cases in a grid case group were already included, so this only affected `RimReservoirGridEnsemble`.

**Source only, never destination**

A calculated result stored in a statistics case is interpreted as computed statistics by `RimEclipseStatisticsCase::hasComputedStatistics()`, and would block recomputation of the statistics. A statistics case is therefore never auto-assigned as destination case, and the destination case list is unchanged.

**Opening the source case**

A statistics case with no computed statistics is not necessarily opened, and `eclipseCaseData()` is then null. Source cases are now opened before the IJK dimensions are validated and before result data is read, so an uncomputed statistics case yields the existing "No data found for variable" message instead of dereferencing a null pointer.

**View not updated after a calculation (second commit)**

While verifying the above, a view displaying the calculated result showed no legend and no cell colors after loading the project from file, although the cell values were correct.

A case in a grid ensemble is displayed by views in the view collection of the grid ensemble, but `RimEclipseCase::reservoirViews()` only inspected the view collection of the case itself and the global view collection. No views were found for such a case, so `RimGridCalculation::updateDependentObjects()` had nothing to refresh and the view kept the display model built earlier in the load sequence, before the calculated result existed.

This part is not specific to statistics cases. It applies to any grid calculation with a destination case in a grid ensemble, and to the other users of `reservoirViews()` for such cases, for example result removal and case reload.
