### PR TITLE
#14704 Guard against zero time-step count in findOrLoadKnownScalarResultForTimeStep

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1846,9 +1846,12 @@ size_t RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep( const Rig
 
         bool resultLoadingSuccess = true;
 
-        if ( type == RiaDefines::ResultCatType::DYNAMIC_NATIVE && timeStepCount > 0 )
+        if ( type == RiaDefines::ResultCatType::DYNAMIC_NATIVE )
         {
-            // A case in an ensemble can have fewer time steps than the case defining the time step axis
+            // A case in an ensemble can have fewer time steps than the case defining the time step axis.
+            // This also catches the case where timeStepCount is zero, i.e. no time steps are known for
+            // this result on this case, which previously fell through and returned scalarResultIndex as
+            // if it were valid without ever resizing m_cellScalarResults for it.
             if ( timeStepIndex >= timeStepCount ) return cvf::UNDEFINED_SIZE_T;
 
             m_cellScalarResults[scalarResultIndex].resize( timeStepCount );


### PR DESCRIPTION
Fixes #14704

## Problem
`RigCaseCellResultsData::findOrLoadKnownScalarResultForTimeStep()` only bounds-checked `timeStepIndex` inside `if ( type == DYNAMIC_NATIVE && timeStepCount > 0 )`. When a result (e.g. SWAT/SGAS) has zero known time steps for a case, that whole block was skipped, `m_cellScalarResults[scalarResultIndex]` was never resized, and the function still returned `scalarResultIndex` as valid.

The caller, `RigSoilResultCalculator::calculate()` (reached via `computeSOILForTimeStep()`), then indexed it via `cellScalarResults()`, whose bounds check is `CAF_ASSERT` only (a no-op in Release builds), causing an out-of-bounds access on an empty vector and a segfault.

## Fix
Removed the `&& timeStepCount > 0` condition so the existing `timeStepIndex >= timeStepCount` guard also catches the zero-time-step case, returning `cvf::UNDEFINED_SIZE_T` instead of a bogus valid index.