### PR TITLE
Fix crash when deleting a sub plot of a multi plot in console mode

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
@@ -885,7 +885,8 @@ void RimMultiPlot::updateZoom()
 //--------------------------------------------------------------------------------------------------
 void RimMultiPlot::recreatePlotWidgets()
 {
-    CAF_ASSERT( m_viewer );
+    // No viewer exists in console mode (e.g. when a sub plot is deleted from Python)
+    if ( !m_viewer ) return;
 
     m_viewer->removeAllPlots();
 

--- a/GrpcInterface/Python/rips/PythonExamples/instance_and_project_management/delete_project_objects.py
+++ b/GrpcInterface/Python/rips/PythonExamples/instance_and_project_management/delete_project_objects.py
@@ -1,0 +1,35 @@
+# Load ResInsight Processing Server Client Library
+import rips
+
+# Connect to ResInsight instance
+resinsight = rips.Instance.find()
+project = resinsight.project
+
+# Any object in the project tree can be removed with delete(). The object is
+# detached from its parent and deleted in ResInsight, and the Python object
+# must not be used afterwards.
+
+# Create two summary plots to work with. Each plot is placed in its own
+# multi plot (the plot window).
+summary_cases = project.descendants(rips.SummaryCase)
+if len(summary_cases) == 0:
+    print("No summary cases loaded. Import a summary case first.")
+    exit()
+
+summary_plot_collection = project.descendants(rips.SummaryPlotCollection)[0]
+summary_plot_collection.new_summary_plot(summary_cases=summary_cases, address="FOPT")
+summary_plot_collection.new_summary_plot(summary_cases=summary_cases, address="FWPT")
+
+summary_plots = project.descendants(rips.SummaryPlot)
+multi_plots = project.descendants(rips.MultiSummaryPlot)
+print(f"Before: {len(summary_plots)} summary plots in {len(multi_plots)} plot windows")
+
+# Delete a single summary plot. The plot window that contained it remains.
+summary_plots[0].delete()
+
+# Delete a whole plot window, including the summary plots inside it.
+multi_plots[-1].delete()
+
+summary_plots = project.descendants(rips.SummaryPlot)
+multi_plots = project.descendants(rips.MultiSummaryPlot)
+print(f"After:  {len(summary_plots)} summary plots in {len(multi_plots)} plot windows")

--- a/GrpcInterface/Python/rips/tests/test_summary_multi_plot.py
+++ b/GrpcInterface/Python/rips/tests/test_summary_multi_plot.py
@@ -54,3 +54,48 @@ def test_summary_multi_plot_layout_override(rips_instance, initialize_test):
     refetched = rips_instance.project.descendants(rips.MultiSummaryPlot)[-1]
     assert refetched.number_of_columns == 1
     assert refetched.rows_per_page == 1
+
+
+def test_delete_summary_plot_in_multi_plot(rips_instance, initialize_test):
+    """Deleting a single summary plot that lives inside a multi-plot must
+    remove the plot without crashing ResInsight (regression: the multi-plot
+    recreated its plot widgets through a null viewer in console mode)."""
+    case_path = dataroot.PATH + "/flow_diagnostics_test/SIMPLE_SUMMARY2.SMSPEC"
+    summary_case = rips_instance.project.import_summary_case(case_path)
+
+    collection = rips_instance.project.descendants(rips.SummaryPlotCollection)[0]
+    collection.new_summary_plot(summary_cases=[summary_case], address="FOPT")
+    collection.new_summary_plot(summary_cases=[summary_case], address="FWPT")
+
+    summary_plots = rips_instance.project.descendants(rips.SummaryPlot)
+    multi_plots = rips_instance.project.descendants(rips.MultiSummaryPlot)
+    assert len(summary_plots) == 2
+    assert len(multi_plots) == 2
+
+    summary_plots[0].delete()
+
+    remaining = rips_instance.project.descendants(rips.SummaryPlot)
+    assert len(remaining) == 1
+    assert remaining[0].id == summary_plots[1].id
+    # The multi-plot that owned the deleted sub-plot still exists.
+    assert len(rips_instance.project.descendants(rips.MultiSummaryPlot)) == 2
+
+    # Deleting the second plot must work as well.
+    remaining[0].delete()
+    assert len(rips_instance.project.descendants(rips.SummaryPlot)) == 0
+
+
+def test_delete_multi_summary_plot(rips_instance, initialize_test):
+    """Deleting a whole multi-plot removes it and its sub-plots."""
+    case_path = dataroot.PATH + "/flow_diagnostics_test/SIMPLE_SUMMARY2.SMSPEC"
+    summary_case = rips_instance.project.import_summary_case(case_path)
+
+    collection = rips_instance.project.descendants(rips.SummaryPlotCollection)[0]
+    collection.new_summary_plot(summary_cases=[summary_case], address="FOPT")
+    collection.new_summary_plot(summary_cases=[summary_case], address="FWPT")
+    assert len(rips_instance.project.descendants(rips.MultiSummaryPlot)) == 2
+
+    rips_instance.project.descendants(rips.MultiSummaryPlot)[0].delete()
+
+    assert len(rips_instance.project.descendants(rips.MultiSummaryPlot)) == 1
+    assert len(rips_instance.project.descendants(rips.SummaryPlot)) == 1


### PR DESCRIPTION
RimMultiPlot::recreatePlotWidgets() dereferenced the viewer unconditionally. The viewer does not exist in console mode, so deleting a summary plot from Python through the generic PdmObject delete() crashed ResInsight in onChildDeleted(). Return early when there is no viewer, matching the other viewer accesses in RimMultiPlot.

Add Python regression tests for deleting a single summary plot inside a multi plot and for deleting a whole multi plot, and an example showing how project tree objects are removed with delete().