### PR TITLE
RHEL8: Name CPack package _el8 when building in a container

### DIFF
--- a/.github/workflows/rhel8-package.yml
+++ b/.github/workflows/rhel8-package.yml
@@ -99,6 +99,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/src/cmakebuild/install \
             -DRESINSIGHT_ENABLE_UNITY_BUILD=false \
+            -DRESINSIGHT_RHEL_SYSTEM_NAME=el8 \
             -DRESINSIGHT_ENABLE_HDF5=false \
             -DRESINSIGHT_ENABLE_GRPC=false \
             -DRESINSIGHT_GCC_STDCPP_EXP_PATH=/opt/libstdcxx-exp/lib \

--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -497,8 +497,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES Windows)
   endif()
 endif()
 
-# Append el5 when compiled on RHEL5 and el6 if compiled on RHEL6
-string(REGEX MATCH "el[6,7,8]?" RESINSIGHT_RHEL_SYSTEM_NAME ${CMAKE_SYSTEM})
+# Append el6/el7/el8 when compiled on RHEL. CMAKE_SYSTEM holds the host kernel
+# release, which says nothing about the distribution when building inside a
+# container, so allow the caller to state it explicitly.
+if(NOT RESINSIGHT_RHEL_SYSTEM_NAME)
+  string(REGEX MATCH "el[6,7,8]?" RESINSIGHT_RHEL_SYSTEM_NAME ${CMAKE_SYSTEM})
+endif()
 
 set(RESINSIGHT_PACKAGE_NAME "ResInsight")
 
@@ -514,12 +518,13 @@ if(NOT ${OCTAVE_VERSION_STRING} EQUAL "")
   )
 endif()
 
-# Append el5 when compiled on RHEL5 and el6 if compiled on RHEL6
+# CPACK_SYSTEM_NAME is only set for Windows above, so guard against appending a
+# bare underscore on platforms where neither name is known.
 if(NOT "${RESINSIGHT_RHEL_SYSTEM_NAME}" STREQUAL "")
   set(RESINSIGHT_PACKAGE_NAME
       "${RESINSIGHT_PACKAGE_NAME}_${RESINSIGHT_RHEL_SYSTEM_NAME}"
   )
-else()
+elseif(NOT "${CPACK_SYSTEM_NAME}" STREQUAL "")
   set(RESINSIGHT_PACKAGE_NAME "${RESINSIGHT_PACKAGE_NAME}_${CPACK_SYSTEM_NAME}")
 endif()
 


### PR DESCRIPTION
The RHEL8 release asset for v2026.09.0 came out as `ResInsight-2026.09.0_.tar.gz` instead of `ResInsight-2026.09.0_el8.tar.gz`.

`CMAKE_SYSTEM` holds the host kernel release. The RHEL8 job runs in a container on an `ubuntu-latest` runner, so it reads e.g. `Linux-6.11.0-1018-azure` and the `el[6,7,8]?` regex never matches. `CPACK_SYSTEM_NAME` is only assigned in the Windows branch above, so the `else()` fallback appended a bare underscore.

The RHEL8 job now passes `-DRESINSIGHT_RHEL_SYSTEM_NAME=el8`, CMake only derives the suffix from `CMAKE_SYSTEM` when the caller has not supplied one, and the fallback is skipped when neither name is known.

Evaluated the naming block with `cmake -P` for the four relevant inputs:

| `CMAKE_SYSTEM` | passed in | result |
| --- | --- | --- |
| `Linux-6.11.0-1018-azure` (CI container) | `el8` | `ResInsight-2026.09.0_el8` |
| `Linux-6.11.0-1018-azure` | – | `ResInsight-2026.09.0` (was `..._`) |
| `Linux-4.18.0-513.el8.x86_64` (real RHEL8) | – | `ResInsight-2026.09.0_el8` |
| `Windows-10.0.26200`, `CPACK_SYSTEM_NAME=win64` | – | `ResInsight-2026.09.0_win64` |

The v2026.09.0 draft release asset has already been renamed by hand.
