### PR TITLE
vcpkg: Patch thrift for GCC 15 via overlay port

### DIFF
--- a/ThirdParty/vcpkg-overlay-ports/thrift/correct-paths.patch
+++ b/ThirdParty/vcpkg-overlay-ports/thrift/correct-paths.patch
@@ -1,0 +1,15 @@
+diff --git a/build/cmake/GenerateConfigModule.cmake b/build/cmake/GenerateConfigModule.cmake
+index 9533c82..d074a1b 100644
+--- a/build/cmake/GenerateConfigModule.cmake
++++ b/build/cmake/GenerateConfigModule.cmake
+@@ -19,8 +19,8 @@
+ 
+ include(CMakePackageConfigHelpers)
+ set(PACKAGE_INCLUDE_INSTALL_DIR "${includedir}/thrift")
+-set(PACKAGE_CMAKE_INSTALL_DIR "${cmakedir}/thrift")
+-set(PACKAGE_BIN_INSTALL_DIR "${exec_prefix}")
++set(PACKAGE_CMAKE_INSTALL_DIR "${prefix}/share/thrift")
++set(PACKAGE_BIN_INSTALL_DIR "${prefix}/tools/thrift")
+ 
+ # In CYGWIN enviroment below commands does not work properly
+ if (NOT CYGWIN)

--- a/ThirdParty/vcpkg-overlay-ports/thrift/gcc15-cstdint.patch
+++ b/ThirdParty/vcpkg-overlay-ports/thrift/gcc15-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/cpp/src/thrift/concurrency/Mutex.h b/lib/cpp/src/thrift/concurrency/Mutex.h
+index 1e5c3fb..12f1729 100644
+--- a/lib/cpp/src/thrift/concurrency/Mutex.h
++++ b/lib/cpp/src/thrift/concurrency/Mutex.h
+@@ -20,6 +20,7 @@
+ #ifndef _THRIFT_CONCURRENCY_MUTEX_H_
+ #define _THRIFT_CONCURRENCY_MUTEX_H_ 1
+ 
++#include <cstdint>
+ #include <memory>
+ #include <thrift/TNonCopyable.h>
+ 

--- a/ThirdParty/vcpkg-overlay-ports/thrift/pc-suffix.patch
+++ b/ThirdParty/vcpkg-overlay-ports/thrift/pc-suffix.patch
@@ -1,0 +1,44 @@
+diff --git a/lib/cpp/thrift-nb.pc.in b/lib/cpp/thrift-nb.pc.in
+index 2c6a96973..e99eff2bc 100644
+--- a/lib/cpp/thrift-nb.pc.in
++++ b/lib/cpp/thrift-nb.pc.in
+@@ -26,5 +26,5 @@ Name: Thrift
+ Description: Thrift Nonblocking API
+ Version: @VERSION@
+ Requires: thrift = @VERSION@
+-Libs: -L${libdir} -lthriftnb
++Libs: -L${libdir} -lthriftnb@THRIFT_RUNTIME_POSTFIX@
+ Cflags: -I${includedir}
+diff --git a/lib/cpp/thrift-qt5.pc.in b/lib/cpp/thrift-qt5.pc.in
+index a8b16663e..2720bea79 100644
+--- a/lib/cpp/thrift-qt5.pc.in
++++ b/lib/cpp/thrift-qt5.pc.in
+@@ -26,5 +26,5 @@ Name: Thrift
+ Description: Thrift Qt5 API
+ Version: @VERSION@
+ Requires: thrift = @VERSION@
+-Libs: -L${libdir} -lthriftqt5
++Libs: -L${libdir} -lthriftqt5@THRIFT_RUNTIME_POSTFIX@
+ Cflags: -I${includedir}
+diff --git a/lib/cpp/thrift-z.pc.in b/lib/cpp/thrift-z.pc.in
+index 467d2e11c..cde44158a 100644
+--- a/lib/cpp/thrift-z.pc.in
++++ b/lib/cpp/thrift-z.pc.in
+@@ -26,5 +26,5 @@ Name: Thrift
+ Description: Thrift Zlib API
+ Version: @VERSION@
+ Requires: thrift = @VERSION@
+-Libs: -L${libdir} -lthriftz
++Libs: -L${libdir} -lthriftz@THRIFT_RUNTIME_POSTFIX@
+ Cflags: -I${includedir}
+diff --git a/lib/cpp/thrift.pc.in b/lib/cpp/thrift.pc.in
+index d11e6db29..77da61c3e 100644
+--- a/lib/cpp/thrift.pc.in
++++ b/lib/cpp/thrift.pc.in
+@@ -25,5 +25,5 @@ includedir=@includedir@
+ Name: Thrift
+ Description: Thrift C++ API
+ Version: @VERSION@
+-Libs: -L${libdir} -lthrift
++Libs: -L${libdir} -lthrift@THRIFT_RUNTIME_POSTFIX@
+ Cflags: -I${includedir}

--- a/ThirdParty/vcpkg-overlay-ports/thrift/portfile.cmake
+++ b/ThirdParty/vcpkg-overlay-ports/thrift/portfile.cmake
@@ -1,0 +1,99 @@
+# We currently insist on static only because:
+# - Thrift doesn't yet support building as a DLL on Windows,
+# - x64-linux only builds static anyway.
+# From https://github.com/apache/thrift/blob/master/CHANGES.md
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(BISON)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/thrift
+    REF "v${VERSION}"
+    SHA512 5e4ee9870b30fe5ba484d39781c435716f7f3903793dc8aae96594ca813b1a5a73363b84719038ca8fa3ab8ef0a419a28410d936ff7b3bbadf36fc085a6883ae
+    HEAD_REF master
+    PATCHES
+      "correct-paths.patch"
+      "pc-suffix.patch"
+      # lib/cpp/src/thrift/concurrency/Mutex.h declares int64_t without
+      # including <cstdint>.  libstdc++ in GCC 15 no longer provides that
+      # header transitively through <memory>, so the port fails to compile
+      # with gcc-toolset-15; gcc-toolset-14 and older are unaffected.  The
+      # upstream vcpkg port carries no patch.
+      "gcc15-cstdint.patch"
+)
+
+if (VCPKG_TARGET_IS_OSX)
+    message(WARNING "${PORT} requires bison version greater than 2.5,\n\
+please use command \`brew install bison\` to install bison")
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" shared_lib)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" static_lib)
+
+# note we specify values for WITH_STATIC_LIB and WITH_SHARED_LIB because even though
+# they're marked as deprecated, Thrift incorrectly hard-codes a value for BUILD_SHARED_LIBS.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    NO_CHARSET_FLAG
+    OPTIONS
+        --trace-expand
+        -DLIB_INSTALL_DIR:PATH=lib
+        -DWITH_SHARED_LIB=${shared_lib}
+        -DWITH_STATIC_LIB=${static_lib}
+        -DBUILD_TESTING=OFF
+        -DBUILD_JAVA=OFF
+        -DWITH_C_GLIB=OFF
+        -DBUILD_C_GLIB=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_GLIB=TRUE
+        -DBUILD_PYTHON=OFF
+        -DBUILD_CPP=ON
+        -DWITH_CPP=ON
+        -DWITH_ZLIB=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_ZLIB=TRUE
+        -DWITH_LIBEVENT=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_Libevent=TRUE
+        -DWITH_OPENSSL=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_OpenSSL=TRUE
+        -DBUILD_TUTORIALS=OFF
+        -DFLEX_EXECUTABLE=${FLEX}
+        -DWITH_QT5=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Qt5=TRUE
+        -DCMAKE_DISABLE_FIND_PACKAGE_Gradle=TRUE
+        -DCMAKE_DISABLE_FIND_PACKAGE_Java=TRUE
+        -DBUILD_JAVASCRIPT=OFF
+        -DBUILD_NODEJS=OFF
+        -DBISON_EXECUTABLE=${BISON}
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_GLIB
+        CMAKE_DISABLE_FIND_PACKAGE_Gradle
+        CMAKE_REQUIRE_FIND_PACKAGE_Libevent
+        CMAKE_REQUIRE_FIND_PACKAGE_OpenSSL
+        CMAKE_REQUIRE_FIND_PACKAGE_ZLIB
+    
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+# Move CMake config files to the right place
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+
+file(GLOB COMPILER "${CURRENT_PACKAGES_DIR}/bin/thrift" "${CURRENT_PACKAGES_DIR}/bin/thrift.exe")
+if(COMPILER)
+    vcpkg_copy_tools(TOOL_NAMES thrift AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if ("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ThirdParty/vcpkg-overlay-ports/thrift/vcpkg.json
+++ b/ThirdParty/vcpkg-overlay-ports/thrift/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "thrift",
+  "version": "0.20.0",
+  "port-version": 2,
+  "$comment": "Local overlay of vcpkg's thrift port: adds gcc15-cstdint.patch so the port builds with GCC 15. See ThirdParty/vcpkg-overlay-ports/thrift/portfile.cmake.",
+  "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
+  "homepage": "https://github.com/apache/thrift",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "boost-date-time",
+    "boost-locale",
+    "boost-range",
+    "boost-scope-exit",
+    "boost-smart-ptr",
+    "libevent",
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/vcpkg-configuration-rhel8.json
+++ b/vcpkg-configuration-rhel8.json
@@ -10,5 +10,8 @@
       "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
       "name": "microsoft"
     }
+  ],
+  "overlay-ports": [
+    "ThirdParty/vcpkg-overlay-ports"
   ]
 }


### PR DESCRIPTION
## Problem

`thrift 0.20.0#1`, a transitive dependency of `arrow`, declares `int64_t` in `lib/cpp/src/thrift/concurrency/Mutex.h` (lines 47 and 60) while including only `<memory>`. libstdc++ in **GCC 15** no longer provides `<cstdint>` transitively through `<memory>`, so the port fails to compile at `TSSLServerSocket.cpp`:

```
lib/cpp/src/thrift/concurrency/Mutex.h:47:26: error: 'int64_t' has not been declared
   47 |   virtual bool timedlock(int64_t milliseconds) const;
```

The upstream vcpkg port carries no patch for this.

**gcc-toolset-14 and older are unaffected**, verified two ways: the patched header compiles clean under gcc-toolset-10 and -15 at both `-std=c++11` and `-std=c++17`, and RHEL8 CI's prebuilt thrift binary is a cache hit under gcc-toolset-14 (a hit requires a matching compiler hash, so GCC 14 compiled the unpatched source successfully).

## Fix

Vendor the thrift port under `ThirdParty/vcpkg-overlay-ports/` and add `gcc15-cstdint.patch`, which adds the missing include. `port-version` is bumped to 2 and a `$comment` marks it as a local overlay. `overlay-ports` is registered in `vcpkg-configuration-rhel8.json`, which the RHEL8 workflow and `Dockerfile.rhel8` copy over `vcpkg-configuration.json`.

## Why an overlay port rather than a triplet flag

A port-scoped flag in the triplet (`if(PORT STREQUAL "thrift") string(APPEND VCPKG_CXX_FLAGS " -include cstdint")`) scopes the flag correctly at build time, but does **not** scope the rebuild. `triplet_abi` is a hash of the triplet *file contents* and is byte-identical across every port:

```
$ grep triplet_abi ThirdParty/vcpkg/buildtrees/{thrift,grpc}/x64-linux-release.vcpkg_abi_info.txt
thrift: 764d83ca...-955af8e3...-f75e7e31...
grpc:   764d83ca...-955af8e3...-f75e7e31...
```

Editing a tracked triplet therefore invalidates all ~194 ports and forces the full cold-cache rebuild that b16c29b2e was written to avoid. Port files hash per-port, so the overlay limits churn to thrift and its dependants.

## Verification

`cmake --preset x64-release` completes successfully on Rocky Linux 8 with gcc-toolset-15:

- `-- Applying patch gcc15-cstdint.patch`
- thrift compiles 97/97 clean; `libthrift.a`, `libthriftnb.a`, `libthriftz.a` and `libarrow.a` install
- installed `include/thrift/concurrency/Mutex.h:23` carries `#include <cstdint>`
- 35 ports rebuilt (thrift plus arrow's dependency closure); the rest restored from the binary cache

## ⚠️ Requires an RHEL8 CI image rebuild before merge lands cleanly

The bumped `port-version` misses the vcpkg binary cache baked into the current CI image, so thrift and arrow recompile on every RHEL8 run:

| Branch | Duration | thrift |
|---|---|---|
| `dev` | 5m16s | restored from `/opt/vcpkg-cache`, 8 ms |
| this PR | 15m18s | `Building thrift:x64-linux@0.20.0#2` 1.6 min, then `arrow` 8.7 min |

The push-triggered image build was **skipped** because `ci-rhel8:2026-09-11` already existed from the nightly (the build step is gated on `if: steps.check.outputs.exists != 'true'`). After merge, the nightly rebuild at 00:00 UTC picks up the overlay and restores the ~10 minutes; a `workflow_dispatch` with `force_rebuild=true` does it immediately.

Note that `build-rhel8-image.yml`'s `paths:` filter lists `vcpkg-configuration-rhel8.json` but not `ThirdParty/vcpkg-overlay-ports/**`, so future edits to the overlay port will not trigger an image rebuild on their own.

## Notes for reviewers

- `vcpkg-configuration.json` is intentionally **not** touched, so the overlay applies on RHEL8 only. Ubuntu and Windows builds keep resolving the unpatched upstream thrift, which is correct while those runners are below GCC 15.
- `vcpkg-readme.md` is left unchanged to keep the diff minimal, so its file table does not yet mention the overlay-ports directory.