### PR TITLE
#14722 Remove object from list before deleting it to avoid crash

### DIFF
--- a/ApplicationLibCode/Commands/RicCloseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCloseCaseFeature.cpp
@@ -182,8 +182,8 @@ void RicCloseCaseFeature::deleteEclipseCase( RimEclipseCase* eclipseCase )
                     for ( size_t i = children.size(); i-- > 0; )
                     {
                         caf::PdmObjectHandle* obj = children[i];
-                        delete obj;
                         caseGroup->statisticsCaseCollection()->reservoirs.erase( i );
+                        delete obj;
                     }
 
                     caseGroup->statisticsCaseCollection()->uiCapability()->updateConnectedEditors();

--- a/ApplicationLibCode/Commands/RicDeleteItemExec.cpp
+++ b/ApplicationLibCode/Commands/RicDeleteItemExec.cpp
@@ -62,9 +62,9 @@ void RicDeleteItemExec::redo()
             m_commandData.m_deletedObjectAsXml = xmlObj( obj )->writeObjectToXmlString();
         }
 
-        delete obj;
-
         listField->erase( m_commandData.m_indexToObject );
+
+        delete obj;
 
         caf::PdmObjectHandle* parentObj = listField->ownerObject();
         parentObj->uiCapability()->updateConnectedEditors();


### PR DESCRIPTION
Fixes #14722.

RicDeleteItemExec::redo() deleted the pdm object before removing it from the owning PdmChildArrayField, which could crash. Swapped the order to remove from the list first, then delete.

Found and fixed the same pattern in RicCloseCaseFeature::deleteEclipseCase().

Searched the rest of the codebase for the same delete-before-remove pattern (\delete obj;\ immediately followed by \->erase(...)\/\emoveChild(...)\ on the owning list) and found no other occurrences.