### PR TITLE
#14714 Add opt-in native window for 3D viewers

### DIFF
--- a/Fwk/AppFwk/cafViewer/CMakeLists.txt
+++ b/Fwk/AppFwk/cafViewer/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
   LibRender
   LibGuiQt
   cafAnimControl
+  cafPdmCore
   ${QT_LIBRARIES}
 )
 

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -39,6 +39,7 @@
 #include "cafCadNavigation.h"
 #include "cafFrameAnimationControl.h"
 #include "cafNavigationPolicy.h"
+#include "cafPdmLogging.h"
 #include "cafPointOfInterestVisualizer.h"
 
 #include "cvfCamera.h"
@@ -141,6 +142,17 @@ caf::Viewer::Viewer( QWidget* parent )
 
     setAutoFillBackground( false );
     setMouseTracking( true );
+
+    // A non-native widget is composited into the top-level backing store, and that composition is not
+    // refreshed when the dock system switches tabs, leaving the shown view black. A native surface
+    // skips compositing, but becomes a subsurface on Wayland, so keep it opt-in.
+    if ( qEnvironmentVariableIntValue( "RESINSIGHT_ENABLE_NATIVE_GL_WIDGET" ) > 0 )
+    {
+        setAttribute( Qt::WA_NativeWindow );
+
+        CAF_PDM_LOG_INFO(
+            QString( "RESINSIGHT_ENABLE_NATIVE_GL_WIDGET is set, using a native window for the 3D viewer" ) );
+    }
 
     // Needed to get keystrokes
     setFocusPolicy( Qt::ClickFocus );


### PR DESCRIPTION
## Summary

Two 3D views docked in the same tab group render black after switching between tabs.

Tracing the render path shows it completes correctly every time: the offscreen FBO is complete, no OpenGL context is created or destroyed on a tab switch, and the blit lands on the widget's own default framebuffer in the widget's own context. The pixels are produced and never reach the screen.

Without a native window a `QOpenGLWidget` is composited into the top-level backing store, and that composition is not refreshed when the dock system hides one viewer and shows another in the same tab group. A native surface skips compositing, and the black view goes away.

On Wayland a native child widget becomes a subsurface with its own rendering and stacking problems, so this is opt-in rather than default. Set `RESINSIGHT_ENABLE_NATIVE_GL_WIDGET=1` to enable it.

`cafViewer` now links `cafPdmCore` so the viewer can log through caf, which is bridged to `RiaLogging` and therefore reaches the ResInsight log file.

## Status

Verified on Windows against a project with two 3D views docked in one tab group in the plot window. Off by default, so behaviour is unchanged unless the variable is set.

Not verified on Linux/X11, which is where #14708 was reported. The variable lets an affected user A/B the change without a new build. Enabling it by default on Linux was tried and reverted: it regresses rendering on Wayland under WSL.

Related: #14708, #14681