### PR TITLE
#14708 Fix black docked views by updating ADS

### DIFF
--- a/Fwk/AppFwk/cafViewer/CMakeLists.txt
+++ b/Fwk/AppFwk/cafViewer/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(
   LibRender
   LibGuiQt
   cafAnimControl
-  cafPdmCore
   ${QT_LIBRARIES}
 )
 

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -39,7 +39,6 @@
 #include "cafCadNavigation.h"
 #include "cafFrameAnimationControl.h"
 #include "cafNavigationPolicy.h"
-#include "cafPdmLogging.h"
 #include "cafPointOfInterestVisualizer.h"
 
 #include "cvfCamera.h"
@@ -142,17 +141,6 @@ caf::Viewer::Viewer( QWidget* parent )
 
     setAutoFillBackground( false );
     setMouseTracking( true );
-
-    // A non-native widget is composited into the top-level backing store, and that composition is not
-    // refreshed when the dock system switches tabs, leaving the shown view black. A native surface
-    // skips compositing, but becomes a subsurface on Wayland, so keep it opt-in.
-    if ( qEnvironmentVariableIntValue( "RESINSIGHT_ENABLE_NATIVE_GL_WIDGET" ) > 0 )
-    {
-        setAttribute( Qt::WA_NativeWindow );
-
-        CAF_PDM_LOG_INFO(
-            QString( "RESINSIGHT_ENABLE_NATIVE_GL_WIDGET is set, using a native window for the 3D viewer" ) );
-    }
 
     // Needed to get keystrokes
     setFocusPolicy( Qt::ClickFocus );


### PR DESCRIPTION
Update Qt Advanced Docking System to the parent-preservation fix cherry-picked onto CeetronSolutions master. Keep inactive docks hidden under the dock manager instead of temporarily making them top-level windows, avoiding disruption of QOpenGLWidget composition without enabling native windows.

Related to #14714. ADS fix cherry-picked from kriben/Qt-Advanced-Docking-System commit 7d6f2e71e374b95d600467602b770a8c8cf85d07.