### PR TITLE
Fix crash in RimWellIADataAccess::interpolatedResultValue for out-of-grid positions

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellIADataAccess.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellIADataAccess.cpp
@@ -131,6 +131,7 @@ double RimWellIADataAccess::interpolatedResultValue( const RigFemPart*         f
                                                      const cvf::Vec3d&         position )
 {
     int elmIdx = elementIndex( position );
+    if ( elmIdx < 0 ) return 0.0;
 
     RigElementType elmType      = femPart->elementType( elmIdx );
     const int*     elementConn  = femPart->connectivities( elmIdx );


### PR DESCRIPTION
## Problem

`interpolatedResultValue` passes `elementIndex()`'s `-1` "not found" result unchecked into `size_t` APIs, causing an out-of-bounds read and crash.

## Fix

Return `0.0` early when no containing element is found, matching the existing guard in `resultIndex()`/`resultValue()`:

```cpp
int elmIdx = elementIndex( position );
if ( elmIdx < 0 ) return 0.0;
```

Build verified. No unit test added — path needs a loaded GeoMech `.odb` case, no such fixture exists.

## Call stack

```
[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:170
[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:302
[3] cvf::Vector3<double>::Vector3<cvf::Vector3<float> >(cvf::Vector3<float> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:104
[4] RimWellIADataAccess::interpolatedResultValue(QString, QString, RigFemResultPosEnum, cvf::Vector3<double>, int, int) at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellIADataAccess.cpp:122
[5] RimWellIASettings::updateResInsightParameters() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellIASettings.cpp:469
[6] RimWellIASettings::extractModelData() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellIASettings.cpp:603
[7] RicRunWellIntegrityAnalysisFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/GeoMechCommands/RicRunWellIntegrityAnalysisFeature.cpp:69
[8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
[59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:267
[60] __libc_start_main at :0
```
