### PR TITLE
#14690 Restore Close context menu command for cases

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCase.cpp
@@ -52,6 +52,10 @@ RimCase::RimCase()
 {
     CAF_PDM_InitScriptableObjectWithNameAndComment( "Case", ":/Case48x48.png", "", "", "Case", "The ResInsight base class for Cases" );
 
+    // Cases are deletable ("Close") by default. Cases that should not be closed by the user directly
+    // (e.g. generated ensemble statistics cases) must opt out by calling setDeletable( false ).
+    setDeletable( true );
+
     CAF_PDM_InitScriptableField( &m_caseUserDescription, "Name", QString(), "Case Name" );
     m_caseUserDescription.registerKeywordAlias( "CaseUserDescription" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_displayNameOption, "NameSetting", "Name Setting" );


### PR DESCRIPTION
Fixes #14690

## Cause
RicCloseCaseFeature::isCommandEnabled() was changed in #14619 (Well target updates) to require RimCase::isDeletable() to return true for all selected cases. However, no case type set this flag to true by default (the base PdmObjectHandle default is `false`), and only a few special-purpose objects (e.g. RimEclipseStatisticsCase) opted in explicitly. As a result the "Close" context menu entry disappeared for regular grid models (Eclipse and GeoMech cases) in the Project Tree.

## Fix
Set `setDeletable( true )` as the default in the `RimCase` constructor, so all cases are closeable by default, matching behavior before #14619.

The one case that intentionally should not be closed directly by the user — the generated ensemble grid case created in `RimWellTargetMapping::generateEnsembleStatistics()` — already calls `setDeletable( false )` explicitly after construction, so it remains protected.
