### PR TITLE
#14542 Summary: Assign unique case ids when importing multiple cases

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -555,15 +555,23 @@ void RimProject::setProjectFileNameAndUpdateDependencies( const QString& project
 //--------------------------------------------------------------------------------------------------
 void RimProject::assignCaseIdToSummaryCase( RimSummaryCase* summaryCase )
 {
-    if ( summaryCase )
-    {
-        int nextValidId = 1;
-        for ( RimSummaryCase* s : allSummaryCases() )
-        {
-            nextValidId = std::max( nextValidId, s->caseId() + 1 );
-        }
+    assignCaseIdsToSummaryCases( { summaryCase } );
+}
 
-        summaryCase->setCaseId( nextValidId );
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimProject::assignCaseIdsToSummaryCases( const std::vector<RimSummaryCase*>& summaryCases )
+{
+    int nextValidId = 1;
+    for ( RimSummaryCase* s : allSummaryCases() )
+    {
+        nextValidId = std::max( nextValidId, s->caseId() + 1 );
+    }
+
+    for ( RimSummaryCase* summaryCase : summaryCases )
+    {
+        if ( summaryCase ) summaryCase->setCaseId( nextValidId++ );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimProject.h
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.h
@@ -132,6 +132,7 @@ public:
     void assignViewIdToView( Rim3dView* view );
     void assignPlotIdToPlotWindow( RimPlotWindow* plotWindow );
     void assignCaseIdToSummaryCase( RimSummaryCase* summaryCase );
+    void assignCaseIdsToSummaryCases( const std::vector<RimSummaryCase*>& summaryCases );
     void assignIdToEnsemble( RimSummaryEnsemble* summaryCaseCollection );
 
     [[nodiscard]] std::vector<RimCase*> allGridCases() const;

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -755,7 +755,6 @@ std::vector<RimSummaryCase*>
                     }
 
                     newSumCase->setSummaryHeaderFileName( smspecFileName );
-                    project->assignCaseIdToSummaryCase( newSumCase );
 
                     sumCases.push_back( newSumCase );
                 }
@@ -771,6 +770,10 @@ std::vector<RimSummaryCase*>
 
         QCoreApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
     }
+
+    // Assign case ids for the complete set of new cases. The cases are not yet part of the project, so the ids must be
+    // assigned in one operation to make sure they are unique. See https://github.com/OPM/ResInsight/issues/14542
+    project->assignCaseIdsToSummaryCases( sumCases );
 
     RimSummaryCaseMainCollection::loadSummaryCaseData( sumCases, readStateFromFirstFile );
 

--- a/ApplicationLibCode/UnitTests/RimSummaryCaseMainCollection-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimSummaryCaseMainCollection-Test.cpp
@@ -4,6 +4,7 @@
 
 #include "RimDeltaSummaryEnsemble.h"
 #include "RimMockSummaryCase.h"
+#include "RimProject.h"
 #include "RimSummaryCaseMainCollection.h"
 #include "RimSummaryCaseUpdateBatch.h"
 #include "RimSummaryEnsemble.h"
@@ -11,6 +12,7 @@
 #include "cafPdmPointer.h"
 
 #include <algorithm>
+#include <set>
 #include <vector>
 
 //--------------------------------------------------------------------------------------------------
@@ -70,4 +72,29 @@ TEST( RimSummaryCaseMainCollection, RemoveCases_NoDanglingInCallerVector )
     delete deltaEnsemble;
     delete ensemble1;
     delete ensemble2;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Summary cases are created before they are added to the project. Case ids must be assigned for the
+/// complete set of new cases, as cases not yet part of the project are invisible to the id search.
+/// https://github.com/OPM/ResInsight/issues/14542
+//--------------------------------------------------------------------------------------------------
+TEST( RimSummaryCaseMainCollection, AssignUniqueCaseIdsToCasesNotInProject )
+{
+    std::vector<RimSummaryCase*> newCases = { createMockCase( 0 ), createMockCase( 1 ), createMockCase( 2 ) };
+
+    RimProject::current()->assignCaseIdsToSummaryCases( newCases );
+
+    std::set<int> caseIds;
+    for ( auto* summaryCase : newCases )
+    {
+        caseIds.insert( summaryCase->caseId() );
+    }
+
+    EXPECT_EQ( newCases.size(), caseIds.size() );
+
+    for ( auto* summaryCase : newCases )
+    {
+        delete summaryCase;
+    }
 }


### PR DESCRIPTION
Fixes #14542

Summary cases are created and given a case id before they are added to the project. `RimProject::assignCaseIdToSummaryCase()` derives the next id from `allSummaryCases()`, which does not yet contain any of the cases being created, so every case in a batch import was given the same id.

The Data Sources tree stores the owning case id in each `RimSummaryAddress`, and all lookups go through `RiaSummaryTools::summaryCaseById()`, which returns the first match. With duplicate ids:

- selecting the same vector from three cases collapsed to a single case id, so `New Summary Plot` created one curve
- dropping a vector from one of the other cases resolved back to the first case, hit the duplicate-curve check and did nothing

The locale is unrelated. The trigger is importing more than one summary case in a single import operation; importing them one at a time gave unique ids and worked.

`RimProject::assignCaseIdsToSummaryCases()` resolves the next free id once and hands out consecutive ids for the whole set, and `RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos()` assigns after the creation loop. The single-case import paths (Reveal, StimPlan, derived, observed) add each case to the collection in the same loop iteration and are unchanged.
