### PR TITLE
#14714 Release offscreen FBO OpenGL resources on context loss/recreation

### DIFF
--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -270,13 +270,14 @@ void caf::Viewer::setupRenderingSequence()
 void caf::Viewer::deleteFboOpenGLResources()
 {
     // The OpenGL resources can be deleted at any time. CeeViz does not delete resources for FBOs, so delete them manually
+    //
+    // Callers (onWidgetOpenGLAboutToBeShutdown()/onWidgetOpenGLReinitialized()) are responsible for making sure the
+    // correct OpenGL context is current before calling this function, so we don't do it here.
 
     if ( m_offscreenFbo.notNull() )
     {
         if ( auto context = cvfOpenGLContext() )
         {
-            context->makeCurrent();
-
             m_offscreenFbo->deleteOrReleaseOpenGLResources( context );
         }
     }
@@ -932,13 +933,27 @@ void caf::Viewer::onWidgetOpenGLReady()
 {
     setupMainRendering();
     setupRenderingSequence();
+}
 
-    QOpenGLContext* myQtOpenGLContext = context();
-    CVF_ASSERT( myQtOpenGLContext );
-    CVF_ASSERT( myQtOpenGLContext->isValid() );
+//--------------------------------------------------------------------------------------------------
+/// Release the offscreen FBO's OpenGL resources while the (old) Qt OpenGL context is still current
+/// and valid, so the cached OpenGL ids don't end up referring to a destroyed context.
+//--------------------------------------------------------------------------------------------------
+void caf::Viewer::onWidgetOpenGLAboutToBeShutdown()
+{
+    deleteFboOpenGLResources();
+}
 
-    // Connect to signal so we get notified when Qt's OpenGL context is about to be destroyed
-    connect( myQtOpenGLContext, &QOpenGLContext::aboutToBeDestroyed, this, &Viewer::deleteFboOpenGLResources );
+//--------------------------------------------------------------------------------------------------
+/// Called after the widget has been re-initialized with a new Qt OpenGL context. Make sure the
+/// offscreen FBO's cached OpenGL ids (which belong to the destroyed context) are reset to 0 so
+/// they get rebuilt, then let the base class trigger a repaint.
+//--------------------------------------------------------------------------------------------------
+void caf::Viewer::onWidgetOpenGLReinitialized()
+{
+    deleteFboOpenGLResources();
+
+    cvfqt::OpenGLWidget::onWidgetOpenGLReinitialized();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -182,6 +182,19 @@ caf::Viewer::Viewer( QWidget* parent )
 //--------------------------------------------------------------------------------------------------
 caf::Viewer::~Viewer()
 {
+    // The offscreen FBO owns textures and renderbuffers that live in the shared context group (AA_ShareOpenGLContexts),
+    // so they outlive our own context unless we release them here. onWidgetOpenGLAboutToBeShutdown() is not called
+    // during widget destruction, since the base class disconnects from aboutToBeDestroyed first.
+    if ( auto context = cvfOpenGLContext() )
+    {
+        makeCurrent();
+
+        if ( context->isCurrent() )
+        {
+            deleteFboOpenGLResources();
+        }
+    }
+
     if ( m_layoutWidget ) m_layoutWidget->deleteLater();
 }
 
@@ -271,8 +284,8 @@ void caf::Viewer::deleteFboOpenGLResources()
 {
     // The OpenGL resources can be deleted at any time. CeeViz does not delete resources for FBOs, so delete them manually
     //
-    // Callers (onWidgetOpenGLAboutToBeShutdown()/onWidgetOpenGLReinitialized()) are responsible for making sure the
-    // correct OpenGL context is current before calling this function, so we don't do it here.
+    // Callers are responsible for making sure the OpenGL context owning the resources is current before calling this
+    // function, so we don't do it here.
 
     if ( m_offscreenFbo.notNull() )
     {
@@ -948,10 +961,15 @@ void caf::Viewer::onWidgetOpenGLAboutToBeShutdown()
 /// Called after the widget has been re-initialized with a new Qt OpenGL context. Make sure the
 /// offscreen FBO's cached OpenGL ids (which belong to the destroyed context) are reset to 0 so
 /// they get rebuilt, then let the base class trigger a repaint.
+///
+/// The ids must be dropped, not deleted, since they are only meaningful in the destroyed context.
 //--------------------------------------------------------------------------------------------------
 void caf::Viewer::onWidgetOpenGLReinitialized()
 {
-    deleteFboOpenGLResources();
+    if ( m_offscreenFbo.notNull() )
+    {
+        m_offscreenFbo->forgetCurrentOpenGLResources();
+    }
 
     cvfqt::OpenGLWidget::onWidgetOpenGLReinitialized();
 }

--- a/Fwk/AppFwk/cafViewer/cafViewer.h
+++ b/Fwk/AppFwk/cafViewer/cafViewer.h
@@ -196,6 +196,8 @@ protected:
     virtual void paintOverlayItems( QPainter* painter ) {};
 
     void onWidgetOpenGLReady() override;
+    void onWidgetOpenGLAboutToBeShutdown() override;
+    void onWidgetOpenGLReinitialized() override;
 
     // Overridable methods to setup the render system
     virtual void optimizeClippingPlanes();

--- a/Fwk/VizFwk/LibGuiQt/cvfqtOpenGLWidget.cpp
+++ b/Fwk/VizFwk/LibGuiQt/cvfqtOpenGLWidget.cpp
@@ -344,9 +344,19 @@ void OpenGLWidget::qtOpenGLContextAboutToBeDestroyed()
         // so that onWidgetOpenGLAboutToBeShutdown() overrides can safely release OpenGL resources.
         makeCurrent();
 
-        // Notify derived classes so they get a chance to release OpenGL resources while the
-        // CVF OpenGL context is still valid.
-        onWidgetOpenGLAboutToBeShutdown();
+        // makeCurrent() silently does nothing if the widget's surface is already gone. Issuing OpenGL calls in that
+        // case would either dereference a NULL current context or hit some other context that happens to be current,
+        // so only notify derived classes if our context really did become current.
+        if (m_cvfForwardingOpenGlContext->isCurrent())
+        {
+            // Notify derived classes so they get a chance to release OpenGL resources while the
+            // CVF OpenGL context is still valid.
+            onWidgetOpenGLAboutToBeShutdown();
+        }
+        else
+        {
+            CVF_LOG_WARNING(m_logger, cvf::String("OpenGLWidget[%1]: Could not make OpenGL context current, skipping shutdown notification").arg(m_instanceNumber));
+        }
 
         CVF_LOG_DEBUG(m_logger, cvf::String("OpenGLWidget[%1]: Shutting down CVF OpenGL context since Qt context is about to be destroyed").arg(m_instanceNumber));
         shutdownCvfOpenGLContext();

--- a/Fwk/VizFwk/LibGuiQt/cvfqtOpenGLWidget.cpp
+++ b/Fwk/VizFwk/LibGuiQt/cvfqtOpenGLWidget.cpp
@@ -154,6 +154,12 @@ OpenGLWidget::~OpenGLWidget()
         }
     }
 
+    // shutdownCvfOpenGLContext() no longer makes the context current itself, so do it here
+    if (m_cvfForwardingOpenGlContext.notNull())
+    {
+        makeCurrent();
+    }
+
     shutdownCvfOpenGLContext();
 }
 
@@ -238,10 +244,11 @@ void OpenGLWidget::initializeGL()
             onWidgetOpenGLReady();
         }
 
-        // Trigger a repaint if we're being re-initialized
+        // Notify that we've been re-initialized with a new OpenGL context
+        // Qt guarantees that myQtOpenGLContext is current at this point
         if (prevInitState == PENDING_REINITIALIZATION)
         {
-            update();
+            onWidgetOpenGLReinitialized();
         }
     }
 }
@@ -296,6 +303,35 @@ void OpenGLWidget::onWidgetOpenGLReady()
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Notification function that will be called just before the CVF OpenGL context is shut down as a
+/// consequence of Qt's underlying OpenGL context being about to be destroyed.
+///
+/// This is called with the *old* Qt OpenGL context current and cvfOpenGLContext() still non-null,
+/// so any OpenGL resources tied to that context can still be released/queried here.
+///
+/// Can be re-implemented in derived classes to take any needed actions.
+//--------------------------------------------------------------------------------------------------
+void OpenGLWidget::onWidgetOpenGLAboutToBeShutdown()
+{
+    // Base implementation does nothing
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Notification function that will be called after the widget has been re-initialized with a new
+/// Qt OpenGL context, i.e. after a previous call to onWidgetOpenGLAboutToBeShutdown().
+///
+/// This is called from initializeGL(), so Qt guarantees that the *new* OpenGL context is current.
+///
+/// Can be re-implemented in derived classes to take any needed actions. Note that overrides must
+/// call the base class implementation (or otherwise trigger a repaint) since the default
+/// implementation is responsible for scheduling a repaint of the widget.
+//--------------------------------------------------------------------------------------------------
+void OpenGLWidget::onWidgetOpenGLReinitialized()
+{
+    update();
+}
+
+//--------------------------------------------------------------------------------------------------
 /// 
 //--------------------------------------------------------------------------------------------------
 void OpenGLWidget::qtOpenGLContextAboutToBeDestroyed()
@@ -304,6 +340,14 @@ void OpenGLWidget::qtOpenGLContextAboutToBeDestroyed()
 
     if (m_cvfForwardingOpenGlContext.notNull())
     {
+        // Make sure the (still valid) Qt OpenGL context is current before notifying and tearing down,
+        // so that onWidgetOpenGLAboutToBeShutdown() overrides can safely release OpenGL resources.
+        makeCurrent();
+
+        // Notify derived classes so they get a chance to release OpenGL resources while the
+        // CVF OpenGL context is still valid.
+        onWidgetOpenGLAboutToBeShutdown();
+
         CVF_LOG_DEBUG(m_logger, cvf::String("OpenGLWidget[%1]: Shutting down CVF OpenGL context since Qt context is about to be destroyed").arg(m_instanceNumber));
         shutdownCvfOpenGLContext();
     }
@@ -321,8 +365,6 @@ void OpenGLWidget::shutdownCvfOpenGLContext()
 {
     if (m_cvfForwardingOpenGlContext.notNull())
     {
-        makeCurrent();
-
         m_cvfOpenGlContextGroup->contextAboutToBeShutdown(m_cvfForwardingOpenGlContext.p());
         m_cvfForwardingOpenGlContext = NULL;
     }

--- a/Fwk/VizFwk/LibGuiQt/cvfqtOpenGLWidget.h
+++ b/Fwk/VizFwk/LibGuiQt/cvfqtOpenGLWidget.h
@@ -72,6 +72,8 @@ protected:
     int                     instanceNumber() const;
 
     virtual void            onWidgetOpenGLReady();
+    virtual void            onWidgetOpenGLAboutToBeShutdown();
+    virtual void            onWidgetOpenGLReinitialized();
 
 private:
     void                    qtOpenGLContextAboutToBeDestroyed();

--- a/Fwk/VizFwk/LibRender/cvfFramebufferObject.cpp
+++ b/Fwk/VizFwk/LibRender/cvfFramebufferObject.cpp
@@ -514,7 +514,66 @@ void FramebufferObject::deleteFramebuffer(OpenGLContext* oglContext)
         CVF_ASSERT(OglRc::isSafeToRelease(m_oglRcBuffer.p()));
         m_oglRcBuffer = NULL;
 
-        m_colorAttachmentVersionTicks.clear();
+        // Reset the version ticks to force reattachment, but keep the size in sync with the number of color
+        // attachments since applyOpenGL() indexes this array directly
+        m_colorAttachmentVersionTicks.assign(m_colorAttachmentVersionTicks.size(), 0);
+    }
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/// 
+//--------------------------------------------------------------------------------------------------
+void FramebufferObject::forgetCurrentOpenGLResources()
+{
+    // Just release our reference. Framebuffer names are per context, so once the owning context is gone the cached
+    // ids must be dropped rather than deleted, since deleting them through another context would hit an unrelated
+    // framebuffer that happens to have been given the same name
+    CVF_ASSERT(OglRc::isSafeToRelease(m_oglRcBuffer.p()));
+    m_oglRcBuffer = NULL;
+
+    m_colorAttachmentVersionTicks.assign(m_colorAttachmentVersionTicks.size(), 0);
+    m_depthAttachmentVersionTick = 0;
+
+    size_t i;
+    for (i = 0; i < m_colorRenderBuffers.size(); i++)
+    {
+        RenderbufferObject* buffer = m_colorRenderBuffers[i].p();
+
+        if (buffer)
+        {
+            buffer->forgetCurrentOglRenderbuffer();
+        }
+    }
+
+    for (i = 0; i < m_colorTextures.size(); i++)
+    {
+        Texture* texture = m_colorTextures[i].p();
+
+        if (texture)
+        {
+            texture->forgetCurrentOglTexture();
+        }
+    }
+
+    if (m_depthRenderBuffer.notNull())
+    {
+        m_depthRenderBuffer->forgetCurrentOglRenderbuffer();
+    }
+
+    if (m_depthTexture2d.notNull())
+    {
+        m_depthTexture2d->forgetCurrentOglTexture();
+    }
+
+    if (m_depthStencilRenderBuffer.notNull())
+    {
+        m_depthStencilRenderBuffer->forgetCurrentOglRenderbuffer();
+    }
+
+    if (m_depthStencilTexture2d.notNull())
+    {
+        m_depthStencilTexture2d->forgetCurrentOglTexture();
     }
 }
 

--- a/Fwk/VizFwk/LibRender/cvfFramebufferObject.h
+++ b/Fwk/VizFwk/LibRender/cvfFramebufferObject.h
@@ -82,6 +82,7 @@ public:
     bool        isFramebufferComplete(OpenGLContext* oglContext, String* failReason) const;
 
     void        deleteOrReleaseOpenGLResources(OpenGLContext* oglContext);
+    void        forgetCurrentOpenGLResources();
 
     static bool supportedOpenGL(OpenGLContext* oglContext);
 

--- a/Fwk/VizFwk/LibRender/cvfRenderbufferObject.cpp
+++ b/Fwk/VizFwk/LibRender/cvfRenderbufferObject.cpp
@@ -157,6 +157,22 @@ void RenderbufferObject::deleteRenderbuffer(OpenGLContext* oglContext)
 
 
 //--------------------------------------------------------------------------------------------------
+/// Release our reference to the OpenGL renderbuffer without deleting it.
+/// 
+/// Use this when the context the renderbuffer belongs to is already gone, in which case the OpenGL
+/// name is meaningless and must not be passed to glDeleteRenderbuffers() on another context.
+//--------------------------------------------------------------------------------------------------
+void RenderbufferObject::forgetCurrentOglRenderbuffer()
+{
+    // Just release our reference
+    CVF_ASSERT(OglRc::isSafeToRelease(m_oglRcBuffer.p()));
+    m_oglRcBuffer = NULL;
+
+    m_versionTick++;
+}
+
+
+//--------------------------------------------------------------------------------------------------
 /// 
 //--------------------------------------------------------------------------------------------------
 cvfGLenum RenderbufferObject::intenalFormatOpenGL() const

--- a/Fwk/VizFwk/LibRender/cvfRenderbufferObject.h
+++ b/Fwk/VizFwk/LibRender/cvfRenderbufferObject.h
@@ -71,6 +71,7 @@ public:
 
     bool    create(OpenGLContext* oglContext);
     void    deleteRenderbuffer(OpenGLContext* oglContext);
+    void    forgetCurrentOglRenderbuffer();
 
     OglId   renderbufferOglId() const;
     uint    versionTick() const;

--- a/Fwk/VizFwk/LibRender/cvfTexture.h
+++ b/Fwk/VizFwk/LibRender/cvfTexture.h
@@ -117,6 +117,7 @@ public:
     bool            setupTexture(OpenGLContext* oglContext);
     void            setupTextureParamsFromSampler(OpenGLContext* oglContext, const Sampler& sampler) const;
     void            deleteTexture(OpenGLContext* oglContext);
+    void            forgetCurrentOglTexture();
 
     OglId           textureOglId() const;
     uint            versionTick() const;
@@ -124,7 +125,6 @@ public:
     static bool     supportedOpenGL(OpenGLContext* oglContext);
 
 private:
-    void            forgetCurrentOglTexture();
     cvfGLenum       textureTypeOpenGL() const;
     cvfGLint        internalFormatOpenGL() const;
 


### PR DESCRIPTION
Fixes #14714.

## Problem

caf::Viewer relied on a QOpenGLContext::aboutToBeDestroyed connection to release the offscreen FBO's OpenGL resources, but the connection was dead code:
- **Slot ordering**: OpenGLWidget's own aboutToBeDestroyed slot ran first and nulled the cvf OpenGL context, so deleteFboOpenGLResources() became a no-op.
- **One-shot connection**: the connection was only ever made once (onWidgetOpenGLReady()), so it did not fire again after a context was recreated (e.g. when a dock widget is reparented across top-level windows, which Qt::AA_ShareOpenGLContexts enables).

As a result m_offscreenFbo kept OpenGL ids belonging to a destroyed context. FramebufferObject::applyOpenGL() only regenerates ids that are still 0, so a stale non-zero id caused glBindFramebuffer to silently create a fresh, attachment-less framebuffer. Attachments are only reapplied when the viewport size changes, so a view re-docked at an unchanged size stayed incomplete and rendered black — this is the reproducible symptom in #14708 (tiling two ensemble contour maps at the same size blacks one out), and likely the underlying cause of the RHEL8 completely-black-view reports.

## Fix

Added explicit, well-documented lifecycle hooks to cvfqt::OpenGLWidget:
- onWidgetOpenGLAboutToBeShutdown() — called before context teardown, with the old context still current.
- onWidgetOpenGLReinitialized() — called from initializeGL() on reinit, with the new context current (replaces the bare update() call).

caf::Viewer overrides both to release/reset the offscreen FBO's cached OpenGL resources, so they get rebuilt correctly in the new context regardless of which lifecycle event actually fires on a given platform.
