### PR TITLE
#14737 Add reordering support to case collections in Project Tree

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechModels.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechModels.cpp
@@ -29,6 +29,8 @@
 #include "RimIntersectionResultDefinition.h"
 #include "RimIntersectionResultsDefinitionCollection.h"
 
+#include "cafPdmFieldReorderCapability.h"
+
 CAF_PDM_SOURCE_INIT( RimGeoMechModels, "ResInsightGeoMechModels" );
 //--------------------------------------------------------------------------------------------------
 ///
@@ -38,6 +40,7 @@ RimGeoMechModels::RimGeoMechModels()
     CAF_PDM_InitObject( "Geomechanical Models", ":/GeoMechCases48x48.png" );
 
     CAF_PDM_InitFieldNoDefault( &m_cases, "Cases", "" );
+    caf::PdmFieldReorderCapability::addToField( &m_cases );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCaseCollection.cpp
@@ -24,6 +24,8 @@
 #include "RimIdenticalGridCaseGroup.h"
 #include "RimReservoirGridEnsemble.h"
 
+#include "cafPdmFieldReorderCapability.h"
+
 CAF_PDM_SOURCE_INIT( RimCaseCollection, "RimCaseCollection" );
 
 //--------------------------------------------------------------------------------------------------
@@ -34,6 +36,7 @@ RimCaseCollection::RimCaseCollection()
     CAF_PDM_InitObject( "Derived Statistics" );
 
     CAF_PDM_InitFieldNoDefault( &reservoirs, "Reservoirs", "Reservoirs ChildArrayField" );
+    caf::PdmFieldReorderCapability::addToField( &reservoirs );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
@@ -35,6 +35,7 @@
 #include "RimReservoirGridEnsemble.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
+#include "cafPdmFieldReorderCapability.h"
 
 CAF_PDM_SOURCE_INIT( RimEclipseCaseCollection, "ResInsightAnalysisModels" );
 //--------------------------------------------------------------------------------------------------
@@ -45,6 +46,7 @@ RimEclipseCaseCollection::RimEclipseCaseCollection()
     CAF_PDM_InitObject( "Grid Models", ":/Cases16x16.png" );
 
     CAF_PDM_InitFieldNoDefault( &cases, "Reservoirs", "" );
+    caf::PdmFieldReorderCapability::addToField( &cases );
 
     CAF_PDM_InitFieldNoDefault( &caseGroups, "CaseGroups", "" );
 


### PR DESCRIPTION
Fixes #14737

Adds `caf::PdmFieldReorderCapability` to the child array fields that hold cases in the Project Tree:

- `RimEclipseCaseCollection::cases` (Grid Models)
- `RimCaseCollection::reservoirs` (statistics case group reservoirs)
- `RimGeoMechModels::m_cases` (Geomechanical Models)

This enables the standard move up/down tree item controls (shown when a single item is selected) so cases can be reordered within their collection, matching the existing pattern used by e.g. `RimSurfaceCollection` and `RimMultiPlot`.
