### PR TITLE
#14538 Well path: Preserve renamed file well name

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
@@ -129,7 +129,7 @@ void RimFileWellPath::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
 //--------------------------------------------------------------------------------------------------
 /// Read JSON or ascii file containing well path data
 //--------------------------------------------------------------------------------------------------
-bool RimFileWellPath::readWellPathFile( QString* errorMessage, RifWellPathImporter* wellPathImporter, bool setWellNameForExport )
+bool RimFileWellPath::readWellPathFile( QString* errorMessage, RifWellPathImporter* wellPathImporter, bool initializeWellNamesFromFile )
 {
     if ( caf::Utils::fileExists( filePath() ) )
     {
@@ -138,13 +138,9 @@ bool RimFileWellPath::readWellPathFile( QString* errorMessage, RifWellPathImport
         RifWellPathImporter::WellMetaData wellMetaData = RifWellPathImporter::readWellMetaData( filePath(), m_wellPathIndexInFile() );
         // General well info
 
-        if ( setWellNameForExport )
+        if ( initializeWellNamesFromFile )
         {
             setName( wellData.m_name );
-        }
-        else
-        {
-            setNameNoUpdateOfExportName( wellData.m_name );
         }
 
         id           = wellMetaData.m_id;

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.h
@@ -28,7 +28,7 @@ public:
 
     QString filePath() const;
     void    setFilepath( const QString& path );
-    bool    readWellPathFile( QString* errorMessage, RifWellPathImporter* wellPathImporter, bool setWellNameForExport );
+    bool    readWellPathFile( QString* errorMessage, RifWellPathImporter* wellPathImporter, bool initializeWellNamesFromFile );
     int     wellPathIndexInFile() const; // -1 means none.
     void    setWellPathIndexInFile( int index );
 

--- a/GrpcInterface/Python/rips/tests/test_wells.py
+++ b/GrpcInterface/Python/rips/tests/test_wells.py
@@ -408,3 +408,24 @@ def test_import_rmswell_with_w_extension(rips_instance, initialize_test):
     # File has 5 points from MD 0-20m, resampled at 1.0m interval gives 21 points
     result = wells[0].trajectory_properties(resampling_interval=1.0)
     assert len(result["measured_depth"]) == 21
+
+
+def test_rmswell_renamed_name_persists(rips_instance, initialize_test, tmp_path):
+    well_path_file = os.path.abspath(
+        "../../../ApplicationLibCode/UnitTests/TestData/RifRmsWellPathReader/55_33-1.rmswell"
+    )
+    project = rips_instance.project
+    project.import_well_paths([well_path_file])
+
+    well = project.well_paths()[0]
+    well.name = "Renamed RMS Well"
+    well.update()
+
+    project_file = tmp_path / "renamed-rms-well.rsp"
+    project.save(str(project_file))
+    project.close()
+
+    reopened_project = project.open(str(project_file))
+    reopened_wells = reopened_project.well_paths()
+    assert len(reopened_wells) == 1
+    assert reopened_wells[0].name == "Renamed RMS Well"


### PR DESCRIPTION
The renamed well path name is serialized correctly, but reopening the project reloads the source well path file and overwrites the saved name with the name from that file. The reload flag only protected the completion export name, despite the loader also updating the displayed well path name.

Only initialize the well path and export names from the source file during first import. Subsequent data reloads preserve the names stored in the project while continuing to refresh geometry and metadata.

Add an RMS well round-trip test that renames an imported well, saves and reopens the project, and verifies that the custom name is retained.

Fixes #14538.