### PR TITLE
Fix crash in RimSeismicSection::wellPathToSectionPoints when points is empty

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/Seismic/RimSeismicSection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Seismic/RimSeismicSection.cpp
@@ -1065,6 +1065,8 @@ std::vector<cvf::Vec3d> RimSeismicSection::wellPathToSectionPoints( RigWellPath*
         currentXline  = xline;
     }
 
+    if ( points.empty() ) return points;
+
     // make sure we include the last point
     if ( points.back() != wellpoints.back() ) points.push_back( wellpoints.back() );
 


### PR DESCRIPTION
Guards against calling points.back() on an empty vector in RimSeismicSection::wellPathToSectionPoints. If all well path points are filtered out by the zmin check, points stays empty and the subsequent points.back() call was undefined behavior, causing a crash. This adds an early return when points is empty.