### PR TITLE
Well path name fix, histogram zoom-all, and histogram tree selection visibility

### DIFF
--- a/ApplicationLibCode/Commands/RicCreateGridStatisticsPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCreateGridStatisticsPlotFeature.cpp
@@ -43,6 +43,10 @@ void RicCreateGridStatisticsPlotFeature::onActionTriggered( bool isChecked )
 
     RimEclipseView* activeView = dynamic_cast<RimEclipseView*>( RiaApplication::instance()->activeGridView() );
     if ( activeView ) dataSource->setPropertiesFromView( activeView );
+
+    histogramPlot->loadDataAndUpdate();
+    histogramPlot->zoomAll();
+
     RiaGuiApplication::instance()->getOrCreateAndShowMainPlotWindow();
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
@@ -138,8 +138,12 @@ bool RimFileWellPath::readWellPathFile( QString* errorMessage, RifWellPathImport
         RifWellPathImporter::WellMetaData wellMetaData = RifWellPathImporter::readWellMetaData( filePath(), m_wellPathIndexInFile() );
         // General well info
 
-        if ( initializeWellNamesFromFile )
+        if ( initializeWellNamesFromFile || name().isEmpty() )
         {
+            // Initialize the well path and export names from the source file during first import, or if no name
+            // has been assigned yet (e.g. projects saved before the well path name was persisted). Subsequent data
+            // reloads of a named well path preserve the name stored in the project while continuing to refresh
+            // geometry and metadata.
             setName( wellData.m_name );
         }
 

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -27,6 +27,8 @@
 #include "Summary/RiaSummaryPlotTools.h"
 #include "Summary/RiaSummaryTools.h"
 
+#include "Histogram/RimHistogramMultiPlot.h"
+#include "Histogram/RimHistogramPlot.h"
 #include "RimEnsembleCurveSetCollection.h"
 #include "RimMainPlotCollection.h"
 #include "RimMultiPlot.h"
@@ -930,6 +932,25 @@ void RiuPlotMainWindow::selectedObjectsChanged( caf::PdmUiTreeView* projectTree,
                 if ( summaryPlot )
                 {
                     multiSummaryPlot->makeSureIsVisible( summaryPlot );
+                }
+            }
+            else if ( auto multiHistogramPlot = firstSelectedObject->firstAncestorOrThisOfType<RimHistogramMultiPlot>() )
+            {
+                // The toolbar shows fields from the histogram multi plot. When a child object is selected, the first
+                // ancestor view window is the sub plot, not the multi plot. Use the multi plot as active plot view
+                // window to make sure the toolbar is available for any object in the multi plot.
+                m_activePlotViewWindow = multiHistogramPlot;
+
+                setBlockViewSelectionOnSubWindowActivated( true );
+                setActiveViewer( multiHistogramPlot->dockWindowName() );
+                setBlockViewSelectionOnSubWindowActivated( false );
+
+                updateMultiPlotToolBar();
+
+                auto histogramPlot = firstSelectedObject->firstAncestorOrThisOfType<RimHistogramPlot>();
+                if ( histogramPlot )
+                {
+                    multiHistogramPlot->makeSureIsVisible( histogramPlot );
                 }
             }
             else


### PR DESCRIPTION
## Summary

- **#14538 Well path: Preserve renamed file well name without breaking legacy projects**
  Reworks the previous fix for #14538 so that a renamed well path name is preserved across
  project reloads, while still initializing the name from the source file for legacy projects
  that never serialized a well path `Name` (e.g. `TestCase_RFT_PLT/RegressionTest.rsp`, which
  was broken by the original fix).
- **Grid statistics: Zoom all on histogram plot after creation**
  When creating a histogram from grid cell results (e.g. PERMX) via "Create Grid Statistics Plot",
  the plot is now zoomed to fit the data right after creation.
- **Histogram: Make selected sub-plot visible in histogram multi plot**
  Selecting a curve or a plot inside a `RimHistogramMultiPlot` in the project tree now scrolls
  the multi plot view to make the containing histogram plot visible, mirroring existing behavior
  for `RimSummaryMultiPlot`.

## Testing

- Built `ApplicationLibCode` and `ResInsight.exe` (Debug) successfully after each change.
- Restored/verified the `test_rmswell_renamed_name_persists` Python round-trip test.
