### PR TITLE
#14511 Activate 3D view after importing grid model from summary case

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
@@ -20,6 +20,7 @@
 
 #include "RiaEclipseFileNameTools.h"
 #include "RiaFractureDefines.h"
+#include "RiaGuiApplication.h"
 #include "RiaImportEclipseCaseTools.h"
 #include "RiaLogging.h"
 #include "RiaPreferencesGrid.h"
@@ -48,9 +49,11 @@
 #include "RimSummaryCaseMainCollection.h"
 
 #include "Riu3DMainWindowTools.h"
+#include "RiuMainWindow.h"
 
 #include "cafAssert.h"
 
+#include <QApplication>
 #include <QFileInfo>
 
 //--------------------------------------------------------------------------------------------------
@@ -229,6 +232,8 @@ bool RimReloadCaseTools::openOrImportGridModelFromSummaryCase( const RimSummaryC
         {
             RiaLogging::info( std::format( "Imported {}", candidateGridFileName ) );
 
+            activateFirstView( RimProject::current()->eclipseCaseFromCaseId( id ) );
+
             return true;
         }
     }
@@ -254,15 +259,30 @@ bool RimReloadCaseTools::findGridModelAndActivateFirstView( const RimSummaryCase
     auto gridCase = RimReloadCaseTools::gridModelFromSummaryCase( summaryCase );
     if ( gridCase )
     {
-        if ( !gridCase->gridViews().empty() )
-        {
-            RicShowMainWindowFeature::showMainWindow();
-
-            Riu3DMainWindowTools::selectAsCurrentItem( gridCase->gridViews().front() );
-        }
+        activateFirstView( gridCase );
 
         return true;
     }
 
     return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Bring the 3D main window to front, and make the first view of the given case the active view
+//--------------------------------------------------------------------------------------------------
+void RimReloadCaseTools::activateFirstView( RimEclipseCase* eclipseCase )
+{
+    if ( !eclipseCase || eclipseCase->gridViews().empty() ) return;
+
+    RicShowMainWindowFeature::showMainWindow();
+
+    Riu3DMainWindowTools::selectAsCurrentItem( eclipseCase->gridViews().front() );
+
+    if ( RiaGuiApplication::isRunning() && RiuMainWindow::instance() )
+    {
+        // Call process events to clear the queue. This makes sure that we are able to raise the 3D window on top of the
+        // plot window. Otherwise the event processing ends up with the plot window on top.
+        QApplication::processEvents();
+        RiuMainWindow::instance()->activateWindow();
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
@@ -53,8 +53,8 @@
 
 #include "cafAssert.h"
 
-#include <QApplication>
 #include <QFileInfo>
+#include <QTimer>
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -278,11 +278,16 @@ void RimReloadCaseTools::activateFirstView( RimEclipseCase* eclipseCase )
 
     Riu3DMainWindowTools::selectAsCurrentItem( eclipseCase->gridViews().front() );
 
-    if ( RiaGuiApplication::isRunning() && RiuMainWindow::instance() )
+    if ( auto mainWindow = RiaGuiApplication::isRunning() ? RiuMainWindow::instance() : nullptr )
     {
-        // Call process events to clear the queue. This makes sure that we are able to raise the 3D window on top of the
-        // plot window. Otherwise the event processing ends up with the plot window on top.
-        QApplication::processEvents();
-        RiuMainWindow::instance()->activateWindow();
+        // Defer the raise until the already queued events have been processed. Activating the window directly ends up
+        // with the plot window on top.
+        QTimer::singleShot( 0,
+                            mainWindow,
+                            [mainWindow]()
+                            {
+                                mainWindow->raise();
+                                mainWindow->activateWindow();
+                            } );
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.h
+++ b/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.h
@@ -47,4 +47,5 @@ private:
     static void updateAllPlots();
 
     static bool findGridModelAndActivateFirstView( const RimSummaryCase* summaryCase );
+    static void activateFirstView( RimEclipseCase* eclipseCase );
 };


### PR DESCRIPTION
Fixes #14511

When importing a grid model from a Summary Case (or from an individual realization of an Ensemble Summary Case), the 3D view was created but stayed in the background — focus remained on the summary plot window.

`RimReloadCaseTools::openOrImportGridModelFromSummaryCase()` had two paths. The "grid already imported" path activated the first view, but the "import from file" path returned right after `openEclipseCaseFromFile()` without activating anything. In addition, `RicShowMainWindowFeature::showMainWindow()` only does `show()`/`raise()`, which is not enough to get the 3D window in front of the plot window.

Changes:
- Activate the first view on both paths, via a shared `activateFirstView()`.
- Raise the 3D window from a zero-delay `QTimer::singleShot`, so the raise is posted behind the already queued events. Same ordering as draining the queue, without re-entering the event loop. Matches the existing idiom in `RicImportGridAndSummaryEnsembleFeature`.