### PR TITLE
#14739 Fix null pointer crash in intersection result text builders

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuFemResultTextBuilder.cpp
+++ b/ApplicationLibCode/UserInterface/RiuFemResultTextBuilder.cpp
@@ -151,7 +151,7 @@ QString RiuFemResultTextBuilder::geometrySelectionText( QString itemSeparator )
                 text += QString( ", ijk[%1, %2, %3]" ).arg( i ).arg( j ).arg( k ) + itemSeparator;
 
                 QString formattedText;
-                if ( m_2dIntersectionView )
+                if ( m_2dIntersectionView && m_2dIntersectionView->flatIntersectionPartMgr() )
                 {
                     formattedText = QString( "Horizontal length from well start: %1" ).arg( m_intersectionPointInDisplay.x(), 5, 'f', 2 );
                     text += formattedText + itemSeparator;

--- a/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp
+++ b/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp
@@ -249,7 +249,7 @@ QString RiuResultTextBuilder::geometrySelectionText( const QString& itemSeparato
             if ( m_intersectionPointInDisplay != cvf::Vec3d::UNDEFINED )
             {
                 QString formattedText;
-                if ( m_2dIntersectionView )
+                if ( m_2dIntersectionView && m_2dIntersectionView->flatIntersectionPartMgr() )
                 {
                     formattedText = QString( "Horizontal length from well start: %1" ).arg( m_intersectionPointInDisplay.x(), 5, 'f', 2 );
                     text += formattedText + itemSeparator;


### PR DESCRIPTION
Fixes #14739

Problem
`RiuResultTextBuilder::geometrySelectionText()` and `RiuFemResultTextBuilder::geometrySelectionText()` checked `m_2dIntersectionView` for null but called `m_2dIntersectionView->flatIntersectionPartMgr()->unflattenTransformMatrix(...)` without checking that `flatIntersectionPartMgr()` itself is non-null. `m_flatIntersectionPartMgr` is only created in `Rim2dIntersectionView::onCreateDisplayModel()`. Result text can be requested via selection-change handling right after a new intersection is appended, before the display model (and part manager) is created, causing a null pointer dereference and crash.

Fix
Add a null check on `flatIntersectionPartMgr()` alongside the existing `m_2dIntersectionView` check in both result text builders.
