### PR TITLE
Fix four crashes found by stacktrace triage

### DIFF
--- a/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp
@@ -19,6 +19,8 @@
 #include "RifElementPropertyReader.h"
 #include "RiaEclipseUnitTools.h"
 #include "RiaLogging.h"
+#include "RiaQStringFormatter.h"
+#include "RifFileParseTools.h"
 #include "RiuMessageDialog.h"
 
 #include "cafAssert.h"
@@ -115,7 +117,15 @@ std::map<std::string, std::vector<float>> RifElementPropertyReader::readAllEleme
     }
 
     RifElementPropertyTable table;
-    RifElementPropertyTableReader::readData( &m_fieldsMetaData[fieldName], &table );
+    try
+    {
+        RifElementPropertyTableReader::readData( &m_fieldsMetaData[fieldName], &table );
+    }
+    catch ( FileParseException& exception )
+    {
+        RiaLogging::error( std::format( "Element property import failed: '{}'.", exception.message ) );
+        return fieldAndData;
+    }
 
     CAF_ASSERT( m_fieldsMetaData[fieldName].dataColumns.size() == table.data.size() );
 

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivFemIntersectionGrid.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivFemIntersectionGrid.cpp
@@ -75,16 +75,19 @@ std::array<cvf::Vec3d, 8> RivFemIntersectionGrid::cellCornerVertices( size_t glo
 {
     auto [part, elementIdx] = m_femParts->partAndElementIndex( globalCellIndex );
 
-    const bool useDisplacements = m_parts->isDisplacementsUsed();
-
     const std::vector<cvf::Vec3f>& nodeCoords    = part->nodes().coordinates;
     const int*                     cornerIndices = part->connectivities( elementIdx );
+
+    const std::vector<cvf::Vec3f>& displacements = m_parts->displacements( part->elementPartId() );
+
+    // Displacements are read per time step, and can be missing or incomplete. Use them only if there is one
+    // displacement per node.
+    const bool useDisplacements = m_parts->isDisplacementsUsed() && ( displacements.size() == nodeCoords.size() );
 
     std::array<cvf::Vec3d, 8> cellCorners;
     if ( useDisplacements )
     {
-        const double                   scaleFactor   = m_parts->currentDisplacementScaleFactor();
-        const std::vector<cvf::Vec3f>& displacements = m_parts->displacements( part->elementPartId() );
+        const double scaleFactor = m_parts->currentDisplacementScaleFactor();
         for ( int i = 0; i < 8; i++ )
         {
             const int idx  = cornerIndices[i];

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -986,12 +986,13 @@ bool RimReservoirGridEnsemble::detectGridDimensionEquality()
 void RimReservoirGridEnsemble::loadGridsInSharedMode()
 {
     auto allCases = cases();
+    if ( allCases.empty() ) return;
 
     RiaLogging::info( std::format( "Grid ensemble '{}': Loading grid in shared mode for {} cases.", name(), allCases.size() ) );
 
     // Load first case fully
     RimEclipseCase* firstCase = allCases[0];
-    if ( firstCase->openEclipseGridFile() )
+    if ( firstCase->openEclipseGridFile() && firstCase->eclipseCaseData() )
     {
         m_mainGrid = firstCase->eclipseCaseData()->mainGrid();
 
@@ -1003,7 +1004,17 @@ void RimReservoirGridEnsemble::loadGridsInSharedMode()
             {
                 resultCase->openAndReadActiveCellData( firstCase->eclipseCaseData() );
             }
-            eclipseCase->eclipseCaseData()->setMainGrid( m_mainGrid );
+
+            // Reading of active cell data can fail, and no case data is created for the case
+            if ( auto caseData = eclipseCase->eclipseCaseData() )
+            {
+                caseData->setMainGrid( m_mainGrid );
+            }
+            else
+            {
+                RiaLogging::warning(
+                    std::format( "Grid ensemble '{}': Failed to load grid data for '{}'.", name(), eclipseCase->gridFileName() ) );
+            }
         }
 
         RigCaseCellResultsData::copyResultsMetaDataFromMainCase( firstCase->eclipseCaseData(),

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -190,6 +190,8 @@ RiuMainWindow::RiuMainWindow()
 //--------------------------------------------------------------------------------------------------
 RiuMainWindow::~RiuMainWindow()
 {
+    setBeingDestroyed();
+
     setPdmRoot( nullptr );
 
     if ( m_pdmUiPropertyView )
@@ -329,6 +331,10 @@ void RiuMainWindow::cleanupGuiCaseClose()
 //--------------------------------------------------------------------------------------------------
 void RiuMainWindow::cleanupGuiBeforeProjectClose()
 {
+    // Closing the last window can trigger a project close while this window is being destroyed. Accessing the
+    // GUI of a window being destroyed is not safe.
+    if ( isBeingDestroyed() ) return;
+
     for ( auto v : viewWindows() )
     {
         v->removeWindowFromDock();

--- a/ApplicationLibCode/UserInterface/RiuMainWindowBase.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindowBase.cpp
@@ -73,6 +73,7 @@ RiuMainWindowBase::RiuMainWindowBase()
     , m_blockSubWindowActivation( false )
     , m_blockSubWindowProjectTreeSelection( false )
     , m_hasBeenVisible( false )
+    , m_isBeingDestroyed( false )
     , m_windowMenu( nullptr )
 {
     ads::CDockManager::setAutoHideConfigFlags( ads::CDockManager::DefaultAutoHideConfig );
@@ -793,6 +794,22 @@ void RiuMainWindowBase::addDefaultEntriesToWindowsMenu()
     m_windowMenu->addSeparator();
     m_windowMenu->addAction( m_tileWindowsAction );
     m_windowMenu->addAction( m_maximizeWindowsAction );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Called when the destructor of a main window starts. Used to avoid operations on a window being destroyed.
+//--------------------------------------------------------------------------------------------------
+void RiuMainWindowBase::setBeingDestroyed()
+{
+    m_isBeingDestroyed = true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiuMainWindowBase::isBeingDestroyed() const
+{
+    return m_isBeingDestroyed;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMainWindowBase.h
+++ b/ApplicationLibCode/UserInterface/RiuMainWindowBase.h
@@ -92,6 +92,9 @@ public:
     void setBlockViewSelectionOnSubWindowActivated( bool block );
     bool isBlockingViewSelectionOnSubWindowActivated() const;
 
+    void setBeingDestroyed();
+    bool isBeingDestroyed() const;
+
     ads::CDockManager* dockManager() const;
 
     QString dockWidgetStateString() const;
@@ -167,6 +170,7 @@ private:
     bool m_blockSubWindowActivation;
     bool m_blockSubWindowProjectTreeSelection;
     bool m_hasBeenVisible;
+    bool m_isBeingDestroyed;
 
     ads::CDockManager* m_dockManager;
 };

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -122,6 +122,8 @@ RiuPlotMainWindow::RiuPlotMainWindow()
 //--------------------------------------------------------------------------------------------------
 RiuPlotMainWindow::~RiuPlotMainWindow()
 {
+    setBeingDestroyed();
+
     m_summaryPlotManagerView->showProperties( nullptr );
     setPdmRoot( nullptr );
 }
@@ -225,6 +227,10 @@ void RiuPlotMainWindow::initializeGuiNewProjectLoaded()
 //--------------------------------------------------------------------------------------------------
 void RiuPlotMainWindow::cleanupGuiBeforeProjectClose()
 {
+    // Closing the last window can trigger a project close while this window is being destroyed. Accessing the
+    // GUI of a window being destroyed is not safe.
+    if ( isBeingDestroyed() ) return;
+
     for ( auto v : viewWindows() )
     {
         v->removeWindowFromDock();


### PR DESCRIPTION
Four unrelated crashes found by triage of the stacktrace reports for 2026.06.1. One commit per crash.

### Missing displacements in GeoMech intersections

**Problem:** `RivFemIntersectionGrid::cellCornerVertices()` reads `displacements[nodeIdx]` based on `isDisplacementsUsed()` alone. The displacement vector is empty when reading displacements for the current time step fails, or when the part id is unknown, and the read goes out of bounds.

**Fix:** Use displacements only when there is one displacement per node, the same guard as in `RivFemPartGeometryGenerator` and `RivFemPartPartMgr`.

<details>
<summary>Call stack</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[3] RivFemIntersectionGrid::cellCornerVertices(unsigned long) const at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:235
[4] RivExtrudedCurveIntersectionGeometryGenerator::calculateArrays(cvf::Array<unsigned char>*) at ResInsight/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.cpp:389
[5] RivExtrudedCurveIntersectionGeometryGenerator::generateSurface(cvf::Array<unsigned char>*) at ResInsight/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionGeometryGenerator.cpp:620
[6] RivExtrudedCurveIntersectionPartMgr::generatePartGeometry(cvf::Array<unsigned char>*, cvf::Transform*) at ResInsight/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp:246
[7] RimIntersectionCollection::appendDynamicPartsToModel(cvf::ModelBasicList*, cvf::Transform*, unsigned long, cvf::Array<unsigned char>*) at ResInsight/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp:248
[8] RimGridView::appendIntersectionsToModel(bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimGridView.cpp:633
[9] RimGeoMechView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:316
[10] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
[11] RiuMainWindow::slotDrawStyleChanged(QAction*) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1654
[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[41] __libc_start_main at :0
```

</details>

### Project close while the main window is being destroyed

**Problem:** The main windows have `Qt::WA_DeleteOnClose`. Events dispatched during `~RiuMainWindow()` can make Qt emit `lastWindowClosed`, which closes the project and calls `cleanupGuiBeforeProjectClose()` on the window currently being destroyed. `RiaGuiApplication::m_mainWindow` is a `QPointer`, and is not cleared until `~QObject()` runs, so the existing null check does not catch this.

**Fix:** Flag the window as being destroyed at the start of the destructor, and skip GUI cleanup for a window in that state. Both main windows are handled, as both use `WA_DeleteOnClose`.

<details>
<summary>Call stack</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[4] RiuMainWindow::cleanupGuiBeforeProjectClose() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:346
[5] RiaGuiApplication::onProjectBeingClosed() at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1409
[6] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1040
[7] RiaGuiApplication::onLastWindowClosed() at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1746
[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[21] RiuMainWindow::~RiuMainWindow() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:206
[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[34] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[35] __libc_start_main at :0
```

</details>

### Parse error in element property file

**Problem:** `RifElementPropertyTableReader::readData()` throws `FileParseException` for a malformed file. The exception propagates out of `RigFemPartResultsCollection::findOrLoadScalarResult()` and through the Qt event loop, and terminates the application.

**Fix:** Catch the exception where the file is read, log an error and return no data, as done for other file readers using `FileParseException`.

<details>
<summary>Call stack</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[5] manageTerminate() at ResInsight/ApplicationExeCode/RiaMainTools.cpp:241
[9] RifElementPropertyTableReader::readData(RifElementPropertyMetadata const*, RifElementPropertyTable*) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyTableReader.cpp:202
[10] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:118
[11] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
[12] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
[13] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
[14] RimGeoMechView::isTimeStepDependentDataVisible() const at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:841
[15] Rim3dView::isTimeStepDependentDataVisibleInThisOrComparisonView() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:603
[16] RimGeoMechView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:278
[17] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
[18] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[34] __libc_start_main at :0
```

</details>

### Missing grid data in a shared grid ensemble

**Problem:** `RimReservoirGridEnsemble::loadGridsInSharedMode()` calls `eclipseCaseData()->setMainGrid()` for all cases. `RimEclipseResultCase::openAndReadActiveCellData()` returns without creating case data if the grid file is missing or cannot be read, and the call is done on a null pointer.

**Fix:** Skip cases without case data and log a warning, and guard the case data of the first case and an empty list of cases.

<details>
<summary>Call stack</summary>

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[3] cvf::ref<RigMainGrid>::swap(cvf::ref<RigMainGrid>&) at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:372
[4] RimReservoirGridEnsemble::loadGridsInSharedMode() at ResInsight/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp:957
[5] RimReservoirGridEnsemble::loadGridDataFromFiles() at ResInsight/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp:868
[6] RimEnsembleFileSetTools::createGridEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:107
[7] doImport at ResInsight/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp:130
[8] RicImportGridAndSummaryEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp:224
[9] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[37] __libc_start_main at :0
```

</details>
