### PR TITLE
Fix GUI thread deadlock caused by orphaned OpenMP pragmas

### DIFF
--- a/ApplicationLibCode/Application/Tools/RiaCurveMerger.inl
+++ b/ApplicationLibCode/Application/Tools/RiaCurveMerger.inl
@@ -195,7 +195,7 @@ void RiaCurveMerger<XValueType>::computeInterpolatedValues( bool includeValuesFr
 
             if ( !RiaCurveDataTools::isValidValue( interpolValue, false ) )
             {
-#pragma omp critical
+                // Each iteration writes to its own element, so no synchronization is required
                 accumulatedValidValues[valueIndex] = HUGE_VAL;
             }
 

--- a/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp
@@ -79,7 +79,7 @@ void RifOpmCommonEclipseSummary::setEnsembleImportState( RifEnsembleImportConfig
 void RifOpmCommonEclipseSummary::resetEnhancedSummaryFileCount()
 {
     // This function can be called from a parallel loop, make it thread safe
-#pragma omp critical
+#pragma omp critical( critical_section_createdEsmryFileCount )
     sm_createdEsmryFileCount = 0;
 }
 
@@ -405,6 +405,6 @@ std::string RifOpmCommonEclipseSummary::keywordForAddress( const RifEclipseSumma
 void RifOpmCommonEclipseSummary::increaseEsmryFileCount()
 {
     // This function can be called from a parallel loop, make it thread safe
-#pragma omp critical
+#pragma omp critical( critical_section_createdEsmryFileCount )
     sm_createdEsmryFileCount++;
 }

--- a/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmSummaryTools.cpp
@@ -107,7 +107,7 @@ std::pair<std::set<RifEclipseSummaryAddress>, std::map<RifEclipseSummaryAddress,
             }
         }
 
-#pragma omp critical
+#pragma omp critical( critical_section_RifOpmSummaryTools_buildAddresses )
         {
             addresses.insert( threadAddresses.begin(), threadAddresses.end() );
             addressToKeywordMap.insert( threadAddressToKeywordMap.begin(), threadAddressToKeywordMap.end() );

--- a/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifRoffFileTools.cpp
@@ -216,7 +216,7 @@ bool RifRoffFileTools::openGridFile( const QString& fileName, RigEclipseCaseData
         size_t numActiveCells = computeActiveCellMatrixIndex( activeCells );
 
         // Loop over cells and fill them with data
-#pragma omp for
+#pragma omp parallel for
         for ( int gridLocalCellIndex = 0; gridLocalCellIndex < cellCount; ++gridLocalCellIndex )
         {
             RigCell& cell = mainGrid->cell( cellStartIndex + gridLocalCellIndex );

--- a/ApplicationLibCode/FileInterface/RifSummaryReaderInterface.cpp
+++ b/ApplicationLibCode/FileInterface/RifSummaryReaderInterface.cpp
@@ -100,7 +100,7 @@ size_t RifSummaryReaderInterface::dataObjectCount() const
 //--------------------------------------------------------------------------------------------------
 void RifSummaryReaderInterface::increaseSerialNumber()
 {
-#pragma omp critical
+#pragma omp critical( critical_section_RifSummaryReaderInterface_serialNumber )
     m_serialNumber = m_nextSerialNumber++;
 }
 

--- a/ApplicationLibCode/ModelVisualization/RivNNCGeometryGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivNNCGeometryGenerator.cpp
@@ -21,6 +21,8 @@
 
 #include <cmath>
 
+#include "RiaOpenMPTools.h"
+
 #include "RigCell.h"
 #include "RigMainGrid.h"
 #include "RigNNCData.h"
@@ -86,61 +88,78 @@ void RivNNCGeometryGenerator::computeArrays()
         mainGrid = m_grid->mainGrid();
     }
 
-#pragma omp parallel for ordered
-    for ( long long nIdx = 0; nIdx < numConnections; ++nIdx )
+    int numberOfThreads = RiaOpenMPTools::availableThreadCount();
+
+    std::vector<std::vector<cvf::Vec3f>> threadVertices( numberOfThreads );
+    std::vector<std::vector<size_t>>     threadTriangleToNNC( numberOfThreads );
+
+#pragma omp parallel
     {
-        size_t conIdx = m_nncIndexes.empty() ? nIdx : m_nncIndexes[nIdx];
+        int myThread = RiaOpenMPTools::currentThreadIndex();
 
-        if ( !m_includeAllanDiagramGeometry && conIdx >= m_nncData->eclipseConnectionCount() )
+        // NB! We are inside a parallel section, do not use "parallel for" here
+#pragma omp for
+        for ( long long nIdx = 0; nIdx < numConnections; ++nIdx )
         {
-            continue;
-        }
+            size_t conIdx = m_nncIndexes.empty() ? nIdx : m_nncIndexes[nIdx];
 
-        const RigConnection& conn = m_nncData->allConnections()[conIdx];
-
-        if ( !conn.polygon().empty() )
-        {
-            bool isVisible = true;
-            if ( isVisibilityCalcActive )
+            if ( !m_includeAllanDiagramGeometry && conIdx >= m_nncData->eclipseConnectionCount() )
             {
-                bool cell1Visible = false;
-                bool cell2Visible = false;
-
-                if ( mainGrid->cell( conn.c1GlobIdx() ).hostGrid() == m_grid.p() )
-                {
-                    size_t cell1GridLocalIdx = mainGrid->cell( conn.c1GlobIdx() ).gridLocalCellIndex();
-                    cell1Visible             = ( *m_cellVisibility )[cell1GridLocalIdx];
-                }
-
-                if ( mainGrid->cell( conn.c2GlobIdx() ).hostGrid() == m_grid.p() )
-                {
-                    size_t cell2GridLocalIdx = mainGrid->cell( conn.c2GlobIdx() ).gridLocalCellIndex();
-                    cell2Visible             = ( *m_cellVisibility )[cell2GridLocalIdx];
-                }
-
-                isVisible = cell1Visible || cell2Visible;
+                continue;
             }
 
-            if ( isVisible )
-            {
-                cvf::Vec3f vx1 = conn.polygon()[0] - offset;
-                cvf::Vec3f vx2;
-                cvf::Vec3f vx3 = conn.polygon()[1] - offset;
+            const RigConnection& conn = m_nncData->allConnections()[conIdx];
 
-                for ( size_t vxIdx = 2; vxIdx < conn.polygon().size(); ++vxIdx )
+            if ( !conn.polygon().empty() )
+            {
+                bool isVisible = true;
+                if ( isVisibilityCalcActive )
                 {
-                    vx2 = vx3;
-                    vx3 = conn.polygon()[vxIdx] - offset;
-#pragma omp critical( critical_section_RivNNCGeometryGenerator_computeArrays )
+                    bool cell1Visible = false;
+                    bool cell2Visible = false;
+
+                    if ( mainGrid->cell( conn.c1GlobIdx() ).hostGrid() == m_grid.p() )
                     {
-                        vertices.push_back( vx1 );
-                        vertices.push_back( vx2 );
-                        vertices.push_back( vx3 );
-                        triangleToNNC.push_back( conIdx );
+                        size_t cell1GridLocalIdx = mainGrid->cell( conn.c1GlobIdx() ).gridLocalCellIndex();
+                        cell1Visible             = ( *m_cellVisibility )[cell1GridLocalIdx];
+                    }
+
+                    if ( mainGrid->cell( conn.c2GlobIdx() ).hostGrid() == m_grid.p() )
+                    {
+                        size_t cell2GridLocalIdx = mainGrid->cell( conn.c2GlobIdx() ).gridLocalCellIndex();
+                        cell2Visible             = ( *m_cellVisibility )[cell2GridLocalIdx];
+                    }
+
+                    isVisible = cell1Visible || cell2Visible;
+                }
+
+                if ( isVisible )
+                {
+                    cvf::Vec3f vx1 = conn.polygon()[0] - offset;
+                    cvf::Vec3f vx2;
+                    cvf::Vec3f vx3 = conn.polygon()[1] - offset;
+
+                    for ( size_t vxIdx = 2; vxIdx < conn.polygon().size(); ++vxIdx )
+                    {
+                        vx2 = vx3;
+                        vx3 = conn.polygon()[vxIdx] - offset;
+
+                        threadVertices[myThread].push_back( vx1 );
+                        threadVertices[myThread].push_back( vx2 );
+                        threadVertices[myThread].push_back( vx3 );
+                        threadTriangleToNNC[myThread].push_back( conIdx );
                     }
                 }
             }
         }
+    }
+
+    // Merge in thread order. The default static schedule assigns contiguous chunks to the threads, so the
+    // resulting geometry is identical from run to run.
+    for ( int i = 0; i < numberOfThreads; i++ )
+    {
+        vertices.insert( vertices.end(), threadVertices[i].begin(), threadVertices[i].end() );
+        triangleToNNC.insert( triangleToNNC.end(), threadTriangleToNNC[i].begin(), threadTriangleToNNC[i].end() );
     }
 
     m_vertices = new cvf::Vec3fArray;

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionGeometryGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfaceIntersectionGeometryGenerator.cpp
@@ -250,7 +250,7 @@ void RivSurfaceIntersectionGeometryGenerator::calculateArrays()
                     std::array<double, 8> cornerWeights2 =
                         caf::HexInterpolator::vertexWeights( cellCorners, clippedTriangleVxes[triVxIdx + 2] );
 
-#pragma omp critical
+#pragma omp critical( critical_section_RivSurfaceIntersectionGeometryGenerator_computeArrays )
                     {
                         outputTriangleVertices.emplace_back( point0 );
                         outputTriangleVertices.emplace_back( point1 );

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp
@@ -486,13 +486,13 @@ void RimPolygonFilter::updateCellsDepthEclipse( const std::vector<cvf::Vec3d>& p
             RigCell cell = grid->cell( n );
             if ( cell.isInvalid() ) continue;
 
-            // get corner coordinates
-            std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( n );
-
             // get cell ijk for k filter
             size_t i, j, k;
             grid->ijkFromCellIndex( n, &i, &j, &k );
             if ( !m_intervalTool.isNumberIncluded( k ) ) continue;
+
+            // get corner coordinates
+            std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( n );
 
             // check if the polygon includes the cell
             if ( cellInsidePolygon2D( cell.center(), hexCorners, points ) )

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp
@@ -18,6 +18,8 @@
 
 #include "RimPolygonFilter.h"
 
+#include "RiaOpenMPTools.h"
+
 #include "RigCellGeometryTools.h"
 #include "RigEclipseCaseData.h"
 #include "RigFemPartCollection.h"
@@ -445,35 +447,62 @@ bool RimPolygonFilter::cellInsidePolygon2D( cvf::Vec3d center, std::array<cvf::V
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Append the cells collected per thread in thread order. The default static schedule assigns
+/// contiguous chunks to the threads, so the resulting cell order is identical from run to run.
+//--------------------------------------------------------------------------------------------------
+namespace
+{
+template <typename CellContainer>
+void appendThreadCells( const std::vector<std::vector<size_t>>& threadCells, CellContainer& cells )
+{
+    for ( const auto& cellsForThread : threadCells )
+    {
+        cells.insert( cells.end(), cellsForThread.begin(), cellsForThread.end() );
+    }
+}
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RimPolygonFilter::updateCellsDepthEclipse( const std::vector<cvf::Vec3d>& points, const RigGridBase* grid )
 {
     // we should look in depth using Z coordinate
     const int gIdx = static_cast<int>( grid->gridIndex() );
+
+    const int                        numberOfThreads = RiaOpenMPTools::availableThreadCount();
+    std::vector<std::vector<size_t>> threadCells( numberOfThreads );
+
     // loop over all cells
-#pragma omp parallel for
-    for ( int n = 0; n < (int)grid->cellCount(); n++ )
+#pragma omp parallel
     {
-        // valid cell?
-        RigCell cell = grid->cell( n );
-        if ( cell.isInvalid() ) continue;
+        const int myThread = RiaOpenMPTools::currentThreadIndex();
 
-        // get corner coordinates
-        std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( n );
-
-        // get cell ijk for k filter
-        size_t i, j, k;
-        grid->ijkFromCellIndex( n, &i, &j, &k );
-        if ( !m_intervalTool.isNumberIncluded( k ) ) continue;
-
-        // check if the polygon includes the cell
-        if ( cellInsidePolygon2D( cell.center(), hexCorners, points ) )
+        // NB! We are inside a parallel section, do not use "parallel for" here
+#pragma omp for
+        for ( int n = 0; n < (int)grid->cellCount(); n++ )
         {
-#pragma omp critical
-            m_cells[gIdx].push_back( n );
+            // valid cell?
+            RigCell cell = grid->cell( n );
+            if ( cell.isInvalid() ) continue;
+
+            // get corner coordinates
+            std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( n );
+
+            // get cell ijk for k filter
+            size_t i, j, k;
+            grid->ijkFromCellIndex( n, &i, &j, &k );
+            if ( !m_intervalTool.isNumberIncluded( k ) ) continue;
+
+            // check if the polygon includes the cell
+            if ( cellInsidePolygon2D( cell.center(), hexCorners, points ) )
+            {
+                threadCells[myThread].push_back( n );
+            }
         }
     }
+
+    appendThreadCells( threadCells, m_cells[gIdx] );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -492,48 +521,56 @@ void RimPolygonFilter::updateCellsKIndexEclipse( const std::vector<cvf::Vec3d>& 
     const bool        closedPolygon = isPolygonClosed();
     const bool        singlePoint   = ( points.size() == 1 );
 
+    const int                        numberOfThreads = RiaOpenMPTools::availableThreadCount();
+    std::vector<std::vector<size_t>> threadCells( numberOfThreads );
+
     // find all cells in the K layer that matches the polygon
-#pragma omp parallel for
-    for ( int i = 0; i < (int)grid->cellCountI(); i++ )
+#pragma omp parallel
     {
-        for ( size_t j = 0; j < grid->cellCountJ(); j++ )
+        const int myThread = RiaOpenMPTools::currentThreadIndex();
+
+        // NB! We are inside a parallel section, do not use "parallel for" here
+#pragma omp for
+        for ( int i = 0; i < (int)grid->cellCountI(); i++ )
         {
-            size_t         cellIdx = grid->cellIndexFromIJKUnguarded( i, j, K );
-            const RigCell& cell    = grid->cell( cellIdx );
-            // valid cell?
-            if ( cell.isInvalid() ) continue;
-
-            // get corner coordinates
-            std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( cellIdx );
-
-            if ( closedPolygon )
+            for ( size_t j = 0; j < grid->cellCountJ(); j++ )
             {
-                // check if the polygon includes the cell
-                if ( cellInsidePolygon2D( cell.center(), hexCorners, points ) )
+                size_t         cellIdx = grid->cellIndexFromIJKUnguarded( i, j, K );
+                const RigCell& cell    = grid->cell( cellIdx );
+                // valid cell?
+                if ( cell.isInvalid() ) continue;
+
+                // get corner coordinates
+                std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( cellIdx );
+
+                if ( closedPolygon )
                 {
-#pragma omp critical
-                    foundCells.push_back( cellIdx );
-                }
-            }
-            else
-            {
-                if ( singlePoint )
-                {
-                    if ( RigCellGeometryTools::pointInsideCellNegK2D( points[0], hexCorners ) )
+                    // check if the polygon includes the cell
+                    if ( cellInsidePolygon2D( cell.center(), hexCorners, points ) )
                     {
-#pragma omp critical
-                        foundCells.push_back( cellIdx );
+                        threadCells[myThread].push_back( cellIdx );
                     }
                 }
-                // check if the polyline touches the top face of the cell
-                else if ( RigCellGeometryTools::polylineIntersectsCellNegK2D( points, hexCorners ) )
+                else
                 {
-#pragma omp critical
-                    foundCells.push_back( cellIdx );
+                    if ( singlePoint )
+                    {
+                        if ( RigCellGeometryTools::pointInsideCellNegK2D( points[0], hexCorners ) )
+                        {
+                            threadCells[myThread].push_back( cellIdx );
+                        }
+                    }
+                    // check if the polyline touches the top face of the cell
+                    else if ( RigCellGeometryTools::polylineIntersectsCellNegK2D( points, hexCorners ) )
+                    {
+                        threadCells[myThread].push_back( cellIdx );
+                    }
                 }
             }
         }
     }
+
+    appendThreadCells( threadCells, foundCells );
 
     // now extend all these cells in one K layer to all K layers
     for ( const size_t cellIdx : foundCells )
@@ -593,31 +630,41 @@ void RimPolygonFilter::updateCellsForEclipse( const std::vector<cvf::Vec3d>& poi
 void RimPolygonFilter::updateCellsDepthGeoMech( const std::vector<cvf::Vec3d>& points, const RigFemPartGrid* grid, int partId )
 {
     // we should look in depth using Z coordinate
+    const int                        numberOfThreads = RiaOpenMPTools::availableThreadCount();
+    std::vector<std::vector<size_t>> threadCells( numberOfThreads );
+
     // loop over all cells
-#pragma omp parallel for
-    for ( int i = 0; i < (int)grid->cellCountI(); i++ )
+#pragma omp parallel
     {
-        for ( size_t j = 0; j < grid->cellCountJ(); j++ )
+        const int myThread = RiaOpenMPTools::currentThreadIndex();
+
+        // NB! We are inside a parallel section, do not use "parallel for" here
+#pragma omp for
+        for ( int i = 0; i < (int)grid->cellCountI(); i++ )
         {
-            for ( size_t k = 0; k < grid->cellCountK(); k++ )
+            for ( size_t j = 0; j < grid->cellCountJ(); j++ )
             {
-                if ( !m_intervalTool.isNumberIncluded( k ) ) continue;
-
-                size_t cellIdx = grid->cellIndexFromIJK( i, j, k );
-                if ( cellIdx == cvf::UNDEFINED_SIZE_T ) continue;
-
-                std::array<cvf::Vec3d, 8> vertices = grid->cellCornerVertices( cellIdx );
-                cvf::Vec3d                center   = grid->cellCentroid( cellIdx );
-
-                // check if the polygon includes the cell
-                if ( cellInsidePolygon2D( center, vertices, points ) )
+                for ( size_t k = 0; k < grid->cellCountK(); k++ )
                 {
-#pragma omp critical
-                    m_cells[partId].push_back( cellIdx );
+                    if ( !m_intervalTool.isNumberIncluded( k ) ) continue;
+
+                    size_t cellIdx = grid->cellIndexFromIJK( i, j, k );
+                    if ( cellIdx == cvf::UNDEFINED_SIZE_T ) continue;
+
+                    std::array<cvf::Vec3d, 8> vertices = grid->cellCornerVertices( cellIdx );
+                    cvf::Vec3d                center   = grid->cellCentroid( cellIdx );
+
+                    // check if the polygon includes the cell
+                    if ( cellInsidePolygon2D( center, vertices, points ) )
+                    {
+                        threadCells[myThread].push_back( cellIdx );
+                    }
                 }
             }
         }
     }
+
+    appendThreadCells( threadCells, m_cells[partId] );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -681,46 +728,54 @@ void RimPolygonFilter::updateCellsKIndexGeoMech( const std::vector<cvf::Vec3d>& 
     // find all cells in this K layer that matches the polygon
     std::list<size_t> foundCells;
 
-#pragma omp parallel for
-    for ( int i = 0; i < (int)grid->cellCountI(); i++ )
+    const int                        numberOfThreads = RiaOpenMPTools::availableThreadCount();
+    std::vector<std::vector<size_t>> threadCells( numberOfThreads );
+
+#pragma omp parallel
     {
-        for ( size_t j = 0; j < grid->cellCountJ(); j++ )
+        const int myThread = RiaOpenMPTools::currentThreadIndex();
+
+        // NB! We are inside a parallel section, do not use "parallel for" here
+#pragma omp for
+        for ( int i = 0; i < (int)grid->cellCountI(); i++ )
         {
-            size_t cellIdx = grid->cellIndexFromIJK( i, j, nk );
-            if ( cellIdx == cvf::UNDEFINED_SIZE_T ) continue;
-
-            // get corner coordinates
-            std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( cellIdx );
-            cvf::Vec3d                center     = grid->cellCentroid( cellIdx );
-
-            if ( closedPolygon )
+            for ( size_t j = 0; j < grid->cellCountJ(); j++ )
             {
-                // check if the polygon includes the cell
-                if ( cellInsidePolygon2D( center, hexCorners, points ) )
+                size_t cellIdx = grid->cellIndexFromIJK( i, j, nk );
+                if ( cellIdx == cvf::UNDEFINED_SIZE_T ) continue;
+
+                // get corner coordinates
+                std::array<cvf::Vec3d, 8> hexCorners = grid->cellCornerVertices( cellIdx );
+                cvf::Vec3d                center     = grid->cellCentroid( cellIdx );
+
+                if ( closedPolygon )
                 {
-#pragma omp critical
-                    foundCells.push_back( cellIdx );
-                }
-            }
-            else
-            {
-                if ( singlePoint )
-                {
-                    if ( RigCellGeometryTools::pointInsideCellNegK2D( points[0], hexCorners ) )
+                    // check if the polygon includes the cell
+                    if ( cellInsidePolygon2D( center, hexCorners, points ) )
                     {
-#pragma omp critical
-                        foundCells.push_back( cellIdx );
+                        threadCells[myThread].push_back( cellIdx );
                     }
                 }
-                // check if the polyline touches the top face of the cell
-                else if ( RigCellGeometryTools::polylineIntersectsCellNegK2D( points, hexCorners ) )
+                else
                 {
-#pragma omp critical
-                    foundCells.push_back( cellIdx );
+                    if ( singlePoint )
+                    {
+                        if ( RigCellGeometryTools::pointInsideCellNegK2D( points[0], hexCorners ) )
+                        {
+                            threadCells[myThread].push_back( cellIdx );
+                        }
+                    }
+                    // check if the polyline touches the top face of the cell
+                    else if ( RigCellGeometryTools::polylineIntersectsCellNegK2D( points, hexCorners ) )
+                    {
+                        threadCells[myThread].push_back( cellIdx );
+                    }
                 }
             }
         }
     }
+
+    appendThreadCells( threadCells, foundCells );
 
     // now extend all these cells in one K layer to all K layers
     for ( const size_t cellIdx : foundCells )

--- a/ApplicationLibCode/ProjectDataModel/RimCornerPointCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCornerPointCase.cpp
@@ -287,7 +287,7 @@ void RimCornerPointCase::buildGrid( RigEclipseCaseData&       eclipseCaseData,
     size_t numActiveCells = RifRoffFileTools::computeActiveCellMatrixIndex( activeCells );
 
     // Loop over cells and fill them with data
-#pragma omp for
+#pragma omp parallel for
     for ( int gridLocalCellIndex = 0; gridLocalCellIndex < cellCount; ++gridLocalCellIndex )
     {
         RigCell& cell = mainGrid->cell( cellStartIndex + gridLocalCellIndex );

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTrianglesGenerator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTrianglesGenerator.cpp
@@ -219,7 +219,7 @@ std::vector<cvf::Vec4d>
                         // Add critical section here due to a weird bug when running in a single thread
                         // Running multi threaded does not require this critical section, as we use a thread local data
                         // structure
-#pragma omp critical
+#pragma omp critical( critical_section_RigContourMapTrianglesGenerator_threadTriangles )
                         threadTriangles[myThread][c].insert( threadTriangles[myThread][c].end(),
                                                              clippedTriangles.begin(),
                                                              clippedTriangles.end() );

--- a/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
@@ -115,7 +115,7 @@ cvf::StructGridInterface::FaceType RigCellFaceGeometryTools::calculateCellFaceOv
 
 void assignThreadConnections( RigConnectionContainer& allConnections, RigConnectionContainer& threadConnections )
 {
-#pragma omp critical
+#pragma omp critical( critical_section_RigCellFaceGeometryTools_assignThreadConnections )
     {
         allConnections.push_back( threadConnections );
     }

--- a/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCellFaceGeometryTools.cpp
@@ -177,18 +177,15 @@ RigConnectionContainer RigCellFaceGeometryTools::computeOtherNncs( const RigMain
             if ( atLeastOneCellActive ) activeFaceIndices.push_back( faceIdx );
         }
 
-        size_t totalNumberOfConnections = 0u;
 #pragma omp parallel
         {
             RigConnectionContainer threadConnections;
-#pragma omp for schedule( guided ) reduction( + : totalNumberOfConnections )
+#pragma omp for schedule( guided )
             for ( int activeFaceIdx = 0; activeFaceIdx < static_cast<int>( activeFaceIndices.size() ); activeFaceIdx++ )
             {
                 size_t faceIdx = activeFaceIndices[activeFaceIdx];
                 extractConnectionsForFace( faultFaces[faceIdx], mainGrid, nativeCellPairs, threadConnections );
             }
-#pragma omp barrier
-            otherConnections.reserve( otherConnections.size() + totalNumberOfConnections );
 
             // Merge together connections per thread
             assignThreadConnections( otherConnections, threadConnections );

--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -989,7 +989,7 @@ void RigMainGrid::buildCellSearchTree() const
             threadIndicesForBoundingBoxes.shrink_to_fit();
             threadBoundingBoxes.shrink_to_fit();
 
-#pragma omp critical
+#pragma omp critical( critical_section_RigMainGrid_buildCellSearchTree )
             {
                 cellIndicesForBoundingBoxes.insert( cellIndicesForBoundingBoxes.end(),
                                                     threadIndicesForBoundingBoxes.begin(),

--- a/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp
+++ b/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp
@@ -496,7 +496,7 @@ bool AABBTree::buildTree()
         {
             bThreadRes = bThreadRes && buildTree(m_previousLevelNodes[i].node, m_previousLevelNodes[i].fromIdx, m_previousLevelNodes[i].toIdx, 4);
         }
-#pragma omp critical
+#pragma omp critical(critical_section_BoundingBoxTree_buildTree)
         {
             bRes = bRes && bThreadRes;
         }
@@ -860,7 +860,7 @@ cvf::BoundingBox BoundingBoxTreeImpl::createLeaves()
             m_ppLeaves[i] = leaf;
             threadBox.addValid(m_validBoundingBoxes[i]);
         }
-#pragma omp critical
+#pragma omp critical(critical_section_BoundingBoxTree_createLeaves)
         {
             box.addValid(threadBox);
         }

--- a/Fwk/VizFwk/LibGuiQt/cvfqtUtils.cpp
+++ b/Fwk/VizFwk/LibGuiQt/cvfqtUtils.cpp
@@ -232,7 +232,6 @@ void Utils::toTextureImageRegion(const QImage& qImage, const cvf::Vec2ui& srcPos
     // Check if QImage has format QImage::Format_ARGB32, and use a more optimized path
     if (qImage.format() == QImage::Format_ARGB32)
     {
-#pragma omp for
         for (int y = 0; y < static_cast<int>(sizeY); ++y)
         {
             const cvf::uint scanLineIdx = srcPosY + sizeY - y - 1;
@@ -255,7 +254,6 @@ void Utils::toTextureImageRegion(const QImage& qImage, const cvf::Vec2ui& srcPos
     else
     {
         cvf::Color4ub cvfRgbVal;
-#pragma omp for
         for (int y = 0; y < static_cast<int>(sizeY); ++y)
         {
             const cvf::uint qImageYPos = srcPosY + sizeY - y - 1;

--- a/docs/agents/coding-style.md
+++ b/docs/agents/coding-style.md
@@ -180,6 +180,74 @@ void RimFoo::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
 }
 ```
 
+## OpenMP
+
+ResInsight builds with MSVC `/openmp`, which is **OpenMP 2.0**. Loop indices must be a signed
+integer type, and `collapse` and min/max reductions are not available.
+
+### Never write an orphaned work-sharing construct
+
+A `#pragma omp for` must have a lexically enclosing `#pragma omp parallel` in the same function.
+An orphaned `#pragma omp for` is not merely useless - it can deadlock the application.
+
+The reason is that the OpenMP master thread is also the Qt GUI thread. When the GUI thread is
+inside a parallel region and a progress update or a repaint runs, Qt work executes directly on
+that thread, which pulls rendering code into the dynamic extent of an active parallel team. An
+orphaned `#pragma omp for` reached that way is encountered by one thread of a team whose other
+threads never reach it, and the implicit barrier at the end of the construct never completes.
+
+```cpp
+// Bad - deadlocks if this function is reached from inside an active parallel region
+void toTextureImageRegion( ... )
+{
+#pragma omp for
+    for ( int y = 0; y < sizeY; ++y )
+```
+
+### Collect per thread, merge afterwards
+
+Do not guard a `push_back` into a shared container with `#pragma omp critical` inside a hot loop.
+Give each thread its own buffer and merge once the region has ended. Merging in thread order also
+makes the result reproducible from run to run, because the default static schedule assigns
+contiguous chunks to the threads.
+
+```cpp
+// Good
+const int                        numberOfThreads = RiaOpenMPTools::availableThreadCount();
+std::vector<std::vector<size_t>> threadCells( numberOfThreads );
+
+#pragma omp parallel
+{
+    const int myThread = RiaOpenMPTools::currentThreadIndex();
+
+    // NB! We are inside a parallel section, do not use "parallel for" here
+#pragma omp for
+    for ( int i = 0; i < cellCount; i++ )
+    {
+        if ( isIncluded( i ) ) threadCells[myThread].push_back( i );
+    }
+}
+
+for ( const auto& cellsForThread : threadCells )
+{
+    cells.insert( cells.end(), cellsForThread.begin(), cellsForThread.end() );
+}
+```
+
+No synchronization is needed when each iteration writes to its own element of a container that was
+sized before the loop. Do not add `critical` for that case.
+
+### Name every critical section
+
+All unnamed `#pragma omp critical` regions share one process-wide lock, so unrelated subsystems
+serialize against each other. Use the `critical_section_<purpose>` convention instead.
+
+### Exceptions and the GUI
+
+An exception that escapes an OpenMP structured block terminates the process on MSVC instead of
+unwinding, so catch inside the loop body. Touch Qt widgets only from the thread owning them; use
+`RiaThreadSafeLogger` or a queued connection to hand data back.
+
 ## Commit Conventions
 
 When creating commits:


### PR DESCRIPTION
Fixes #14596

An orphaned `#pragma omp for` (no enclosing `omp parallel`) is not compiled away by MSVC. It emits a `vcomp_barrier` sized for the calling thread's OpenMP team, so the thread blocks forever waiting for pool workers that never reach it. In `cvfqt::Utils::toTextureImageRegion`, reached from `caf::Viewer::paintGL`, this freezes the GUI.

The fix removes the orphaned directives, and the rest of the branch is the follow up from reviewing all OpenMP use in the code base.

| Commit | Change |
| --- | --- |
| Remove stray `#pragma omp for` | The deadlock itself, in `cvfqt::Utils::toTextureImageRegion` |
| Use `#pragma omp parallel for` | Same orphaned construct in `RifRoffFileTools` and `RimCornerPointCase`, given the parallelism it was meant to have |
| Remove dead reserve and barrier | `RigCellFaceGeometryTools`: the reduction variable was never incremented, so the `reserve` was a no-op called unsynchronized by every thread |
| Remove dead `ordered` clause | `RivNNCGeometryGenerator`: `ordered` with no `ordered` region, plus a lock per triangle, replaced by per thread buffers |
| Remove unnecessary critical | `RiaCurveMerger`: each iteration writes to its own element |
| Collect cells per thread | `RimPolygonFilter`: eight critical sections removed from per cell loops |
| Document OpenMP conventions | `docs/agents/coding-style.md` |
| Name the remaining critical sections | All unnamed regions share one process wide lock |

Each commit is independent and can be dropped on its own. The parallelism change to the two import loops is a performance change, not a correctness fix, and has not been benchmarked.
