### PR TITLE
Bump version to 2026.09.1-dev.01 after release

### DIFF
--- a/ResInsightVersion.cmake
+++ b/ResInsightVersion.cmake
@@ -1,17 +1,17 @@
 
 set(RESINSIGHT_MAJOR_VERSION 2026)
 set(RESINSIGHT_MINOR_VERSION 09)
-set(RESINSIGHT_PATCH_VERSION 0)
+set(RESINSIGHT_PATCH_VERSION 1)
 
 # Opional text with no restrictions
-#set(RESINSIGHT_VERSION_TEXT "-dev")
+set(RESINSIGHT_VERSION_TEXT "-dev")
 #set(RESINSIGHT_VERSION_TEXT "-RC_1")
 
 # Optional text
 # Must be unique and increasing within one combination of major/minor/patch version 
 # The uniqueness of this text is independent of RESINSIGHT_VERSION_TEXT 
 # Format of text must be ".xx"
-#set(RESINSIGHT_DEV_VERSION ".05")
+set(RESINSIGHT_DEV_VERSION ".01")
 
 set(STRPRODUCTVER ${RESINSIGHT_MAJOR_VERSION}.${RESINSIGHT_MINOR_VERSION}.${RESINSIGHT_PATCH_VERSION}${RESINSIGHT_VERSION_TEXT}${RESINSIGHT_DEV_VERSION})
 


### PR DESCRIPTION
Start the next development cycle after the 2026.09.0 release: patch version 1, `-dev` text and dev version `.01` re-enabled.
