### PR TITLE
#14626 Add Import Summary Case to the File menu in the main window

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -118,6 +118,7 @@ void RiuMenuBarBuildTools::addImportMenuForMainWindow( QObject* parent, QMenu* m
     QMenu* importMenu = menu->addMenu( QIcon( ":/import.svg" ), "&Import" );
 
     importMenu->addAction( cmdFeatureMgr->action( "RicImportGridModelFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
 
     importMenu->addSeparator();


### PR DESCRIPTION
Importing a summary case required switching to the Summary Plot window first, while grid models are reachable from File -> Import in the main window. Add the existing `RicImportSummaryCaseFeature` action directly below "Import Grid Models".

The feature already opens the standard summary import dialog and is used from the main window Import toolbar, so no other wiring is needed.

Fixes #14626