### PR TITLE
#14627 Grid statistics: Fix NaN deviation for near-constant results

### DIFF
--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
@@ -82,8 +82,7 @@ void RigStatisticsMath::calculateBasicStatistics( const std::vector<double>& val
     double m_mean( HUGE_VAL );
     double m_dev( HUGE_VAL );
 
-    double m_sum      = 0.0;
-    double sumSquared = 0.0;
+    double m_sum = 0.0;
 
     size_t validValueCount = 0;
 
@@ -98,21 +97,34 @@ void RigStatisticsMath::calculateBasicStatistics( const std::vector<double>& val
         if ( val > m_max ) m_max = val;
 
         m_sum += val;
-        sumSquared += ( val * val );
     }
 
     if ( validValueCount > 0 )
     {
         m_mean = m_sum / validValueCount;
 
-        // http://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
-        // Running standard deviation
+        // Two-pass computation of the deviation. The single-pass sum-of-squares formula
+        // n*sum(x*x) - sum(x)*sum(x) subtracts two large and nearly equal numbers, and for values with a
+        // spread below the rounding noise floor the result can become negative, making sqrt() return NaN.
+        //
+        // Welford's online algorithm avoids the same cancellation in a single pass, but is only required when the
+        // values cannot be revisited. All values are available here, and centering on the exact mean is more
+        // accurate than Welford's running estimate.
+        //
+        // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
 
-        double s0 = static_cast<double>( validValueCount );
-        double s1 = m_sum;
-        double s2 = sumSquared;
+        double sumSquaredDeviations = 0.0;
 
-        m_dev = sqrt( ( s0 * s2 ) - ( s1 * s1 ) ) / s0;
+        for ( size_t i = 0; i < values.size(); i++ )
+        {
+            double val = values[i];
+            if ( RigStatisticsTools::isInvalidNumber<double>( val ) ) continue;
+
+            double deviation = val - m_mean;
+            sumSquaredDeviations += deviation * deviation;
+        }
+
+        m_dev = sqrt( sumSquaredDeviations / validValueCount );
     }
 
     if ( min ) *min = m_min;

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
@@ -26,7 +26,6 @@
 #include <cassert>
 #include <cmath>
 #include <expected>
-#include <numeric>
 
 namespace
 {
@@ -443,19 +442,21 @@ std::expected<std::vector<double>, std::string>
 //--------------------------------------------------------------------------------------------------
 double RigStatisticsMath::calculateMean( const std::vector<double>& values )
 {
-    std::vector<double> validValues = values;
-    validValues.erase( std::remove_if( validValues.begin(),
-                                       validValues.end(),
-                                       []( double x ) { return !RigStatisticsTools::isValidNumber( x ); } ),
-                       validValues.end() );
+    double valueSum        = 0.0;
+    size_t validValueCount = 0;
 
-    if ( !validValues.empty() )
+    for ( size_t i = 0; i < values.size(); i++ )
     {
-        double valueSum = std::accumulate( validValues.begin(), validValues.end(), 0.0 );
-        return valueSum / validValues.size();
+        double val = values[i];
+        if ( RigStatisticsTools::isInvalidNumber<double>( val ) ) continue;
+
+        valueSum += val;
+        validValueCount++;
     }
 
-    return HUGE_VAL;
+    if ( validValueCount == 0 ) return HUGE_VAL;
+
+    return valueSum / validValueCount;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
@@ -126,7 +126,8 @@ void RigStatisticsMath::calculateBasicStatistics( const std::vector<double>& val
 
     if ( min ) *min = m_min;
     if ( max ) *max = m_max;
-    if ( sum ) *sum = m_sum;
+    // Report the sum as undefined when there is nothing to sum, so it is not mistaken for a computed zero
+    if ( sum ) *sum = ( validValueCount > 0 ) ? m_sum : HUGE_VAL;
     if ( range ) *range = m_max - m_min;
 
     if ( mean ) *mean = m_mean;

--- a/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
+++ b/ApplicationLibCode/ResultStatisticsCache/RigStatisticsMath.cpp
@@ -58,15 +58,12 @@ bool areValidPercentiles( const std::vector<double>& percentiles )
 ///   mean = sum(x) / n
 ///
 ///   Standard deviation (population):
-///   stdev = sqrt((n * sum(x^2) - (sum(x))^2)) / n
-///
-///   Which is equivalent to: sqrt(sum((x - mean)^2) / n)
+///   stdev = sqrt(sum((x - mean)^2) / n)
 ///
 ///   range = max - min
 ///
 /// References:
 ///   Standard deviation: https://en.wikipedia.org/wiki/Standard_deviation
-///   Rapid calculation method: https://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
 //--------------------------------------------------------------------------------------------------
 
 void RigStatisticsMath::calculateBasicStatistics( const std::vector<double>& values,

--- a/ApplicationLibCode/UnitTests/RigStatisticsMath-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigStatisticsMath-Test.cpp
@@ -26,6 +26,7 @@
 #include "QElapsedTimer"
 
 #include <cmath>
+#include <limits>
 #include <numeric>
 
 //--------------------------------------------------------------------------------------------------
@@ -61,6 +62,25 @@ TEST( RigStatisticsMath, BasicTest )
     EXPECT_DOUBLE_EQ( 198022.7472017490000, range );
     EXPECT_DOUBLE_EQ( 16313.8051759152000, mean );
     EXPECT_DOUBLE_EQ( 66104.391542887200, stdev );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// All outputs must report as undefined when the input holds no valid values. The sum in particular
+/// must not report the zero it was accumulated from, as that reads as a computed value.
+//--------------------------------------------------------------------------------------------------
+TEST( RigStatisticsMath, NoValidValues )
+{
+    std::vector<double> values = { HUGE_VAL, -HUGE_VAL, std::numeric_limits<double>::quiet_NaN() };
+
+    double min, max, sum, range, mean, stdev;
+    RigStatisticsMath::calculateBasicStatistics( values, &min, &max, &sum, &range, &mean, &stdev );
+
+    EXPECT_FALSE( RigStatisticsTools::isValidNumber( min ) );
+    EXPECT_FALSE( RigStatisticsTools::isValidNumber( max ) );
+    EXPECT_FALSE( RigStatisticsTools::isValidNumber( sum ) );
+    EXPECT_FALSE( RigStatisticsTools::isValidNumber( range ) );
+    EXPECT_FALSE( RigStatisticsTools::isValidNumber( mean ) );
+    EXPECT_FALSE( RigStatisticsTools::isValidNumber( stdev ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UnitTests/RigStatisticsMath-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigStatisticsMath-Test.cpp
@@ -64,6 +64,56 @@ TEST( RigStatisticsMath, BasicTest )
 }
 
 //--------------------------------------------------------------------------------------------------
+/// A porosity value that is identical in all realizations has zero deviation. The sum-of-squares
+/// formula computes n*sum(x*x) - sum(x)*sum(x), a difference of two large and nearly equal numbers,
+/// so rounding can make the radicand negative and sqrt() return NaN.
+//--------------------------------------------------------------------------------------------------
+TEST( RigStatisticsMath, DeviationOfIdenticalValues )
+{
+    const std::vector<double> porosities   = { 0.2345, 0.1, 0.31415926, 0.27, 0.185, 0.3, 0.15 };
+    const std::vector<size_t> sourceCounts = { 3, 5, 10, 25, 50, 100 };
+
+    for ( double porosity : porosities )
+    {
+        for ( size_t sourceCount : sourceCounts )
+        {
+            SCOPED_TRACE( "porosity " + std::to_string( porosity ) + " in " + std::to_string( sourceCount ) + " cases" );
+
+            std::vector<double> values( sourceCount, porosity );
+
+            double min, max, sum, range, mean, stdev;
+            RigStatisticsMath::calculateBasicStatistics( values, &min, &max, &sum, &range, &mean, &stdev );
+
+            EXPECT_FALSE( std::isnan( stdev ) );
+            EXPECT_NEAR( 0.0, stdev, 1e-12 );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Same cancellation, but for values that differ far below the rounding noise floor.
+//--------------------------------------------------------------------------------------------------
+TEST( RigStatisticsMath, DeviationOfNearlyIdenticalValues )
+{
+    const double porosity      = 0.2345;
+    const double relativeNoise = 1e-9;
+
+    std::vector<double> values;
+    for ( size_t i = 0; i < 100; i++ )
+    {
+        // Alternating tiny perturbation around the base value
+        double sign = ( i % 2 == 0 ) ? 1.0 : -1.0;
+        values.push_back( porosity + sign * porosity * relativeNoise );
+    }
+
+    double min, max, sum, range, mean, stdev;
+    RigStatisticsMath::calculateBasicStatistics( values, &min, &max, &sum, &range, &mean, &stdev );
+
+    EXPECT_FALSE( std::isnan( stdev ) );
+    EXPECT_NEAR( porosity * relativeNoise, stdev, 1e-12 );
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 TEST( RigStatisticsMath, RankPercentiles )


### PR DESCRIPTION
Fixes #14627

### NaN deviation

`RigStatisticsMath::calculateBasicStatistics` computed the deviation with the single-pass sum-of-squares formula `sqrt(n*sum(x*x) - sum(x)*sum(x)) / n`. The radicand is mathematically non-negative, but it is the difference of two large and nearly equal numbers. Where a result is identical or near-identical across the realizations, the true variance falls below the rounding noise floor, the radicand turns negative and `sqrt()` returns NaN. This is what users see as NaN in PORO_DEV for scattered cells, while MIN, MAX, SUM, MEAN, RANGE and the percentiles stay valid.

The deviation is now computed in two passes, centering on the exact mean. This also removes the loss of significance the old formula had for values with a large common offset, where `1e12 +/- 1` returned 29658 instead of 1.

Welford's online algorithm avoids the same cancellation in a single pass, but is only needed when the values cannot be revisited. All values are in memory here, and centering on the exact mean is more accurate than Welford's running estimate.

New tests `DeviationOfIdenticalValues` and `DeviationOfNearlyIdenticalValues` in `RigStatisticsMath-Test.cpp` reproduce the NaN before the fix.

### Undefined sum

Min, max, range, mean and deviation all report `HUGE_VAL` when the input holds no valid values, but the sum reported the zero it was accumulated from, which a caller testing with `isValidNumber` would accept as real data. No current caller consumes the sum, so this is a latent inconsistency rather than an observed bug. Covered by the new `NoValidValues` test.

### Cleanup

`calculateMean` copied and compacted the whole input vector only to skip the invalid values, allocating on every call. It now accumulates in a single pass, with the same summation order and bit-identical results.

The header of `calculateBasicStatistics` still documented the formula that was replaced, and referenced the rapid calculation method it deliberately no longer uses.
