### PR TITLE
#14558 3D filters: Reconnect filter signals after project load

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimFilterInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimFilterInViewCollection.cpp
@@ -145,6 +145,14 @@ QString RimFilterInViewCollection::activeFiltersDisplayText() const
 }
 
 //--------------------------------------------------------------------------------------------------
+//
+//--------------------------------------------------------------------------------------------------
+void RimFilterInViewCollection::initAfterRead()
+{
+    connectSourceSignals();
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 void RimFilterInViewCollection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString /*uiConfigName*/ )

--- a/ApplicationLibCode/ProjectDataModel/CellFilters/RimFilterInViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/CellFilters/RimFilterInViewCollection.h
@@ -57,6 +57,7 @@ public:
     QString activeFiltersDisplayText() const;
 
 protected:
+    void initAfterRead() override;
     void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -87,6 +87,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimWellPathGeometryDef-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimWellRftPlot-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDataFilterCollection-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimFilterInViewCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseMainCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryTimeAxisProperties-Test.cpp

--- a/ApplicationLibCode/UnitTests/RimFilterInViewCollection-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimFilterInViewCollection-Test.cpp
@@ -1,0 +1,96 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026 Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RimCellFilterCollection.h"
+#include "RimDataFilterInViewCollection.h"
+#include "RimEclipsePropertyFilterCollection.h"
+#include "RimEclipseView.h"
+#include "RimFilterInViewCollection.h"
+
+#include "cafPdmDefaultObjectFactory.h"
+#include "cafPdmXmlObjectHandle.h"
+#include "cafSignal.h"
+
+#include <memory>
+
+namespace
+{
+bool observesSignal( const caf::SignalObserver* observer, const caf::AbstractSignal* signal )
+{
+    for ( const auto* observed : observer->observedSignals() )
+    {
+        if ( observed == signal ) return true;
+    }
+    return false;
+}
+
+RimFilterInViewCollection* filterFacade( RimEclipseView* view )
+{
+    auto facades = view->descendantsIncludingThisOfType<RimFilterInViewCollection>();
+    return facades.empty() ? nullptr : facades.front();
+}
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimFilterInViewCollection, facadeObservesCellFiltersInNewView )
+{
+    auto view = std::make_unique<RimEclipseView>();
+
+    auto* facade = filterFacade( view.get() );
+    ASSERT_TRUE( facade != nullptr );
+
+    EXPECT_EQ( view->cellFilterCollection(), facade->cellFilters() );
+    EXPECT_TRUE( observesSignal( facade, &facade->cellFilters()->filtersChanged ) );
+    EXPECT_TRUE( observesSignal( facade, &facade->propertyFilters()->filtersChanged ) );
+    EXPECT_TRUE( observesSignal( facade, &facade->dataFiltersInView()->wrappersChanged ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RimFilterInViewCollection, facadeObservesCellFiltersAfterProjectRead )
+{
+    auto    sourceView = std::make_unique<RimEclipseView>();
+    QString xml        = sourceView->xmlCapability()->writeObjectToXmlString();
+
+    auto readView = std::make_unique<RimEclipseView>();
+
+    const auto* facadeBeforeRead     = filterFacade( readView.get() );
+    const auto* collectionBeforeRead = readView->cellFilterCollection();
+
+    readView->xmlCapability()->readObjectFromXmlString( xml, caf::PdmDefaultObjectFactory::instance() );
+    readView->xmlCapability()->resolveReferencesRecursively();
+    readView->xmlCapability()->initAfterReadRecursively();
+
+    auto* facade = filterFacade( readView.get() );
+    ASSERT_TRUE( facade != nullptr );
+
+    EXPECT_EQ( facadeBeforeRead, facade );
+    EXPECT_EQ( collectionBeforeRead, readView->cellFilterCollection() );
+    EXPECT_EQ( readView->cellFilterCollection(), facade->cellFilters() );
+
+    // Reading the ptr fields disconnects the signals set up by the view constructor. Without a
+    // reconnect, the tree node is not refreshed when a filter is added to a loaded project.
+    EXPECT_TRUE( observesSignal( facade, &facade->cellFilters()->filtersChanged ) );
+    EXPECT_TRUE( observesSignal( facade, &facade->propertyFilters()->filtersChanged ) );
+    EXPECT_TRUE( observesSignal( facade, &facade->dataFiltersInView()->wrappersChanged ) );
+}


### PR DESCRIPTION
Fixes #14558

## Problem

After saving a project, closing it and loading it again, creating a cell filter (e.g. an I slice filter) does not update the project tree. The Filters node stays empty until the filter collection is toggled on/off, after which the new filter shows up.

## Root cause

`RimFilterInViewCollection` holds the three filter collections in `caf::PdmPtrField`s and refreshes its tree node when they emit `filtersChanged` / `wrappersChanged`. The connections are established once, from `RimEclipseView`'s constructor, via `setSourceCollections()`.

## Fix

Reconnect the source signals in `RimFilterInViewCollection::initAfterRead()`, which runs after `resolveReferencesRecursively()` during project load. This is the same pattern already used by `RimDataFilterInViewCollection::initAfterRead()`. Cell filters, Eclipse property filters and per-view data filter wrappers are all covered.

## Tests

Added `RimFilterInViewCollection-Test.cpp`, verifying that the facade observes all three source collections both in a new view and after an XML write/read/resolve round trip. The round trip test fails without the fix.
