### PR TITLE
#14669 Delay ensemble curve filter slider update until release

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveFilter.cpp
@@ -546,6 +546,11 @@ void RimEnsembleCurveFilter::defineEditorAttribute( const caf::PdmFieldHandle* f
 
             attr->m_minimum = m_lowerLimit;
             attr->m_maximum = m_upperLimit;
+
+            // Avoid updating the filter and re-computing/redrawing all curves for every slider drag event, as this can be a
+            // very slow operation for large ensembles. Only update when the slider is released.
+            // https://github.com/OPM/ResInsight/issues/14669
+            attr->m_delaySliderUpdateUntilRelease = true;
         }
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
@@ -22,6 +22,8 @@
 #include "RiaFieldHandleTools.h"
 #include "RiaFilePathTools.h"
 #include "RiaLogging.h"
+#include "RiaOpenMPTools.h"
+#include "RiaPreferencesSummary.h"
 #include "RiaQStringFormatter.h"
 #include "RiaStdStringTools.h"
 #include "RiaTextStringTools.h"
@@ -859,22 +861,42 @@ void RimSummaryEnsemble::computeMinMax( const RifEclipseSummaryAddress& address 
 {
     if ( m_minMaxValues.count( address ) > 0 ) return;
 
-    double minimumValue( std::numeric_limits<double>::infinity() );
-    double maximumValue( -std::numeric_limits<double>::infinity() );
+    const auto& cases = m_cases();
 
-    for ( const auto& s : m_cases() )
+    // Reading summary values for each case is independent, and can be a slow operation for large ensembles (many
+    // realizations and/or long time series). Use multiple threads to speed up the initial computation of min/max
+    // values. The HDF5-backed reader is not thread safe, so multi-threading is disabled for that reader type.
+    // https://github.com/OPM/ResInsight/issues/14669
+    const bool canUseMultipleThreads =
+        RiaPreferencesSummary::current()->summaryDataReader() != RiaPreferencesSummary::SummaryReaderMode::HDF5_OPM_COMMON;
+
+    const int numberOfThreads = canUseMultipleThreads ? RiaOpenMPTools::availableThreadCount() : 1;
+
+    std::vector<double> minimumValuePerThread( numberOfThreads, std::numeric_limits<double>::infinity() );
+    std::vector<double> maximumValuePerThread( numberOfThreads, -std::numeric_limits<double>::infinity() );
+
+#pragma omp parallel num_threads( numberOfThreads ) if ( canUseMultipleThreads )
     {
-        if ( auto reader = s->summaryReader() )
+        int myThread = RiaOpenMPTools::currentThreadIndex();
+
+#pragma omp for schedule( dynamic )
+        for ( int i = 0; i < static_cast<int>( cases.size() ); i++ )
         {
-            auto [isOk, values] = reader->values( address );
-            if ( values.empty() ) continue;
+            if ( auto reader = cases[i]->summaryReader() )
+            {
+                auto [isOk, values] = reader->values( address );
+                if ( values.empty() ) continue;
 
-            const auto [min, max] = std::minmax_element( values.begin(), values.end() );
+                const auto [min, max] = std::minmax_element( values.begin(), values.end() );
 
-            minimumValue = std::min( *min, minimumValue );
-            maximumValue = std::max( *max, maximumValue );
+                minimumValuePerThread[myThread] = std::min( *min, minimumValuePerThread[myThread] );
+                maximumValuePerThread[myThread] = std::max( *max, maximumValuePerThread[myThread] );
+            }
         }
     }
+
+    double minimumValue = *std::min_element( minimumValuePerThread.begin(), minimumValuePerThread.end() );
+    double maximumValue = *std::max_element( maximumValuePerThread.begin(), maximumValuePerThread.end() );
 
     if ( minimumValue != std::numeric_limits<double>::infinity() && maximumValue != -std::numeric_limits<double>::infinity() )
     {


### PR DESCRIPTION
Fixes #14669

## Problem
The value range slider used to filter ensemble curves (RimEnsembleCurveFilter::m_valueRange) triggered a full filter re-evaluation (pplyFilter) and curve/statistics redraw on **every intermediate slider drag position**, not just when the drag finished. For large ensembles (many realizations / large summary datasets), this made interacting with the ensemble curve filter's range slider very slow, as reported in the issue.

## Fix
caf::PdmUiDoubleSliderEditorAttribute already supports m_delaySliderUpdateUntilRelease, which defers the field update (and therefore the expensive filter/redraw) until the slider is released, only updating the line edit text during the drag. This flag was not being set for RimEnsembleCurveFilter's value range slider, unlike other similar sliders in the codebase (RimPlotDataFilterItem, RimGeoMechContourMapProjection, RimStatisticsContourMap), which already use this flag for the same reason.

This change sets ttr->m_delaySliderUpdateUntilRelease = true; in RimEnsembleCurveFilter::defineEditorAttribute, so filtering/redraw happens once on release instead of on every drag tick.

## Testing
- Built ResInsight target successfully (RelWithDebInfo debug preset), no errors.
