### PR TITLE
#14720 Probe std::stacktrace by linking instead of trusting the feature macro

### DIFF
--- a/ApplicationExeCode/RiaMainTools.cpp
+++ b/ApplicationExeCode/RiaMainTools.cpp
@@ -40,16 +40,19 @@
 #include <typeinfo>
 #include <version>
 
-// std::stacktrace is C++23; libc++ in Homebrew llvm@19 (and older) does not
-// ship it.  Without it we skip stack-trace capture in the crash path but
-// still log the signal.  Use the feature-test macro from <version> rather
-// than __has_include, since the header may be present without a usable
-// implementation.  See #14045.
+// std::stacktrace is C++23 and not usable on all toolchains.  The build system
+// probes it by linking and may force it off via RIA_HAS_STD_STACKTRACE=0, see
+// cmake/StdStacktrace.cmake and #14045.
+#ifndef RIA_HAS_STD_STACKTRACE
 #if defined( __cpp_lib_stacktrace ) && __cpp_lib_stacktrace >= 202011L
-#include <stacktrace>
 #define RIA_HAS_STD_STACKTRACE 1
 #else
 #define RIA_HAS_STD_STACKTRACE 0
+#endif
+#endif
+
+#if RIA_HAS_STD_STACKTRACE
+#include <stacktrace>
 #endif
 
 #ifndef WIN32

--- a/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.h
+++ b/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.h
@@ -31,16 +31,19 @@
 #include <vector>
 #include <version>
 
-// std::stacktrace is C++23.  libc++ shipped with Homebrew llvm@19 (and
-// older toolchains) does not provide it yet, so guard the include + the
-// reportCrash overload that uses it.  Use the feature-test macro from
-// <version> rather than __has_include, since the header may be present
-// without a usable implementation.  See #14045.
+// std::stacktrace is C++23 and not usable on all toolchains.  The build system
+// probes it by linking and may force it off via RIA_HAS_STD_STACKTRACE=0, see
+// cmake/StdStacktrace.cmake and #14045.
+#ifndef RIA_HAS_STD_STACKTRACE
 #if defined( __cpp_lib_stacktrace ) && __cpp_lib_stacktrace >= 202011L
-#include <stacktrace>
 #define RIA_HAS_STD_STACKTRACE 1
 #else
 #define RIA_HAS_STD_STACKTRACE 0
+#endif
+#endif
+
+#if RIA_HAS_STD_STACKTRACE
+#include <stacktrace>
 #endif
 
 class QString;

--- a/ApplicationLibCode/CMakeLists.txt
+++ b/ApplicationLibCode/CMakeLists.txt
@@ -321,33 +321,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   # According to ivarun rt is needed on OpenSuse, and Fedora. See:
   # https://github.com/OPM/ResInsight/pull/7
   list(APPEND EXTERNAL_LINK_LIBRARIES rt)
-
-  # std::stacktrace requires stdc++exp. If a custom build of GCC stdc++exp is
-  # required, define the search path here.
-  set(RESINSIGHT_GCC_STDCPP_EXP_PATH
-      ""
-      CACHE PATH "Path to search for stdc++exp"
-  )
-
-  if(RESINSIGHT_GCC_STDCPP_EXP_PATH)
-    find_library(
-      STDCPP_EXP_LIBRARY
-      NAMES stdc++exp
-      HINTS ${RESINSIGHT_GCC_STDCPP_EXP_PATH}
-    )
-    if(STDCPP_EXP_LIBRARY)
-      message(
-        STATUS
-          "stdc++exp library found at custom location: ${STDCPP_EXP_LIBRARY}"
-      )
-      list(APPEND EXTERNAL_LINK_LIBRARIES ${STDCPP_EXP_LIBRARY})
-    endif()
-  else()
-    # stdc++exp is required for std::stacktrace
-    message(STATUS "stdc++exp library found at default location")
-    list(APPEND EXTERNAL_LINK_LIBRARIES stdc++exp)
-  endif()
 endif()
+
+# std::stacktrace needs stdc++exp on most libstdc++ toolchains. Which library,
+# if any, is probed in cmake/StdStacktrace.cmake.
+list(APPEND EXTERNAL_LINK_LIBRARIES ${RESINSIGHT_STACKTRACE_LIBRARIES})
 
 target_link_libraries(
   ApplicationLibCode PUBLIC ${LINK_LIBRARIES} ${EXTERNAL_LINK_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNO_DEBUG")
 endif()
 
+include(cmake/StdStacktrace.cmake)
+
 # ##############################################################################
 # Asserts
 # ##############################################################################

--- a/cmake/StdStacktrace.cmake
+++ b/cmake/StdStacktrace.cmake
@@ -1,0 +1,81 @@
+# ##############################################################################
+# std::stacktrace availability
+#
+# libstdc++ has shipped <stacktrace> and defined __cpp_lib_stacktrace since GCC
+# 13, but the implementation lives in a separate library (libstdc++exp).  Some
+# distributions ship the headers without that library -- Red Hat's gcc-toolset
+# is one -- so the header-only feature test in RiaMainTools.cpp and
+# RiaOpenTelemetryManager.h reports the feature as present and the link then
+# fails with undefined references to std::__stacktrace_impl::_S_current.
+#
+# Probe by actually linking: first with no extra library (libc++, and any
+# libstdc++ that folds the implementation in), then with stdc++exp, from
+# RESINSIGHT_GCC_STDCPP_EXP_PATH when a custom GCC build is used.  If neither
+# links, define RIA_HAS_STD_STACKTRACE=0 for the whole project so the crash
+# handler compiles out its stack-trace capture and logs the signal only.
+#
+# Sets RESINSIGHT_STACKTRACE_LIBRARIES for the link line (empty when the
+# feature needs no extra library, or is unavailable).
+# ##############################################################################
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+set(RESINSIGHT_GCC_STDCPP_EXP_PATH
+    ""
+    CACHE PATH "Path to search for stdc++exp"
+)
+
+set(RESINSIGHT_STACKTRACE_LIBRARIES "")
+
+set(_ri_stacktrace_source
+    "#include <stacktrace>
+int main()
+{
+    return static_cast<int>( std::stacktrace::current().size() );
+}"
+)
+
+cmake_push_check_state(RESET)
+check_cxx_source_compiles(
+  "${_ri_stacktrace_source}" RESINSIGHT_STACKTRACE_NO_EXTRA_LIBRARY
+)
+
+if(NOT RESINSIGHT_STACKTRACE_NO_EXTRA_LIBRARY)
+  # Default to the plain library name and let the compiler driver resolve it
+  # from its own library directories, which find_library() does not search.
+  set(_ri_stdcpp_exp stdc++exp)
+  if(RESINSIGHT_GCC_STDCPP_EXP_PATH)
+    find_library(
+      STDCPP_EXP_LIBRARY
+      NAMES stdc++exp
+      HINTS ${RESINSIGHT_GCC_STDCPP_EXP_PATH}
+    )
+    if(STDCPP_EXP_LIBRARY)
+      set(_ri_stdcpp_exp ${STDCPP_EXP_LIBRARY})
+    endif()
+  endif()
+
+  set(CMAKE_REQUIRED_LIBRARIES ${_ri_stdcpp_exp})
+  check_cxx_source_compiles(
+    "${_ri_stacktrace_source}" RESINSIGHT_STACKTRACE_NEEDS_STDCPP_EXP
+  )
+  if(RESINSIGHT_STACKTRACE_NEEDS_STDCPP_EXP)
+    set(RESINSIGHT_STACKTRACE_LIBRARIES ${_ri_stdcpp_exp})
+  endif()
+endif()
+cmake_pop_check_state()
+
+if(RESINSIGHT_STACKTRACE_NO_EXTRA_LIBRARY)
+  message(STATUS "std::stacktrace: available, no extra library required")
+elseif(RESINSIGHT_STACKTRACE_NEEDS_STDCPP_EXP)
+  message(
+    STATUS "std::stacktrace: available, linking ${RESINSIGHT_STACKTRACE_LIBRARIES}"
+  )
+else()
+  message(
+    STATUS
+      "std::stacktrace: not usable with this toolchain (no stdc++exp), crash handler will log signals without stack traces"
+  )
+  add_compile_definitions(RIA_HAS_STD_STACKTRACE=0)
+endif()


### PR DESCRIPTION
### Problem

`RiaMainTools.cpp` and `RiaOpenTelemetryManager.h` gate `std::stacktrace` on the `__cpp_lib_stacktrace` feature macro. libstdc++ defines that macro from GCC 13 on, but the implementation lives in a separate library, `libstdc++exp`, which some distributions do not ship — Red Hat's gcc-toolset among them.

On those toolchains the feature test passes, the code compiles, and the link then fails with undefined references to `std::__stacktrace_impl::_S_current`. `ApplicationLibCode/CMakeLists.txt` also appended `stdc++exp` unconditionally on Linux, which fails the same way when the library is absent.

### Change

Add `cmake/StdStacktrace.cmake`, which probes the feature by actually linking rather than trusting the macro:

1. try `std::stacktrace::current()` with no extra library (libc++, and any libstdc++ that folds the implementation in),
2. then with `stdc++exp`, honouring `RESINSIGHT_GCC_STDCPP_EXP_PATH` for custom GCC builds,
3. if neither links, define `RIA_HAS_STD_STACKTRACE=0` project-wide so the crash handler compiles out its stack-trace capture and logs the signal only.

The result selects the link library through `RESINSIGHT_STACKTRACE_LIBRARIES`, replacing the hardcoded logic in `ApplicationLibCode/CMakeLists.txt`. Both headers now honour a `RIA_HAS_STD_STACKTRACE` supplied by the build system and include `<stacktrace>` only when the feature is enabled.

The configure step reports which branch it took, e.g. `std::stacktrace: available, linking stdc++exp`.

Closes #14720