### PR TITLE
#14614 Orion Events: Add menu item for importing events from file

### DIFF
--- a/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
+++ b/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
@@ -33,6 +33,7 @@ const std::vector<RiaExperimentalFeatures::Feature>& RiaExperimentalFeatures::av
         { "osdu-well-logs", "OSDU Well Logs", "Enable import of well logs from OSDU." },
         { "undo-redo-view", "Undo/Redo View", "Show the command undo/redo history view." },
         { "oil-volume-result", "Oil Volume Result", "Compute the derived oil volume cell result." },
+        { "orion-events-import", "Orion Events Import", "Enable import of Orion well events from file." },
         { "remember-dialog-size",
           "Remember Dialog Size",
           "Remember the size of property and preferences dialogs between sessions and restore it the next time they "

--- a/ApplicationLibCode/Commands/WellPathCommands/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/WellPathCommands/CMakeLists_files.cmake
@@ -17,6 +17,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicNewPolylineTargetFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicDeletePolylineTargetFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicImportWellMeasurementsFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicImportOrionEventsFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicNewWellPathLateralAtDepthFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicNewWellPathLateralFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicPasteModeledWellPathFeature.cpp

--- a/ApplicationLibCode/Commands/WellPathCommands/RicImportOrionEventsFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicImportOrionEventsFeature.cpp
@@ -1,0 +1,92 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicImportOrionEventsFeature.h"
+
+#include "RiaApplication.h"
+#include "RiaGuiApplication.h"
+#include "RiaLogging.h"
+
+#include "Riu3DMainWindowTools.h"
+#include "RiuFileDialogTools.h"
+#include "RiuMainWindow.h"
+
+#include <QAction>
+#include <QFileInfo>
+#include <QMessageBox>
+
+CAF_CMD_SOURCE_INIT( RicImportOrionEventsFeature, "RicImportOrionEventsFeature" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportOrionEventsFeature::onActionTriggered( bool isChecked )
+{
+    // The import runs as a Python child process which applies the events to this instance through
+    // gRPC, so both the script server and a Python interpreter must be available.
+    RiaApplication* app = RiaApplication::instance();
+    if ( !app->activeGrpcPortNumber() )
+    {
+        QMessageBox::warning( Riu3DMainWindowTools::mainWindowWidget(),
+                              "Import Orion Events",
+                              "The Python script server is not running. Enable it in Preferences -> Scripting and restart ResInsight." );
+        return;
+    }
+
+    if ( app->pythonPath().isEmpty() )
+    {
+        QMessageBox::warning( Riu3DMainWindowTools::mainWindowWidget(),
+                              "Import Orion Events",
+                              "No Python executable is configured in Preferences -> Scripting." );
+        return;
+    }
+
+    QString defaultDir = app->lastUsedDialogDirectory( "ORION_EVENTS_DIR" );
+    QString fileName   = RiuFileDialogTools::getOpenFileName( Riu3DMainWindowTools::mainWindowWidget(),
+                                                            "Import Orion Events",
+                                                            defaultDir,
+                                                            "Orion Events Files (*.orion);;All Files (*.*)" );
+    if ( fileName.isEmpty() ) return;
+
+    app->setLastUsedDialogDirectory( "ORION_EVENTS_DIR", QFileInfo( fileName ).absolutePath() );
+
+    // Show the process monitor so the report and any errors from the child process are visible.
+    RiuMainWindow* mainWindow = RiuMainWindow::instance();
+    if ( !mainWindow )
+    {
+        mainWindow = RiaGuiApplication::instance()->getOrCreateAndShowMainWindow();
+    }
+    mainWindow->showProcessMonitorDockPanel();
+
+    // Unbuffered output ("-u") so the report streams into the process monitor promptly. The child
+    // process finds this instance through the RESINSIGHT_GRPC_PORT environment variable.
+    QStringList arguments = { "-u", "-m", "rips.orion_events", "--apply", fileName };
+    if ( !app->launchProcess( app->pythonPath(), arguments, app->pythonProcessEnvironment() ) )
+    {
+        RiaLogging::error( "Failed to launch the Python interpreter. Another script may already be running." );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportOrionEventsFeature::setupActionLook( QAction* actionToSetup )
+{
+    actionToSetup->setText( "Import Orion Events" );
+    actionToSetup->setIcon( QIcon( ":/Well.svg" ) );
+}

--- a/ApplicationLibCode/Commands/WellPathCommands/RicImportOrionEventsFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicImportOrionEventsFeature.h
@@ -1,0 +1,33 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cafCmdFeature.h"
+
+//==================================================================================================
+///
+//==================================================================================================
+class RicImportOrionEventsFeature : public caf::CmdFeature
+{
+    CAF_CMD_HEADER_INIT;
+
+protected:
+    void onActionTriggered( bool isChecked ) override;
+    void setupActionLook( QAction* actionToSetup ) override;
+};

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -354,7 +354,10 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
             menuBuilder.addSeparator();
             menuBuilder << "RicWellPathImportPerforationIntervalsFeature";
             menuBuilder << "RicImportWellMeasurementsFeature";
-            menuBuilder << "RicImportOrionEventsFeature";
+            if ( RiaPreferencesSystem::current()->isFeatureEnabled( "orion-events-import" ) )
+            {
+                menuBuilder << "RicImportOrionEventsFeature";
+            }
             menuBuilder.subMenuEnd();
             menuBuilder.addSeparator();
             menuBuilder.subMenuStart( "Export Well Paths", QIcon( ":/Save.svg" ) );

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -354,6 +354,7 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
             menuBuilder.addSeparator();
             menuBuilder << "RicWellPathImportPerforationIntervalsFeature";
             menuBuilder << "RicImportWellMeasurementsFeature";
+            menuBuilder << "RicImportOrionEventsFeature";
             menuBuilder.subMenuEnd();
             menuBuilder.addSeparator();
             menuBuilder.subMenuStart( "Export Well Paths", QIcon( ":/Save.svg" ) );

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -138,6 +138,7 @@ void RiuMenuBarBuildTools::addImportMenuForMainWindow( QObject* parent, QMenu* m
     importWellMenu->addAction( cmdFeatureMgr->action( "RicWellLogsImportFileFeature" ) );
     importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathFormationsImportFileFeature" ) );
     importWellMenu->addAction( cmdFeatureMgr->action( "RicImportWellMeasurementsFeature" ) );
+    importWellMenu->addAction( cmdFeatureMgr->action( "RicImportOrionEventsFeature" ) );
 
     importMenu->addSeparator();
     importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -18,6 +18,8 @@
 
 #include "RiuMenuBarBuildTools.h"
 
+#include "RiaPreferencesSystem.h"
+
 #include "RimEclipseCaseCollection.h"
 
 #include "RiuToolTipMenu.h"
@@ -138,7 +140,10 @@ void RiuMenuBarBuildTools::addImportMenuForMainWindow( QObject* parent, QMenu* m
     importWellMenu->addAction( cmdFeatureMgr->action( "RicWellLogsImportFileFeature" ) );
     importWellMenu->addAction( cmdFeatureMgr->action( "RicWellPathFormationsImportFileFeature" ) );
     importWellMenu->addAction( cmdFeatureMgr->action( "RicImportWellMeasurementsFeature" ) );
-    importWellMenu->addAction( cmdFeatureMgr->action( "RicImportOrionEventsFeature" ) );
+    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "orion-events-import" ) )
+    {
+        importWellMenu->addAction( cmdFeatureMgr->action( "RicImportOrionEventsFeature" ) );
+    }
 
     importMenu->addSeparator();
     importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );

--- a/GrpcInterface/Python/rips/orion_events.py
+++ b/GrpcInterface/Python/rips/orion_events.py
@@ -2252,14 +2252,63 @@ _COMPLETION_EVENT_TYPES = (
 # ---------------------------------------------------------------------------
 
 
+def _apply_to_running_instance(document: OrionDocument) -> int:
+    """Apply a parsed document to the well event timeline of a running
+    ResInsight instance found through the RESINSIGHT_GRPC_PORT environment
+    variable. Returns a process exit code."""
+
+    import rips
+
+    resinsight = rips.Instance.find()
+    if resinsight is None:
+        print("Error: no running ResInsight instance found")
+        return 1
+
+    project = resinsight.project
+    well_path_collections = project.descendants(rips.WellPathCollection)
+    if not well_path_collections:
+        print("Error: the project has no well path collection")
+        return 1
+    timeline = well_path_collections[0].event_timeline()
+
+    # A case is only needed to materialize FILTER declarations; default to the
+    # first case when one is loaded.
+    cases = project.cases()
+    case = cases[0] if cases else None
+
+    try:
+        report = apply_orion_document(
+            document, timeline, project, case=case, on_unknown_well="warn"
+        )
+    except RipsError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"  Events applied: {report.events_applied}")
+    print(f"  Events skipped: {report.events_skipped}")
+    if report.report_dates:
+        print(f"  Report dates:   {', '.join(report.report_dates)}")
+    for warning in report.warnings:
+        print(f"  Warning: {warning}")
+    for error in report.errors:
+        print(f"  Error: {error}")
+    return 1 if report.errors else 0
+
+
 def _cli(argv: Optional[List[str]] = None) -> int:
     import argparse
 
     arg_parser = argparse.ArgumentParser(
         prog="python3 -m rips.orion_events",
-        description="Validate an ORIONEVENTS file (parse only; no ResInsight needed).",
+        description="Validate an ORIONEVENTS file (parse only; no ResInsight "
+        "needed), and optionally apply it to a running ResInsight instance.",
     )
     arg_parser.add_argument("file", help="path to the ORIONEVENTS file")
+    arg_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="apply the events to a running ResInsight instance after validating",
+    )
     args = arg_parser.parse_args(argv)
 
     try:
@@ -2292,6 +2341,9 @@ def _cli(argv: Optional[List[str]] = None) -> int:
     normalized = coalesce_orion_document(document)
     for warning in normalized.warnings:
         print(f"  Warning line {warning.loc.line}: {warning.message}")
+
+    if args.apply:
+        return _apply_to_running_instance(document)
     return 0
 
 

--- a/GrpcInterface/Python/rips/tests/test_orion_events.py
+++ b/GrpcInterface/Python/rips/tests/test_orion_events.py
@@ -1001,6 +1001,85 @@ class TestValidatorCli:
         assert "Error" in capsys.readouterr().out
 
 
+class FakeWellPathCollection:
+    def __init__(self, timeline):
+        self._timeline = timeline
+
+    def event_timeline(self):
+        return self._timeline
+
+
+class FakeCliProject(FakeProject):
+    """A project whose well path collections are discoverable via descendants."""
+
+    def __init__(self, names, cases=(), collections=()):
+        super().__init__(names, cases)
+        self._collections = list(collections)
+
+    def descendants(self, cls):
+        return self._collections
+
+
+class FakeInstance:
+    def __init__(self, project):
+        self.project = project
+
+
+class TestApplyCli:
+    def _write(self, tmp_path, text):
+        path = tmp_path / "events.orion"
+        path.write_text(text)
+        return str(path)
+
+    def test_apply_exits_zero_and_reports_applied_events(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        timeline = FakeTimeline()
+        project = FakeCliProject(
+            ("55_33-A-1", "55_33-A-2"),
+            collections=[FakeWellPathCollection(timeline)],
+        )
+        monkeypatch.setattr(
+            rips.Instance, "find", staticmethod(lambda: FakeInstance(project))
+        )
+        path = self._write(tmp_path, SAMPLE)
+        assert _cli([path, "--apply"]) == 0
+        out = capsys.readouterr().out
+        assert "Events applied: 4" in out
+        assert len(timeline.perf_calls) == 2
+        assert len(timeline.keyword_calls) == 2
+
+    def test_apply_without_running_instance_exits_nonzero(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        monkeypatch.setattr(rips.Instance, "find", staticmethod(lambda: None))
+        path = self._write(tmp_path, SAMPLE)
+        assert _cli([path, "--apply"]) == 1
+        assert "no running ResInsight instance" in capsys.readouterr().out
+
+    def test_apply_without_well_path_collection_exits_nonzero(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        project = FakeCliProject(("55_33-A-1",), collections=[])
+        monkeypatch.setattr(
+            rips.Instance, "find", staticmethod(lambda: FakeInstance(project))
+        )
+        path = self._write(tmp_path, SAMPLE)
+        assert _cli([path, "--apply"]) == 1
+        assert "no well path collection" in capsys.readouterr().out
+
+    def test_validate_only_does_not_contact_instance(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        def fail():
+            raise AssertionError("Instance.find must not be called")
+
+        monkeypatch.setattr(rips.Instance, "find", staticmethod(fail))
+        path = self._write(tmp_path, SAMPLE)
+        assert _cli([path]) == 0
+        assert "OK" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # Layer B: applying
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add RicImportOrionEventsFeature to File -> Import -> Well Data and the well path collection context menu. The feature opens a file dialog and launches the Python interpreter asynchronously with the new --apply mode of the rips.orion_events CLI, which connects back to the running instance through RESINSIGHT_GRPC_PORT and applies the events to the well event timeline. Output is shown in the Process Monitor panel.

Fixes #14614.