### PR TITLE
MSW export: Report a grid cell only once in COMPSEGS

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -758,6 +758,20 @@ std::vector<RigMswBranch> buildValveBranches( const RimWellPath*                
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Measured depth where the fracture segment starts. A fracture along the well path is centred on
+/// the fracture MD, and starts half a perforation length above it.
+//--------------------------------------------------------------------------------------------------
+double fractureStartMD( const RimWellPathFracture* fracture )
+{
+    double startMD = fracture->fractureMD();
+    if ( fracture->fractureTemplate()->orientationType() == RimFractureTemplate::ALONG_WELL_PATH )
+    {
+        startMD -= 0.5 * fracture->fractureTemplate()->perforationLength();
+    }
+    return startMD;
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 std::vector<RigMswBranch> buildFractureBranches( RimEclipseCase*                      eclipseCase,
@@ -772,18 +786,25 @@ std::vector<RigMswBranch> buildFractureBranches( RimEclipseCase*                
 
     const QString wellNameForExport = wellPath->completionSettings()->wellNameForExport();
 
-    for ( RimWellPathFracture* fracture : wellPath->fractureCollection()->activeFractures() )
+    // Number the fracture branches by position along the well path, so that the branch numbers follow
+    // the well no matter in what order the fractures were created. The order also decides which
+    // fracture connects a grid cell shared by two of them.
+    auto fractures = wellPath->fractureCollection()->activeFractures();
+    std::stable_sort( fractures.begin(),
+                      fractures.end(),
+                      []( const RimWellPathFracture* lhs, const RimWellPathFracture* rhs )
+                      { return fractureStartMD( lhs ) < fractureStartMD( rhs ); } );
+
+    for ( RimWellPathFracture* fracture : fractures )
     {
         fracture->ensureValidNonDarcyProperties();
 
-        double position = fracture->fractureMD();
-        double width    = fracture->fractureTemplate()->computeFractureWidth( fracture );
+        const double position = fractureStartMD( fracture );
 
+        double width = fracture->fractureTemplate()->computeFractureWidth( fracture );
         if ( fracture->fractureTemplate()->orientationType() == RimFractureTemplate::ALONG_WELL_PATH )
         {
-            double perforationLength = fracture->fractureTemplate()->perforationLength();
-            position -= 0.5 * perforationLength;
-            width = perforationLength;
+            width = fracture->fractureTemplate()->perforationLength();
         }
 
         const double endMD    = position + width;

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicMswBranchBuilder.cpp
@@ -848,7 +848,7 @@ std::vector<RigMswBranch> buildFractureBranches( RimEclipseCase*                
         seg.description         = fracture->name().toStdString();
         seg.intersections       = std::move( compsegs );
 
-        result.push_back( RigMswBranch{ fracBranch, std::nullopt, { std::move( seg ) } } );
+        result.push_back( RigMswBranch{ fracBranch, std::nullopt, { std::move( seg ) }, RigMswBranchSource::Fracture } );
     }
 
     return result;
@@ -993,7 +993,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
 
             fishbonesContext.icdSegments.push_back( { icdSegNum, std::move( icdGlobalCellIndices ) } );
 
-            result.push_back( RigMswBranch{ icdBranch, std::nullopt, { std::move( icdSeg ) } } );
+            result.push_back( RigMswBranch{ icdBranch, std::nullopt, { std::move( icdSeg ) }, RigMswBranchSource::Fishbones } );
 
             // Lateral sub-segments
             for ( size_t lateralIndex : lateralIndices )
@@ -1099,7 +1099,7 @@ std::vector<RigMswBranch> buildFishbonesBranches( const RimEclipseCase*         
 
                 fishbonesContext.laterals.push_back( std::move( lateralContext ) );
 
-                result.push_back( RigMswBranch{ latBranch, std::nullopt, std::move( latSegs ) } );
+                result.push_back( RigMswBranch{ latBranch, std::nullopt, std::move( latSegs ), RigMswBranchSource::Fishbones } );
             }
         }
     }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/MswExport/RicWellPathExportMswGeometryPath.cpp
@@ -41,6 +41,9 @@
 #include "cafAssert.h"
 
 #include <algorithm>
+#include <numeric>
+#include <set>
+#include <tuple>
 
 namespace RicWellPathExportMswGeometryPath
 {
@@ -504,7 +507,13 @@ RigMswTableData collectTableData( const RigMswWellExportData& exportData, RiaDef
     tableData.setWelsegsHeader( exportData.header );
 
     // Collected while the segments are visited, and added to the table data ordered by branch number.
-    std::vector<CompsegsRow> compsegsRows;
+    // The branch source is kept alongside the row to resolve cells claimed by several branches.
+    struct CollectedCompsegsRow
+    {
+        CompsegsRow        row;
+        RigMswBranchSource source;
+    };
+    std::vector<CollectedCompsegsRow> compsegsRows;
 
     auto emitSegment = [&]( const RigMswBranch& branch, const RigMswSegment& seg )
     {
@@ -533,7 +542,7 @@ RigMswTableData collectTableData( const RigMswWellExportData& exportData, RiaDef
             compRow.distanceStart = inter.distanceStart;
             compRow.distanceEnd   = inter.distanceEnd;
             compRow.gridName      = inter.gridName;
-            compsegsRows.push_back( compRow );
+            compsegsRows.push_back( { compRow, branch.source } );
         }
 
         // WSEGVALV row
@@ -554,14 +563,37 @@ RigMswTableData collectTableData( const RigMswWellExportData& exportData, RiaDef
         tableData.addMswBranch( branch );
     }
 
+    // A grid cell has a single COMPDAT connection and must be connected to exactly one segment. When
+    // several branches intersect the same cell, the branch carrying most flow claims it: perforations
+    // first, then fishbones, then fractures. Visit the rows in that order and drop the later claims.
+    std::vector<size_t> claimOrder( compsegsRows.size() );
+    std::iota( claimOrder.begin(), claimOrder.end(), size_t( 0 ) );
+    std::stable_sort( claimOrder.begin(),
+                      claimOrder.end(),
+                      [&]( size_t lhs, size_t rhs ) { return compsegsRows[lhs].source < compsegsRows[rhs].source; } );
+
+    std::set<std::tuple<std::string, size_t, size_t, size_t>> connectedCells;
+    std::vector<bool>                                         isCellOwner( compsegsRows.size(), false );
+    for ( size_t index : claimOrder )
+    {
+        const auto& row    = compsegsRows[index].row;
+        isCellOwner[index] = connectedCells.emplace( row.gridName, row.i, row.j, row.k ).second;
+    }
+
     // COMPSEGS is ordered by branch number. WELSEGS keeps the order the branches are listed in, where
     // the completion branches follow the lateral they are connected to and thus are not sorted by
     // branch number. The sort is stable, so the rows of a branch keep their order along the well path.
-    std::stable_sort( compsegsRows.begin(),
-                      compsegsRows.end(),
+    std::vector<CompsegsRow> ownedRows;
+    for ( size_t index = 0; index < compsegsRows.size(); ++index )
+    {
+        if ( isCellOwner[index] ) ownedRows.push_back( compsegsRows[index].row );
+    }
+
+    std::stable_sort( ownedRows.begin(),
+                      ownedRows.end(),
                       []( const CompsegsRow& lhs, const CompsegsRow& rhs ) { return lhs.branch < rhs.branch; } );
 
-    for ( const auto& compsegsRow : compsegsRows )
+    for ( const auto& compsegsRow : ownedRows )
     {
         tableData.addCompsegsRow( compsegsRow );
     }

--- a/ApplicationLibCode/Commands/RicCreateGridStatisticsPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCreateGridStatisticsPlotFeature.cpp
@@ -43,6 +43,10 @@ void RicCreateGridStatisticsPlotFeature::onActionTriggered( bool isChecked )
 
     RimEclipseView* activeView = dynamic_cast<RimEclipseView*>( RiaApplication::instance()->activeGridView() );
     if ( activeView ) dataSource->setPropertiesFromView( activeView );
+
+    histogramPlot->loadDataAndUpdate();
+    histogramPlot->zoomAll();
+
     RiaGuiApplication::instance()->getOrCreateAndShowMainPlotWindow();
 }
 

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimFileWellPath.cpp
@@ -138,8 +138,12 @@ bool RimFileWellPath::readWellPathFile( QString* errorMessage, RifWellPathImport
         RifWellPathImporter::WellMetaData wellMetaData = RifWellPathImporter::readWellMetaData( filePath(), m_wellPathIndexInFile() );
         // General well info
 
-        if ( initializeWellNamesFromFile )
+        if ( initializeWellNamesFromFile || name().isEmpty() )
         {
+            // Initialize the well path and export names from the source file during first import, or if no name
+            // has been assigned yet (e.g. projects saved before the well path name was persisted). Subsequent data
+            // reloads of a named well path preserve the name stored in the project while continuing to refresh
+            // geometry and metadata.
             setName( wellData.m_name );
         }
 

--- a/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswSegment.h
+++ b/ApplicationLibCode/ReservoirDataModel/CompletionsMsw/RigMswSegment.h
@@ -69,6 +69,19 @@ struct RigMswSegment
 
 
 //==================================================================================================
+/// Origin of a branch, used to decide which branch connects a grid cell when several branches
+/// intersect the same cell. The enum is ordered by priority, so the branch carrying most flow
+/// claims the cell first.
+//==================================================================================================
+enum class RigMswBranchSource
+{
+    Perforation, // Main bore and perforation valve branches
+    Fishbones,
+    Fracture
+};
+
+
+//==================================================================================================
 /// One branch in the MSW export.
 /// All segments share the same IBRANCH number, which is stored here rather than per-segment.
 /// An optional tie-in valve segment (ICV) may appear at the start of lateral branches.
@@ -78,6 +91,8 @@ struct RigMswBranch
     int                          branchNumber;  // IBRANCH for all segments in this branch
     std::optional<RigMswSegment> tieInValve;    // Optional ICV at the tie-in point (laterals only)
     std::vector<RigMswSegment>   segments;      // Segments of this branch
+
+    RigMswBranchSource source = RigMswBranchSource::Perforation;  // Decides COMPSEGS cell ownership
 };
 
 

--- a/ApplicationLibCode/UnitTests/RicWellPathExportMswGeometryPath-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RicWellPathExportMswGeometryPath-Test.cpp
@@ -62,9 +62,19 @@ RigMswSegment makeSegment( int segNum, int outletSegNum, double length = 10.0, d
 //--------------------------------------------------------------------------------------------------
 /// Build a minimal RigMswBranch with the given branch number and segments.
 //--------------------------------------------------------------------------------------------------
-RigMswBranch makeBranch( int branchNum, std::vector<RigMswSegment> segs )
+RigMswBranch makeBranch( int branchNum, std::vector<RigMswSegment> segs, RigMswBranchSource source = RigMswBranchSource::Perforation )
 {
-    return RigMswBranch{ branchNum, std::nullopt, std::move( segs ) };
+    return RigMswBranch{ branchNum, std::nullopt, std::move( segs ), source };
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Build a branch with a single segment intersecting the given main grid cell.
+//--------------------------------------------------------------------------------------------------
+RigMswBranch makeBranchIntersectingCell( int branchNum, int segNum, size_t i, size_t j, size_t k, RigMswBranchSource source )
+{
+    RigMswSegment seg = makeSegment( segNum, 1 );
+    seg.intersections = { RigMswCellIntersection{ i, j, k, 100.0, 110.0, "" } };
+    return makeBranch( branchNum, { seg }, source );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -429,6 +439,65 @@ TEST( RicWellPathExportMswGeometryPath, HeaderFieldsPropagated )
     EXPECT_DOUBLE_EQ( 2345.6, result.welsegsHeader().topLength );
     EXPECT_EQ( "ABS", result.welsegsHeader().infoType );
     EXPECT_EQ( RiaDefines::EclipseUnitSystem::UNITS_FIELD, result.unitSystem() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A grid cell has a single COMPDAT connection and must be connected to one segment only. When two
+/// branches of the same kind intersect the cell, the branch listed first keeps it.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, CompsegsCellIsConnectedOnlyOnce )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    exportData.branches = { makeBranchIntersectingCell( 2, 10, 3, 5, 7, RigMswBranchSource::Fracture ),
+                            makeBranchIntersectingCell( 3, 11, 3, 5, 7, RigMswBranchSource::Fracture ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 2u, result.welsegsData().size() );
+    ASSERT_EQ( 1u, result.compsegsData().size() );
+    EXPECT_EQ( 2, result.compsegsData()[0].branch );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The branch carrying most flow claims a shared cell: perforations before fishbones before
+/// fractures, regardless of the order the branches are listed in.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, CompsegsCellIsClaimedByTheBranchWithMostFlow )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    exportData.branches = { makeBranchIntersectingCell( 4, 12, 3, 5, 7, RigMswBranchSource::Fracture ),
+                            makeBranchIntersectingCell( 3, 11, 3, 5, 7, RigMswBranchSource::Fishbones ),
+                            makeBranchIntersectingCell( 2, 10, 3, 5, 7, RigMswBranchSource::Perforation ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 1u, result.compsegsData().size() );
+    EXPECT_EQ( 2, result.compsegsData()[0].branch );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The same IJK in the main grid and in an LGR are different cells, and both are connected.
+//--------------------------------------------------------------------------------------------------
+TEST( RicWellPathExportMswGeometryPath, CompsegsSeparatesMainGridAndLgrCells )
+{
+    RigMswWellExportData exportData;
+    exportData.header = makeHeader();
+
+    RigMswSegment lgrSeg = makeSegment( 11, 1 );
+    lgrSeg.intersections = { RigMswCellIntersection{ 3, 5, 7, 100.0, 110.0, "LGR_NEAR_WELL" } };
+
+    exportData.branches = { makeBranchIntersectingCell( 2, 10, 3, 5, 7, RigMswBranchSource::Fracture ),
+                            makeBranch( 3, { lgrSeg }, RigMswBranchSource::Fracture ) };
+
+    auto result = RicWellPathExportMswGeometryPath::collectTableData( exportData, RiaDefines::EclipseUnitSystem::UNITS_METRIC );
+
+    ASSERT_EQ( 2u, result.compsegsData().size() );
+    EXPECT_TRUE( result.compsegsData()[0].isMainGrid() );
+    EXPECT_EQ( "LGR_NEAR_WELL", result.compsegsData()[1].gridName );
 }
 
 //==================================================================================================

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -27,6 +27,8 @@
 #include "Summary/RiaSummaryPlotTools.h"
 #include "Summary/RiaSummaryTools.h"
 
+#include "Histogram/RimHistogramMultiPlot.h"
+#include "Histogram/RimHistogramPlot.h"
 #include "RimEnsembleCurveSetCollection.h"
 #include "RimMainPlotCollection.h"
 #include "RimMultiPlot.h"
@@ -930,6 +932,25 @@ void RiuPlotMainWindow::selectedObjectsChanged( caf::PdmUiTreeView* projectTree,
                 if ( summaryPlot )
                 {
                     multiSummaryPlot->makeSureIsVisible( summaryPlot );
+                }
+            }
+            else if ( auto multiHistogramPlot = firstSelectedObject->firstAncestorOrThisOfType<RimHistogramMultiPlot>() )
+            {
+                // The toolbar shows fields from the histogram multi plot. When a child object is selected, the first
+                // ancestor view window is the sub plot, not the multi plot. Use the multi plot as active plot view
+                // window to make sure the toolbar is available for any object in the multi plot.
+                m_activePlotViewWindow = multiHistogramPlot;
+
+                setBlockViewSelectionOnSubWindowActivated( true );
+                setActiveViewer( multiHistogramPlot->dockWindowName() );
+                setBlockViewSelectionOnSubWindowActivated( false );
+
+                updateMultiPlotToolBar();
+
+                auto histogramPlot = firstSelectedObject->firstAncestorOrThisOfType<RimHistogramPlot>();
+                if ( histogramPlot )
+                {
+                    multiHistogramPlot->makeSureIsVisible( histogramPlot );
                 }
             }
             else


### PR DESCRIPTION
Fixes #14646

Stacked on #14644 — the first three commits belong to that PR.

**Report a grid cell only once across COMPSEGS branches.** A cell has a single COMPDAT connection and must be connected to exactly one segment, but the export emitted one COMPSEGS row per branch intersecting the cell. The legacy codepath kept a well-global set of connected cells, ordered perforations, fishbones, fractures; that was lost when the legacy path was removed in 313ed1e4fc. `RigMswBranch` now carries a `RigMswBranchSource`, and `collectTableData()` keeps the first claim on each `(gridName, i, j, k)` in that priority order.

**Number fracture branches by measured depth.** `buildFractureBranches()` followed collection order, so fractures appended to a well were numbered after the existing ones no matter where along the well they sit. They are now sorted by fracture start MD, which also decides which fracture connects a shared cell.
