### PR TITLE
Keep MdiWindowController as project file keyword

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimDockWindowController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimDockWindowController.cpp
@@ -34,7 +34,12 @@
 #include "DockManager.h"
 #include "DockWidget.h"
 
-CAF_PDM_XML_SOURCE_INIT( RimDockWindowController, "DockWindowController", "MdiWindowController" );
+// Keep "MdiWindowController" as the keyword written to the project file. Older versions of ResInsight depend on this
+// keyword to create the window controller for plot windows (3D windows works with both keywords). The change to dock window was introduced
+// in 2026.09. "DockWindowController" was used as the keyword name during development, and is kept for intermediate project files. Revert
+// this ordering after 2-3 major releases, so the new statement becomes
+// CAF_PDM_XML_SOURCE_INIT( RimDockWindowController, "DockWindowController", "MdiWindowController" );
+CAF_PDM_XML_SOURCE_INIT( RimDockWindowController, "MdiWindowController", "DockWindowController" );
 
 //--------------------------------------------------------------------------------------------------
 ///


### PR DESCRIPTION
Fixes #14600

The MDI to dock widget refactoring renamed the PDM class `RimMdiWindowController` to `RimDockWindowController`, and with it the class keyword written to the project file. In `CAF_PDM_XML_SOURCE_INIT` the first keyword is the one written to file, the remaining ones are read aliases, so dev started writing `<WindowController><DockWindowController>`.

Previous versions of ResInsight have no factory entry for `DockWindowController`. When `PdmChildField::readFieldData` meets an unknown class name it only fails when the field is empty at read time, and this is exactly what separates 3D views from plots:

- `Rim3dView` creates the controller in its constructor, so the field is already populated. The keyword mismatch only makes the stored fields be skipped, and the view is still displayed.
- Plots get a controller only from the project file. The factory returns null, the element is skipped, `isMdiWindow()` is false and no MDI subwindow is ever created, so the plot is silently invisible.

This restores `MdiWindowController` as the keyword written to file and keeps `DockWindowController` as a read alias, so project files written by intermediate dev builds still load. The dropped geometry fields are harmless, `RimMdiWindowGeometry::isValid()` returns false and the previous version falls back to a default subwindow size, which is the same path the 3D views already take.
