### PR TITLE
#14709 Auto-import per-realization formation zone files for grid ensembles

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -37,6 +37,7 @@
 #include "EnsembleFileSet/RimEnsembleFileSetTools.h"
 #include "Formations/RimFormationNames.h"
 #include "Formations/RimFormationNamesCollection.h"
+#include "Formations/RimFormationTools.h"
 #include "Rim2dIntersectionViewCollection.h"
 #include "RimCaseCollection.h"
 #include "RimDataFilterCollection.h"
@@ -1048,6 +1049,13 @@ void RimReservoirGridEnsemble::createCaseObjects()
         RimEclipseResultCase* resultCase = new RimEclipseResultCase();
         resultCase->setGridFileName( gridFile );
         // DO NOT call openEclipseGridFile() here - deferred loading
+
+        // Auto-import per-realization formation zone file (.lyr), if present next to the grid file.
+        auto folderNames = RimFormationTools::formationFoldersFromCaseFileName( gridFile );
+        if ( RimFormationNames* formations = RimFormationTools::loadFormationNamesFromFolder( folderNames ) )
+        {
+            resultCase->setFormationNames( formations );
+        }
 
         RimProject::current()->assignCaseIdToCase( resultCase );
         m_caseCollection->reservoirs().push_back( resultCase );


### PR DESCRIPTION
Fixes #14709

Grid ensembles created from an EnsembleFileSet (RimReservoirGridEnsemble) never loaded per-realization formation zone (.lyr) files when creating case objects, unlike the legacy RimEclipseCaseEnsemble which auto-detects these files via RimEclipseResultCase::initAfterRead(). As a result, no case ever had an active RimFormationNames assigned, so the Formation Selection group in Ensemble Contour Map settings never appeared for ensembles with individual grids/formation files.

This mirrors the existing auto-import logic (RimFormationTools) already used by RicCreateGridCaseEnsemblesFromFilesFeature, applying it in RimReservoirGridEnsemble::createCaseObjects() so each realization case picks up its formation zone file, if present, next to the grid file.