### PR TITLE
Reduce noise in cvf debug logging and make it opt-in

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -219,7 +219,7 @@ RiaApplication::~RiaApplication()
     // Shutdown CAF logging bridge
     RiaCafLoggingManager::shutdownCafLogging();
 
-    RiaCvfLoggingManager::shutdownCvfLogging();
+    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "cvf-logging" ) ) RiaCvfLoggingManager::shutdownCvfLogging();
 
     caf::SelectionManager::instance()->setPdmRootObject( nullptr );
 
@@ -1725,7 +1725,7 @@ void RiaApplication::initialize()
     initializeLoggers();
 
     // Initialize cvf logging bridge to forward cvf framework messages to ResInsight logging
-    RiaCvfLoggingManager::initializeCvfLogging();
+    if ( RiaPreferencesSystem::current()->isFeatureEnabled( "cvf-logging" ) ) RiaCvfLoggingManager::initializeCvfLogging();
 
     RiaConnectorTools::configureCloudServices();
 

--- a/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
+++ b/ApplicationLibCode/Application/RiaExperimentalFeatures.cpp
@@ -38,6 +38,13 @@ const std::vector<RiaExperimentalFeatures::Feature>& RiaExperimentalFeatures::av
           "Remember Dialog Size",
           "Remember the size of property and preferences dialogs between sessions and restore it the next time they "
           "open." },
+        { "cvf-logging",
+          "CVF Logging",
+          "Forward log messages from the cvf visualization framework to the ResInsight log (message panel and log "
+          "file), prefixed 'cvf[<logger-name>]: '. Restart required. Combine with --loglevel debug (or the Debug "
+          "log level in preferences) to also see cvf's debug-level messages, e.g. OpenGL context and widget "
+          "lifecycle events; note that debug level also logs one message per rendering pass and per part, every "
+          "frame, so the log can grow quickly." },
     };
 
     return features;

--- a/ApplicationLibCode/Application/Tools/RiaToCvfLogging.h
+++ b/ApplicationLibCode/Application/Tools/RiaToCvfLogging.h
@@ -21,6 +21,21 @@
 // Forwards the cvf framework's own logging (cee.cvf, cee.cvf.qt, cee.cvf.OpenGL) to ResInsight's
 // RiaLogging system, so messages end up in the log file and the message panel alongside the rest of
 // the application's log output. Without this, cvf logs to a console destination nobody reads.
+//
+// How to use:
+// 1. Enable the "CVF Logging" experimental feature (keyword "cvf-logging") in
+//    Preferences -> System -> Experimental Features, or add "cvf-logging" to the legacy
+//    "Keywords to enable experimental features" field, and restart ResInsight. This is required
+//    because RiaCvfLoggingManager::initializeCvfLogging()/shutdownCvfLogging() are only called
+//    when RiaPreferencesSystem::isFeatureEnabled("cvf-logging") returns true (see RiaApplication.cpp).
+// 2. Start ResInsight with debug-level logging, e.g. `ResInsight --loglevel debug`, or enable it via
+//    preferences, to actually see cvf's debug output; at the default INFO level only cvf
+//    info/warning/error messages are forwarded.
+// 3. Look for lines prefixed "cvf[<logger-name>]: " in the message panel/log file, e.g.
+//    "cvf[cee.cvf.qt]: OpenGLWidget[0]::initializeGL()".
+// Note: at debug level, cvf::Rendering/cvf::RenderEngine log one message per rendering pass and one
+// more per part in that pass, every frame, so the log can grow very quickly. Disable the feature
+// again (and restart) once done troubleshooting.
 
 #include "cvfLogDestination.h"
 


### PR DESCRIPTION
## Problem
cvf's internal logging is bridged into ResInsight's log unconditionally. At debug level, cvf logs one message per rendering pass and per part, every frame — this can flood the log very quickly.

## Fix
Add a `cvf-logging` experimental feature flag (Preferences -> System -> Experimental Features). The cvf logging bridge is now off by default and only initialized/shut down when the flag is enabled.

## How to use
1. Enable "CVF Logging" in Preferences -> System -> Experimental Features, restart.
2. Run with `--loglevel debug` to see cvf's debug messages, prefixed `cvf[<logger-name>]: `.
