### PR TITLE
CI: Build vcpkg ports release-only to cut cold-cache time

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -31,6 +31,7 @@ jobs:
               publish-to-pypi: false,
               enable-asserts: false,
               vcpkg-bootstrap: bootstrap-vcpkg.bat,
+              vcpkg-triplet: x64-windows-release,
               qt-version: 6.10.1,
               ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
@@ -45,6 +46,7 @@ jobs:
               publish-to-pypi: true,
               enable-asserts: false,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
+              vcpkg-triplet: x64-linux-release,
               qt-version: 6.7.0,
               ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
@@ -59,6 +61,7 @@ jobs:
               publish-to-pypi: false,
               enable-asserts: true,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
+              vcpkg-triplet: x64-linux-release,
               qt-version: 6.7.0,
               ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
@@ -241,7 +244,7 @@ jobs:
         id: vcpkg-cache
         uses: CeetronSolutions/vcpkg-cache@copilot/optimize-cache-storage-structure
         with:
-          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.image-version.outputs.version }}-${{ steps.compiler-hash.outputs.hash }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          cache-key: ${{ runner.os }}-${{ matrix.config.cxx }}-${{ steps.image-version.outputs.version }}-${{ steps.compiler-hash.outputs.hash }}-${{ matrix.config.vcpkg-triplet }}-${{ steps.vcpkg-sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           prefix: vcpkg-${{ matrix.config.cxx}}/
           
       - name: Print CMake version
@@ -264,7 +267,8 @@ jobs:
           CXX: ${{ matrix.config.cxx }}
         run: >
           cmake -S . -B cmakebuild
-          -DVCPKG_BUILD_TYPE=release
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.config.vcpkg-triplet }}
+          -DVCPKG_HOST_TRIPLET=${{ matrix.config.vcpkg-triplet }}
           -DCMAKE_INSTALL_PREFIX=cmakebuild/install
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DRESINSIGHT_INCLUDE_APPLICATION_UNIT_TESTS=true

--- a/ThirdParty/vcpkg-overlay-triplets/x64-linux-release.cmake
+++ b/ThirdParty/vcpkg-overlay-triplets/x64-linux-release.cmake
@@ -1,0 +1,16 @@
+# Release-only variant of vcpkg's x64-linux triplet, used by CI.
+# See x64-windows-release.cmake for the rationale; the only differences here
+# are the library linkage and target system.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_BUILD_TYPE release)
+
+# CMake 4.x removed compatibility with cmake_minimum_required(VERSION < 3.5).
+# See x64-osx.cmake for the full rationale.  Must be kept in sync with the
+# x64-linux triplet this one shadows.
+list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)

--- a/ThirdParty/vcpkg-overlay-triplets/x64-windows-release.cmake
+++ b/ThirdParty/vcpkg-overlay-triplets/x64-windows-release.cmake
@@ -1,0 +1,24 @@
+# Release-only variant of vcpkg's x64-windows triplet, used by CI.
+#
+# Why this exists:
+#   vcpkg builds every port in both debug and release unless VCPKG_BUILD_TYPE
+#   says otherwise, and that variable is only read from the triplet file --
+#   passing -DVCPKG_BUILD_TYPE=release to the top-level CMake call has no
+#   effect on the ports vcpkg builds.  CI only ever links release binaries, so
+#   the debug half is pure cost: on a cold cache it is roughly half of an
+#   85 minute vcpkg step (grpc, arrow, openssl and protobuf dominate).
+#
+#   Kept as a separate triplet rather than folded into x64-windows so local
+#   developer builds keep their debug dependencies.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_PROVIDED_FORTRAN ON)
+
+set(VCPKG_BUILD_TYPE release)
+
+# CMake 4.x removed compatibility with cmake_minimum_required(VERSION < 3.5).
+# See x64-osx.cmake for the full rationale.  Must be kept in sync with the
+# x64-windows triplet this one shadows.
+list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")


### PR DESCRIPTION
## Problem

`-DVCPKG_BUILD_TYPE=release` in the Configure step never did anything. vcpkg only reads `VCPKG_BUILD_TYPE` from the triplet file — `scripts/buildsystems/vcpkg.cmake` has no reference to it — so every port was built in both debug and release.

From [run 33372999270](https://github.com/OPM/ResInsight/actions/runs/33372999270/job/99428104221) (Windows, cold cache, 90 of 102 ports built from source):

| Step | Duration |
| --- | --- |
| Configure (vcpkg) | 85 min 34 s |
| Build | 38 min 09 s |
| Total job | 2 h 09 min |

The log shows `-- Building x64-windows-dbg` throughout. Worst ports: grpc 37 min, arrow 15 min, openssl 11 min, protobuf 9.4 min — about 72 of the 85 minutes.

## Change

Add release-only overlay triplets for `x64-windows` and `x64-linux`, and select them from the workflow matrix.

- They mirror the stock triplets rather than reusing vcpkg's own `x64-windows-release`, which lacks the `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` option that libevent, protobuf, grpc and the boost shims need under CMake 4.x.
- Separate triplets rather than an override of the stock ones, so local developer builds keep their debug dependencies.
- `VCPKG_HOST_TRIPLET` is set alongside the target triplet. Without it 12 host-tool ports — openssl and protobuf among them — get built a second time under the stock triplet.
- The triplet is now part of the vcpkg cache key, since it changes every binary's ABI hash.

## Verification

`vcpkg install --dry-run` with both triplets set resolves 102 packages, all `x64-windows-release`, matching the package count in the CI log. With only the target triplet set, 12 fall back to `x64-windows`.

The first run on this branch is cold by design — all ABI hashes change — so it measures the saving itself. Expect Configure to land around 45–50 min on Windows.

## Notes

Linux gets the same treatment on the identical mechanism, but the timing evidence above is Windows-only.
