### PR TITLE
#14345 Compute and recompute ResInsight-calculated results for released time steps

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1817,6 +1817,17 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
     if ( scalarResultIndex == cvf::UNDEFINED_SIZE_T ) return cvf::UNDEFINED_SIZE_T;
     if ( type == RiaDefines::ResultCatType::GENERATED ) return scalarResultIndex;
 
+    // Results computed by ResInsight (e.g. riOILVOLUME) can not be read from file for a single time step.
+    // Delegate to findOrLoadKnownScalarResult(), which computes all time steps using the result
+    // calculators. Data already present is not computed again.
+    const bool isComputedResult = mustBeCalculated( scalarResultIndex ) || resultName == RiaResultNames::riCellVolumeResultName() ||
+                                  resultName == RiaResultNames::riOilVolumeResultName() || resultName == RiaResultNames::riPorvSoil() ||
+                                  resultName == RiaResultNames::riPorvSgas() || resultName == RiaResultNames::riPorvSoilSgas();
+    if ( isComputedResult )
+    {
+        return findOrLoadKnownScalarResult( resVarAddr );
+    }
+
     if ( m_readerInterface.notNull() )
     {
         size_t timeStepCount = infoForEachResultIndex()[scalarResultIndex].timeStepInfos().size();

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1516,7 +1516,15 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResult( const RigEclipseResu
 
     if ( isDataPresent( scalarResultIndex ) )
     {
-        return scalarResultIndex;
+        // Data for some time steps can have been released to reduce memory usage, see
+        // RimGridCalculation::getActiveCellValues(). Results computed by ResInsight can not be reloaded from
+        // file, so continue to recompute them if data is missing for any time step.
+        const bool mustRecompute = isResultComputedByResInsight( resultName, scalarResultIndex ) &&
+                                   hasEmptyDataForAnyTimeStep( scalarResultIndex );
+        if ( !mustRecompute )
+        {
+            return scalarResultIndex;
+        }
     }
 
     if ( resultName == RiaResultNames::soil() )
@@ -1819,12 +1827,16 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
 
     // Results computed by ResInsight (e.g. riOILVOLUME) can not be read from file for a single time step.
     // Delegate to findOrLoadKnownScalarResult(), which computes all time steps using the result
-    // calculators. Data already present is not computed again.
-    const bool isComputedResult = mustBeCalculated( scalarResultIndex ) || resultName == RiaResultNames::riCellVolumeResultName() ||
-                                  resultName == RiaResultNames::riOilVolumeResultName() || resultName == RiaResultNames::riPorvSoil() ||
-                                  resultName == RiaResultNames::riPorvSgas() || resultName == RiaResultNames::riPorvSoilSgas();
-    if ( isComputedResult )
+    // calculators. Skip the delegation if data is already present for the requested time step, to avoid
+    // repeated recomputation when data for other time steps is released during a calculation.
+    if ( isResultComputedByResInsight( resultName, scalarResultIndex ) )
     {
+        const auto& valuesAllTimeSteps = m_cellScalarResults[scalarResultIndex];
+        if ( timeStepIndex < valuesAllTimeSteps.size() && !valuesAllTimeSteps[timeStepIndex].empty() )
+        {
+            return scalarResultIndex;
+        }
+
         return findOrLoadKnownScalarResult( resVarAddr );
     }
 
@@ -3149,6 +3161,28 @@ RigAllanDiagramData* RigCaseCellResultsData::allanDiagramData()
 bool RigCaseCellResultsData::isDataPresent( size_t scalarResultIndex ) const
 {
     return allocatedValueCount( scalarResultIndex ) > 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Returns true for results that are computed by ResInsight and can not be read from file
+//--------------------------------------------------------------------------------------------------
+bool RigCaseCellResultsData::isResultComputedByResInsight( const QString& resultName, size_t scalarResultIndex ) const
+{
+    return mustBeCalculated( scalarResultIndex ) || resultName == RiaResultNames::riCellVolumeResultName() ||
+           resultName == RiaResultNames::riOilVolumeResultName() || resultName == RiaResultNames::riPorvSoil() ||
+           resultName == RiaResultNames::riPorvSgas() || resultName == RiaResultNames::riPorvSoilSgas();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RigCaseCellResultsData::hasEmptyDataForAnyTimeStep( size_t scalarResultIndex ) const
+{
+    if ( scalarResultIndex >= resultCount() ) return false;
+
+    const std::vector<std::vector<double>>& valuesAllTimeSteps = m_cellScalarResults[scalarResultIndex];
+
+    return std::any_of( valuesAllTimeSteps.begin(), valuesAllTimeSteps.end(), []( const auto& values ) { return values.empty(); } );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
@@ -218,6 +218,9 @@ private:
     bool mustBeCalculated( size_t scalarResultIndex ) const;
     void setMustBeCalculated( size_t scalarResultIndex );
 
+    bool isResultComputedByResInsight( const QString& resultName, size_t scalarResultIndex ) const;
+    bool hasEmptyDataForAnyTimeStep( size_t scalarResultIndex ) const;
+
     void computeSOILForTimeStep( size_t timeStepIndex );
     void computeSgasForTimeStep( size_t timeStepIndex );
 


### PR DESCRIPTION
Split out of #14348.

Two related fixes for ResInsight-calculated results (e.g. riOILVOLUME) appearing as undefined:

- findOrLoadKnownScalarResultForTimeStep() tried to read ResInsight-calculated results from the restart file. For lazily loaded grid case group members these results are never computed, so every cell ended up undefined and the grid calculator produced zero sums for all additional cases. Delegate to findOrLoadKnownScalarResult() for results flagged as must-be-calculated and for the ri* volume results.
- The grid calculator releases result data per time step to reduce memory usage when calculating for many cases. If only some time steps are released, findOrLoadKnownScalarResult() returned early because data was present for other time steps, leaving the released time steps empty. Recompute results computed by ResInsight when data is missing for any time step, while skipping the delegation from the single time step variant when the requested time step already has data, to avoid repeated recomputation while the calculator releases other time steps.