### PR TITLE
#14698 Guard ensemble parameter correlation against NaN/Inf and overflow

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp
@@ -569,7 +569,7 @@ std::vector<std::pair<RigEnsembleParameter, double>>
                 }
             }
         }
-        if ( closestValue != std::numeric_limits<double>::infinity() )
+        if ( std::isfinite( closestValue ) )
         {
             caseValuesAtTimestep.push_back( closestValue );
 
@@ -591,7 +591,7 @@ std::vector<std::pair<RigEnsembleParameter, double>>
     {
         double correlation = 0.0;
         double pearson     = RigStatisticsTools::pearsonCorrelation( parameterValuesPair.second, caseValuesAtTimestep );
-        if ( pearson != std::numeric_limits<double>::infinity() ) correlation = pearson;
+        if ( std::isfinite( pearson ) ) correlation = pearson;
         correlationResults.push_back( std::make_pair( parameterValuesPair.first, correlation ) );
     }
     return correlationResults;

--- a/ApplicationLibCode/ReservoirDataModel/RigEnsembleParameter.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigEnsembleParameter.cpp
@@ -58,7 +58,16 @@ double RigEnsembleParameter::normalizedStdDeviation() const
     }
 
     double normalisedStdDev = stdDeviation() / maxAbs;
-    if ( normalisedStdDev < eps )
+    if ( !std::isfinite( normalisedStdDev ) )
+    {
+        // stdDeviation() sums squared values, which can overflow to NaN/Inf for parameter values with
+        // extreme (but finite) magnitudes. Fall back to a range-based variation estimate so the
+        // parameter is not silently treated as having no variation and dropped from correlation
+        // analysis.
+        normalisedStdDev = ( maxValue - minValue ) / maxAbs;
+    }
+
+    if ( !std::isfinite( normalisedStdDev ) || normalisedStdDev < eps )
     {
         return 0.0;
     }

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -93,6 +93,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCaseMainCollection-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryTimeAxisProperties-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimDeltaSummaryEnsemble-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimSummaryEnsemble-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RimEnsembleCurveFilter-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifActiveCellsReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifCsvDataTableFormatter-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigStatisticsTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigStatisticsTools-Test.cpp
@@ -21,6 +21,8 @@
 #include "RigStatisticsTools.h"
 
 #include <QDebug>
+
+#include <cmath>
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -82,6 +84,20 @@ TEST( RigStatisticsTools, NegativeCorrelation )
     }
     double correlation = RigStatisticsTools::pearsonCorrelation( a, b );
     EXPECT_NEAR( correlation, -1.0, 1.0e-2 );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extremely large but finite magnitudes can overflow the sum-of-squares to +Inf, and the final
+/// Inf/Inf division then yields NaN even though every individual input value is finite. Callers of
+/// pearsonCorrelation() (e.g. RimSummaryEnsemble::parameterCorrelations()) must guard against this.
+//--------------------------------------------------------------------------------------------------
+TEST( RigStatisticsTools, OverflowProducesNan )
+{
+    std::vector<double> a = { 1.0e200, 2.0e200, 3.0e200 };
+    std::vector<double> b = { 1.0e200, 2.0e200, 3.0e200 };
+
+    double correlation = RigStatisticsTools::pearsonCorrelation( a, b );
+    EXPECT_TRUE( std::isnan( correlation ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UnitTests/RimSummaryEnsemble-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RimSummaryEnsemble-Test.cpp
@@ -1,0 +1,108 @@
+#include "gtest/gtest.h"
+
+#include "RifEclipseSummaryAddress.h"
+#include "RigCaseRealizationParameters.h"
+#include "RigEnsembleParameter.h"
+#include "RimMockSummaryCase.h"
+#include "RimSummaryEnsemble.h"
+
+#include <cmath>
+#include <memory>
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Creates a mock case with a numeric realization parameter and a single-valued FOPT vector at time 0.
+//--------------------------------------------------------------------------------------------------
+RimSummaryCase* createCaseWithParameterAndValue( int realizationNumber, double parameterValue, double resultValue )
+{
+    auto* mockCase = static_cast<RimMockSummaryCase*>( createMockCase( realizationNumber ) );
+
+    auto parameters = mockCase->caseRealizationParameters();
+    parameters->addParameter( "PARAM1", parameterValue );
+
+    // Note: the sentinel "no closest timestep found yet" value used internally by
+    // RimSummaryEnsemble::parameterCorrelations() is time_t( 0 ), so the query timestep used in the
+    // tests below must be non-zero for the closest-timestep search to pick up the value at all.
+    mockCase->addVector( RifEclipseSummaryAddress::fieldAddress( "FOPT" ), { 100 }, { resultValue } );
+
+    return mockCase;
+}
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+/// A realization with a NaN/Inf value in the calculated vector must be excluded from the correlation
+/// computation instead of turning the whole result into NaN.
+//--------------------------------------------------------------------------------------------------
+TEST( RimSummaryEnsemble, ParameterCorrelations_NanRealizationExcluded )
+{
+    RimSummaryEnsemble ensemble;
+    ensemble.setAsEnsemble( true );
+
+    // Perfectly correlated realizations
+    ensemble.addCase( createCaseWithParameterAndValue( 0, 1.0, 10.0 ), false );
+    ensemble.addCase( createCaseWithParameterAndValue( 1, 2.0, 20.0 ), false );
+
+    // A realization with an invalid (NaN) result value, e.g. from a calculated vector dividing by zero
+    ensemble.addCase( createCaseWithParameterAndValue( 2, 3.0, std::numeric_limits<double>::quiet_NaN() ), false );
+
+    auto address = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+
+    auto correlations = ensemble.parameterCorrelations( address, 100 );
+    ASSERT_EQ( size_t( 1 ), correlations.size() );
+
+    double correlation = correlations.front().second;
+    EXPECT_TRUE( std::isfinite( correlation ) );
+    EXPECT_NEAR( 1.0, correlation, 1.0e-6 );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// A realization with an infinite value in the calculated vector must be excluded from the
+/// correlation computation instead of turning the whole result into NaN/Inf.
+//--------------------------------------------------------------------------------------------------
+TEST( RimSummaryEnsemble, ParameterCorrelations_InfRealizationExcluded )
+{
+    RimSummaryEnsemble ensemble;
+    ensemble.setAsEnsemble( true );
+
+    ensemble.addCase( createCaseWithParameterAndValue( 0, 1.0, 10.0 ), false );
+    ensemble.addCase( createCaseWithParameterAndValue( 1, 2.0, 20.0 ), false );
+    ensemble.addCase( createCaseWithParameterAndValue( 2, 3.0, std::numeric_limits<double>::infinity() ), false );
+
+    auto address = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+
+    auto correlations = ensemble.parameterCorrelations( address, 100 );
+    ASSERT_EQ( size_t( 1 ), correlations.size() );
+
+    double correlation = correlations.front().second;
+    EXPECT_TRUE( std::isfinite( correlation ) );
+    EXPECT_NEAR( 1.0, correlation, 1.0e-6 );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Reproduces a NaN correlation value reaching the tornado plot without any NaN/Inf value in the
+/// input data: extremely large but finite parameter/result magnitudes overflow the sum-of-squares in
+/// RigStatisticsTools::pearsonCorrelation() to +Inf, and the resulting Inf/Inf division yields NaN.
+/// RimSummaryEnsemble::parameterCorrelations() must guard against surfacing that NaN to the plot.
+//--------------------------------------------------------------------------------------------------
+TEST( RimSummaryEnsemble, ParameterCorrelations_OverflowNanGuarded )
+{
+    RimSummaryEnsemble ensemble;
+    ensemble.setAsEnsemble( true );
+
+    // Every value here is finite (std::isfinite is true), but the magnitudes are large enough that
+    // pearsonCorrelation() overflows internally and returns NaN. See RigStatisticsTools-Test.cpp,
+    // OverflowProducesNan, for a direct reproduction of that overflow.
+    ensemble.addCase( createCaseWithParameterAndValue( 0, 1.0e200, 1.0e200 ), false );
+    ensemble.addCase( createCaseWithParameterAndValue( 1, 2.0e200, 2.0e200 ), false );
+    ensemble.addCase( createCaseWithParameterAndValue( 2, 3.0e200, 3.0e200 ), false );
+
+    auto address = RifEclipseSummaryAddress::fieldAddress( "FOPT" );
+
+    auto correlations = ensemble.parameterCorrelations( address, 100 );
+    ASSERT_EQ( size_t( 1 ), correlations.size() );
+
+    double correlation = correlations.front().second;
+    EXPECT_TRUE( std::isfinite( correlation ) ) << "Tornado plot must never receive a NaN/Inf correlation value";
+    EXPECT_FALSE( std::isnan( correlation ) );
+}


### PR DESCRIPTION
Fixes #14698

## Problem
When making a Tornado plot for uncertainty correlation, a realization whose calculated summary vector value was NaN or Inf at the selected timestep propagated into the whole correlation result, corrupting the plot. In addition, extremely large but finite parameter/result magnitudes could overflow the sum-of-squares in `RigStatisticsTools::pearsonCorrelation()` and in `RigEnsembleParameter::stdDeviation()`, producing NaN even though every individual input value was finite - in the parameter-variation case this silently dropped the parameter from correlation analysis entirely (empty result) instead of surfacing a guarded value.

## Fix
* Exclude realizations with a non-finite calculated vector value from the Pearson correlation computation instead of letting NaN/Inf propagate.
* Guard the final correlation value against NaN (previously only checked against +Infinity).
* Guard `RigEnsembleParameter::normalizedStdDeviation()` against overflow-induced NaN by falling back to a range-based variation estimate, so parameters with extreme magnitudes are retained for correlation analysis instead of being silently treated as having no variation.
* Added regression tests in `RimSummaryEnsemble-Test.cpp` and `RigStatisticsTools-Test.cpp` covering NaN/Inf realizations and the overflow scenario.