### PR TITLE
#14584 Stop Windows build race copying Qt DLLs into the shared build root

### DIFF
--- a/.github/workflows/ResInsightMac.yml
+++ b/.github/workflows/ResInsightMac.yml
@@ -205,8 +205,8 @@ jobs:
         shell: bash
         run: |
           echo "Content of unit test folder"
-          ls cmakebuild/ResInsight-tests
-          cmakebuild/ResInsight-tests
+          ls cmakebuild/ApplicationLibCode/UnitTests
+          cmakebuild/ApplicationLibCode/UnitTests/ResInsight-tests
 
       - name: Write macOS launch instructions
         run: |

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -33,7 +33,7 @@ jobs:
               enable-asserts: false,
               vcpkg-bootstrap: bootstrap-vcpkg.bat,
               qt-version: 6.10.1,
-              ri-unit-test-path: "ResInsight-tests",
+              ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
           - {
               name: "Ubuntu 24.04 gcc",
@@ -48,7 +48,7 @@ jobs:
               enable-asserts: false,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
               qt-version: 6.7.0,
-              ri-unit-test-path: "ResInsight-tests",
+              ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
           - {
               name: "Ubuntu 24.04 clang-19",
@@ -63,7 +63,7 @@ jobs:
               enable-asserts: true,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
               qt-version: 6.7.0,
-              ri-unit-test-path: "ResInsight-tests",
+              ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
     env:
       BUILD_TYPE: Release

--- a/.github/workflows/rhel8-unit-tests.yml
+++ b/.github/workflows/rhel8-unit-tests.yml
@@ -118,4 +118,4 @@ jobs:
       - name: Run Unit Tests
         run: |
           source /opt/rh/gcc-toolset-14/enable
-          /src/cmakebuild/ResInsight-tests
+          /src/cmakebuild/ApplicationLibCode/UnitTests/ResInsight-tests

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -222,7 +222,23 @@ set_property(
   TARGET ResInsightDummyTestTarget PROPERTY FOLDER "FileCopyTargetsTest"
 )
 
-# create a custom target that copies the files to the build folder
+# Keep the test executable out of the shared build root. The POST_BUILD step
+# below copies the Qt runtime DLLs next to the executable, and the build root
+# has ResInsight.exe running out of it during Python code generation with those
+# same DLLs loaded. Overwriting a mapped DLL is a sharing violation on Windows,
+# and nothing orders the two build edges relative to each other.
+set(RESINSIGHT_TESTS_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+# create a custom target that copies the files to the test output folder
+list(
+  APPEND
+  copyCommands
+  COMMAND
+  ${CMAKE_COMMAND}
+  -E
+  make_directory
+  ${RESINSIGHT_TESTS_OUTPUT_DIRECTORY}
+)
 foreach(riFileName ${RI_FILENAMES})
   list(
     APPEND
@@ -232,7 +248,7 @@ foreach(riFileName ${RI_FILENAMES})
     -E
     copy_if_different
     ${riFileName}
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    ${RESINSIGHT_TESTS_OUTPUT_DIRECTORY}
   )
 endforeach()
 add_custom_target(PreBuildFileCopyTest ${copyCommands})
@@ -242,6 +258,11 @@ qt_add_executable(ResInsight-tests ${SOURCE_UNITTEST_FILES} main.cpp)
 
 # Make ResInsight-tests depend on the prebuild target.
 add_dependencies(ResInsight-tests PreBuildFileCopyTest)
+
+set_target_properties(
+  ResInsight-tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                              ${RESINSIGHT_TESTS_OUTPUT_DIRECTORY}
+)
 
 configure_file(
   ${CMAKE_CURRENT_LIST_DIR}/RiaTestDataDirectory.h.cmake

--- a/ThirdParty/extract-projectfile-versions/CMakeLists.txt
+++ b/ThirdParty/extract-projectfile-versions/CMakeLists.txt
@@ -13,12 +13,25 @@ add_executable(extract-projectfile-versions main.cpp)
 
 target_link_libraries(extract-projectfile-versions Qt6::Core Qt6::Sql)
 
+# This standalone developer tool must not share the output directory with the
+# application. The POST_BUILD step below copies Qt6Core.dll and Qt6Sql.dll next
+# to the executable, and the build root has ResInsight.exe running out of it
+# during Python code generation with those same DLLs loaded. Overwriting a
+# mapped DLL is a sharing violation on Windows, and nothing orders the two build
+# edges relative to each other.
+set_target_properties(
+  extract-projectfile-versions
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
 if(MSVC)
   add_custom_command(
     TARGET extract-projectfile-versions
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:extract-projectfile-versions>
-            $<TARGET_FILE_DIR:extract-projectfile-versions>
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_RUNTIME_DLLS:extract-projectfile-versions>
+      $<TARGET_FILE_DIR:extract-projectfile-versions>
     COMMAND_EXPAND_LISTS
   )
 endif(MSVC)


### PR DESCRIPTION
Fixes #14584

## Problem

`extract-projectfile-versions` links into the shared build root and copies `Qt6Core.dll` and `Qt6Sql.dll` next to its executable as a `POST_BUILD` step. The `generated_classes.py` edge runs `ResInsight.exe` out of that same directory with those DLLs loaded, and nothing orders the two edges relative to each other, so Ninja is free to schedule them concurrently. Overwriting a mapped DLL is a sharing violation on Windows, which fails the copy and takes the build down.

## Fix

Give the target its own `RUNTIME_OUTPUT_DIRECTORY`. It is a standalone developer tool with no reason to share the application output directory, so moving it removes the conflict rather than narrowing it. The copy also becomes `copy_if_different`, matching the equivalent step in the unit test target.

Ordering the two edges with a dependency was considered. It closes this specific race, but it is one hand-written edge per racer, it puts an unrelated ThirdParty tool on the critical path to the Python bindings, and nothing stops the next target that lands in the build root from reintroducing the same bug.

## ResInsight-tests

While fixing the reported target, `ResInsight-tests` turned out to be in the same position: `CMakeLists.txt:62` points `CMAKE_RUNTIME_OUTPUT_DIRECTORY` at the build root for everything, and the test target copies its full runtime DLL set there with the same unordered `POST_BUILD` pattern. That set is a superset of the one that failed, covering Qt6Gui, Qt6Widgets, arrow, protobuf, abseil and the rest. It fires rarely only because `copy_if_different` compares content, so windeployqt having already placed identical DLLs makes it a no-op — on a cold build where the copy wins that race it genuinely writes.

It is moved out of the build root the same way. The companion `PreBuildFileCopyTest` target hardcoded `${CMAKE_RUNTIME_OUTPUT_DIRECTORY}`, so it is pointed at the new directory as well to keep the ODB, OpenVDS and HDF5 runtime files next to the executable; it runs before the link creates that directory, so the directory is created first.

The three workflows that run the test executable by path are updated: `ResInsightWithCache.yml` (three matrix entries), `ResInsightMac.yml` and `rhel8-unit-tests.yml`. `Dockerfile.rhel8` and the rhel8 build step reference only the target name and are unaffected.

## Install packages are unchanged

Packaging on every platform goes through `cmake --build --target install`. Diffing every generated `cmake_install.cmake` in the tree from pristine `dev` to this branch, excluding FetchContent `_deps/*-subbuild` scaffolding, the entire diff is one line — the *source* path of the tool executable. The `DESTINATION` is identical, since `install(TARGETS ...)` tracks `RUNTIME_OUTPUT_DIRECTORY` automatically. `ResInsight-tests` has no install rule and contributes nothing.

`Qt6Sql.dll` was checked specifically, since losing it from the package would have been a real regression: `RiaProjectBackupTools.cpp` uses `QSqlDatabase` and both `ApplicationExeCode` and `ApplicationLibCode` link `Qt6::Sql`, so it is a genuine `ResInsight.exe` dependency deployed by `qt_generate_deploy_app_script(TARGET ResInsight)` and by `RUNTIME_DEPENDENCIES` on Windows — never by the copy being moved here.

## Verification

Verified locally on Windows (MSVC 19.51, Ninja, Qt 6.10.1):

- Both targets build; executables and their runtime DLLs land in the new directories.
- `extract-projectfile-versions.exe` still runs from its new location.
- Full unit test suite run from the new location: 1056 tests in 185 suites, all passed. No missing DLLs and no Qt platform plugin problem — `RiaConsoleApplication` derives from `QCoreApplication`, so no GUI plugin is required — and test data resolves through the absolute paths baked into `RiaTestDataDirectory.h.cmake`.
- `cmake-format` run with `cmake/cmake-format.py` on the `ApplicationLibCode` file covered by the format workflow.

Not verified locally: the Linux and macOS legs. They move the test binary too, and while `RI_FILENAMES` there is the OpenVDS shared libraries plus `SEGYImport`, all copied along to the new directory, shared-library resolution on those platforms goes through RPATH rather than the executable directory. CI is the real confirmation.

One cosmetic note for existing build trees: a stale `extract-projectfile-versions.exe` and `ResInsight-tests` remain in the build root, since Ninja does not remove outputs of retired edges. Harmless, cleared by `ninja -t cleandead` or a fresh configure directory.
