### PR TITLE
Make contour maps available in 3d views

### DIFF
--- a/ApplicationLibCode/Application/RiaDefines.h
+++ b/ApplicationLibCode/Application/RiaDefines.h
@@ -268,10 +268,11 @@ enum class View3dContent
 
 enum class ItemIn3dView
 {
-    NONE    = 0b00000000,
-    SURFACE = 0b00000001,
-    POLYGON = 0b00000010,
-    ALL     = 0b00000011
+    NONE        = 0b00000000,
+    SURFACE     = 0b00000001,
+    POLYGON     = 0b00000010,
+    CONTOUR_MAP = 0b00000100,
+    ALL         = 0b00000111
 };
 
 QString betaFeaturePostfix();

--- a/ApplicationLibCode/Commands/RicContourMapPickEventHandler.cpp
+++ b/ApplicationLibCode/Commands/RicContourMapPickEventHandler.cpp
@@ -20,10 +20,13 @@
 
 #include "ContourMap/RigContourMapProjection.h"
 
+#include "ContourMap/RimContourMapInView.h"
+#include "ContourMap/RimContourMapInViewCollection.h"
 #include "ContourMap/RimContourMapProjection.h"
 #include "ContourMap/RimEclipseContourMapView.h"
 #include "Rim3dView.h"
 #include "RimGeoMechContourMapView.h"
+#include "RimGridView.h"
 
 #include "RiuMainWindow.h"
 
@@ -60,10 +63,37 @@ bool RicContourMapPickEventHandler::handle3dPickEvent( const Ric3dPickEvent& eve
         RimContourMapProjection* contourMap = dynamic_cast<RimContourMapProjection*>( sourceInfo->object() );
         if ( contourMap )
         {
-            RiuMainWindow::instance()->selectAsCurrentItem( contourMap );
-
-            RimGridView* view = contourMap->firstAncestorOrThisOfTypeAsserted<RimGridView>();
+            // The RimContourMapProjection displayed inside a regular 3d view is owned by an internal, hidden
+            // RimEclipseContourMapView/RimGeoMechContourMapView, so climbing its own ancestor chain would find that
+            // hidden view rather than the visible one. Use the view the pick actually happened in instead.
+            RimGridView* view = dynamic_cast<RimGridView*>( eventObject.m_view );
             if ( !view ) return false;
+
+            // When the contour map is shown inside a regular 3d view, keep the project tree selection on the
+            // RimContourMapInView object rather than jumping to the internal RimContourMapProjection object.
+            RimContourMapInViewCollection* contourMapCollection = view->contourMapInViewCollection();
+            RimContourMapInView*           contourMapInView     = nullptr;
+            if ( contourMapCollection )
+            {
+                for ( RimContourMapInView* candidate : contourMapCollection->allContourMapsInView() )
+                {
+                    RimEclipseContourMapView* candidateSourceView = candidate->sourceItem();
+                    if ( candidateSourceView && candidateSourceView->contourMapProjection() == contourMap )
+                    {
+                        contourMapInView = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if ( contourMapInView )
+            {
+                RiuMainWindow::instance()->selectAsCurrentItem( contourMapInView );
+            }
+            else
+            {
+                RiuMainWindow::instance()->selectAsCurrentItem( contourMap );
+            }
 
             const auto& firstPickItem       = eventObject.m_pickItemInfos.front();
             auto        targetPointInDomain = view->displayCoordTransform()->transformToDomainCoord( firstPickItem.globalPickedPoint() );

--- a/ApplicationLibCode/ModelVisualization/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ModelVisualization/CMakeLists_files.cmake
@@ -36,6 +36,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RivSimWellConnectionSourceInfo.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Riv3dWellLogDrawSurfaceGenerator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivMeshLinesSourceInfo.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RivContourMapElevationProvider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivContourMapProjectionPartMgr.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivAnnotationsPartMgr.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RivTextAnnotationPartMgr.cpp

--- a/ApplicationLibCode/ModelVisualization/RivContourMapElevationProvider.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivContourMapElevationProvider.cpp
@@ -1,0 +1,102 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RivContourMapElevationProvider.h"
+
+#include "ContourMap/RigContourMapTopography.h"
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RivContourMapElevationProvider::~RivContourMapElevationProvider()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RivContourMapElevationProvider::resamplingDistance() const
+{
+    return 0.0;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RivContourMapFlatElevation::RivContourMapFlatElevation( double domainElevation )
+    : m_domainElevation( domainElevation )
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RivContourMapFlatElevation::~RivContourMapFlatElevation()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<double> RivContourMapFlatElevation::domainElevation( const cvf::Vec2d& localPos2d ) const
+{
+    return m_domainElevation;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RivContourMapTopographyElevation::RivContourMapTopographyElevation( std::shared_ptr<const RigContourMapTopography> topography, double offset )
+    : m_topography( topography )
+    , m_offset( offset )
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RivContourMapTopographyElevation::~RivContourMapTopographyElevation()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<double> RivContourMapTopographyElevation::domainElevation( const cvf::Vec2d& localPos2d ) const
+{
+    if ( !m_topography ) return {};
+
+    auto elevation = m_topography->elevationAtLocalPos( localPos2d );
+    if ( !elevation ) return {};
+
+    return *elevation + m_offset;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RivContourMapTopographyElevation::resamplingDistance() const
+{
+    if ( !m_topography ) return 0.0;
+
+    // Several samples per raster cell, so a polyline picks up the shape of the geometry between the
+    // raster vertices instead of only at them
+    const double samplesPerRasterCell = 8.0;
+
+    return m_topography->sampleSpacing() / samplesPerRasterCell;
+}

--- a/ApplicationLibCode/ModelVisualization/RivContourMapElevationProvider.h
+++ b/ApplicationLibCode/ModelVisualization/RivContourMapElevationProvider.h
@@ -1,0 +1,90 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cvfVector2.h"
+
+#include <memory>
+#include <optional>
+
+class RigContourMapTopography;
+
+//==================================================================================================
+///
+/// Supplies the domain z coordinate used when contour map geometry is placed in a scene.
+///
+/// Contour map geometry is generated in a flat, contour map local coordinate space where z is
+/// always zero. Consumers normally lift it to RigContourMapGrid::origin3d(), which places the map
+/// at the minimum z of the expanded bounding box. In a 3d view the map must be placed elsewhere,
+/// and the contour lines may be draped on the visible grid geometry. This interface is the single
+/// point where that decision is made.
+///
+//==================================================================================================
+class RivContourMapElevationProvider
+{
+public:
+    virtual ~RivContourMapElevationProvider();
+
+    // localPos2d is relative to RigContourMapGrid::origin2d(). Returns the domain z to use, or
+    // nothing when no elevation is defined at the given position.
+    virtual std::optional<double> domainElevation( const cvf::Vec2d& localPos2d ) const = 0;
+
+    // How closely a polyline has to be sampled for the elevation to be followed faithfully. Contour
+    // polygons are simplified, so a single segment can span a long distance and would otherwise cut
+    // straight through everything between its end points. Zero means the elevation does not vary, so
+    // the end points are enough.
+    virtual double resamplingDistance() const;
+};
+
+//==================================================================================================
+///
+/// Places the whole contour map on a single horizontal plane.
+///
+//==================================================================================================
+class RivContourMapFlatElevation : public RivContourMapElevationProvider
+{
+public:
+    explicit RivContourMapFlatElevation( double domainElevation );
+    ~RivContourMapFlatElevation() override;
+
+    std::optional<double> domainElevation( const cvf::Vec2d& localPos2d ) const override;
+
+private:
+    double m_domainElevation;
+};
+
+//==================================================================================================
+///
+/// Follows the top of the visible grid geometry, lifted by a constant offset. Returns nothing where
+/// no visible geometry is found, which makes the consumer drop the affected geometry.
+///
+//==================================================================================================
+class RivContourMapTopographyElevation : public RivContourMapElevationProvider
+{
+public:
+    RivContourMapTopographyElevation( std::shared_ptr<const RigContourMapTopography> topography, double offset );
+    ~RivContourMapTopographyElevation() override;
+
+    std::optional<double> domainElevation( const cvf::Vec2d& localPos2d ) const override;
+    double                resamplingDistance() const override;
+
+private:
+    std::shared_ptr<const RigContourMapTopography> m_topography;
+    double                                         m_offset;
+};

--- a/ApplicationLibCode/ModelVisualization/RivContourMapProjectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivContourMapProjectionPartMgr.cpp
@@ -24,6 +24,7 @@
 #include "ContourMap/RigContourMapGrid.h"
 #include "ContourMap/RigContourPolygonsTools.h"
 
+#include "RivContourMapElevationProvider.h"
 #include "RivMeshLinesSourceInfo.h"
 #include "RivPartPriority.h"
 #include "RivScalarMapperUtils.h"
@@ -39,10 +40,13 @@
 #include "cvfPart.h"
 #include "cvfPrimitiveSetIndexedUInt.h"
 #include "cvfRay.h"
+#include "cvfRenderStatePolygonOffset.h"
 #include "cvfScalarMapper.h"
 #include "cvfViewport.h"
 #include "cvfqtUtils.h"
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 
 #include <QDebug>
@@ -61,14 +65,112 @@ RivContourMapProjectionPartMgr::RivContourMapProjectionPartMgr( caf::PdmObject* 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RivContourMapProjectionPartMgr::appendProjectionToModel( cvf::ModelBasicList*              model,
-                                                              const caf::DisplayCoordTransform* displayCoordTransform,
-                                                              const std::vector<cvf::Vec4d>&    vertices,
-                                                              const RigContourMapGrid&          contourMapGrid,
-                                                              const cvf::Color3f&               backgroundColor,
-                                                              cvf::ScalarMapper*                scalarMapper ) const
+cvf::Color3f RivContourLineAppearance::colorForLevel( const cvf::Color3f& levelColor ) const
 {
-    cvf::ref<cvf::Part> mapPart = createProjectionMapPart( displayCoordTransform, vertices, contourMapGrid, backgroundColor, scalarMapper );
+    return color.value_or( RiaColorTools::contrastColor( levelColor ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<cvf::Vec3d> RivContourMapProjectionPartMgr::toDomainCoord( const cvf::Vec3d&                     localVertex,
+                                                                         const RigContourMapGrid&              contourMapGrid,
+                                                                         const RivContourMapElevationProvider* elevationProvider )
+{
+    cvf::Vec3d domainVertex = localVertex + contourMapGrid.origin3d();
+
+    if ( elevationProvider )
+    {
+        auto elevation = elevationProvider->domainElevation( cvf::Vec2d( localVertex.x(), localVertex.y() ) );
+        if ( !elevation ) return {};
+
+        domainVertex.z() = *elevation;
+    }
+
+    return domainVertex;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<cvf::Vec3d> RivContourMapProjectionPartMgr::toDisplayCoord( const cvf::Vec3d&                     localVertex,
+                                                                          const RigContourMapGrid&              contourMapGrid,
+                                                                          const caf::DisplayCoordTransform*     displayCoordTransform,
+                                                                          const RivContourMapElevationProvider* elevationProvider )
+{
+    auto domainVertex = toDomainCoord( localVertex, contourMapGrid, elevationProvider );
+    if ( !domainVertex ) return {};
+
+    return displayCoordTransform->transformToDisplayCoord( *domainVertex );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<std::pair<cvf::Vec3d, cvf::Vec3d>>
+    RivContourMapProjectionPartMgr::resampledDisplaySegments( const std::vector<cvf::Vec3d>&        localVertices,
+                                                              const RigContourMapGrid&              contourMapGrid,
+                                                              const caf::DisplayCoordTransform*     displayCoordTransform,
+                                                              const RivContourMapElevationProvider* elevationProvider )
+{
+    std::vector<std::pair<cvf::Vec3d, cvf::Vec3d>> segments;
+
+    const size_t nVertices = localVertices.size();
+    if ( nVertices < 2 ) return segments;
+
+    const double resamplingDistance = elevationProvider ? elevationProvider->resamplingDistance() : 0.0;
+
+    // Keeps a pathologically long segment from producing an unbounded number of samples
+    const int maxSamplesPerSegment = 200;
+
+    segments.reserve( nVertices );
+
+    for ( size_t v = 0; v < nVertices; ++v )
+    {
+        const cvf::Vec3d& localVertex1 = localVertices[v];
+        const cvf::Vec3d& localVertex2 = ( v < nVertices - 1 ) ? localVertices[v + 1] : localVertices[0];
+
+        int sampleCount = 1;
+        if ( resamplingDistance > 0.0 )
+        {
+            const double segmentLength = ( localVertex2 - localVertex1 ).length();
+
+            sampleCount = static_cast<int>( std::ceil( segmentLength / resamplingDistance ) );
+            sampleCount = std::clamp( sampleCount, 1, maxSamplesPerSegment );
+        }
+
+        auto previous = toDisplayCoord( localVertex1, contourMapGrid, displayCoordTransform, elevationProvider );
+
+        for ( int sample = 1; sample <= sampleCount; ++sample )
+        {
+            const double     fraction   = static_cast<double>( sample ) / sampleCount;
+            const cvf::Vec3d localPoint = localVertex1 + ( localVertex2 - localVertex1 ) * fraction;
+
+            auto current = toDisplayCoord( localPoint, contourMapGrid, displayCoordTransform, elevationProvider );
+
+            // A gap is left wherever there is no elevation, which splits a draped polyline into pieces
+            if ( previous && current ) segments.emplace_back( *previous, *current );
+
+            previous = current;
+        }
+    }
+
+    return segments;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RivContourMapProjectionPartMgr::appendProjectionToModel( cvf::ModelBasicList*                  model,
+                                                              const caf::DisplayCoordTransform*     displayCoordTransform,
+                                                              const std::vector<cvf::Vec4d>&        vertices,
+                                                              const RigContourMapGrid&              contourMapGrid,
+                                                              const cvf::Color3f&                   backgroundColor,
+                                                              cvf::ScalarMapper*                    scalarMapper,
+                                                              const RivContourMapElevationProvider* elevationProvider ) const
+{
+    cvf::ref<cvf::Part> mapPart =
+        createProjectionMapPart( displayCoordTransform, vertices, contourMapGrid, backgroundColor, scalarMapper, elevationProvider );
     if ( mapPart.notNull() )
     {
         model->addPart( mapPart.p() );
@@ -134,12 +236,14 @@ void RivContourMapProjectionPartMgr::appendContourLinesToModel( const cvf::Camer
                                                                 cvf::ModelBasicList*              model,
                                                                 const caf::DisplayCoordTransform* displayCoordTransform,
                                                                 const std::vector<RigContourPolygonsTools::ContourPolygons>& contourLinePolygons,
-                                                                const RigContourMapGrid& contourMapGrid,
-                                                                cvf::ScalarMapper*       mapper,
-                                                                bool                     showContourLines,
-                                                                bool                     showContourLabels,
-                                                                caf::NumberFormatType    numberFormat,
-                                                                int                      precision )
+                                                                const RigContourMapGrid&              contourMapGrid,
+                                                                cvf::ScalarMapper*                    mapper,
+                                                                bool                                  showContourLines,
+                                                                bool                                  showContourLabels,
+                                                                caf::NumberFormatType                 numberFormat,
+                                                                int                                   precision,
+                                                                const RivContourMapElevationProvider* elevationProvider,
+                                                                const RivContourLineAppearance&       lineAppearance )
 {
     if ( showContourLines )
     {
@@ -148,12 +252,20 @@ void RivContourMapProjectionPartMgr::appendContourLinesToModel( const cvf::Camer
 
         if ( showContourLabels )
         {
-            labelDrawables =
-                createContourLabels( camera, displayCoordTransform, &labelBBoxes, contourLinePolygons, contourMapGrid, mapper, numberFormat, precision );
+            labelDrawables = createContourLabels( camera,
+                                                  displayCoordTransform,
+                                                  &labelBBoxes,
+                                                  contourLinePolygons,
+                                                  contourMapGrid,
+                                                  mapper,
+                                                  numberFormat,
+                                                  precision,
+                                                  elevationProvider,
+                                                  lineAppearance );
         }
 
         std::vector<std::vector<cvf::ref<cvf::Drawable>>> contourDrawablesForAllLevels =
-            createContourPolygons( displayCoordTransform, labelBBoxes, contourLinePolygons, mapper, contourMapGrid );
+            createContourPolygons( displayCoordTransform, labelBBoxes, contourLinePolygons, mapper, contourMapGrid, elevationProvider );
 
         std::vector<double> tickValues;
         mapper->majorTickValues( &tickValues );
@@ -163,16 +275,19 @@ void RivContourMapProjectionPartMgr::appendContourLinesToModel( const cvf::Camer
             std::vector<cvf::ref<cvf::Drawable>> contourDrawables = contourDrawablesForAllLevels[i];
 
             cvf::Color3f backgroundColor( mapper->mapToColor( tickValues[i] ) );
-            cvf::Color3f lineColor = RiaColorTools::contrastColor( backgroundColor );
+            cvf::Color3f lineColor = lineAppearance.colorForLevel( backgroundColor );
 
             for ( cvf::ref<cvf::Drawable> contourDrawable : contourDrawables )
             {
                 if ( contourDrawable.notNull() && contourDrawable->boundingBox().isValid() )
                 {
                     caf::MeshEffectGenerator meshEffectGen( lineColor );
-                    meshEffectGen.setLineWidth( 1.0f );
-                    caf::MeshEffectGenerator::createAndConfigurePolygonOffsetRenderState( caf::PO_1 );
+                    meshEffectGen.setLineWidth( lineAppearance.lineWidth );
 
+                    // NB: polygon offset cannot be used to keep these lines clear of the map surface.
+                    // It only applies to polygon primitives, and these are line primitives. Callers that
+                    // draw the lines on top of other geometry have to lift them through the elevation
+                    // provider instead.
                     cvf::ref<cvf::Effect> effect = meshEffectGen.generateCachedEffect();
 
                     cvf::ref<cvf::Part> part = new cvf::Part;
@@ -206,9 +321,11 @@ void RivContourMapProjectionPartMgr::appendContourLinesToModel( const cvf::Camer
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::ref<cvf::DrawableText> RivContourMapProjectionPartMgr::createTextLabel( const cvf::Color3f& textColor, const cvf::Color3f& backgroundColor )
+cvf::ref<cvf::DrawableText> RivContourMapProjectionPartMgr::createTextLabel( const cvf::Color3f&      textColor,
+                                                                             const cvf::Color3f&      backgroundColor,
+                                                                             caf::FontTools::FontSize fontSize )
 {
-    auto font = RiaFontCache::getFont( RiaFontCache::FontSize::FONT_SIZE_10 );
+    auto font = RiaFontCache::getFont( fontSize );
 
     cvf::ref<cvf::DrawableText> labelDrawable = new cvf::DrawableText();
     labelDrawable->setFont( font.p() );
@@ -227,26 +344,62 @@ cvf::ref<cvf::DrawableText> RivContourMapProjectionPartMgr::createTextLabel( con
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::ref<cvf::Part> RivContourMapProjectionPartMgr::createProjectionMapPart( const caf::DisplayCoordTransform* displayCoordTransform,
-                                                                             const std::vector<cvf::Vec4d>&    vertices,
-                                                                             const RigContourMapGrid&          contourMapGrid,
-                                                                             const cvf::Color3f&               backgroundColor,
-                                                                             cvf::ScalarMapper*                scalarMapper ) const
+cvf::ref<cvf::Part> RivContourMapProjectionPartMgr::createProjectionMapPart( const caf::DisplayCoordTransform*     displayCoordTransform,
+                                                                             const std::vector<cvf::Vec4d>&        vertices,
+                                                                             const RigContourMapGrid&              contourMapGrid,
+                                                                             const cvf::Color3f&                   backgroundColor,
+                                                                             cvf::ScalarMapper*                    scalarMapper,
+                                                                             const RivContourMapElevationProvider* elevationProvider ) const
 {
     if ( vertices.size() < 3u )
     {
         return cvf::ref<cvf::Part>();
     }
-    cvf::ref<cvf::Vec3fArray> vertexArray = new cvf::Vec3fArray( vertices.size() );
-    cvf::ref<cvf::UIntArray>  faceList    = new cvf::UIntArray( vertices.size() );
-    std::vector<double>       values( vertices.size() );
-    for ( uint i = 0; i < vertices.size(); ++i )
+
+    // The vertices form a triangle soup, three consecutive entries per triangle. A triangle is dropped
+    // when the elevation provider has no elevation for one of its vertices.
+    std::vector<cvf::Vec3f> displayVertices;
+    std::vector<double>     values;
+    displayVertices.reserve( vertices.size() );
+    values.reserve( vertices.size() );
+
+    for ( size_t i = 0; i + 2 < vertices.size(); i += 3 )
     {
-        cvf::Vec3d globalVertex = cvf::Vec3d( vertices[i].x(), vertices[i].y(), vertices[i].z() ) + contourMapGrid.origin3d();
-        cvf::Vec3f displayVertexPos( displayCoordTransform->transformToDisplayCoord( globalVertex ) );
-        ( *vertexArray )[i] = displayVertexPos;
-        ( *faceList )[i]    = i;
-        values[i]           = vertices[i].w();
+        std::array<cvf::Vec3d, 3> triangle;
+        bool                      allVerticesDefined = true;
+
+        for ( size_t n = 0; n < 3; ++n )
+        {
+            const cvf::Vec4d& vertex = vertices[i + n];
+            auto              displayVertex =
+                toDisplayCoord( cvf::Vec3d( vertex.x(), vertex.y(), vertex.z() ), contourMapGrid, displayCoordTransform, elevationProvider );
+            if ( !displayVertex )
+            {
+                allVerticesDefined = false;
+                break;
+            }
+            triangle[n] = *displayVertex;
+        }
+
+        if ( !allVerticesDefined ) continue;
+
+        for ( size_t n = 0; n < 3; ++n )
+        {
+            displayVertices.push_back( cvf::Vec3f( triangle[n] ) );
+            values.push_back( vertices[i + n].w() );
+        }
+    }
+
+    if ( displayVertices.size() < 3u )
+    {
+        return cvf::ref<cvf::Part>();
+    }
+
+    cvf::ref<cvf::Vec3fArray> vertexArray = new cvf::Vec3fArray( displayVertices );
+    cvf::ref<cvf::UIntArray>  faceList    = new cvf::UIntArray( displayVertices.size() );
+    for ( uint i = 0; i < displayVertices.size(); ++i )
+    {
+        ( *faceList )[i] = i;
     }
 
     cvf::ref<cvf::PrimitiveSetIndexedUInt> indexUInt = new cvf::PrimitiveSetIndexedUInt( cvf::PrimitiveType::PT_TRIANGLES, faceList.p() );
@@ -275,7 +428,8 @@ std::vector<std::vector<cvf::ref<cvf::Drawable>>>
                                                            const std::vector<std::vector<cvf::BoundingBox>>& labelBBoxes,
                                                            const std::vector<RigContourPolygonsTools::ContourPolygons>& contourLinePolygons,
                                                            cvf::ScalarMapper*                                           scalarMapper,
-                                                           const RigContourMapGrid& contourMapGrid ) const
+                                                           const RigContourMapGrid&                                     contourMapGrid,
+                                                           const RivContourMapElevationProvider* elevationProvider ) const
 {
     std::vector<double> tickValues;
     scalarMapper->majorTickValues( &tickValues );
@@ -295,23 +449,13 @@ std::vector<std::vector<cvf::ref<cvf::Drawable>>>
             QString     qLabelText = QString::number( contourLinePolygons[i][j].value, 'g', 2 );
             cvf::String labelText  = cvfqt::Utils::toString( qLabelText );
 
-            size_t nVertices = contourLinePolygons[i][j].vertices.size();
+            const auto displaySegments =
+                resampledDisplaySegments( contourLinePolygons[i][j].vertices, contourMapGrid, displayCoordTransform, elevationProvider );
 
             std::vector<cvf::Vec3f> displayLines;
-            displayLines.reserve( nVertices * 2 );
-            for ( size_t v = 0; v < nVertices; ++v )
+            displayLines.reserve( displaySegments.size() * 2 );
+            for ( const auto& [displayVertex1, displayVertex2] : displaySegments )
             {
-                cvf::Vec3d globalVertex1  = contourLinePolygons[i][j].vertices[v] + contourMapGrid.origin3d();
-                cvf::Vec3d displayVertex1 = displayCoordTransform->transformToDisplayCoord( globalVertex1 );
-
-                cvf::Vec3d globalVertex2;
-                if ( v < nVertices - 1 )
-                    globalVertex2 = contourLinePolygons[i][j].vertices[v + 1] + contourMapGrid.origin3d();
-                else
-                    globalVertex2 = contourLinePolygons[i][j].vertices[0] + contourMapGrid.origin3d();
-
-                cvf::Vec3d displayVertex2 = displayCoordTransform->transformToDisplayCoord( globalVertex2 );
-
                 cvf::BoundingBox lineBBox;
                 lineBBox.add( displayVertex1 );
                 lineBBox.add( displayVertex2 );
@@ -410,7 +554,9 @@ std::vector<cvf::ref<cvf::Drawable>>
                                                          const RigContourMapGrid&                                     contourMapGrid,
                                                          const cvf::ScalarMapper*                                     scalarMapper,
                                                          caf::NumberFormatType                                        numberFormat,
-                                                         int                                                          precision ) const
+                                                         int                                                          precision,
+                                                         const RivContourMapElevationProvider*                        elevationProvider,
+                                                         const RivContourLineAppearance&                              lineAppearance ) const
 {
     CAF_ASSERT( camera && displayCoordTransform && labelBBoxes );
 
@@ -430,9 +576,11 @@ std::vector<cvf::ref<cvf::Drawable>>
     const RigContourPolygonsTools::ContourPolygons* previousLevel = nullptr;
     for ( int64_t i = (int64_t)contourLinePolygons.size() - 1; i > 0; --i )
     {
-        cvf::Color3f                backgroundColor( scalarMapper->mapToColor( tickValues[i] ) );
-        cvf::Color3f                textColor = RiaColorTools::contrastColor( backgroundColor );
-        cvf::ref<cvf::DrawableText> label     = createTextLabel( textColor, backgroundColor );
+        cvf::Color3f backgroundColor( scalarMapper->mapToColor( tickValues[i] ) );
+
+        // A label belongs to its contour line, so it takes the same color
+        cvf::Color3f                textColor = lineAppearance.colorForLevel( backgroundColor );
+        cvf::ref<cvf::DrawableText> label     = createTextLabel( textColor, backgroundColor, lineAppearance.labelFontSize );
 
         for ( size_t j = 0; j < contourLinePolygons[i].size(); ++j )
         {
@@ -460,8 +608,12 @@ std::vector<cvf::ref<cvf::Drawable>>
                     continue;
                 }
 
-                cvf::Vec3d globalVertex1 = localVertex1 + contourMapGrid.origin3d();
-                cvf::Vec3d globalVertex2 = localVertex2 + contourMapGrid.origin3d();
+                auto globalVertex1Candidate = toDomainCoord( localVertex1, contourMapGrid, elevationProvider );
+                auto globalVertex2Candidate = toDomainCoord( localVertex2, contourMapGrid, elevationProvider );
+                if ( !globalVertex1Candidate || !globalVertex2Candidate ) continue;
+
+                cvf::Vec3d globalVertex1 = *globalVertex1Candidate;
+                cvf::Vec3d globalVertex2 = *globalVertex2Candidate;
 
                 cvf::Vec3d globalVertex = 0.5 * ( globalVertex1 + globalVertex2 );
 
@@ -471,7 +623,12 @@ std::vector<cvf::ref<cvf::Drawable>>
                 camera->project( displayVertex, &windowVertex );
                 CAF_ASSERT( !windowVertex.isUndefined() );
                 displayVertex.z() += 10.0f;
-                cvf::BoundingBox windowBBox = label->textBoundingBox( labelText, cvf::Vec3f::ZERO, cvf::Vec3f( segment.getNormalized() ) );
+
+                // The text direction is interpreted in screen space by the drawer
+                const cvf::Vec3f labelDirection = lineAppearance.alignLabelsWithCamera ? cvf::Vec3f::X_AXIS
+                                                                                       : cvf::Vec3f( segment.getNormalized() );
+
+                cvf::BoundingBox windowBBox = label->textBoundingBox( labelText, cvf::Vec3f::ZERO, labelDirection );
                 cvf::Vec3d       displayBBoxMin, displayBBoxMax;
                 camera->unproject( windowBBox.min() + windowVertex, &displayBBoxMin );
                 camera->unproject( windowBBox.max() + windowVertex, &displayBBoxMax );
@@ -512,7 +669,7 @@ std::vector<cvf::ref<cvf::Drawable>>
                 {
                     cvf::Vec3f displayVertexV( displayVertex );
                     CAF_ASSERT( !displayVertex.isUndefined() );
-                    label->addText( labelText, displayVertexV, cvf::Vec3f( segment.getNormalized() ) );
+                    label->addText( labelText, displayVertexV, labelDirection );
                     labelBBoxes->at( i ).push_back( displayBBox );
                     distanceSinceLastLabel = 0.0;
                 }
@@ -549,9 +706,12 @@ cvf::ref<cvf::DrawableGeo> RivContourMapProjectionPartMgr::createPickPointVisDra
 
     for ( size_t i = 0; i < pickPointPolygon.size(); ++i )
     {
-        cvf::Vec3d globalPoint = pickPointPolygon[i] + contourMapGrid.origin3d();
-        cvf::Vec3f displayPoint( displayCoordTransform->transformToDisplayCoord( globalPoint ) );
-        ( *vertexArray )[i] = displayPoint;
+        // The pick point marker is only used by the 2d contour map views, and is always placed on the
+        // contour map plane. Without an elevation provider a display coordinate is always produced.
+        auto displayPoint = toDisplayCoord( pickPointPolygon[i], contourMapGrid, displayCoordTransform, nullptr );
+        CAF_ASSERT( displayPoint );
+
+        ( *vertexArray )[i] = cvf::Vec3f( displayPoint.value_or( cvf::Vec3d::ZERO ) );
     }
 
     cvf::ref<cvf::DrawableGeo> geo = nullptr;

--- a/ApplicationLibCode/ModelVisualization/RivContourMapProjectionPartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/RivContourMapProjectionPartMgr.h
@@ -21,17 +21,22 @@
 #include "ContourMap/RigContourPolygonsTools.h"
 
 #include "cafDisplayCoordTransform.h"
+#include "cafFontTools.h"
 #include "cafPdmObject.h"
 #include "cafPdmPointer.h"
 #include "cafPdmUiNumberFormat.h"
 
+#include "cvfColor3.h"
 #include "cvfDrawableGeo.h"
 #include "cvfDrawableText.h"
 #include "cvfObject.h"
 #include "cvfVector2.h"
 #include "cvfVector4.h"
 
+#include <optional>
+
 class RigContourMapGrid;
+class RivContourMapElevationProvider;
 
 namespace cvf
 {
@@ -42,17 +47,47 @@ class ModelBasicList;
 class Part;
 } // namespace cvf
 
+//==================================================================================================
+///
+/// How the contour lines are drawn.
+///
+/// The defaults reproduce the appearance used by the 2d contour map views: one hairline per contour
+/// level, coloured to contrast the level colour of the map underneath it.
+///
+//==================================================================================================
+struct RivContourLineAppearance
+{
+    // When not set, every contour level gets a colour contrasting its own level colour
+    std::optional<cvf::Color3f> color;
+    float                       lineWidth = 1.0f;
+
+    caf::FontTools::FontSize labelFontSize = caf::FontTools::FontSize::FONT_SIZE_10;
+
+    // Labels are drawn along the contour segment they belong to. The direction is a screen space one,
+    // which only lines up with the segment while the camera looks straight down at the map, so in a 3d
+    // view the text ends up rotated arbitrarily. Set this to keep the labels upright on screen instead.
+    bool alignLabelsWithCamera = false;
+
+    // The colour to draw a contour level in. Shared by the lines and their labels so the two cannot
+    // drift apart. levelColor is the map colour of the level, used when no explicit colour is set.
+    cvf::Color3f colorForLevel( const cvf::Color3f& levelColor ) const;
+};
+
 class RivContourMapProjectionPartMgr : public cvf::Object
 {
 public:
     RivContourMapProjectionPartMgr( caf::PdmObject* contourMapProjection );
 
-    void appendProjectionToModel( cvf::ModelBasicList*              model,
-                                  const caf::DisplayCoordTransform* displayCoordTransform,
-                                  const std::vector<cvf::Vec4d>&    vertices,
-                                  const RigContourMapGrid&          contourMapGrid,
-                                  const cvf::Color3f&               backgroundColor,
-                                  cvf::ScalarMapper*                scalarMapper ) const;
+    // elevationProvider controls where the geometry is placed vertically. When null, the geometry is
+    // placed on the horizontal plane at RigContourMapGrid::origin3d(), which is the behaviour used by
+    // the 2d contour map views.
+    void appendProjectionToModel( cvf::ModelBasicList*                  model,
+                                  const caf::DisplayCoordTransform*     displayCoordTransform,
+                                  const std::vector<cvf::Vec4d>&        vertices,
+                                  const RigContourMapGrid&              contourMapGrid,
+                                  const cvf::Color3f&                   backgroundColor,
+                                  cvf::ScalarMapper*                    scalarMapper,
+                                  const RivContourMapElevationProvider* elevationProvider = nullptr ) const;
 
     void appendContourLinesToModel( const cvf::Camera*                                           camera,
                                     cvf::ModelBasicList*                                         model,
@@ -63,7 +98,9 @@ public:
                                     bool                                                         showContourLines,
                                     bool                                                         showContourLabels,
                                     caf::NumberFormatType                                        numberFormat,
-                                    int                                                          precision );
+                                    int                                                          precision,
+                                    const RivContourMapElevationProvider*                        elevationProvider = nullptr,
+                                    const RivContourLineAppearance&                              lineAppearance    = {} );
 
     void appendPickPointVisToModel( cvf::ModelBasicList*              model,
                                     const caf::DisplayCoordTransform* displayCoordTransform,
@@ -73,28 +110,53 @@ public:
     cvf::ref<cvf::Vec2fArray> createTextureCoords( const std::vector<double>& values, cvf::ScalarMapper* scalarMapper ) const;
 
 private:
-    static cvf::ref<cvf::DrawableText> createTextLabel( const cvf::Color3f& textColor, const cvf::Color3f& backgroundColor );
-    cvf::ref<cvf::Part>                createProjectionMapPart( const caf::DisplayCoordTransform* displayCoordTransform,
-                                                                const std::vector<cvf::Vec4d>&    vertices,
-                                                                const RigContourMapGrid&          contourMapGrid,
-                                                                const cvf::Color3f&               backgroundColor,
-                                                                cvf::ScalarMapper*                scalarMapper ) const;
+    // Convert a contour map local vertex to domain coordinates. Without an elevation provider this is
+    // the vertex offset by RigContourMapGrid::origin3d(). With one, the z component is replaced by the
+    // elevation reported for the vertex position, and nothing is returned where the provider has no
+    // elevation to offer.
+    static std::optional<cvf::Vec3d> toDomainCoord( const cvf::Vec3d&                     localVertex,
+                                                    const RigContourMapGrid&              contourMapGrid,
+                                                    const RivContourMapElevationProvider* elevationProvider );
+
+    static std::optional<cvf::Vec3d> toDisplayCoord( const cvf::Vec3d&                     localVertex,
+                                                     const RigContourMapGrid&              contourMapGrid,
+                                                     const caf::DisplayCoordTransform*     displayCoordTransform,
+                                                     const RivContourMapElevationProvider* elevationProvider );
+
+    // The segments of a closed contour polygon in display coordinates, sampled densely enough to follow
+    // the elevation reported by the provider. Segments where no elevation is defined are left out.
+    static std::vector<std::pair<cvf::Vec3d, cvf::Vec3d>> resampledDisplaySegments( const std::vector<cvf::Vec3d>&    localVertices,
+                                                                                    const RigContourMapGrid&          contourMapGrid,
+                                                                                    const caf::DisplayCoordTransform* displayCoordTransform,
+                                                                                    const RivContourMapElevationProvider* elevationProvider );
+
+    static cvf::ref<cvf::DrawableText>
+        createTextLabel( const cvf::Color3f& textColor, const cvf::Color3f& backgroundColor, caf::FontTools::FontSize fontSize );
+    cvf::ref<cvf::Part> createProjectionMapPart( const caf::DisplayCoordTransform*     displayCoordTransform,
+                                                 const std::vector<cvf::Vec4d>&        vertices,
+                                                 const RigContourMapGrid&              contourMapGrid,
+                                                 const cvf::Color3f&                   backgroundColor,
+                                                 cvf::ScalarMapper*                    scalarMapper,
+                                                 const RivContourMapElevationProvider* elevationProvider ) const;
 
     std::vector<std::vector<cvf::ref<cvf::Drawable>>>
         createContourPolygons( const caf::DisplayCoordTransform*                            displayCoordTransform,
                                const std::vector<std::vector<cvf::BoundingBox>>&            labelBBoxes,
                                const std::vector<RigContourPolygonsTools::ContourPolygons>& contourLinePolygons,
                                cvf::ScalarMapper*                                           scalarMapper,
-                               const RigContourMapGrid&                                     contourMapGrid ) const;
+                               const RigContourMapGrid&                                     contourMapGrid,
+                               const RivContourMapElevationProvider*                        elevationProvider ) const;
 
     std::vector<cvf::ref<cvf::Drawable>> createContourLabels( const cvf::Camera*                          camera,
                                                               const caf::DisplayCoordTransform*           displayCoordTransform,
                                                               std::vector<std::vector<cvf::BoundingBox>>* labelBBoxes,
                                                               const std::vector<RigContourPolygonsTools::ContourPolygons>& contourLinePolygons,
-                                                              const RigContourMapGrid& contourMapGrid,
-                                                              const cvf::ScalarMapper* scalarMapper,
-                                                              caf::NumberFormatType    numberFormat,
-                                                              int                      precision ) const;
+                                                              const RigContourMapGrid&              contourMapGrid,
+                                                              const cvf::ScalarMapper*              scalarMapper,
+                                                              caf::NumberFormatType                 numberFormat,
+                                                              int                                   precision,
+                                                              const RivContourMapElevationProvider* elevationProvider,
+                                                              const RivContourLineAppearance&       lineAppearance ) const;
 
     cvf::ref<cvf::DrawableGeo> createPickPointVisDrawable( const caf::DisplayCoordTransform* displayCoordTransform,
                                                            const cvf::Vec2d&                 pickPoint,

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/CMakeLists_files.cmake
@@ -1,5 +1,7 @@
 set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimContourMapResolutionTools.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimContourMapInView.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimContourMapInViewCollection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimContourMapProjection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimEclipseContourMapProjection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimEclipseContourMapView.cpp

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInView.cpp
@@ -1,0 +1,519 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimContourMapInView.h"
+
+#include "ContourMap/RigContourMapGrid.h"
+#include "ContourMap/RigContourMapTopography.h"
+#include "RigEclipseCaseData.h"
+#include "RigMainGrid.h"
+#include "Surface/RigSurface.h"
+
+#include "ContourMap/RimContourMapProjection.h"
+#include "ContourMap/RimEclipseContourMapView.h"
+#include "Rim3dView.h"
+#include "RimEclipseCase.h"
+#include "RimEclipseView.h"
+#include "RimGridView.h"
+#include "RimRegularLegendConfig.h"
+#include "Surfaces/RimSurface.h"
+#include "Surfaces/RimSurfaceInView.h"
+#include "Surfaces/RimSurfaceInViewCollection.h"
+
+#include "RivContourMapElevationProvider.h"
+#include "RivContourMapProjectionPartMgr.h"
+
+#include "RiuViewer.h"
+
+#include "cvfCamera.h"
+#include "cvfModelBasicList.h"
+
+CAF_PDM_SOURCE_INIT( RimContourMapInView, "RimContourMapInView" );
+
+namespace caf
+{
+template <>
+void AppEnum<RimContourMapInView::MapPosition>::setUp()
+{
+    addItem( RimContourMapInView::MapPosition::TOP_OF_CASE, "TOP_OF_CASE", "Top of Case" );
+    addItem( RimContourMapInView::MapPosition::BOTTOM_OF_CASE, "BOTTOM_OF_CASE", "Bottom of Case" );
+    addItem( RimContourMapInView::MapPosition::USER_DEFINED_DEPTH, "USER_DEFINED_DEPTH", "User Defined Depth" );
+    setDefault( RimContourMapInView::MapPosition::TOP_OF_CASE );
+}
+
+template <>
+void AppEnum<RimContourMapInView::LineColorMode>::setUp()
+{
+    addItem( RimContourMapInView::LineColorMode::CONTRAST_TO_MAP, "CONTRAST_TO_MAP", "Contrast to Map" );
+    addItem( RimContourMapInView::LineColorMode::SINGLE_COLOR, "SINGLE_COLOR", "Single Color" );
+    setDefault( RimContourMapInView::LineColorMode::CONTRAST_TO_MAP );
+}
+} // namespace caf
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInView::RimContourMapInView()
+{
+    CAF_PDM_InitObject( "Contour Map", ":/2DMap16x16.png" );
+
+    CAF_PDM_InitFieldNoDefault( &m_contourMapView, "ContourMapView", "Contour Map" );
+    m_contourMapView.uiCapability()->setUiHidden( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_nameProxy, "ContourMapName", "Name" );
+    m_nameProxy.registerGetMethod( this, &RimContourMapInView::name );
+    m_nameProxy.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_mapPosition, "MapPosition", "Map Position" );
+
+    CAF_PDM_InitField( &m_depthOffset, "DepthOffset", 0.0, "Depth Offset" );
+    m_depthOffset.uiCapability()->setUiToolTip( "Positive values move the map upwards." );
+
+    CAF_PDM_InitField( &m_userDefinedDepth, "UserDefinedDepth", 0.0, "Depth" );
+
+    CAF_PDM_InitField( &m_showMapSurface, "ShowMapSurface", true, "Show Map Surface" );
+    CAF_PDM_InitField( &m_showContourLines, "ShowContourLines", true, "Show Contour Lines" );
+
+    CAF_PDM_InitField( &m_projectSurfaceOnGeometry, "ProjectSurfaceOnGeometry", false, "Project Surface on Geometry" );
+    m_projectSurfaceOnGeometry.uiCapability()->setUiToolTip(
+        "Follow the top of the visible geometry instead of drawing the map surface on the map plane." );
+
+    CAF_PDM_InitField( &m_projectLinesOnGeometry, "ProjectLinesOnGeometry", false, "Project Lines on Geometry" );
+    m_projectLinesOnGeometry.uiCapability()->setUiToolTip(
+        "Follow the top of the visible geometry instead of drawing the contour lines on the map plane." );
+
+    CAF_PDM_InitField( &m_showContourLabels, "ShowContourLabels", false, "Show Contour Labels" );
+
+    CAF_PDM_InitField( &m_labelFontSize, "LabelFontSize", RiaFontCache::FontSizeEnum( RiaFontCache::FontSize::FONT_SIZE_10 ), "Label Font Size" );
+
+    CAF_PDM_InitField( &m_lineColorMode, "LineColorMode", caf::AppEnum<LineColorMode>( LineColorMode::CONTRAST_TO_MAP ), "Line Color Mode" );
+    m_lineColorMode.uiCapability()->setUiToolTip( "Contrast to Map gives every contour level a color contrasting the map underneath it." );
+
+    CAF_PDM_InitField( &m_lineColor, "LineColor", cvf::Color3f( cvf::Color3f::BLACK ), "Line Color" );
+
+    CAF_PDM_InitField( &m_lineThickness, "LineThickness", 1, "Line Thickness" );
+    m_lineThickness.setRange( 1, 10 );
+
+    nameField()->uiCapability()->setUiHidden( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInView::~RimContourMapInView()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseContourMapView* RimContourMapInView::contourMapView() const
+{
+    return m_contourMapView();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimEclipseContourMapView* RimContourMapInView::sourceItem() const
+{
+    return contourMapView();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::setContourMapView( RimEclipseContourMapView* contourMapView )
+{
+    m_contourMapView = contourMapView;
+
+    clearGeometry();
+    updateUiIconFromToggleField();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RimContourMapInView::name() const
+{
+    if ( !m_contourMapView() ) return "Contour Map";
+
+    return m_contourMapView()->name();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::PdmFieldHandle* RimContourMapInView::userDescriptionField()
+{
+    return &m_nameProxy;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapProjection* RimContourMapInView::contourMapProjection() const
+{
+    if ( !m_contourMapView() ) return nullptr;
+
+    return m_contourMapView()->contourMapProjection();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RivContourMapProjectionPartMgr* RimContourMapInView::partMgr()
+{
+    if ( m_partMgr.isNull() ) m_partMgr = new RivContourMapProjectionPartMgr( contourMapProjection() );
+
+    return m_partMgr.p();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::clearPartMgr()
+{
+    m_partMgr = nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::clearGeometry()
+{
+    clearPartMgr();
+
+    m_topography               = nullptr;
+    m_topographyMapGrid        = nullptr;
+    m_topographyMainGrid       = nullptr;
+    m_topographyCellVisibility = nullptr;
+    m_topographySurfaces.clear();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<double> RimContourMapInView::mapElevation() const
+{
+    auto projection = contourMapProjection();
+    if ( !projection ) return {};
+
+    const RigContourMapGrid* mapGrid = projection->mapGrid();
+    if ( !mapGrid ) return {};
+
+    double elevation = 0.0;
+    switch ( m_mapPosition() )
+    {
+        case MapPosition::TOP_OF_CASE:
+            elevation = mapGrid->expandedBoundingBox().max().z();
+            break;
+        case MapPosition::BOTTOM_OF_CASE:
+            elevation = mapGrid->origin3d().z();
+            break;
+        case MapPosition::USER_DEFINED_DEPTH:
+            elevation = -m_userDefinedDepth();
+            break;
+    }
+
+    return elevation + m_depthOffset();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimContourMapInView::mapSampleSpacing() const
+{
+    auto projection = contourMapProjection();
+    if ( !projection || !projection->mapGrid() ) return 0.0;
+
+    return projection->mapGrid()->sampleSpacing();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimContourMapInView::surfaceDrapeLift() const
+{
+    // Draped straight onto the geometry the map surface would be coplanar with it and the two would
+    // z-fight. Lift it clear instead. Scales with the model, and is small enough to be invisible at any
+    // reasonable zoom level.
+    return 0.01 * mapSampleSpacing();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimContourMapInView::contourLineLift() const
+{
+    // Twice the lift of the map surface, so the lines stay on top of it whether it is draped or flat
+    return 2.0 * surfaceDrapeLift();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::shared_ptr<const RigContourMapTopography> RimContourMapInView::topography()
+{
+    auto projection = contourMapProjection();
+    if ( !projection || !projection->mapGrid() ) return nullptr;
+
+    // The drape follows the geometry of the view the contour map is shown in, not the geometry of the
+    // case the contour map was computed from.
+    auto hostView = firstAncestorOfType<RimEclipseView>();
+    if ( !hostView || !hostView->eclipseCase() || !hostView->eclipseCase()->eclipseCaseData() ) return nullptr;
+
+    RigMainGrid* mainGrid = hostView->eclipseCase()->eclipseCaseData()->mainGrid();
+    if ( !mainGrid ) return nullptr;
+
+    const RigContourMapGrid*  mapGrid        = projection->mapGrid();
+    cvf::ref<cvf::UByteArray> cellVisibility = hostView->currentTotalCellVisibility();
+
+    // A view can be showing surfaces and no grid cells at all, so both are drape targets
+    std::vector<RigSurface*> surfaces;
+    if ( auto surfaceCollection = hostView->surfaceInViewCollection() )
+    {
+        for ( RimSurfaceInView* surfaceInView : surfaceCollection->visibleSurfacesInView() )
+        {
+            if ( !surfaceInView->surface() ) continue;
+
+            if ( RigSurface* surfaceData = surfaceInView->surface()->surfaceData() ) surfaces.push_back( surfaceData );
+        }
+    }
+
+    // Cell filters and property filters make the view produce a new visibility array, a resolution
+    // change makes the projection produce a new map grid, reloading the case produces a new main grid,
+    // and surfaces come and go as they are checked. Any of those invalidates the raster.
+    if ( m_topography && m_topographyMapGrid == mapGrid && m_topographyMainGrid == mainGrid &&
+         m_topographyCellVisibility.p() == cellVisibility.p() && m_topographySurfaces == surfaces )
+    {
+        return m_topography;
+    }
+
+    m_topography               = std::make_shared<const RigContourMapTopography>( *mapGrid, *mainGrid, cellVisibility.p(), surfaces );
+    m_topographyMapGrid        = mapGrid;
+    m_topographyMainGrid       = mainGrid;
+    m_topographyCellVisibility = cellVisibility.p();
+    m_topographySurfaces       = surfaces;
+
+    return m_topography;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::appendPartsToModel( cvf::ModelBasicList*              model,
+                                              const caf::DisplayCoordTransform* displayCoordTransform,
+                                              const cvf::Camera*                camera )
+{
+    if ( !isChecked() || !model || !displayCoordTransform ) return;
+
+    auto sourceView = m_contourMapView();
+    if ( !sourceView || !sourceView->eclipseCase() || !sourceView->eclipseCase()->eclipseCaseData() ) return;
+
+    auto projection = contourMapProjection();
+    if ( !projection || !projection->isChecked() ) return;
+
+    // The projection is owned by the contour map view and shared with it, so it is generated for the
+    // time step that view is on. Driving it to the host view's time step instead would leave the contour
+    // map view holding results for a step it is not showing, and make the two views recompute the whole
+    // projection against each other on every redraw. Generating is still needed here, since the contour
+    // map view may never have been opened.
+    projection->generateResultsIfNecessary( sourceView->currentTimeStep() );
+    projection->generateGeometryIfNecessary();
+
+    if ( !projection->mapGrid() ) return;
+
+    auto* mapLegendConfig = projection->legendConfig();
+    if ( !mapLegendConfig || !mapLegendConfig->scalarMapper() ) return;
+
+    auto elevation = mapElevation();
+    if ( !elevation ) return;
+
+    // Falls back to the map plane when the topography cannot be built, for instance when the host view
+    // has no loaded grid
+    std::shared_ptr<const RigContourMapTopography> mapTopography;
+    if ( m_projectSurfaceOnGeometry() || m_projectLinesOnGeometry() ) mapTopography = topography();
+
+    RivContourMapFlatElevation flatElevation( *elevation );
+
+    if ( m_showMapSurface() )
+    {
+        std::unique_ptr<RivContourMapTopographyElevation> surfaceTopography;
+        if ( m_projectSurfaceOnGeometry() && mapTopography )
+        {
+            // Lifted clear of the geometry it follows, otherwise the two are coplanar and z-fight
+            surfaceTopography = std::make_unique<RivContourMapTopographyElevation>( mapTopography, m_depthOffset() + surfaceDrapeLift() );
+        }
+
+        const RivContourMapElevationProvider* surfaceElevation =
+            surfaceTopography ? static_cast<const RivContourMapElevationProvider*>( surfaceTopography.get() ) : &flatElevation;
+
+        partMgr()->appendProjectionToModel( model,
+                                            displayCoordTransform,
+                                            projection->trianglesWithVertexValues(),
+                                            *projection->mapGrid(),
+                                            sourceView->backgroundColor(),
+                                            mapLegendConfig->scalarMapper(),
+                                            surfaceElevation );
+    }
+
+    if ( !m_showContourLines() || !camera ) return;
+
+    // The lines are drawn as line primitives, which OpenGL polygon offset does not apply to, so they
+    // have to be lifted above the surface they follow to win the depth test against it.
+    const double lineLift = contourLineLift();
+
+    std::unique_ptr<RivContourMapTopographyElevation> lineTopography;
+    if ( m_projectLinesOnGeometry() && mapTopography )
+    {
+        lineTopography = std::make_unique<RivContourMapTopographyElevation>( mapTopography, m_depthOffset() + lineLift );
+    }
+
+    RivContourMapFlatElevation flatLineElevation( *elevation + lineLift );
+
+    const RivContourMapElevationProvider* lineElevation =
+        lineTopography ? static_cast<const RivContourMapElevationProvider*>( lineTopography.get() ) : &flatLineElevation;
+
+    RivContourLineAppearance lineAppearance;
+    if ( m_lineColorMode() == LineColorMode::SINGLE_COLOR ) lineAppearance.color = m_lineColor();
+    lineAppearance.lineWidth = static_cast<float>( m_lineThickness() );
+
+    lineAppearance.labelFontSize = m_labelFontSize();
+
+    // The camera moves freely here, unlike in the 2d contour map views, so labels are kept upright
+    lineAppearance.alignLabelsWithCamera = true;
+
+    // The labels are anchored in 3d and re-projected to the screen every frame, so they stay readable
+    // and correctly placed while navigating. Only the layout decisions, which labels were dropped for
+    // overlapping and how the text is rotated, are made from the camera as it is right now.
+    partMgr()->appendContourLinesToModel( camera,
+                                          model,
+                                          displayCoordTransform,
+                                          projection->contourPolygons(),
+                                          *projection->mapGrid(),
+                                          mapLegendConfig->scalarMapper(),
+                                          true,
+                                          m_showContourLabels(),
+                                          mapLegendConfig->tickNumberFormat(),
+                                          mapLegendConfig->significantDigitsInData(),
+                                          lineElevation,
+                                          lineAppearance );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimRegularLegendConfig* RimContourMapInView::legendConfig() const
+{
+    auto projection = contourMapProjection();
+    if ( !projection ) return nullptr;
+
+    return projection->legendConfig();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::updateLegendRangesTextAndVisibility( RiuViewer* nativeOrOverrideViewer, bool isUsingOverrideViewer )
+{
+    if ( !isChecked() || !nativeOrOverrideViewer ) return;
+
+    auto projection = contourMapProjection();
+    if ( !projection || !projection->isChecked() ) return;
+
+    // Sets both the ranges and the title
+    projection->updateLegend();
+
+    auto* mapLegendConfig = projection->legendConfig();
+    if ( !mapLegendConfig || !mapLegendConfig->showLegend() ) return;
+
+    nativeOrOverrideViewer->addColorLegendToBottomLeftCorner( mapLegendConfig->titledOverlayFrame(), isUsingOverrideViewer );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    uiOrdering.add( &m_nameProxy );
+
+    caf::PdmUiGroup* positionGroup = uiOrdering.addNewGroup( "Position" );
+    positionGroup->add( &m_mapPosition );
+    if ( m_mapPosition() == MapPosition::USER_DEFINED_DEPTH )
+    {
+        positionGroup->add( &m_userDefinedDepth );
+    }
+    positionGroup->add( &m_depthOffset );
+
+    caf::PdmUiGroup* surfaceGroup = uiOrdering.addNewGroup( "Map Surface" );
+    surfaceGroup->add( &m_showMapSurface );
+    surfaceGroup->add( &m_projectSurfaceOnGeometry );
+    m_projectSurfaceOnGeometry.uiCapability()->setUiReadOnly( !m_showMapSurface() );
+
+    caf::PdmUiGroup* contourLineGroup = uiOrdering.addNewGroup( "Contour Lines" );
+    contourLineGroup->add( &m_showContourLines );
+    contourLineGroup->add( &m_projectLinesOnGeometry );
+    contourLineGroup->add( &m_lineColorMode );
+    if ( m_lineColorMode() == LineColorMode::SINGLE_COLOR )
+    {
+        contourLineGroup->add( &m_lineColor );
+    }
+    contourLineGroup->add( &m_lineThickness );
+    contourLineGroup->add( &m_showContourLabels );
+    contourLineGroup->add( &m_labelFontSize );
+
+    // The toggle itself stays editable, everything it controls does not
+    const bool linesDisabled = !m_showContourLines();
+    m_projectLinesOnGeometry.uiCapability()->setUiReadOnly( linesDisabled );
+    m_lineColorMode.uiCapability()->setUiReadOnly( linesDisabled );
+    m_lineColor.uiCapability()->setUiReadOnly( linesDisabled );
+    m_lineThickness.uiCapability()->setUiReadOnly( linesDisabled );
+    m_showContourLabels.uiCapability()->setUiReadOnly( linesDisabled );
+    m_labelFontSize.uiCapability()->setUiReadOnly( linesDisabled || !m_showContourLabels() );
+
+    uiOrdering.skipRemainingFields( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
+{
+    updateUiIconFromToggleField();
+
+    if ( changedField == &m_mapPosition || changedField == &m_projectSurfaceOnGeometry || changedField == &m_projectLinesOnGeometry ||
+         changedField == &m_lineColorMode || changedField == &m_showContourLines || changedField == &m_showMapSurface ||
+         changedField == &m_showContourLabels )
+    {
+        updateConnectedEditors();
+    }
+
+    if ( auto view = firstAncestorOfType<Rim3dView>() )
+    {
+        view->scheduleCreateDisplayModelAndRedraw();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInView::initAfterRead()
+{
+    updateUiIconFromToggleField();
+}

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInView.cpp
@@ -31,6 +31,7 @@
 #include "RimEclipseView.h"
 #include "RimGridView.h"
 #include "RimRegularLegendConfig.h"
+#include "RimViewNameConfig.h"
 #include "Surfaces/RimSurface.h"
 #include "Surfaces/RimSurfaceInView.h"
 #include "Surfaces/RimSurfaceInViewCollection.h"
@@ -38,6 +39,7 @@
 #include "RivContourMapElevationProvider.h"
 #include "RivContourMapProjectionPartMgr.h"
 
+#include "Riu3DMainWindowTools.h"
 #include "RiuViewer.h"
 
 #include "cvfCamera.h"
@@ -153,7 +155,10 @@ QString RimContourMapInView::name() const
 {
     if ( !m_contourMapView() ) return "Contour Map";
 
-    return m_contourMapView()->name();
+    // Use the auto-generated name (custom name part plus generated tags) instead of only the custom name part.
+    // Some contour map view types (e.g. RimStatisticsContourMapView) intentionally leave the custom name part
+    // empty and rely fully on the generated tags, which would otherwise result in an empty name here.
+    return m_contourMapView()->nameConfig()->name();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -452,6 +457,11 @@ void RimContourMapInView::updateLegendRangesTextAndVisibility( RiuViewer* native
 void RimContourMapInView::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
     uiOrdering.add( &m_nameProxy );
+
+    if ( m_contourMapView() )
+    {
+        uiOrdering.addNewButton( "Go to Contour Map", [this]() { Riu3DMainWindowTools::selectAsCurrentItem( m_contourMapView() ); } );
+    }
 
     caf::PdmUiGroup* positionGroup = uiOrdering.addNewGroup( "Position" );
     positionGroup->add( &m_mapPosition );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInView.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInView.h
@@ -1,0 +1,163 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RimCheckableNamedObject.h"
+
+#include "RiaFontCache.h"
+
+#include "cafAppEnum.h"
+#include "cafPdmFieldCvfColor.h"
+#include "cafPdmProxyValueField.h"
+#include "cafPdmPtrField.h"
+
+#include "cvfArray.h"
+#include "cvfObject.h"
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+class RigContourMapGrid;
+class RigContourMapTopography;
+class RigMainGrid;
+class RigSurface;
+class RimEclipseContourMapView;
+class RimContourMapProjection;
+class RimRegularLegendConfig;
+class RivContourMapProjectionPartMgr;
+class RiuViewer;
+
+namespace cvf
+{
+class Camera;
+class ModelBasicList;
+} // namespace cvf
+
+namespace caf
+{
+class DisplayCoordTransform;
+}
+
+//==================================================================================================
+///
+/// A contour map shown inside a 3d view.
+///
+/// This is a presentation wrapper only. The contour map itself, including the result, the
+/// aggregation and the computed geometry, is owned by the contour map view this object points at.
+/// The wrapper decides where the map is placed vertically in the 3d scene and what parts of it are
+/// drawn.
+///
+//==================================================================================================
+class RimContourMapInView : public RimCheckableNamedObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    using SourceItemT = RimEclipseContourMapView;
+
+    enum class MapPosition
+    {
+        TOP_OF_CASE,
+        BOTTOM_OF_CASE,
+        USER_DEFINED_DEPTH
+    };
+
+    enum class LineColorMode
+    {
+        CONTRAST_TO_MAP,
+        SINGLE_COLOR
+    };
+
+    RimContourMapInView();
+    ~RimContourMapInView() override;
+
+    // Follows the name of the contour map this wrapper points at
+    QString name() const override;
+
+    RimEclipseContourMapView* contourMapView() const;
+    RimEclipseContourMapView* sourceItem() const;
+    void                      setContourMapView( RimEclipseContourMapView* contourMapView );
+
+    void appendPartsToModel( cvf::ModelBasicList* model, const caf::DisplayCoordTransform* displayCoordTransform, const cvf::Camera* camera );
+
+    RimRegularLegendConfig* legendConfig() const;
+    void                    updateLegendRangesTextAndVisibility( RiuViewer* nativeOrOverrideViewer, bool isUsingOverrideViewer );
+
+    // Drops the drawables only. The topography raster depends on the host view, not on the contour map,
+    // and is expensive enough to be worth keeping when only the contour map itself has changed.
+    void clearPartMgr();
+    void clearGeometry();
+
+protected:
+    void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void initAfterRead() override;
+
+    caf::PdmFieldHandle* userDescriptionField() override;
+
+private:
+    RimContourMapProjection* contourMapProjection() const;
+
+    // The domain z the contour map is placed on, including the depth offset.
+    std::optional<double> mapElevation() const;
+
+    double mapSampleSpacing() const;
+
+    // Draped geometry is lifted clear of the geometry it follows, since coplanar geometry z-fights.
+    // The map surface is lifted the least, and the contour lines sit above it.
+    double surfaceDrapeLift() const;
+    double contourLineLift() const;
+
+    // Lazily built, and rebuilt whenever the geometry is cleared.
+    std::shared_ptr<const RigContourMapTopography> topography();
+
+    RivContourMapProjectionPartMgr* partMgr();
+
+private:
+    caf::PdmPtrField<RimEclipseContourMapView*> m_contourMapView;
+    caf::PdmProxyValueField<QString>            m_nameProxy;
+
+    caf::PdmField<caf::AppEnum<MapPosition>> m_mapPosition;
+    caf::PdmField<double>                    m_depthOffset;
+    caf::PdmField<double>                    m_userDefinedDepth;
+
+    caf::PdmField<bool> m_showMapSurface;
+    caf::PdmField<bool> m_showContourLines;
+    caf::PdmField<bool> m_projectSurfaceOnGeometry;
+    caf::PdmField<bool> m_projectLinesOnGeometry;
+
+    caf::PdmField<bool>                       m_showContourLabels;
+    caf::PdmField<RiaFontCache::FontSizeEnum> m_labelFontSize;
+
+    caf::PdmField<caf::AppEnum<LineColorMode>> m_lineColorMode;
+    caf::PdmField<cvf::Color3f>                m_lineColor;
+    caf::PdmField<int>                         m_lineThickness;
+
+    cvf::ref<RivContourMapProjectionPartMgr>       m_partMgr;
+    std::shared_ptr<const RigContourMapTopography> m_topography;
+
+    // What the cached topography was built from. The raster is expensive, so it is kept until one of
+    // these changes. All are rebuilt or replaced as objects by their owners, so comparing identity is
+    // enough.
+    cvf::cref<cvf::UByteArray> m_topographyCellVisibility;
+    const RigContourMapGrid*   m_topographyMapGrid  = nullptr;
+    const RigMainGrid*         m_topographyMainGrid = nullptr;
+    std::vector<RigSurface*>   m_topographySurfaces;
+};

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInViewCollection.cpp
@@ -1,0 +1,283 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RimContourMapInViewCollection.h"
+
+#include "RiaDefines.h"
+
+#include "ContourMap/RimContourMapInView.h"
+#include "ContourMap/RimEclipseContourMapView.h"
+#include "Rim3dView.h"
+#include "RimGridView.h"
+#include "RimProject.h"
+
+#include "cafPdmUiTreeOrdering.h"
+
+#include <algorithm>
+
+CAF_PDM_SOURCE_INIT( RimContourMapInViewCollection, "RimContourMapInViewCollection" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInViewCollection::RimContourMapInViewCollection()
+{
+    CAF_PDM_InitObject( "Contour Maps" + RiaDefines::betaFeaturePostfix(), ":/2DMap16x16.png" );
+
+    CAF_PDM_InitFieldNoDefault( &m_contourMapsInView, "ContourMapsInView", "Contour Maps" );
+
+    // The name field is the user description field, and is what the project tree displays
+    setName( "Contour Maps" + RiaDefines::betaFeaturePostfix() );
+    nameField()->uiCapability()->setUiHidden( true );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInViewCollection::~RimContourMapInViewCollection()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInView* RimContourMapInViewCollection::findContourMapInViewForSource( const RimEclipseContourMapView* contourMapView ) const
+{
+    for ( RimContourMapInView* contourMapInView : m_contourMapsInView )
+    {
+        if ( contourMapInView && contourMapInView->contourMapView() == contourMapView ) return contourMapInView;
+    }
+
+    return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimEclipseContourMapView*> RimContourMapInViewCollection::allContourMapViewsInProject()
+{
+    std::vector<RimEclipseContourMapView*> contourMapViews;
+
+    RimProject* project = RimProject::current();
+    if ( !project ) return contourMapViews;
+
+    // The ensemble statistics contour maps are owned by their ensemble and are not part of the oil field
+    // collection, but they are views of the same type and show up here as well.
+    for ( Rim3dView* view : project->allViews() )
+    {
+        if ( auto contourMapView = dynamic_cast<RimEclipseContourMapView*>( view ) ) contourMapViews.push_back( contourMapView );
+    }
+
+    return contourMapViews;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::updateFromContourMapCollection()
+{
+    // Sweep the wrappers whose contour map has been deleted. The pointer field is set to null by the
+    // project data model when that happens.
+    for ( RimContourMapInView* contourMapInView : m_contourMapsInView.childrenByType() )
+    {
+        if ( !contourMapInView->contourMapView() )
+        {
+            m_contourMapsInView.removeChild( contourMapInView );
+            delete contourMapInView;
+        }
+    }
+
+    // Find or create a wrapper per contour map, then reorder to match the project
+    std::vector<RimContourMapInView*> orderedContourMapsInView;
+    for ( RimEclipseContourMapView* contourMapView : allContourMapViewsInProject() )
+    {
+        RimContourMapInView* contourMapInView = findContourMapInViewForSource( contourMapView );
+        if ( !contourMapInView )
+        {
+            contourMapInView = new RimContourMapInView;
+            contourMapInView->setContourMapView( contourMapView );
+
+            // A new contour map is not shown until the user asks for it
+            contourMapInView->setCheckState( false );
+        }
+
+        orderedContourMapsInView.push_back( contourMapInView );
+    }
+
+    // Anything left over points at a contour map that is no longer part of the project
+    for ( RimContourMapInView* contourMapInView : m_contourMapsInView.childrenByType() )
+    {
+        if ( std::find( orderedContourMapsInView.begin(), orderedContourMapsInView.end(), contourMapInView ) == orderedContourMapsInView.end() )
+        {
+            m_contourMapsInView.removeChild( contourMapInView );
+            delete contourMapInView;
+        }
+    }
+
+    m_contourMapsInView.clearWithoutDelete();
+    for ( RimContourMapInView* contourMapInView : orderedContourMapsInView )
+    {
+        m_contourMapsInView.push_back( contourMapInView );
+    }
+
+    updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimContourMapInView*> RimContourMapInViewCollection::allContourMapsInView() const
+{
+    return m_contourMapsInView.childrenByType();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimContourMapInView*> RimContourMapInViewCollection::visibleContourMapsInView() const
+{
+    if ( !isChecked() ) return {};
+
+    std::vector<RimContourMapInView*> visibleContourMaps;
+    for ( RimContourMapInView* contourMapInView : m_contourMapsInView )
+    {
+        if ( contourMapInView && contourMapInView->isChecked() ) visibleContourMaps.push_back( contourMapInView );
+    }
+
+    return visibleContourMaps;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::appendPartsToModel( cvf::ModelBasicList*              model,
+                                                        const caf::DisplayCoordTransform* displayCoordTransform,
+                                                        const cvf::Camera*                camera )
+{
+    for ( RimContourMapInView* contourMapInView : visibleContourMapsInView() )
+    {
+        contourMapInView->appendPartsToModel( model, displayCoordTransform, camera );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RimRegularLegendConfig*> RimContourMapInViewCollection::legendConfigs() const
+{
+    std::vector<RimRegularLegendConfig*> configs;
+    for ( RimContourMapInView* contourMapInView : visibleContourMapsInView() )
+    {
+        if ( auto* legendConfig = contourMapInView->legendConfig() ) configs.push_back( legendConfig );
+    }
+
+    return configs;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::updateLegendRangesTextAndVisibility( RiuViewer* nativeOrOverrideViewer, bool isUsingOverrideViewer )
+{
+    for ( RimContourMapInView* contourMapInView : visibleContourMapsInView() )
+    {
+        contourMapInView->updateLegendRangesTextAndVisibility( nativeOrOverrideViewer, isUsingOverrideViewer );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::updateViewTreeItemsInAllViews()
+{
+    RimProject* project = RimProject::current();
+    if ( !project ) return;
+
+    for ( Rim3dView* view : project->allViews() )
+    {
+        if ( view ) view->updateViewTreeItems( RiaDefines::ItemIn3dView::CONTOUR_MAP );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::scheduleRedrawOfViewsShowing( const RimEclipseContourMapView* contourMapView )
+{
+    if ( !contourMapView ) return;
+
+    RimProject* project = RimProject::current();
+    if ( !project ) return;
+
+    for ( Rim3dView* view : project->allViews() )
+    {
+        auto gridView = dynamic_cast<RimGridView*>( view );
+        if ( !gridView ) continue;
+
+        auto contourMaps = gridView->contourMapInViewCollection();
+        if ( !contourMaps ) continue;
+
+        bool showsContourMap = false;
+        for ( RimContourMapInView* contourMapInView : contourMaps->visibleContourMapsInView() )
+        {
+            if ( contourMapInView->contourMapView() != contourMapView ) continue;
+
+            // Only the drawables are stale. The topography raster follows the host view, which has not
+            // changed, and rebuilding it here would re-raster on every time step change of the contour
+            // map view.
+            contourMapInView->clearPartMgr();
+            showsContourMap = true;
+        }
+
+        if ( showsContourMap )
+        {
+            // The contour map parts belong to the frame scene, and are appended from
+            // onUpdateDisplayModelForCurrentTimeStep. A scheduled redraw only reaches
+            // createDisplayModelAndRedraw, which does not call that, so ask for the time step update
+            // directly. The contour map has finished generating its data by the time we get here, so the
+            // views pick up real geometry.
+            gridView->updateDisplayModelForCurrentTimeStepAndRedraw();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
+{
+    RimCheckableNamedObject::fieldChangedByUi( changedField, oldValue, newValue );
+
+    updateUiIconFromToggleField();
+
+    if ( changedField == &m_isChecked )
+    {
+        if ( auto view = firstAncestorOfType<Rim3dView>() )
+        {
+            view->scheduleCreateDisplayModelAndRedraw();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimContourMapInViewCollection::initAfterRead()
+{
+    updateUiIconFromToggleField();
+}

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapInViewCollection.h
@@ -1,0 +1,92 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RimCheckableNamedObject.h"
+
+#include "cafPdmChildArrayField.h"
+
+#include <vector>
+
+class RimContourMapInView;
+class RimEclipseContourMapView;
+class RimRegularLegendConfig;
+class RiuViewer;
+
+namespace cvf
+{
+class Camera;
+class ModelBasicList;
+} // namespace cvf
+
+namespace caf
+{
+class DisplayCoordTransform;
+}
+
+//==================================================================================================
+///
+/// The contour maps of the project, mirrored into a single 3d view.
+///
+/// The project level collection of contour map views is the owner of the contour maps. This
+/// collection holds one wrapper per contour map, carrying the presentation state that belongs to
+/// this view only. Wrappers start out unchecked, so a view shows nothing until asked to.
+///
+//==================================================================================================
+class RimContourMapInViewCollection : public RimCheckableNamedObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RimContourMapInViewCollection();
+    ~RimContourMapInViewCollection() override;
+
+    void updateFromContourMapCollection();
+
+    std::vector<RimContourMapInView*> allContourMapsInView() const;
+    std::vector<RimContourMapInView*> visibleContourMapsInView() const;
+
+    void appendPartsToModel( cvf::ModelBasicList* model, const caf::DisplayCoordTransform* displayCoordTransform, const cvf::Camera* camera );
+
+    std::vector<RimRegularLegendConfig*> legendConfigs() const;
+    void updateLegendRangesTextAndVisibility( RiuViewer* nativeOrOverrideViewer, bool isUsingOverrideViewer );
+
+    // Redraw every 3d view mirroring the given contour map. Reading a project loads the ordinary 3d
+    // views before the contour map views, so a 3d view can draw a contour map whose own view has not
+    // been loaded yet, and reads it as empty. Calling this once the contour map view is ready lets
+    // those views rebuild against real data.
+    static void scheduleRedrawOfViewsShowing( const RimEclipseContourMapView* contourMapView );
+
+    // Let every 3d view pick up contour maps that have been added or removed
+    static void updateViewTreeItemsInAllViews();
+
+protected:
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
+    void initAfterRead() override;
+
+private:
+    RimContourMapInView* findContourMapInViewForSource( const RimEclipseContourMapView* contourMapView ) const;
+
+    // Every contour map of the project, in a stable order. Includes the ensemble statistics contour
+    // maps, which live on their ensemble rather than in the oil field collection.
+    static std::vector<RimEclipseContourMapView*> allContourMapViewsInProject();
+
+private:
+    caf::PdmChildArrayField<RimContourMapInView*> m_contourMapsInView;
+};

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp
@@ -23,6 +23,7 @@
 #include "RiuViewer.h"
 #include "RivContourMapProjectionPartMgr.h"
 
+#include "ContourMap/RimContourMapInViewCollection.h"
 #include "Polygons/RimPolygonInViewCollection.h"
 #include "Rim3dOverlayInfoConfig.h"
 #include "RimAnnotationInViewCollection.h"
@@ -302,6 +303,11 @@ void RimEclipseContourMapView::updateGeometry()
     appendWellsAndFracturesToModel();
 
     m_overlayInfoConfig()->update3DInfo();
+
+    // The results and the geometry are ready only now, so this is where the 3d views showing this
+    // contour map can pick them up. Doing it when the view is loaded is too early, that only schedules
+    // the rebuild that ends up here.
+    RimContourMapInViewCollection::scheduleRedrawOfViewsShowing( this );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -650,6 +656,16 @@ void RimEclipseContourMapView::onLegendConfigChanged( const caf::SignalEmitter* 
 RimSurfaceInViewCollection* RimEclipseContourMapView::surfaceInViewCollection() const
 {
     // Surfaces should not be shown in contour map.
+    return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInViewCollection* RimEclipseContourMapView::contourMapInViewCollection() const
+{
+    // A contour map view shows its own contour map, and should not offer to show the other contour maps
+    // of the project.
     return nullptr;
 }
 

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.h
@@ -23,6 +23,7 @@
 #include "cafPdmProxyValueField.h"
 
 enum class RimLegendConfigChangeType;
+class RimContourMapInViewCollection;
 class RimEclipseContourMapProjection;
 class RimRegularLegendConfig;
 class RimViewNameConfig;
@@ -44,9 +45,10 @@ public:
     void    setDefaultCustomName();
     void    updatePickPointAndRedraw();
 
-    RimSurfaceInViewCollection* surfaceInViewCollection() const override;
-    void                        zoomAll() override;
-    bool                        isScaleZEditable() const override;
+    RimSurfaceInViewCollection*    surfaceInViewCollection() const override;
+    RimContourMapInViewCollection* contourMapInViewCollection() const override;
+    void                           zoomAll() override;
+    bool                           isScaleZEditable() const override;
 
     void setCompatibleDrawStyle();
 

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapViewCollection.cpp
@@ -1,7 +1,10 @@
 #include "RimEclipseContourMapViewCollection.h"
 
+#include "ContourMap/RimContourMapInViewCollection.h"
+#include "Rim3dView.h"
 #include "RimEclipseCase.h"
 #include "RimEclipseContourMapView.h"
+#include "RimProject.h"
 
 CAF_PDM_SOURCE_INIT( RimEclipseContourMapViewCollection, "Eclipse2dViewCollection" );
 
@@ -36,6 +39,8 @@ std::vector<RimEclipseContourMapView*> RimEclipseContourMapViewCollection::views
 void RimEclipseContourMapViewCollection::addView( RimEclipseContourMapView* contourMap )
 {
     addItem( contourMap );
+
+    RimContourMapInViewCollection::updateViewTreeItemsInAllViews();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -46,6 +51,17 @@ void RimEclipseContourMapViewCollection::onChildDeleted( caf::PdmChildArrayField
 {
     auto eclipseCase = firstAncestorOrThisOfType<RimEclipseCase>();
     if ( eclipseCase ) eclipseCase->updateConnectedEditors();
+
+    RimContourMapInViewCollection::updateViewTreeItemsInAllViews();
+
+    // A deleted contour map may have been visible in a 3d view
+    if ( RimProject* project = RimProject::current() )
+    {
+        for ( Rim3dView* view : project->allViews() )
+        {
+            if ( view ) view->scheduleCreateDisplayModelAndRedraw();
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp
@@ -39,14 +39,17 @@
 #include "RigPolyLinesData.h"
 #include "RigStatisticsMath.h"
 
+#include "ContourMap/RimContourMapInViewCollection.h"
 #include "Formations/RimFormationNames.h"
 #include "Polygons/RimPolygon.h"
 #include "Polygons/RimPolygonCollection.h"
+#include "Rim3dView.h"
 #include "RimEclipseCase.h"
 #include "RimEclipseCaseEnsemble.h"
 #include "RimEclipseContourMapProjection.h"
 #include "RimEclipseResultCase.h"
 #include "RimEclipseResultDefinition.h"
+#include "RimProject.h"
 #include "RimReservoirGridEnsemble.h"
 #include "RimSimWellInViewCollection.h"
 #include "RimStatisticsContourMapProjection.h"
@@ -1342,4 +1345,26 @@ void RimStatisticsContourMap::addView( RimStatisticsContourMapView* view )
         view->scheduleCreateDisplayModelAndRedraw();
     }
     m_views.push_back( view );
+
+    // The 3d views mirror every contour map of the project, these included
+    RimContourMapInViewCollection::updateViewTreeItemsInAllViews();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimStatisticsContourMap::onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects )
+{
+    if ( childArray != &m_views ) return;
+
+    RimContourMapInViewCollection::updateViewTreeItemsInAllViews();
+
+    // A deleted contour map may have been visible in a 3d view
+    if ( RimProject* project = RimProject::current() )
+    {
+        for ( Rim3dView* view : project->allViews() )
+        {
+            if ( view ) view->scheduleCreateDisplayModelAndRedraw();
+        }
+    }
 }

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.h
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.h
@@ -109,6 +109,7 @@ protected:
     void setupBeforeSave() override;
     void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
+    void onChildDeleted( caf::PdmChildArrayFieldHandle* childArray, std::vector<caf::PdmObjectHandle*>& referringObjects ) override;
 
     void switchToSelectedSourceCase();
 

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp
@@ -1080,6 +1080,16 @@ const RimPropertyFilterCollection* RimGeoMechView::propertyFilterCollection() co
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RimContourMapInViewCollection* RimGeoMechView::contourMapInViewCollection() const
+{
+    // Only Eclipse contour maps exist, and this view has no way of rendering them. Mirroring them here
+    // would fill the view, and the project file, with entries that can never be shown.
+    return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 QString RimGeoMechView::activeFiltersDisplayText() const
 {
     QStringList parts;

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.h
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.h
@@ -77,6 +77,8 @@ public:
 
     const RimPropertyFilterCollection* propertyFilterCollection() const override;
 
+    RimContourMapInViewCollection* contourMapInViewCollection() const override;
+
     const RimGeoMechPartCollection* partsCollection() const;
 
     RimGeoMechPropertyFilterCollection*       geoMechPropertyFilterCollection();

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -29,6 +29,8 @@
 
 #include "HoloLensCommands/RicExportToSharingServerScheduler.h"
 
+#include "ContourMap/RimContourMapInViewCollection.h"
+
 #include "RicfCommandObject.h"
 #include "RigActiveCellInfo.h"
 #include "RigCaseCellResultsData.h"
@@ -850,6 +852,10 @@ void RimEclipseView::onCreateDisplayModel()
     }
     else
     {
+        // onUpdateDisplayModelForCurrentTimeStep is not called for a view showing only static results,
+        // so the contour maps have to be appended here to be shown at all
+        appendContourMapsToModel();
+
         m_overlayInfoConfig()->update3DInfo();
         onUpdateLegends();
     }
@@ -957,6 +963,7 @@ void RimEclipseView::onUpdateDisplayModelForCurrentTimeStep()
     appendWellsAndFracturesToModel();
     appendElementVectorResultToModel();
     appendStreamlinesToModel();
+    appendContourMapsToModel();
 
     m_overlayInfoConfig()->update3DInfo();
 
@@ -1232,6 +1239,35 @@ void RimEclipseView::appendStreamlinesToModel()
             frameScene->addModel( frameParts.p() );
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimEclipseView::appendContourMapsToModel()
+{
+    if ( !nativeOrOverrideViewer() ) return;
+    if ( !contourMapInViewCollection() ) return;
+
+    // A contour map draped on the geometry follows the cell visibility, which is time step dependent, so
+    // the parts belong to the frame scene rather than to a static model. A view showing only static
+    // results has no frame scenes at all, and everything it shows lives in the main scene.
+    cvf::Scene* scene = nativeOrOverrideViewer()->frame( m_currentTimeStep, isUsingOverrideViewer() );
+    if ( !scene ) scene = nativeOrOverrideViewer()->mainScene( isUsingOverrideViewer() );
+    if ( !scene ) return;
+
+    cvf::String name = "ContourMapsInView";
+    RimEclipseView::removeModelByName( scene, name );
+
+    cvf::ref<cvf::ModelBasicList> frameParts = new cvf::ModelBasicList;
+    frameParts->setName( name );
+
+    cvf::ref<caf::DisplayCoordTransform> transform = displayCoordTransform();
+
+    contourMapInViewCollection()->appendPartsToModel( frameParts.p(), transform.p(), nativeOrOverrideViewer()->mainCamera() );
+
+    frameParts->updateBoundingBoxesRecursive();
+    scene->addModel( frameParts.p() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1679,6 +1715,11 @@ void RimEclipseView::onUpdateLegends()
     if ( m_seismicSectionCollection->isChecked() )
     {
         m_seismicSectionCollection->updateLegendRangesTextAndVisibility( nativeOrOverrideViewer(), isUsingOverrideViewer() );
+    }
+
+    if ( auto contourMaps = contourMapInViewCollection() )
+    {
+        contourMaps->updateLegendRangesTextAndVisibility( nativeOrOverrideViewer(), isUsingOverrideViewer() );
     }
 
     if ( m_streamlineCollection )
@@ -2141,6 +2182,7 @@ void RimEclipseView::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrderin
     uiTreeOrdering.add( m_polygonInViewCollection );
 
     if ( surfaceInViewCollection() ) uiTreeOrdering.add( surfaceInViewCollection() );
+    if ( contourMapInViewCollection() ) uiTreeOrdering.add( contourMapInViewCollection() );
     if ( seismicSectionCollection()->shouldBeVisibleInTree() ) uiTreeOrdering.add( seismicSectionCollection() );
 
     uiTreeOrdering.add( annotationCollection() );
@@ -2536,6 +2578,14 @@ std::vector<RimLegendConfig*> RimEclipseView::legendConfigs() const
     if ( surfaceInViewCollection() )
     {
         for ( auto legendConfig : surfaceInViewCollection()->legendConfigs() )
+        {
+            absLegends.push_back( legendConfig );
+        }
+    }
+
+    if ( auto contourMaps = contourMapInViewCollection() )
+    {
+        for ( auto legendConfig : contourMaps->legendConfigs() )
         {
             absLegends.push_back( legendConfig );
         }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
@@ -208,6 +208,7 @@ protected:
     void appendWellsAndFracturesToModel();
     void appendElementVectorResultToModel();
     void appendStreamlinesToModel();
+    void appendContourMapsToModel();
 
     void                             onCreateDisplayModel() override;
     RimPropertyFilterCollection*     nativePropertyFilterCollection();

--- a/ApplicationLibCode/ProjectDataModel/RimGridView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridView.cpp
@@ -45,6 +45,8 @@
 #include "RimWellMeasurementInViewCollection.h"
 #include "RimWellPathCollection.h"
 
+#include "ContourMap/RimContourMapInViewCollection.h"
+
 #include "Polygons/RimPolygonInView.h"
 #include "Polygons/RimPolygonInViewCollection.h"
 
@@ -106,6 +108,9 @@ RimGridView::RimGridView()
     CAF_PDM_InitFieldNoDefault( &m_polygonInViewCollection, "PolygonInViewCollection", "Polygon Collection Field" );
     m_polygonInViewCollection = new RimPolygonInViewCollection();
     m_polygonInViewCollection->uiCapability()->setUiIcon( caf::IconProvider( ":/PolylinesFromFile16x16.png" ) );
+
+    CAF_PDM_InitFieldNoDefault( &m_contourMapInViewCollection, "ContourMapInViewCollection", "Contour Map Collection Field" );
+    m_contourMapInViewCollection = new RimContourMapInViewCollection();
 
     CAF_PDM_InitFieldNoDefault( &m_cellFilterCollection, "RangeFilters", "Cell Filter Collection Field" );
     m_cellFilterCollection = new RimCellFilterCollection();
@@ -181,6 +186,14 @@ RimSeismicSectionCollection* RimGridView::seismicSectionCollection() const
 RimPolygonInViewCollection* RimGridView::polygonInViewCollection() const
 {
     return m_polygonInViewCollection();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimContourMapInViewCollection* RimGridView::contourMapInViewCollection() const
+{
+    return m_contourMapInViewCollection();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -555,6 +568,12 @@ void RimGridView::updateViewTreeItems( RiaDefines::ItemIn3dView itemType )
     if ( bitmaskEnum.AnyOf( RiaDefines::ItemIn3dView::POLYGON ) )
     {
         m_polygonInViewCollection->updateFromPolygonCollection();
+    }
+
+    if ( bitmaskEnum.AnyOf( RiaDefines::ItemIn3dView::CONTOUR_MAP ) )
+    {
+        // Null for views that do not show contour maps, the 2d contour map views in particular
+        if ( auto contourMaps = contourMapInViewCollection() ) contourMaps->updateFromContourMapCollection();
     }
 
     updateConnectedEditors();

--- a/ApplicationLibCode/ProjectDataModel/RimGridView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimGridView.h
@@ -33,6 +33,7 @@ class RimWellMeasurementInViewCollection;
 class RimSurfaceInViewCollection;
 class RimSeismicSectionCollection;
 class RimPolygonInViewCollection;
+class RimContourMapInViewCollection;
 
 class RimGridView : public Rim3dView
 {
@@ -56,6 +57,7 @@ public:
     RimWellMeasurementInViewCollection*         measurementCollection() const;
     RimSeismicSectionCollection*                seismicSectionCollection() const;
     RimPolygonInViewCollection*                 polygonInViewCollection() const;
+    virtual RimContourMapInViewCollection*      contourMapInViewCollection() const;
 
     virtual const RimPropertyFilterCollection* propertyFilterCollection() const = 0;
 
@@ -112,6 +114,7 @@ protected:
     caf::PdmChildField<RimCellFilterCollection*>            m_overrideCellFilterCollection;
     caf::PdmChildField<RimSeismicSectionCollection*>        m_seismicSectionCollection;
     caf::PdmChildField<RimPolygonInViewCollection*>         m_polygonInViewCollection;
+    caf::PdmChildField<RimContourMapInViewCollection*>      m_contourMapInViewCollection;
 
 private:
     void onCreatePartCollectionFromSelection( cvf::Collection<cvf::Part>* parts ) override;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp
@@ -603,6 +603,31 @@ std::vector<RimRegularLegendConfig*> RimSurfaceInViewCollection::legendConfigs()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<RimSurfaceInView*> RimSurfaceInViewCollection::visibleSurfacesInView() const
+{
+    if ( !isChecked() ) return {};
+
+    std::vector<RimSurfaceInView*> surfaces;
+
+    for ( RimSurfaceInViewCollection* coll : m_collectionsInView )
+    {
+        if ( !coll ) continue;
+
+        std::vector<RimSurfaceInView*> collSurfaces = coll->visibleSurfacesInView();
+        surfaces.insert( surfaces.end(), collSurfaces.begin(), collSurfaces.end() );
+    }
+
+    for ( RimSurfaceInView* surf : m_surfacesInView )
+    {
+        if ( surf && surf->isActive() ) surfaces.push_back( surf );
+    }
+
+    return surfaces;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 std::vector<const RivIntersectionGeometryGeneratorInterface*> RimSurfaceInViewCollection::intersectionGeometryGenerators() const
 {
     std::vector<const RivIntersectionGeometryGeneratorInterface*> generators;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h
@@ -78,6 +78,9 @@ public:
 
     std::vector<RimRegularLegendConfig*> legendConfigs();
 
+    // The surfaces this collection contributes to the scene, recursing into the checked sub collections
+    std::vector<RimSurfaceInView*> visibleSurfacesInView() const;
+
     std::vector<const RivIntersectionGeometryGeneratorInterface*> intersectionGeometryGenerators() const;
 
 protected:

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/CMakeLists_files.cmake
@@ -4,6 +4,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigContourPolygonsTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigContourMapCalculator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigContourMapProjection.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigContourMapTopography.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigContourMapTrianglesGenerator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigEclipseContourMapProjection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigGeoMechContourMapProjection.cpp

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTopography.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTopography.cpp
@@ -1,0 +1,282 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RigContourMapTopography.h"
+
+#include "RigCell.h"
+#include "RigContourMapGrid.h"
+#include "RigGridBase.h"
+#include "RigHexIntersectionTools.h"
+#include "RigMainGrid.h"
+#include "Surface/RigSurface.h"
+#include "Surface/RigSurfaceResampler.h"
+
+#include "cvfBoundingBox.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RigContourMapTopography::RigContourMapTopography( const RigContourMapGrid&        contourMapGrid,
+                                                  const RigMainGrid&              mainGrid,
+                                                  const cvf::UByteArray*          cellVisibility,
+                                                  const std::vector<RigSurface*>& surfaces )
+{
+    // The contour map grid is far too coarse to follow stair stepped cell geometry. Between two of its
+    // vertices the interpolated elevation ramps smoothly while the geometry steps, so a curve drawn on
+    // it sinks into the cell it just stepped down from. Sample on a finer lattice over the same extent
+    // instead, which is what decides how closely a draped curve can follow the geometry.
+    const cvf::Vec2ui mapSize = contourMapGrid.numberOfElementsIJ();
+
+    m_sampleSpacing = contourMapGrid.sampleSpacing() / sm_refinementFactor;
+    m_vertexCountIJ = cvf::Vec2ui( mapSize.x() * sm_refinementFactor + 1u, mapSize.y() * sm_refinementFactor + 1u );
+
+    const cvf::Vec2d origin2d = contourMapGrid.origin2d();
+
+    // The rays are cast against the grid of the view the map is shown in, which need not be the grid of
+    // the case the contour map was computed from. A ray has to clear that grid at both ends, otherwise
+    // it starts inside a cell and only the exit point is found, and cells above it are missed entirely.
+    double                 highestZ = 0.0;
+    double                 lowestZ  = 0.0;
+    const cvf::BoundingBox gridBBox = mainGrid.boundingBox();
+    if ( gridBBox.isValid() )
+    {
+        const double margin = std::max( 1.0, gridBBox.extent().z() * 0.01 );
+        highestZ            = gridBBox.max().z() + margin;
+        lowestZ             = gridBBox.min().z() - margin;
+    }
+
+    // A surface can lie outside the depth range of the case, so each one is given its own ray range
+    const std::vector<SurfaceAndZRange> surfacesToSearch = surfacesWithZRange( surfaces );
+
+    const size_t vertexCount = static_cast<size_t>( m_vertexCountIJ.x() ) * m_vertexCountIJ.y();
+
+    m_vertexElevations.resize( vertexCount, std::numeric_limits<double>::infinity() );
+
+#pragma omp parallel for
+    for ( int index = 0; index < static_cast<int>( vertexCount ); ++index )
+    {
+        const unsigned int i = static_cast<unsigned int>( index ) % m_vertexCountIJ.x();
+        const unsigned int j = static_cast<unsigned int>( index ) / m_vertexCountIJ.x();
+
+        // Vertex (0,0) of the contour map grid sits on the local origin, so the finer lattice shares it
+        cvf::Vec2d domainPos2d( origin2d.x() + i * m_sampleSpacing, origin2d.y() + j * m_sampleSpacing );
+
+        const double cellElevation    = topCellElevationAtDomainPos( domainPos2d, mainGrid, cellVisibility, highestZ, lowestZ );
+        const double surfaceElevation = topSurfaceElevationAtDomainPos( domainPos2d, surfacesToSearch );
+
+        // Whatever is on top of what the view is showing
+        if ( cellElevation == std::numeric_limits<double>::infinity() )
+        {
+            m_vertexElevations[index] = surfaceElevation;
+        }
+        else if ( surfaceElevation == std::numeric_limits<double>::infinity() )
+        {
+            m_vertexElevations[index] = cellElevation;
+        }
+        else
+        {
+            m_vertexElevations[index] = std::max( cellElevation, surfaceElevation );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<RigContourMapTopography::SurfaceAndZRange> RigContourMapTopography::surfacesWithZRange( const std::vector<RigSurface*>& surfaces )
+{
+    std::vector<SurfaceAndZRange> surfacesToSearch;
+
+    for ( RigSurface* surface : surfaces )
+    {
+        if ( !surface || surface->vertices().empty() ) continue;
+
+        SurfaceAndZRange entry;
+        entry.surface  = surface;
+        entry.highestZ = -std::numeric_limits<double>::max();
+        entry.lowestZ  = std::numeric_limits<double>::max();
+
+        for ( const cvf::Vec3d& vertex : surface->vertices() )
+        {
+            entry.highestZ = std::max( entry.highestZ, vertex.z() );
+            entry.lowestZ  = std::min( entry.lowestZ, vertex.z() );
+        }
+
+        // The ray has to clear the surface at both ends for the intersection test to find it
+        const double margin = std::max( 1.0, ( entry.highestZ - entry.lowestZ ) * 0.01 );
+        entry.highestZ += margin;
+        entry.lowestZ -= margin;
+
+        surface->ensureIntersectionSearchTreeIsBuilt();
+
+        surfacesToSearch.push_back( entry );
+    }
+
+    return surfacesToSearch;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RigContourMapTopography::topSurfaceElevationAtDomainPos( const cvf::Vec2d& domainPos2d, const std::vector<SurfaceAndZRange>& surfaces )
+{
+    double topElevation = std::numeric_limits<double>::infinity();
+
+    for ( const SurfaceAndZRange& entry : surfaces )
+    {
+        cvf::Vec3d pointAbove( domainPos2d, entry.highestZ );
+        cvf::Vec3d pointBelow( domainPos2d, entry.lowestZ );
+
+        cvf::Vec3d intersectionPoint;
+        if ( !RigSurfaceResampler::computeIntersectionWithLine( entry.surface, pointAbove, pointBelow, intersectionPoint ) ) continue;
+
+        if ( topElevation == std::numeric_limits<double>::infinity() || intersectionPoint.z() > topElevation )
+        {
+            topElevation = intersectionPoint.z();
+        }
+    }
+
+    return topElevation;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RigContourMapTopography::topCellElevationAtDomainPos( const cvf::Vec2d&      domainPos2d,
+                                                             const RigMainGrid&     mainGrid,
+                                                             const cvf::UByteArray* cellVisibility,
+                                                             double                 highestZ,
+                                                             double                 lowestZ )
+{
+    if ( highestZ <= lowestZ ) return std::numeric_limits<double>::infinity();
+
+    cvf::Vec3d highestPoint( domainPos2d, highestZ );
+    cvf::Vec3d lowestPoint( domainPos2d, lowestZ );
+
+    cvf::BoundingBox rayBBox;
+    rayBBox.add( highestPoint );
+    rayBBox.add( lowestPoint );
+
+    const std::vector<size_t> candidateCells = mainGrid.findIntersectingCells( rayBBox );
+
+    double topElevation = std::numeric_limits<double>::infinity();
+
+    for ( size_t globalCellIdx : candidateCells )
+    {
+        const RigCell& cell = mainGrid.cell( globalCellIdx );
+        if ( cell.isInvalid() ) continue;
+
+        // The visibility array is the authority on what the view is showing, and already accounts for
+        // cell filters, property filters and cells refined by a local grid.
+        if ( cellVisibility && globalCellIdx < cellVisibility->size() && !( *cellVisibility )[globalCellIdx] ) continue;
+
+        RigGridBase* localGrid = cell.hostGrid();
+        if ( !localGrid ) continue;
+
+        std::array<cvf::Vec3d, 8>        hexCorners = localGrid->cellCornerVertices( cell.gridLocalCellIndex() );
+        std::vector<HexIntersectionInfo> intersections;
+
+        if ( RigHexIntersectionTools::lineHexCellIntersection( highestPoint, lowestPoint, hexCorners, 0, &intersections ) )
+        {
+            for ( const HexIntersectionInfo& intersection : intersections )
+            {
+                double z = intersection.m_intersectionPoint.z();
+                if ( topElevation == std::numeric_limits<double>::infinity() || z > topElevation )
+                {
+                    topElevation = z;
+                }
+            }
+        }
+    }
+
+    return topElevation;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RigContourMapTopography::sampleSpacing() const
+{
+    return m_sampleSpacing;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RigContourMapTopography::elevationAtVertex( unsigned int i, unsigned int j ) const
+{
+    if ( i >= m_vertexCountIJ.x() || j >= m_vertexCountIJ.y() ) return std::numeric_limits<double>::infinity();
+
+    size_t index = static_cast<size_t>( j ) * m_vertexCountIJ.x() + i;
+    if ( index >= m_vertexElevations.size() ) return std::numeric_limits<double>::infinity();
+
+    return m_vertexElevations[index];
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<double> RigContourMapTopography::elevationAtLocalPos( const cvf::Vec2d& localPos2d ) const
+{
+    if ( m_sampleSpacing <= 0.0 || m_vertexCountIJ.x() < 2u || m_vertexCountIJ.y() < 2u ) return {};
+
+    // The vertices form a regular lattice with the sample spacing as the step, with vertex (0,0) at
+    // the local origin. Interpolate bilinearly between the four vertices surrounding the position.
+    double u = localPos2d.x() / m_sampleSpacing;
+    double v = localPos2d.y() / m_sampleSpacing;
+
+    const double maxU = static_cast<double>( m_vertexCountIJ.x() - 1u );
+    const double maxV = static_cast<double>( m_vertexCountIJ.y() - 1u );
+
+    // The lattice covers the full extent of the map, so a position on the far edge is inside it
+    const double tolerance = 1.0e-6;
+    if ( u < -tolerance || v < -tolerance || u > maxU + tolerance || v > maxV + tolerance ) return {};
+
+    u = std::clamp( u, 0.0, maxU );
+    v = std::clamp( v, 0.0, maxV );
+
+    // A position exactly on the far edge belongs to the last cell, not to a cell past the end
+    double uFloor = std::min( std::floor( u ), maxU - 1.0 );
+    double vFloor = std::min( std::floor( v ), maxV - 1.0 );
+
+    auto i = static_cast<unsigned int>( uFloor );
+    auto j = static_cast<unsigned int>( vFloor );
+
+    double fractionX = u - uFloor;
+    double fractionY = v - vFloor;
+
+    std::array<double, 4> cornerElevations = { elevationAtVertex( i, j ),
+                                               elevationAtVertex( i + 1u, j ),
+                                               elevationAtVertex( i, j + 1u ),
+                                               elevationAtVertex( i + 1u, j + 1u ) };
+
+    for ( double elevation : cornerElevations )
+    {
+        if ( elevation == std::numeric_limits<double>::infinity() ) return {};
+    }
+
+    double bottom = cornerElevations[0] * ( 1.0 - fractionX ) + cornerElevations[1] * fractionX;
+    double top    = cornerElevations[2] * ( 1.0 - fractionX ) + cornerElevations[3] * fractionX;
+
+    return bottom * ( 1.0 - fractionY ) + top * fractionY;
+}

--- a/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTopography.h
+++ b/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTopography.h
@@ -1,0 +1,96 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cvfArray.h"
+#include "cvfVector2.h"
+
+#include <optional>
+#include <vector>
+
+class RigContourMapGrid;
+class RigMainGrid;
+class RigSurface;
+
+//==================================================================================================
+///
+/// Elevation of the top of the visible geometry, sampled on a raster over a contour map grid.
+///
+/// Used to drape contour map geometry on what the view is showing. A vertical ray is dropped at
+/// every raster vertex and the highest intersection with a visible cell or surface is kept, giving
+/// a raster that is cheap to interpolate. Positions where nothing was hit stay undefined, so the
+/// consumer can leave a gap rather than draw a line hanging in space.
+///
+/// The raster is deliberately finer than the contour map grid. Cell geometry is stair stepped, and
+/// the raster spacing is what limits how closely a draped curve can follow it: between two raster
+/// vertices the elevation is interpolated smoothly while the geometry steps, leaving the curve
+/// buried in the cell it stepped down from. Sampling the curve itself more densely does not help,
+/// since that only samples the same smoothed raster more often.
+///
+//==================================================================================================
+class RigContourMapTopography
+{
+public:
+    // cellVisibility is indexed by global reservoir cell index and may be null, in which case all
+    // cells are considered visible. Both the cells and the surfaces are optional, a view may be
+    // showing only one of them.
+    RigContourMapTopography( const RigContourMapGrid&        contourMapGrid,
+                             const RigMainGrid&              mainGrid,
+                             const cvf::UByteArray*          cellVisibility,
+                             const std::vector<RigSurface*>& surfaces );
+
+    // localPos2d is relative to RigContourMapGrid::origin2d(). Returns nothing when the position is
+    // outside the map, or when any of the vertices used for the interpolation is undefined.
+    std::optional<double> elevationAtLocalPos( const cvf::Vec2d& localPos2d ) const;
+
+    // Spacing of the underlying raster, finer than the contour map grid. Elevations vary at this scale,
+    // so it is also the scale a curve has to be sampled at to follow them.
+    double sampleSpacing() const;
+
+private:
+    struct SurfaceAndZRange
+    {
+        RigSurface* surface  = nullptr;
+        double      highestZ = 0.0;
+        double      lowestZ  = 0.0;
+    };
+
+    static double topCellElevationAtDomainPos( const cvf::Vec2d&      domainPos2d,
+                                               const RigMainGrid&     mainGrid,
+                                               const cvf::UByteArray* cellVisibility,
+                                               double                 highestZ,
+                                               double                 lowestZ );
+
+    static double topSurfaceElevationAtDomainPos( const cvf::Vec2d& domainPos2d, const std::vector<SurfaceAndZRange>& surfaces );
+
+    static std::vector<SurfaceAndZRange> surfacesWithZRange( const std::vector<RigSurface*>& surfaces );
+
+    double elevationAtVertex( unsigned int i, unsigned int j ) const;
+
+private:
+    // How much finer than the contour map grid the raster is sampled. Cell geometry is stair stepped,
+    // so following it closely needs several samples across each contour map cell. Costs this squared in
+    // rays, which is why it is not larger.
+    static constexpr unsigned int sm_refinementFactor = 4u;
+
+private:
+    std::vector<double> m_vertexElevations; // infinity marks an undefined vertex
+    cvf::Vec2ui         m_vertexCountIJ;
+    double              m_sampleSpacing = 0.0;
+};


### PR DESCRIPTION
Closes #14670

Adds the option to show a contour map (including statistics contour maps) directly inside a regular Eclipse or GeoMech 3d view, instead of only in its own dedicated flat contour map view.

- Toggle the map surface and/or contour lines independently
- Drape the map surface and lines onto the underlying grid/terrain geometry, or show them flat
- Position the map at the top or bottom of the case, or at a user defined depth
- Configure contour line color/thickness and label visibility/size
- Click the map in the 3d view to select it in the project tree, and quickly navigate back to the source contour map from the project tree