### PR TITLE
Only add PendingRelease label when issue is closed as completed

### DIFF
--- a/.github/workflows/close-label.yml
+++ b/.github/workflows/close-label.yml
@@ -5,6 +5,8 @@ on:
       - closed
 jobs:
   label_issues:
+    # Skip issues closed as "not planned" or "duplicate"
+    if: github.event.issue.state_reason == 'completed'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
The workflow labelled every closed issue, including those closed as "not planned" or "duplicate". Guard the job on `github.event.issue.state_reason == 'completed'` so only genuinely completed issues get `PendingRelease`.