### PR TITLE
#14699 Guard against null-pointer derefs during view/dock teardown

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimNameConfig.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimNameConfig.cpp
@@ -104,7 +104,9 @@ void RimNameConfig::fieldChangedByUi( const caf::PdmFieldHandle* changedField, c
 //--------------------------------------------------------------------------------------------------
 QString RimNameConfig::autoName() const
 {
-    RimNameConfigHolderInterface* plotHolder = firstAncestorOrThisOfTypeAsserted<RimNameConfigHolderInterface>();
+    RimNameConfigHolderInterface* plotHolder = firstAncestorOrThisOfType<RimNameConfigHolderInterface>();
+    if ( !plotHolder ) return {};
+
     return plotHolder->createAutoName();
 }
 
@@ -132,10 +134,12 @@ void RimNameConfig::updateAllSettings()
     m_autoName.uiCapability()->updateConnectedEditors();
     m_customName.uiCapability()->updateConnectedEditors();
 
-    RimNameConfigHolderInterface* holder = firstAncestorOrThisOfTypeAsserted<RimNameConfigHolderInterface>();
+    RimNameConfigHolderInterface* holder = firstAncestorOrThisOfType<RimNameConfigHolderInterface>();
+    if ( !holder ) return;
+
     holder->updateAutoName();
-    caf::PdmObject* pdmObject = dynamic_cast<caf::PdmObject*>( holder );
-    if ( pdmObject )
+
+    if ( caf::PdmObject* pdmObject = dynamic_cast<caf::PdmObject*>( holder ) )
     {
         pdmObject->updateConnectedEditors();
     }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp
@@ -159,8 +159,8 @@ PdmUiTreeViewEditor::PdmUiTreeViewEditor()
 //--------------------------------------------------------------------------------------------------
 PdmUiTreeViewEditor::~PdmUiTreeViewEditor()
 {
-    m_treeView->removeEventFilter( this );
-    m_treeViewModel->setPdmItemRoot( nullptr );
+    if ( m_treeView ) m_treeView->removeEventFilter( this );
+    if ( m_treeViewModel ) m_treeViewModel->setPdmItemRoot( nullptr );
 
     delete m_mainWidget;
     m_mainWidget = nullptr;
@@ -404,25 +404,19 @@ void PdmUiTreeViewEditor::customMenuRequested( QPoint pos )
 //--------------------------------------------------------------------------------------------------
 PdmChildArrayFieldHandle* PdmUiTreeViewEditor::currentChildArrayFieldHandle()
 {
-    PdmUiItem* currentSelectedItem = SelectionManager::instance()->selectedItem( SelectionManager::FIRST_LEVEL );
+    auto* currentSelectedItem = SelectionManager::instance()->selectedItem( SelectionManager::FIRST_LEVEL );
 
-    PdmUiFieldHandle* uiFieldHandle = dynamic_cast<PdmUiFieldHandle*>( currentSelectedItem );
-    if ( uiFieldHandle )
+    if ( auto* uiFieldHandle = dynamic_cast<PdmUiFieldHandle*>( currentSelectedItem ) )
     {
-        PdmFieldHandle* fieldHandle = uiFieldHandle->fieldHandle();
-
-        if ( dynamic_cast<PdmChildArrayFieldHandle*>( fieldHandle ) )
+        if ( auto* childArrayField = dynamic_cast<PdmChildArrayFieldHandle*>( uiFieldHandle->fieldHandle() ) )
         {
-            return dynamic_cast<PdmChildArrayFieldHandle*>( fieldHandle );
+            return childArrayField;
         }
     }
 
-    PdmObjectHandle* pdmObject = dynamic_cast<caf::PdmObjectHandle*>( currentSelectedItem );
-    if ( pdmObject )
+    if ( auto* pdmObject = dynamic_cast<PdmObjectHandle*>( currentSelectedItem ) )
     {
-        PdmChildArrayFieldHandle* parentChildArray = dynamic_cast<PdmChildArrayFieldHandle*>( pdmObject->parentField() );
-
-        if ( parentChildArray )
+        if ( auto* parentChildArray = dynamic_cast<PdmChildArrayFieldHandle*>( pdmObject->parentField() ) )
         {
             return parentChildArray;
         }
@@ -436,6 +430,8 @@ PdmChildArrayFieldHandle* PdmUiTreeViewEditor::currentChildArrayFieldHandle()
 //--------------------------------------------------------------------------------------------------
 void PdmUiTreeViewEditor::selectAsCurrentItem( const PdmUiItem* uiItem )
 {
+    if ( !m_treeView || !m_treeViewModel || !m_filterModel ) return;
+
     QModelIndex index        = m_treeViewModel->findModelIndex( uiItem );
     QModelIndex indexForItem = m_filterModel->mapFromSource( index );
 
@@ -454,6 +450,8 @@ void PdmUiTreeViewEditor::selectAsCurrentItem( const PdmUiItem* uiItem )
 //--------------------------------------------------------------------------------------------------
 void PdmUiTreeViewEditor::selectItems( std::vector<const PdmUiItem*> uiItems )
 {
+    if ( !m_treeView ) return;
+
     m_treeView->clearSelection();
 
     if ( uiItems.empty() )
@@ -487,6 +485,8 @@ void PdmUiTreeViewEditor::slotOnSelectionChanged( const QItemSelection& selected
 //--------------------------------------------------------------------------------------------------
 void PdmUiTreeViewEditor::setExpanded( const PdmUiItem* uiItem, bool doExpand ) const
 {
+    if ( !m_treeView || !m_treeViewModel || !m_filterModel ) return;
+
     QModelIndex index       = m_treeViewModel->findModelIndex( uiItem );
     QModelIndex filterIndex = m_filterModel->mapFromSource( index );
 
@@ -508,13 +508,12 @@ QModelIndex PdmUiTreeViewEditor::mapIndexIfNecessary( QModelIndex index ) const
 {
     const QAbstractProxyModel* proxyModel = dynamic_cast<const QAbstractProxyModel*>( index.model() );
 
-    QModelIndex returnIndex = index;
     if ( proxyModel )
     {
-        returnIndex = proxyModel->mapToSource( index );
+        return proxyModel->mapToSource( index );
     }
 
-    return returnIndex;
+    return index;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -541,6 +540,8 @@ PdmUiTreeOrdering* PdmUiTreeViewEditor::uiTreeOrderingFromModelIndex( const QMod
 //--------------------------------------------------------------------------------------------------
 QModelIndex PdmUiTreeViewEditor::findModelIndex( const PdmUiItem* object ) const
 {
+    if ( !m_treeViewModel || !m_filterModel ) return {};
+
     QModelIndex index = m_treeViewModel->findModelIndex( object );
     return m_filterModel->mapFromSource( index );
 }

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 set(PROJECT_FILES
     cafUserInterface_UnitTests.cpp
     cafPdmUiTreeViewModelTest.cpp
+    cafPdmUiTreeViewEditorTest.cpp
     cafPdmUiTreeSelectionQModelTest.cpp
     cafPdmUiTableViewQModelTest.cpp
     cafPdmUiNumberFormatTest.cpp

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiTreeViewEditorTest.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiTreeViewEditorTest.cpp
@@ -1,0 +1,214 @@
+
+#include "gtest/gtest.h"
+
+#include "cafPdmChildArrayField.h"
+#include "cafPdmObject.h"
+#include "cafPdmUiTreeViewEditor.h"
+
+#include <QModelIndex>
+#include <QTreeView>
+#include <QWidget>
+
+using namespace caf;
+
+namespace PdmUiTreeViewEditorTestNs
+{
+class SimpleObj : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    SimpleObj()
+        : PdmObject()
+    {
+        CAF_PDM_InitObject( "SimpleObj", "", "Tooltip SimpleObj", "WhatsThis SimpleObj" );
+    }
+    ~SimpleObj() {}
+};
+// Registered under a unique keyword: the object factory keys on this string regardless of C++
+// namespace, and cafPdmUiTreeViewModelTest.cpp already registers "SimpleObj"/"DemoPdmObject".
+CAF_PDM_SOURCE_INIT( SimpleObj, "TreeViewEditorTest_SimpleObj" );
+
+class DemoPdmObject : public caf::PdmObject
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    DemoPdmObject()
+    {
+        CAF_PDM_InitObject( "DemoPdmObject", "", "Tooltip DemoPdmObject", "WhatsThis DemoPdmObject" );
+
+        CAF_PDM_InitFieldNoDefault( &m_simpleObjPtrField, "SimpleObjPtrField", "SimpleObjPtrField", "", "Tooltip", "WhatsThis" );
+        m_simpleObjPtrField.uiCapability()->setUiTreeHidden( false );
+    }
+
+    caf::PdmChildArrayField<caf::PdmObjectHandle*> m_simpleObjPtrField;
+};
+
+CAF_PDM_SOURCE_INIT( DemoPdmObject, "TreeViewEditorTest_DemoPdmObject" );
+} // namespace PdmUiTreeViewEditorTestNs
+
+using namespace PdmUiTreeViewEditorTestNs;
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTreeViewEditorTest, CreateWidgetAndVerifyEmptyState )
+{
+    PdmUiTreeViewEditor editor;
+
+    QWidget* widget = editor.getOrCreateWidget( nullptr );
+    ASSERT_TRUE( widget != nullptr );
+    ASSERT_TRUE( editor.treeView() != nullptr );
+
+    // No item is bound yet, so no valid model index should be found
+    SimpleObj   obj;
+    QModelIndex mi = editor.findModelIndex( &obj );
+    EXPECT_FALSE( mi.isValid() );
+
+    delete widget;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTreeViewEditorTest, SetPdmItemRootAndFindModelIndex )
+{
+    SimpleObj* obj1 = new SimpleObj;
+    SimpleObj* obj2 = new SimpleObj;
+
+    DemoPdmObject* demoObj = new DemoPdmObject;
+    demoObj->m_simpleObjPtrField.push_back( obj1 );
+    demoObj->m_simpleObjPtrField.push_back( obj2 );
+
+    PdmUiTreeViewEditor editor;
+    editor.getOrCreateWidget( nullptr );
+
+    editor.setPdmItemRoot( demoObj );
+    editor.updateUi( "" );
+
+    QModelIndex mi1 = editor.findModelIndex( obj1 );
+    EXPECT_TRUE( mi1.isValid() );
+
+    QModelIndex mi2 = editor.findModelIndex( obj2 );
+    EXPECT_TRUE( mi2.isValid() );
+
+    EXPECT_EQ( obj1, dynamic_cast<PdmObjectHandle*>( editor.uiItemFromModelIndex( mi1 ) ) );
+    EXPECT_EQ( obj2, dynamic_cast<PdmObjectHandle*>( editor.uiItemFromModelIndex( mi2 ) ) );
+
+    delete demoObj;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTreeViewEditorTest, DeleteItemAndVerifyModelIndexInvalidated )
+{
+    SimpleObj* obj1 = new SimpleObj;
+    SimpleObj* obj2 = new SimpleObj;
+
+    DemoPdmObject* demoObj = new DemoPdmObject;
+    demoObj->m_simpleObjPtrField.push_back( obj1 );
+    demoObj->m_simpleObjPtrField.push_back( obj2 );
+
+    PdmUiTreeViewEditor editor;
+    editor.getOrCreateWidget( nullptr );
+    editor.setPdmItemRoot( demoObj );
+    editor.updateUi( "" );
+
+    QModelIndex mi = editor.findModelIndex( obj1 );
+    EXPECT_TRUE( mi.isValid() );
+
+    demoObj->m_simpleObjPtrField.removeChild( obj1 );
+    demoObj->m_simpleObjPtrField().uiCapability()->updateConnectedEditors();
+
+    mi = editor.findModelIndex( obj1 );
+    EXPECT_FALSE( mi.isValid() );
+
+    delete obj1;
+    delete demoObj;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTreeViewEditorTest, SelectAsCurrentItemAndVerifySelection )
+{
+    SimpleObj* obj1 = new SimpleObj;
+    SimpleObj* obj2 = new SimpleObj;
+
+    DemoPdmObject* demoObj = new DemoPdmObject;
+    demoObj->m_simpleObjPtrField.push_back( obj1 );
+    demoObj->m_simpleObjPtrField.push_back( obj2 );
+
+    PdmUiTreeViewEditor editor;
+    editor.getOrCreateWidget( nullptr );
+    editor.setPdmItemRoot( demoObj );
+    editor.updateUi( "" );
+
+    editor.selectAsCurrentItem( obj2 );
+
+    std::vector<PdmUiItem*> selectedItems;
+    editor.selectedUiItems( selectedItems );
+
+    ASSERT_EQ( size_t( 1 ), selectedItems.size() );
+    EXPECT_EQ( obj2, dynamic_cast<PdmObjectHandle*>( selectedItems[0] ) );
+
+    delete demoObj;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTreeViewEditorTest, SetExpandedDoesNotCrashForValidAndInvalidItems )
+{
+    SimpleObj* obj1 = new SimpleObj;
+
+    DemoPdmObject* demoObj = new DemoPdmObject;
+    demoObj->m_simpleObjPtrField.push_back( obj1 );
+
+    PdmUiTreeViewEditor editor;
+    editor.getOrCreateWidget( nullptr );
+    editor.setPdmItemRoot( demoObj );
+    editor.updateUi( "" );
+
+    // Should not crash for a valid item
+    editor.setExpanded( demoObj, true );
+    editor.setExpanded( demoObj, false );
+
+    // Should not crash for an item not present in the tree
+    SimpleObj detachedObj;
+    editor.setExpanded( &detachedObj, true );
+
+    delete demoObj;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// The tree view widget can be destroyed by Qt while the editor is still reachable, for instance
+/// during teardown of the parent widget. All accessors must then be no-ops instead of crashing.
+/// https://github.com/OPM/ResInsight/issues/14699
+//--------------------------------------------------------------------------------------------------
+TEST( PdmUiTreeViewEditorTest, AccessorsAreNoOpsAfterWidgetIsDestroyed )
+{
+    SimpleObj* obj1 = new SimpleObj;
+
+    DemoPdmObject* demoObj = new DemoPdmObject;
+    demoObj->m_simpleObjPtrField.push_back( obj1 );
+
+    PdmUiTreeViewEditor editor;
+    QWidget*            widget = editor.getOrCreateWidget( nullptr );
+    editor.setPdmItemRoot( demoObj );
+    editor.updateUi( "" );
+
+    EXPECT_TRUE( editor.findModelIndex( obj1 ).isValid() );
+
+    delete widget;
+    EXPECT_TRUE( editor.treeView() == nullptr );
+
+    // The models outlive the widget, so these must be no-ops rather than crashes
+    editor.selectAsCurrentItem( obj1 );
+    editor.selectItems( { obj1 } );
+    editor.setExpanded( obj1, true );
+
+    delete demoObj;
+}


### PR DESCRIPTION
Fixes #14699

## Problem
Two related null-pointer crashes during view/dock teardown, both reported against #14699:

1. `RimNameConfig::autoName()` called `firstAncestorOrThisOfTypeAsserted<RimNameConfigHolderInterface>()` and unconditionally dereferenced the result. `CAF_ASSERT` is compiled out in release builds, so when the object has no `RimNameConfigHolderInterface` ancestor (e.g. transiently while a view is mid-destruction during dock teardown, or while the tree view/a combo-box editor renders it), the function silently returned `nullptr` and the following `plotHolder->createAutoName()` call crashed.

2. `PdmUiTreeViewEditor::selectAsCurrentItem()` dereferenced `m_treeView`, `m_treeViewModel`, and `m_filterModel` (all `QPointer<...>` members) without a null check. If the underlying tree-view widget/model is destroyed while the editor wrapper is still alive and receiving a dock-visibility-changed signal (e.g. during `tileViewWindows()` or dock teardown), the `QPointer`s are silently reset to null and the dereference crashes.

3. `PdmUiTreeViewEditor`'s destructor unconditionally dereferenced `m_treeView`/`m_treeViewModel` (also `QPointer`s), found while adding unit tests for the editor. If the tree widget is destroyed externally before the editor object itself, this crashes for the same reason as (2).

