### PR TITLE
Increase Windows buildcache size limit to 1.5 GiB

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -32,6 +32,7 @@ jobs:
               enable-asserts: false,
               vcpkg-bootstrap: bootstrap-vcpkg.bat,
               vcpkg-triplet: x64-windows-release,
+              buildcache-max-size: 1610612736,
               qt-version: 6.10.1,
               ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
@@ -47,6 +48,7 @@ jobs:
               enable-asserts: false,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
               vcpkg-triplet: x64-linux-release,
+              buildcache-max-size: 524288000,
               qt-version: 6.7.0,
               ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
@@ -62,6 +64,7 @@ jobs:
               enable-asserts: true,
               vcpkg-bootstrap: bootstrap-vcpkg.sh,
               vcpkg-triplet: x64-linux-release,
+              buildcache-max-size: 524288000,
               qt-version: 6.7.0,
               ri-unit-test-path: "ApplicationLibCode/UnitTests/ResInsight-tests",
             }
@@ -69,8 +72,12 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
-      # 500 MB, in bytes
-      BUILDCACHE_MAX_CACHE_SIZE: 524288000
+      # Per-configuration size limit, in bytes. The cache must hold a full
+      # build with room to spare; at the limit buildcache evicts entries the
+      # same build still needs and the hit ratio collapses. MSVC objects are
+      # roughly twice the size of the gcc/clang ones, so Windows gets 1.5 GiB
+      # while Linux stays at 500 MB.
+      BUILDCACHE_MAX_CACHE_SIZE: ${{ matrix.config.buildcache-max-size }}
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       # Supply-chain hardening: never install Python packages published within
       # the last week, to avoid pulling freshly published (potentially


### PR DESCRIPTION
The Windows leg of `ResInsight Build With Cache` has been taking ~70 minutes while the Linux legs finish the same build in ~80 seconds. The cause is the shared `BUILDCACHE_MAX_CACHE_SIZE` of 500 MB.

MSVC objects are roughly twice the size of the gcc/clang ones, so a single full Windows build writes about 550 MB of buildcache entries (6567 entries averaging 83 KiB, ~2 per compile). The cache is restored already over the limit and buildcache evicts throughout the build — and what it evicts is whatever the running build has not reached yet.

Run [33703720853](https://github.com/OPM/ResInsight/actions/runs/33703720853) shows this cleanly, because both attempts built the same commit and attempt 2 restored the cache attempt 1 had just written:

| | attempt 1 | attempt 2 |
| --- | --- | --- |
| restored | `...-2026-09-02` | `...-2026-09-03` (written by attempt 1) |
| cache at end | 6265 entries, 508.5 MiB (101.7%) | 6567 entries, 530.3 MiB (106.1%) |
| hits this run | — | 1755 hits / 2191 misses = 44% |
| build wall time | 1h58m | 1h13m |

Rebuilding an unchanged tree against a cache written by that very tree still recompiled more than half the objects. The misses are spread evenly across all targets, which is what capacity eviction looks like — a hashing problem would cluster in specific targets.

For comparison, `ResInsightMac.yml` sets no limit at all and runs at 15% of buildcache's 5 GiB default with an 89.5% hit ratio.

This moves the limit into the matrix: Windows gets 1.5 GiB, Linux keeps 500 MB.

Note the repository is at 10.74 GB against the 10 GB Actions cache quota, so GitHub is already evicting. There is roughly 3.3 GB of unreachable vcpkg and Qt entries from superseded key schemes that should be cleaned up; that is a separate change.
