### PR TITLE
Write a compatibility window controller section to the project file

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/CMakeLists_files.cmake
@@ -63,6 +63,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimStackablePlotCurve.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimAdvancedSnapshotExportDefinition.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDockWindowController.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimMdiWindowController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimNamedObject.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimCheckableNamedObject.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimCheckableObject.cpp

--- a/ApplicationLibCode/ProjectDataModel/RimDockWindowController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimDockWindowController.cpp
@@ -34,7 +34,9 @@
 #include "DockManager.h"
 #include "DockWidget.h"
 
-CAF_PDM_XML_SOURCE_INIT( RimDockWindowController, "DockWindowController", "MdiWindowController" );
+// The keyword "MdiWindowController" is owned by RimMdiWindowController_OBSOLETE, used to write a compatibility
+// section readable by ResInsight 2026.06 and older. See RimViewWindow::m_legacyWindowController.
+CAF_PDM_XML_SOURCE_INIT( RimDockWindowController, "DockWindowController" );
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -52,6 +54,23 @@ RimDockWindowController::RimDockWindowController()
 RimDockWindowController::~RimDockWindowController()
 {
     m_viewToControl = nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Project files written by ResInsight 2026.06 and older, and by development versions using the class keyword
+/// "DockWindowController" in the compatibility section, have no window controller outside that section. Restore the
+/// window controller in use from the compatibility section, see RimMdiWindowController_OBSOLETE.
+///
+/// Project files written by current versions have both sections, and they are always in sync.
+//--------------------------------------------------------------------------------------------------
+void RimDockWindowController::initAfterRead()
+{
+    if ( m_mainWindowID() == MAIN_WINDOW_ID_UNASSIGNED ) return;
+
+    auto viewWindow = firstAncestorOrThisOfType<RimViewWindow>();
+    if ( !viewWindow || viewWindow->m_legacyWindowController != this ) return;
+
+    viewWindow->dockInWindow( m_mainWindowID() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimDockWindowController.h
+++ b/ApplicationLibCode/ProjectDataModel/RimDockWindowController.h
@@ -56,6 +56,8 @@ public:
     void removeWindowFromDock();
 
 protected:
+    void initAfterRead() override;
+
     RimViewWindow*     viewPdmObject();
     QWidget*           viewWidget();
     RiuMainWindowBase* getMainWindow();

--- a/ApplicationLibCode/ProjectDataModel/RimMdiWindowController.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMdiWindowController.cpp
@@ -1,0 +1,21 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimMdiWindowController.h"
+
+CAF_PDM_XML_SOURCE_INIT( RimMdiWindowController_OBSOLETE, "MdiWindowController" );

--- a/ApplicationLibCode/ProjectDataModel/RimMdiWindowController.h
+++ b/ApplicationLibCode/ProjectDataModel/RimMdiWindowController.h
@@ -1,0 +1,37 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RimDockWindowController.h"
+
+//==================================================================================================
+/// Compatibility object used to make project files readable by ResInsight 2026.06 and older.
+///
+/// These versions create the window controller for a view window from the class keyword
+/// "MdiWindowController". Without a section using this keyword, plot windows are never made visible
+/// when the project file is opened by an older version.
+///
+/// The object adds no behavior, it is only used to write the main window id using the old class
+/// keyword. It is stored in RimViewWindow::m_legacyWindowController, and is kept in sync with the
+/// window controller in use. Can be removed after 2-3 major releases.
+//==================================================================================================
+class RimMdiWindowController_OBSOLETE : public RimDockWindowController
+{
+    CAF_PDM_HEADER_INIT;
+};

--- a/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp
@@ -26,6 +26,7 @@
 #include "RicfCommandObject.h"
 
 #include "RimDockWindowController.h"
+#include "RimMdiWindowController.h"
 
 #include "RiuDockWidgetTools.h"
 
@@ -51,8 +52,12 @@ RimViewWindow::RimViewWindow()
 {
     CAF_PDM_InitScriptableObjectWithNameAndComment( "View window", "", "", "", "ViewWindow", "The Base Class for all Views and Plots in ResInsight" );
 
-    CAF_PDM_InitFieldNoDefault( &m_windowController, "WindowController", "" );
+    CAF_PDM_InitFieldNoDefault( &m_windowController, "DockWindow", "" );
     m_windowController.uiCapability()->setUiTreeChildrenHidden( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_legacyWindowController, "WindowController", "" );
+    m_legacyWindowController.uiCapability()->setUiTreeChildrenHidden( true );
+    m_legacyWindowController.uiCapability()->setUiHidden( true );
 
     CAF_PDM_InitField( &m_showWindow, "ShowWindow", true, "Show Window" );
     m_showWindow.uiCapability()->setUiHidden( true );
@@ -67,6 +72,7 @@ RimViewWindow::RimViewWindow()
 RimViewWindow::~RimViewWindow()
 {
     if ( m_windowController() ) delete m_windowController();
+    if ( m_legacyWindowController() ) delete m_legacyWindowController();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -391,6 +397,13 @@ void RimViewWindow::dockInWindow( int mainWindowID )
     }
     m_windowController->setViewToControl( this );
     m_windowController->setMainWindowId( mainWindowID );
+
+    // Keep the compatibility section in sync, see RimMdiWindowController_OBSOLETE
+    if ( m_legacyWindowController == nullptr )
+    {
+        m_legacyWindowController = new RimMdiWindowController_OBSOLETE();
+    }
+    m_legacyWindowController->setMainWindowId( mainWindowID );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimViewWindow.h
+++ b/ApplicationLibCode/ProjectDataModel/RimViewWindow.h
@@ -114,6 +114,10 @@ private:
 protected:
     caf::PdmChildField<RimDockWindowController*> m_windowController;
 
+    // Compatibility section making the project file readable by ResInsight 2026.06 and older, holds a
+    // RimMdiWindowController_OBSOLETE
+    caf::PdmChildField<RimDockWindowController*> m_legacyWindowController;
+
     caf::PdmField<bool>    m_showWindow;
     ads::CDockWidget*      m_dockWidget;
     caf::PdmField<QString> m_dockWindowId;


### PR DESCRIPTION
Alternative to #14601. Only one of the two should be merged.

Fixes #14600

#14601 solves the problem by making `MdiWindowController` the keyword written to file again, and keeping `DockWindowController` as a read alias. This PR keeps `DockWindowController` as the keyword of the window controller in use, and writes the main window id a second time using the old keyword, so the previous release reads `MdiWindowController` and the dev branch reads `DockWindowController`.

Both sections cannot live inside the same field. `PdmFieldXmlCap<PdmChildField>::readFieldData` reads a single start element and then does one `readNext()` expecting the end element of the field, so a second sibling element desynchronizes the stream. `RimViewWindow` therefore has two child fields:

```xml
<WindowController>                      <!-- read by 2026.06 and older -->
  <MdiWindowController>
    <MainWindowID>1</MainWindowID>
  </MdiWindowController>
</WindowController>
<DockWindow>                            <!-- read by the dev branch, unknown field to older versions -->
  <DockWindowController>
    <MainWindowID>1</MainWindowID>
    <ViewToControl>...</ViewToControl>
  </DockWindowController>
</DockWindow>
```

Unknown fields are skipped by `PdmXmlObjectHandle::readFields`, so the previous release ignores `DockWindow` without complaining.

The compatibility section cannot be empty. The old controller resolves its main window using `mainWindowByID( m_mainWindowID )`, and the default value -1 returns a null main window, so `updateViewerWidget()` returns early and the plot is still invisible. The main window id has to be written. The geometry fields can be left out, `RimMdiWindowGeometry::isValid()` returns false and the previous version falls back to a default subwindow size, the same path the 3D views already take.

Removing the compatibility section after 2-3 major releases is deleting one field and one class.
