### PR TITLE
#14632 Guard against out-of-range time step index when loading results

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigSoilResultCalculator.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ResultCalculators/RigSoilResultCalculator.cpp
@@ -94,10 +94,7 @@ void RigSoilResultCalculator::calculate( const RigEclipseResultAddress& resVarAd
                                                                timeStepIndex );
 
     // Early exit if none of SWAT or SGAS is present
-    if ( scalarIndexSWAT == cvf::UNDEFINED_SIZE_T && scalarIndexSGAS == cvf::UNDEFINED_SIZE_T )
-    {
-        return;
-    }
+    if ( scalarIndexSWAT == cvf::UNDEFINED_SIZE_T && scalarIndexSGAS == cvf::UNDEFINED_SIZE_T ) return;
 
     size_t soilResultValueCount = 0;
     size_t soilTimeStepCount    = 0;
@@ -124,8 +121,13 @@ void RigSoilResultCalculator::calculate( const RigEclipseResultAddress& resVarAd
         }
     }
 
+    // The result may be present in metadata but unavailable for this time step.
+    if ( soilResultValueCount == 0 ) return;
+
     // Make sure memory is allocated for the new SOIL results
     size_t soilResultScalarIndex = m_resultsData->findScalarResultIndexFromAddress( resVarAddr );
+    if ( soilResultScalarIndex == cvf::UNDEFINED_SIZE_T ) return;
+
     m_resultsData->m_cellScalarResults[soilResultScalarIndex].resize( soilTimeStepCount );
 
     if ( !m_resultsData->cellScalarResults( resVarAddr, timeStepIndex ).empty() )
@@ -143,28 +145,19 @@ void RigSoilResultCalculator::calculate( const RigEclipseResultAddress& resVarAd
     if ( scalarIndexSWAT != cvf::UNDEFINED_SIZE_T )
     {
         swatForTimeStep = &( m_resultsData->cellScalarResults( SWATAddr, timeStepIndex ) );
-        if ( swatForTimeStep->empty() )
-        {
-            swatForTimeStep = nullptr;
-        }
+        if ( swatForTimeStep->empty() ) swatForTimeStep = nullptr;
     }
 
     if ( scalarIndexSGAS != cvf::UNDEFINED_SIZE_T )
     {
         sgasForTimeStep = &( m_resultsData->cellScalarResults( SGASAddr, timeStepIndex ) );
-        if ( sgasForTimeStep->empty() )
-        {
-            sgasForTimeStep = nullptr;
-        }
+        if ( sgasForTimeStep->empty() ) sgasForTimeStep = nullptr;
     }
 
     if ( scalarIndexSSOL != cvf::UNDEFINED_SIZE_T )
     {
         ssolForTimeStep = &( m_resultsData->cellScalarResults( SSOLAddr, timeStepIndex ) );
-        if ( ssolForTimeStep->empty() )
-        {
-            ssolForTimeStep = nullptr;
-        }
+        if ( ssolForTimeStep->empty() ) ssolForTimeStep = nullptr;
     }
 
     std::vector<double>* soilForTimeStep = m_resultsData->modifiableCellScalarResult( resVarAddr, timeStepIndex );

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1765,7 +1765,11 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
 
         if ( mustBeCalculated( soilScalarResultIndex ) )
         {
-            m_cellScalarResults[soilScalarResultIndex].resize( maxTimeStepCount() );
+            // A case in an ensemble can have fewer time steps than the case defining the time step axis
+            const size_t timeStepCount = maxTimeStepCount();
+            if ( timeStepIndex >= timeStepCount ) return cvf::UNDEFINED_SIZE_T;
+
+            m_cellScalarResults[soilScalarResultIndex].resize( timeStepCount );
 
             std::vector<double>& values = m_cellScalarResults[soilScalarResultIndex][timeStepIndex];
             if ( values.empty() )
@@ -1782,7 +1786,11 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
 
         if ( mustBeCalculated( sgasScalarResultIndex ) )
         {
-            m_cellScalarResults[sgasScalarResultIndex].resize( maxTimeStepCount() );
+            // A case in an ensemble can have fewer time steps than the case defining the time step axis
+            const size_t timeStepCount = maxTimeStepCount();
+            if ( timeStepIndex >= timeStepCount ) return cvf::UNDEFINED_SIZE_T;
+
+            m_cellScalarResults[sgasScalarResultIndex].resize( timeStepCount );
 
             if ( m_cellScalarResults[sgasScalarResultIndex][timeStepIndex].empty() )
             {
@@ -1817,6 +1825,9 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
 
         if ( type == RiaDefines::ResultCatType::DYNAMIC_NATIVE && timeStepCount > 0 )
         {
+            // A case in an ensemble can have fewer time steps than the case defining the time step axis
+            if ( timeStepIndex >= timeStepCount ) return cvf::UNDEFINED_SIZE_T;
+
             m_cellScalarResults[scalarResultIndex].resize( timeStepCount );
 
             std::vector<double>& values = m_cellScalarResults[scalarResultIndex][timeStepIndex];


### PR DESCRIPTION
Fixes #14632

A case in an ensemble can have fewer time steps than the case defining the time step axis of a statistics case. `findOrLoadKnownScalarResultForTimeStep` used the requested time step index to index `m_cellScalarResults` directly, reading past the end of the vector in Release where `CAF_ASSERT` is a no-op. Return `cvf::UNDEFINED_SIZE_T` instead, the existing "result not available" return, so every caller is protected and not only the statistics evaluator.

Guards added to the SOIL and SGAS branches and to the generic dynamic native branch. `RigSoilResultCalculator` returns early when the source saturation is empty for the time step, avoiding a `resize( 0 )` that discarded SOIL already computed for other time steps, and checks the result index like `RigSgasResultCalculator` already does.
